### PR TITLE
perf: avoid cloning full network topology in more scenarios

### DIFF
--- a/rs/canonical_state/src/traversal.rs
+++ b/rs/canonical_state/src/traversal.rs
@@ -64,7 +64,10 @@ mod tests {
             ExecutionState, ExportedFunctions, NumWasmPages,
             execution_state::{CustomSection, CustomSectionType, WasmBinary, WasmMetadata},
         },
-        metadata_state::{ApiBoundaryNodeEntry, SubnetTopology, testing::NetworkTopologyTesting},
+        metadata_state::{
+            ApiBoundaryNodeEntry, SubnetTopology,
+            testing::{NetworkTopologyTesting, SystemMetadataTesting},
+        },
         page_map::PageMap,
         testing::{ReplicatedStateTesting, StreamTesting},
     };
@@ -766,55 +769,57 @@ mod tests {
     fn test_traverse_subnet() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-        state.metadata.network_topology.set_subnets(btreemap! {
-            // For test coverage, this test adds one subnet for each subnet type
-            subnet_test_id(0) => SubnetTopology {
-                public_key: vec![1, 2, 3, 4],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::Application,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            },
-            subnet_test_id(1) => SubnetTopology {
-                public_key: vec![5, 6, 7, 8],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::System,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            },
-            subnet_test_id(2) => SubnetTopology {
-                public_key: vec![9, 10, 11, 12],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::VerifiedApplication,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            },
-            subnet_test_id(3) => SubnetTopology {
-                public_key: vec![13, 14, 15, 16],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::CloudEngine,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            }
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                // For test coverage, this test adds one subnet for each subnet type
+                subnet_test_id(0) => SubnetTopology {
+                    public_key: vec![1, 2, 3, 4],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::Application,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                },
+                subnet_test_id(1) => SubnetTopology {
+                    public_key: vec![5, 6, 7, 8],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::System,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                },
+                subnet_test_id(2) => SubnetTopology {
+                    public_key: vec![9, 10, 11, 12],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::VerifiedApplication,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                },
+                subnet_test_id(3) => SubnetTopology {
+                    public_key: vec![13, 14, 15, 16],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::CloudEngine,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                }
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    id_range(0, 10) => subnet_test_id(0),
+                    id_range(11, 20) => subnet_test_id(1),
+                    id_range(21, 30) => subnet_test_id(0),
+                    id_range(31, 40) => subnet_test_id(2),
+                    id_range(41, 50) => subnet_test_id(3),
+                })
+                .unwrap(),
+            );
         });
-        state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                id_range(0, 10) => subnet_test_id(0),
-                id_range(11, 20) => subnet_test_id(1),
-                id_range(21, 30) => subnet_test_id(0),
-                id_range(31, 40) => subnet_test_id(2),
-                id_range(41, 50) => subnet_test_id(3),
-            })
-            .unwrap(),
-        );
         state.metadata.node_public_keys = btreemap! {
             node_test_id(2) => vec![9, 10, 11, 12],
         };
@@ -1032,38 +1037,40 @@ mod tests {
     fn test_traverse_large_or_empty_routing_table() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-        state.metadata.network_topology.set_subnets(btreemap! {
-            subnet_test_id(0) => SubnetTopology {
-                public_key: vec![1, 2, 3, 4],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::Application,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            },
-            subnet_test_id(1) => SubnetTopology {
-                public_key: vec![5, 6, 7, 8],
-                nodes: BTreeSet::new(),
-                subnet_type: SubnetType::VerifiedApplication,
-                subnet_features: SubnetFeatures::default(),
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            }
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                subnet_test_id(0) => SubnetTopology {
+                    public_key: vec![1, 2, 3, 4],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::Application,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                },
+                subnet_test_id(1) => SubnetTopology {
+                    public_key: vec![5, 6, 7, 8],
+                    nodes: BTreeSet::new(),
+                    subnet_type: SubnetType::VerifiedApplication,
+                    subnet_features: SubnetFeatures::default(),
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                }
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    id_range(0, 10) => subnet_test_id(0),
+                    id_range(21, 30) => subnet_test_id(0),
+                    id_range(36, 40) => subnet_test_id(0),
+                    id_range(51, 51) => subnet_test_id(0),
+                    id_range(61, 70) => subnet_test_id(0),
+                    id_range(81, 90) => subnet_test_id(0),
+                    id_range(105, 110) => subnet_test_id(0),
+                })
+                .unwrap(),
+            );
         });
-        state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                id_range(0, 10) => subnet_test_id(0),
-                id_range(21, 30) => subnet_test_id(0),
-                id_range(36, 40) => subnet_test_id(0),
-                id_range(51, 51) => subnet_test_id(0),
-                id_range(61, 70) => subnet_test_id(0),
-                id_range(81, 90) => subnet_test_id(0),
-                id_range(105, 110) => subnet_test_id(0),
-            })
-            .unwrap(),
-        );
 
         let height = 0;
 

--- a/rs/canonical_state/src/traversal.rs
+++ b/rs/canonical_state/src/traversal.rs
@@ -769,8 +769,8 @@ mod tests {
     fn test_traverse_subnet() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 // For test coverage, this test adds one subnet for each subnet type
                 subnet_test_id(0) => SubnetTopology {
                     public_key: vec![1, 2, 3, 4],
@@ -809,7 +809,7 @@ mod tests {
                     subnet_admins: BTreeSet::new(),
                 }
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     id_range(0, 10) => subnet_test_id(0),
                     id_range(11, 20) => subnet_test_id(1),
@@ -1037,8 +1037,8 @@ mod tests {
     fn test_traverse_large_or_empty_routing_table() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 subnet_test_id(0) => SubnetTopology {
                     public_key: vec![1, 2, 3, 4],
                     nodes: BTreeSet::new(),
@@ -1058,7 +1058,7 @@ mod tests {
                     subnet_admins: BTreeSet::new(),
                 }
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     id_range(0, 10) => subnet_test_id(0),
                     id_range(21, 30) => subnet_test_id(0),

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -56,7 +56,8 @@ use ic_replicated_state::{
     CallContextManager, CallOrigin, CanisterState, CanisterStatus, ReplicatedState,
     canister_state::system_state::wasm_chunk_store::{self, ChunkValidationResult},
     metadata_state::{
-        subnet_call_context_manager::InstallCodeCallId, testing::NetworkTopologyTesting,
+        subnet_call_context_manager::InstallCodeCallId,
+        testing::{NetworkTopologyTesting, SystemMetadataTesting},
     },
     page_map::TestPageAllocatorFileDescriptorImpl,
     testing::{CanisterQueuesTesting, SystemStateTesting},
@@ -339,12 +340,10 @@ fn initial_state(subnet_id: SubnetId, use_specified_ids_routing_table: bool) -> 
         })
         .unwrap()
     };
-    state
-        .metadata
-        .network_topology
-        .set_routing_table(routing_table);
-
-    state.metadata.network_topology.nns_subnet_id = subnet_id;
+    state.metadata.modify_network_topology(|nt| {
+        nt.set_routing_table(routing_table);
+        nt.nns_subnet_id = subnet_id;
+    });
     state.metadata.init_allocation_ranges_if_empty().unwrap();
     state
 }
@@ -405,7 +404,7 @@ fn install_code(
         None,
         old_canister,
         time,
-        Arc::new(network_topology),
+        network_topology,
         execution_parameters,
         round_limits,
         CompilationCostHandling::CountFullAmount,

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -340,9 +340,9 @@ fn initial_state(subnet_id: SubnetId, use_specified_ids_routing_table: bool) -> 
         })
         .unwrap()
     };
-    state.metadata.modify_network_topology(|nt| {
-        nt.set_routing_table(routing_table);
-        nt.nns_subnet_id = subnet_id;
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology.set_routing_table(routing_table);
+        network_topology.nns_subnet_id = subnet_id;
     });
     state.metadata.init_allocation_ranges_if_empty().unwrap();
     state

--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -1203,12 +1203,16 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_1, own_subnet_id);
-        nt.routing_table_mut()
-            .assign_canister(canister_id_2, own_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_1, own_subnet_id);
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_2, own_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `InstallCodeCall` and does not produce a response.
@@ -1222,10 +1226,13 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates canister 1 to another subnet.
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_1, other_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_1, other_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `InstallCodeCall` and produced a reject response.
@@ -1290,10 +1297,13 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     );
 
     // Simulate a subnet split that migrates canister 2 to another subnet.
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_2, other_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_2, other_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `InstallCodeCall` and set the ingress state to `Failed`.

--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -14,7 +14,7 @@ use ic_replicated_state::{
     canister_state::{
         NextExecution, execution_state::WasmExecutionMode, system_state::wasm_chunk_store,
     },
-    metadata_state::testing::NetworkTopologyTesting,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
 };
 use ic_test_utilities_execution_environment::{
     ExecutionTest, ExecutionTestBuilder, check_ingress_status, get_reply,
@@ -1203,16 +1203,12 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_1, own_subnet_id);
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_2, own_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_1, own_subnet_id);
+        nt.routing_table_mut()
+            .assign_canister(canister_id_2, own_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `InstallCodeCall` and does not produce a response.
@@ -1226,11 +1222,10 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates canister 1 to another subnet.
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_1, other_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_1, other_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `InstallCodeCall` and produced a reject response.
@@ -1295,11 +1290,10 @@ fn subnet_split_cleans_in_progress_install_code_calls() {
     );
 
     // Simulate a subnet split that migrates canister 2 to another subnet.
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_2, other_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_2, other_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `InstallCodeCall` and set the ingress state to `Failed`.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3465,7 +3465,7 @@ impl ExecutionEnvironment {
             execution_parameters,
             subnet_available_memory,
             &self.hypervisor,
-            Arc::new(state.metadata.network_topology.clone()),
+            state.metadata.network_topology.clone(),
             &self.log,
             &self.metrics.state_changes_error,
             metrics,
@@ -4130,7 +4130,7 @@ impl ExecutionEnvironment {
             prepaid_execution_cycles,
             old_canister,
             state.time(),
-            Arc::new(state.metadata.network_topology.clone()),
+            state.metadata.network_topology.clone(),
             execution_parameters,
             round_limits,
             compilation_cost_handling,
@@ -4308,7 +4308,7 @@ impl ExecutionEnvironment {
                     ingress_with_cycles_error: &self.metrics.ingress_with_cycles_error,
                 };
                 let round = RoundContext {
-                    network_topology: Arc::new(state.metadata.network_topology.clone()),
+                    network_topology: state.metadata.network_topology.clone(),
                     hypervisor: &self.hypervisor,
                     cycles_account_manager: &self.cycles_account_manager,
                     counters: round_counters,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3465,7 +3465,7 @@ impl ExecutionEnvironment {
             execution_parameters,
             subnet_available_memory,
             &self.hypervisor,
-            state.metadata.network_topology.clone(),
+            Arc::clone(&state.metadata.network_topology),
             &self.log,
             &self.metrics.state_changes_error,
             metrics,
@@ -4130,7 +4130,7 @@ impl ExecutionEnvironment {
             prepaid_execution_cycles,
             old_canister,
             state.time(),
-            state.metadata.network_topology.clone(),
+            Arc::clone(&state.metadata.network_topology),
             execution_parameters,
             round_limits,
             compilation_cost_handling,
@@ -4308,7 +4308,7 @@ impl ExecutionEnvironment {
                     ingress_with_cycles_error: &self.metrics.ingress_with_cycles_error,
                 };
                 let round = RoundContext {
-                    network_topology: state.metadata.network_topology.clone(),
+                    network_topology: Arc::clone(&state.metadata.network_topology),
                     hypervisor: &self.hypervisor,
                     cycles_account_manager: &self.cycles_account_manager,
                     counters: round_counters,

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -20,7 +20,7 @@ use ic_replicated_state::{
     CanisterStatus, ReplicatedState, SystemState,
     canister_state::{DEFAULT_QUEUE_CAPACITY, WASM_PAGE_SIZE_IN_BYTES},
     metadata_state::subnet_call_context_manager::PreSignatureStash,
-    metadata_state::testing::NetworkTopologyTesting,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
     testing::{CanisterQueuesTesting, SystemStateTesting},
 };
 use ic_test_utilities::assert_utils::assert_balance_equals;
@@ -1825,16 +1825,12 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_1, own_subnet_id);
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_2, own_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_1, own_subnet_id);
+        nt.routing_table_mut()
+            .assign_canister(canister_id_2, own_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `StopCanisterCall` and does not produce a response.
@@ -1848,11 +1844,10 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates canister 1 to another subnet.
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_1, other_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_1, other_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `StopCanisterCall` and produced a reject response.
@@ -1906,11 +1901,10 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     );
 
     // Simulate a subnet split that migrates canister 2 to another subnet.
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id_2, other_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id_2, other_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `StopCanisterCall` and set the ingress state to `Failed`.

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1825,12 +1825,16 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_1, own_subnet_id);
-        nt.routing_table_mut()
-            .assign_canister(canister_id_2, own_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_1, own_subnet_id);
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_2, own_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `StopCanisterCall` and does not produce a response.
@@ -1844,10 +1848,13 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates canister 1 to another subnet.
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_1, other_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_1, other_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `StopCanisterCall` and produced a reject response.
@@ -1901,10 +1908,13 @@ fn subnet_split_cleans_in_progress_stop_canister_calls() {
     );
 
     // Simulate a subnet split that migrates canister 2 to another subnet.
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id_2, other_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id_2, other_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `StopCanisterCall` and set the ingress state to `Failed`.

--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -148,7 +148,7 @@ impl<'a> QueryContext<'a> {
         cycles_account_manager: Arc<CyclesAccountManager>,
         instruction_observation: Option<Arc<AtomicU64>>,
     ) -> Self {
-        let network_topology = state.get_ref().metadata.network_topology.clone();
+        let network_topology = Arc::clone(&state.get_ref().metadata.network_topology);
         let round_limits = RoundLimits {
             instructions: as_round_instructions(max_query_call_graph_instructions),
             subnet_available_memory,

--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -148,7 +148,7 @@ impl<'a> QueryContext<'a> {
         cycles_account_manager: Arc<CyclesAccountManager>,
         instruction_observation: Option<Arc<AtomicU64>>,
     ) -> Self {
-        let network_topology = Arc::new(state.get_ref().metadata.network_topology.clone());
+        let network_topology = state.get_ref().metadata.network_topology.clone();
         let round_limits = RoundLimits {
             instructions: as_round_instructions(max_query_call_graph_instructions),
             subnet_available_memory,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -525,7 +525,7 @@ impl SchedulerImpl {
                 active_canisters_partitioned_by_cores,
                 current_round,
                 state.time(),
-                state.metadata.network_topology.clone(),
+                Arc::clone(&state.metadata.network_topology),
                 subnet_cycles_config,
                 &mut round_limits,
                 state.resource_limits(),
@@ -678,7 +678,7 @@ impl SchedulerImpl {
 
             // Start execution of the canisters on each thread.
             for (canisters, result) in execution_data_by_thread {
-                let network_topology = network_topology.clone();
+                let network_topology = Arc::clone(&network_topology);
                 let metrics = Arc::clone(&self.metrics);
                 let logger = new_logger!(self.log; messaging.round => round_id.get());
                 let rate_limiting_of_heap_delta = self.rate_limiting_of_heap_delta;
@@ -1700,7 +1700,7 @@ fn execute_canisters_on_thread(
                 canister_arc,
                 instruction_limits.clone(),
                 config.max_instructions_per_query_message,
-                network_topology.clone(),
+                Arc::clone(&network_topology),
                 time,
                 &mut round_limits,
                 resource_limits,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -525,7 +525,7 @@ impl SchedulerImpl {
                 active_canisters_partitioned_by_cores,
                 current_round,
                 state.time(),
-                Arc::new(state.metadata.network_topology.clone()),
+                state.metadata.network_topology.clone(),
                 subnet_cycles_config,
                 &mut round_limits,
                 state.resource_limits(),
@@ -678,7 +678,7 @@ impl SchedulerImpl {
 
             // Start execution of the canisters on each thread.
             for (canisters, result) in execution_data_by_thread {
-                let network_topology = Arc::clone(&network_topology);
+                let network_topology = network_topology.clone();
                 let metrics = Arc::clone(&self.metrics);
                 let logger = new_logger!(self.log; messaging.round => round_id.get());
                 let rate_limiting_of_heap_delta = self.rate_limiting_of_heap_delta;
@@ -1700,7 +1700,7 @@ fn execute_canisters_on_thread(
                 canister_arc,
                 instruction_limits.clone(),
                 config.max_instructions_per_query_message,
-                Arc::clone(&network_topology),
+                network_topology.clone(),
                 time,
                 &mut round_limits,
                 resource_limits,

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -984,8 +984,8 @@ impl SchedulerTestBuilder {
 
         let mut registry_settings = self.registry_settings;
 
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(generate_subnets(
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(generate_subnets(
                 vec![self.own_subnet_id, self.nns_subnet_id],
                 self.nns_subnet_id,
                 None,
@@ -995,8 +995,8 @@ impl SchedulerTestBuilder {
                 self.cost_schedule,
                 self.subnet_admins,
             ));
-            nt.set_routing_table(routing_table);
-            nt.nns_subnet_id = self.nns_subnet_id;
+            network_topology.set_routing_table(routing_table);
+            network_topology.nns_subnet_id = self.nns_subnet_id;
         });
         state.metadata.batch_time = self.batch_time;
 
@@ -1004,10 +1004,12 @@ impl SchedulerTestBuilder {
         subnet_config.scheduler_config = self.scheduler_config.clone();
 
         for key_id in &self.master_public_key_ids {
-            state.metadata.modify_network_topology(|nt| {
-                nt.chain_key_enabled_subnets
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology
+                    .chain_key_enabled_subnets
                     .insert(key_id.clone(), vec![self.own_subnet_id]);
-                nt.subnets_mut()
+                network_topology
+                    .subnets_mut()
                     .get_mut(&self.own_subnet_id)
                     .unwrap()
                     .chain_keys_held

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -40,7 +40,7 @@ use ic_replicated_state::{
     CanisterState, ExecutionState, ExportedFunctions, InputQueueType, Memory, NumWasmPages,
     OutputRequest, ReplicatedState,
     canister_state::execution_state::{self, WasmExecutionMode, WasmMetadata},
-    metadata_state::testing::NetworkTopologyTesting,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
     metrics::ReplicatedStateMetrics,
     num_bytes_try_from,
     page_map::TestPageAllocatorFileDescriptorImpl,
@@ -984,10 +984,8 @@ impl SchedulerTestBuilder {
 
         let mut registry_settings = self.registry_settings;
 
-        state
-            .metadata
-            .network_topology
-            .set_subnets(generate_subnets(
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(generate_subnets(
                 vec![self.own_subnet_id, self.nns_subnet_id],
                 self.nns_subnet_id,
                 None,
@@ -997,30 +995,24 @@ impl SchedulerTestBuilder {
                 self.cost_schedule,
                 self.subnet_admins,
             ));
-        state
-            .metadata
-            .network_topology
-            .set_routing_table(routing_table);
-        state.metadata.network_topology.nns_subnet_id = self.nns_subnet_id;
+            nt.set_routing_table(routing_table);
+            nt.nns_subnet_id = self.nns_subnet_id;
+        });
         state.metadata.batch_time = self.batch_time;
 
         let mut subnet_config = SubnetConfig::new(self.subnet_type);
         subnet_config.scheduler_config = self.scheduler_config.clone();
 
         for key_id in &self.master_public_key_ids {
-            state
-                .metadata
-                .network_topology
-                .chain_key_enabled_subnets
-                .insert(key_id.clone(), vec![self.own_subnet_id]);
-            state
-                .metadata
-                .network_topology
-                .subnets_mut()
-                .get_mut(&self.own_subnet_id)
-                .unwrap()
-                .chain_keys_held
-                .insert(key_id.clone());
+            state.metadata.modify_network_topology(|nt| {
+                nt.chain_key_enabled_subnets
+                    .insert(key_id.clone(), vec![self.own_subnet_id]);
+                nt.subnets_mut()
+                    .get_mut(&self.own_subnet_id)
+                    .unwrap()
+                    .chain_keys_held
+                    .insert(key_id.clone());
+            });
 
             registry_settings.chain_key_settings.insert(
                 key_id.clone(),

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -680,10 +680,13 @@ fn online_split_cleans_in_progress_raw_rand_requests() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id, own_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id, own_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `RawRandContext` and does not produce a response.
@@ -698,10 +701,13 @@ fn online_split_cleans_in_progress_raw_rand_requests() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates the canister to another subnet.
-    test.state_mut().metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
-            .assign_canister(canister_id, other_subnet_id);
-    });
+    test.state_mut()
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology
+                .routing_table_mut()
+                .assign_canister(canister_id, other_subnet_id);
+        });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `RawRandContext` and produced a reject response.

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -10,7 +10,10 @@ use ic_management_canister_types_private::{
     CanisterStatusType, EcdsaKeyId, EmptyBlob, Method, Payload as _, SchnorrKeyId,
 };
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::{CanisterStatus, metadata_state::testing::NetworkTopologyTesting};
+use ic_replicated_state::{
+    CanisterStatus,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
+};
 use ic_state_machine_tests::{PayloadBuilder, StateMachineBuilder};
 use ic_test_utilities_metrics::{fetch_counter, fetch_histogram_vec_buckets};
 use ic_test_utilities_state::get_running_canister;
@@ -677,11 +680,10 @@ fn online_split_cleans_in_progress_raw_rand_requests() {
     assert_ne!(own_subnet_id, other_subnet_id);
 
     // A no-op subnet split (no canisters migrated).
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id, own_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id, own_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Retains the `RawRandContext` and does not produce a response.
@@ -696,11 +698,10 @@ fn online_split_cleans_in_progress_raw_rand_requests() {
     assert!(!test.state().subnet_queues().has_output());
 
     // Simulate a subnet split that migrates the canister to another subnet.
-    test.state_mut()
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .assign_canister(canister_id, other_subnet_id);
+    test.state_mut().metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .assign_canister(canister_id, other_subnet_id);
+    });
     test.online_split_state(own_subnet_id, other_subnet_id);
 
     // Should have removed the `RawRandContext` and produced a reject response.

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -19,7 +19,7 @@ use ic_management_canister_types_private::{
 };
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::metadata_state::testing::NetworkTopologyTesting;
+use ic_replicated_state::metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting};
 use ic_replicated_state::metrics::ReplicatedStateMetrics;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_test_utilities_metrics::{
@@ -38,6 +38,7 @@ use ic_types_cycles::{
 };
 use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id, user_test_id};
 use more_asserts::assert_ge;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[test]
@@ -498,18 +499,17 @@ fn replicated_state_metrics_all_canisters_in_routing_table() {
     state.put_canister_state(get_running_canister(canister_test_id(1)));
     state.put_canister_state(get_running_canister(canister_test_id(2)));
 
-    state
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .insert(
-            CanisterIdRange {
-                start: canister_test_id(0),
-                end: canister_test_id(3),
-            },
-            subnet_test_id(1),
-        )
-        .unwrap();
+    state.metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .insert(
+                CanisterIdRange {
+                    start: canister_test_id(0),
+                    end: canister_test_id(3),
+                },
+                subnet_test_id(1),
+            )
+            .unwrap();
+    });
 
     let registry = MetricsRegistry::new();
     let state_metrics = ReplicatedStateMetrics::new(&registry);
@@ -558,18 +558,17 @@ fn replicated_state_metrics_some_canisters_not_in_routing_table() {
     state.put_canister_state(get_running_canister(canister_test_id(2)));
     state.put_canister_state(get_running_canister(canister_test_id(100)));
 
-    state
-        .metadata
-        .network_topology
-        .routing_table_mut()
-        .insert(
-            CanisterIdRange {
-                start: canister_test_id(0),
-                end: canister_test_id(5),
-            },
-            subnet_test_id(1),
-        )
-        .unwrap();
+    state.metadata.modify_network_topology(|nt| {
+        nt.routing_table_mut()
+            .insert(
+                CanisterIdRange {
+                    start: canister_test_id(0),
+                    end: canister_test_id(5),
+                },
+                subnet_test_id(1),
+            )
+            .unwrap();
+    });
 
     let registry = MetricsRegistry::new();
     let state_metrics = ReplicatedStateMetrics::new(&registry);

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -499,8 +499,9 @@ fn replicated_state_metrics_all_canisters_in_routing_table() {
     state.put_canister_state(get_running_canister(canister_test_id(1)));
     state.put_canister_state(get_running_canister(canister_test_id(2)));
 
-    state.metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology
+            .routing_table_mut()
             .insert(
                 CanisterIdRange {
                     start: canister_test_id(0),
@@ -558,8 +559,9 @@ fn replicated_state_metrics_some_canisters_not_in_routing_table() {
     state.put_canister_state(get_running_canister(canister_test_id(2)));
     state.put_canister_state(get_running_canister(canister_test_id(100)));
 
-    state.metadata.modify_network_topology(|nt| {
-        nt.routing_table_mut()
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology
+            .routing_table_mut()
             .insert(
                 CanisterIdRange {
                     start: canister_test_id(0),

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -38,7 +38,6 @@ use ic_types_cycles::{
 };
 use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id, user_test_id};
 use more_asserts::assert_ge;
-use std::sync::Arc;
 use std::time::Duration;
 
 #[test]

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -259,7 +259,7 @@ pub fn default_get_latest_state() -> Labeled<Arc<ReplicatedState>> {
         None,
     );
 
-    metadata.network_topology = network_topology.into();
+    metadata.network_topology = Arc::new(network_topology);
     metadata.batch_time = UNIX_EPOCH;
 
     Labeled::new(

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -259,7 +259,7 @@ pub fn default_get_latest_state() -> Labeled<Arc<ReplicatedState>> {
         None,
     );
 
-    metadata.network_topology = network_topology;
+    metadata.network_topology = network_topology.into();
     metadata.batch_time = UNIX_EPOCH;
 
     Labeled::new(

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -627,7 +627,7 @@ impl StateMachine for FakeStateMachine {
         node_public_keys: NodePublicKeys,
         api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState {
-        state.metadata.network_topology = network_topology;
+        state.metadata.network_topology = network_topology.into();
         state.metadata.own_subnet_features = subnet_features;
         state.metadata.own_resource_limits = resource_limits;
         state.metadata.node_public_keys = node_public_keys;
@@ -1025,7 +1025,10 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         // defined above). Additionally check the `registry_execution_settings` are also passed
         // correctly (they are stored in the internal `Arc` of the fake state machine itself).
         let latest_state = state_manager.get_latest_state().take();
-        assert_ne!(&network_topology, &latest_state.metadata.network_topology);
+        assert_ne!(
+            &network_topology,
+            latest_state.metadata.network_topology.as_ref()
+        );
         assert_ne!(
             own_subnet_features,
             latest_state.metadata.own_subnet_features
@@ -1050,7 +1053,10 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             replica_version: ReplicaVersion::default(),
         });
         let latest_state = state_manager.get_latest_state().take();
-        assert_eq!(&network_topology, &latest_state.metadata.network_topology);
+        assert_eq!(
+            &network_topology,
+            latest_state.metadata.network_topology.as_ref()
+        );
         assert_eq!(
             own_subnet_features,
             latest_state.metadata.own_subnet_features

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -627,7 +627,7 @@ impl StateMachine for FakeStateMachine {
         node_public_keys: NodePublicKeys,
         api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState {
-        state.metadata.network_topology = network_topology.into();
+        state.metadata.network_topology = Arc::new(network_topology);
         state.metadata.own_subnet_features = subnet_features;
         state.metadata.own_resource_limits = resource_limits;
         state.metadata.node_public_keys = node_public_keys;

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -172,8 +172,8 @@ fn reject_local_request() {
 fn build_streams_success() {
     with_test_replica_logger(|log| {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(RoutingTable::try_from(
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
                 },
@@ -297,9 +297,11 @@ fn build_streams_local_canisters() {
         let routing_table = RoutingTable::try_from(btreemap! {
             CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => LOCAL_SUBNET,
         }).unwrap();
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(routing_table.clone());
-        });
+        provided_state
+            .metadata
+            .modify_network_topology(|network_topology| {
+                network_topology.set_routing_table(routing_table.clone());
+            });
 
         // Set up the expected Stream from the messages.
         let expected_stream = Stream::new(
@@ -323,9 +325,11 @@ fn build_streams_local_canisters() {
             streams.insert(LOCAL_SUBNET, expected_stream);
         });
 
-        expected_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(routing_table.clone());
-        });
+        expected_state
+            .metadata
+            .modify_network_topology(|network_topology| {
+                network_topology.set_routing_table(routing_table.clone());
+            });
 
         let result_state = stream_builder.build_streams(provided_state);
 
@@ -382,8 +386,8 @@ fn build_streams_at_limit_leaves_state_untouched_impl(
             target_stream_size_bytes,
             SYSTEM_SUBNET_STREAM_MSG_LIMIT,
         );
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(RoutingTable::try_from(
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
                 },
@@ -473,8 +477,8 @@ fn build_streams_respects_limits(
             target_stream_size_bytes,
             SYSTEM_SUBNET_STREAM_MSG_LIMIT,
         );
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(RoutingTable::try_from(
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
                 },
@@ -642,13 +646,13 @@ fn build_streams_with_messages_targeted_to_other_subnets() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         // Ensure the routing table knows about the `REMOTE_SUBNET`.
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(RoutingTable::try_from(
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
                 },
             ).unwrap());
-            nt.subnets_mut().insert(REMOTE_SUBNET, Default::default());
+            network_topology.subnets_mut().insert(REMOTE_SUBNET, Default::default());
         });
 
         // Set up the provided_canister_states.
@@ -734,14 +738,14 @@ fn build_streams_with_best_effort_messages_impl(
         let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
         // Set the subnet types of the local and remote subnets.
-        provided_state.metadata.modify_network_topology(|nt| {
+        provided_state.metadata.modify_network_topology(|network_topology| {
             // Set the subnet types of the local and remote subnets.
-            nt.set_subnets(btreemap! {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology {subnet_type: local_subnet_type, ..Default::default()},
                 REMOTE_SUBNET => SubnetTopology {subnet_type: remote_subnet_type, ..Default::default()},
             });
             // Ensure that the routing table knows about `LOCAL_SUBNET` and `REMOTE_SUBNET`.
-            nt.set_routing_table(RoutingTable::try_from(
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                     CanisterIdRange{ start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -825,12 +829,12 @@ fn build_streams_engine_src_rejects_guaranteed_response_request() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
                 REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                     CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -894,12 +898,12 @@ fn build_streams_engine_src_rejects_cycles_request() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
                 REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                     CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -966,12 +970,12 @@ fn build_streams_engine_src_drops_cycles_response() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
                 REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                     CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -1038,12 +1042,12 @@ fn build_streams_engine_src_strips_and_routes_guaranteed_response() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
                 REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
             });
-            nt.set_routing_table(
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                     CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -1107,12 +1111,12 @@ fn build_streams_drops_refunds_at_engine_boundary() {
             let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
             provided_state.metadata.own_subnet_type = own_subnet_type;
-            provided_state.metadata.modify_network_topology(|nt| {
-                nt.set_subnets(btreemap! {
+            provided_state.metadata.modify_network_topology(|network_topology| {
+                network_topology.set_subnets(btreemap! {
                     LOCAL_SUBNET => SubnetTopology { subnet_type: own_subnet_type, ..Default::default() },
                     REMOTE_SUBNET => SubnetTopology { subnet_type: remote_subnet_type, ..Default::default() },
                 });
-                nt.set_routing_table(
+                network_topology.set_routing_table(
                     RoutingTable::try_from(btreemap! {
                         CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
                         CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
@@ -1218,13 +1222,13 @@ fn build_streams_with_refunds(
         );
 
         // Set the type of both subnets and map canisters to subnets.
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_subnets(btreemap! {
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
                 REMOTE_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
             });
             // Map local canisters to `LOCAL_SUBNET`, remote canisters to `REMOTE_SUBNET`.
-            nt.set_routing_table(RoutingTable::try_from(
+            network_topology.set_routing_table(RoutingTable::try_from(
                 btreemap! {
                     CanisterIdRange{ start: first_local_canister, end: last_local_canister } => LOCAL_SUBNET,
                     CanisterIdRange{ start: first_remote_canister, end: last_remote_canister } => REMOTE_SUBNET,
@@ -1514,8 +1518,8 @@ fn build_streams_with_oversized_payloads() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         // Map local canister to `LOCAL_SUBNET` and remote canister to `REMOTE_SUBNET`.
-        provided_state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(
+        provided_state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
                     CanisterIdRange{ start: remote_canister, end: remote_canister } => REMOTE_SUBNET,
@@ -1629,8 +1633,8 @@ fn test_observe_misrouted_messages_on_splitting_subnet() {
 
         // Routing table: `migrating_canister` is still hosted by the local subnet;
         // `migrated_canister` has already migrated from the local subnet to B.
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
                     CanisterIdRange{ start: migrating_canister, end: migrating_canister } => LOCAL_SUBNET,
@@ -1642,7 +1646,7 @@ fn test_observe_misrouted_messages_on_splitting_subnet() {
             );
             // Canister migrations: both `migrating_canister` and `migrated_canister` are
             // migrating from the local subnet to B.
-            nt.canister_migrations = Arc::new(
+            network_topology.canister_migrations = Arc::new(
                 CanisterMigrations::try_from(btreemap! {
                     CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
                     CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
@@ -1741,8 +1745,8 @@ fn test_observe_misrouted_messages_on_third_party_subnet() {
 
         // Routing table: `migrating_canister` is still hosted by subnet A;
         // `migrated_canister` has already migrated from A to B.
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
                     CanisterIdRange{ start: canister_on_a, end: canister_on_a } => REMOTE_SUBNET_A,
@@ -1755,7 +1759,7 @@ fn test_observe_misrouted_messages_on_third_party_subnet() {
             );
             // Canister migrations: both `migrating_canister` and `migrated_canister` are
             // migrating from A to B.
-            nt.canister_migrations = Arc::new(
+            network_topology.canister_migrations = Arc::new(
                 CanisterMigrations::try_from(btreemap! {
                     CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],
                     CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -737,7 +737,6 @@ fn build_streams_with_best_effort_messages_impl(
 
         let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
-        // Set the subnet types of the local and remote subnets.
         provided_state.metadata.modify_network_topology(|network_topology| {
             // Set the subnet types of the local and remote subnets.
             network_topology.set_subnets(btreemap! {
@@ -1221,8 +1220,8 @@ fn build_streams_with_refunds(
             system_subnet_stream_msg_limit,
         );
 
-        // Set the type of both subnets and map canisters to subnets.
         provided_state.metadata.modify_network_topology(|network_topology| {
+            // Set the type of both subnets.
             network_topology.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
                 REMOTE_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
@@ -1631,9 +1630,9 @@ fn test_observe_misrouted_messages_on_splitting_subnet() {
         let canister_on_b = canister_test_id(400);
         let canister_on_z = canister_test_id(500);
 
-        // Routing table: `migrating_canister` is still hosted by the local subnet;
-        // `migrated_canister` has already migrated from the local subnet to B.
         state.metadata.modify_network_topology(|network_topology| {
+            // Routing table: `migrating_canister` is still hosted by the local subnet;
+            // `migrated_canister` has already migrated from the local subnet to B.
             network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
@@ -1743,9 +1742,9 @@ fn test_observe_misrouted_messages_on_third_party_subnet() {
         let canister_on_b = canister_test_id(500);
         let canister_on_z = canister_test_id(600);
 
-        // Routing table: `migrating_canister` is still hosted by subnet A;
-        // `migrated_canister` has already migrated from A to B.
         state.metadata.modify_network_topology(|network_topology| {
+            // Routing table: `migrating_canister` is still hosted by subnet A;
+            // `migrated_canister` has already migrated from A to B.
             network_topology.set_routing_table(
                 RoutingTable::try_from(btreemap! {
                     CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -10,7 +10,7 @@ use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTabl
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterState, CanisterStates, InputQueueType, ReplicatedState, Stream, SubnetTopology,
-    metadata_state::testing::NetworkTopologyTesting,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
     testing::{
         CanisterQueuesTesting, OutputRequestBuilder, ReplicatedStateTesting, StreamTesting,
         SystemStateTesting,
@@ -172,11 +172,13 @@ fn reject_local_request() {
 fn build_streams_success() {
     with_test_replica_logger(|log| {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
-            },
-        ).unwrap());
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
+                },
+            ).unwrap());
+        });
 
         let msgs = generate_messages_for_test(/* senders = */ 2, /* receivers = */ 2);
 
@@ -295,10 +297,9 @@ fn build_streams_local_canisters() {
         let routing_table = RoutingTable::try_from(btreemap! {
             CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => LOCAL_SUBNET,
         }).unwrap();
-        provided_state
-            .metadata
-            .network_topology
-            .set_routing_table(routing_table.clone());
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(routing_table.clone());
+        });
 
         // Set up the expected Stream from the messages.
         let expected_stream = Stream::new(
@@ -322,10 +323,9 @@ fn build_streams_local_canisters() {
             streams.insert(LOCAL_SUBNET, expected_stream);
         });
 
-        expected_state
-            .metadata
-            .network_topology
-            .set_routing_table(routing_table.clone());
+        expected_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(routing_table.clone());
+        });
 
         let result_state = stream_builder.build_streams(provided_state);
 
@@ -382,11 +382,13 @@ fn build_streams_at_limit_leaves_state_untouched_impl(
             target_stream_size_bytes,
             SYSTEM_SUBNET_STREAM_MSG_LIMIT,
         );
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
-            },
-        ).unwrap());
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
+                },
+            ).unwrap());
+        });
 
         // We put an empty stream for the destination subnet into the state because
         // the implementation of stream builder will always allow one message if
@@ -471,11 +473,13 @@ fn build_streams_respects_limits(
             target_stream_size_bytes,
             SYSTEM_SUBNET_STREAM_MSG_LIMIT,
         );
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
-            },
-        ).unwrap());
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
+                },
+            ).unwrap());
+        });
 
         assert!(
             msg_count > expected_messages as usize,
@@ -638,16 +642,14 @@ fn build_streams_with_messages_targeted_to_other_subnets() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         // Ensure the routing table knows about the `REMOTE_SUBNET`.
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
-            },
-        ).unwrap());
-        provided_state
-            .metadata
-            .network_topology
-            .subnets_mut()
-            .insert(REMOTE_SUBNET, Default::default());
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
+                },
+            ).unwrap());
+            nt.subnets_mut().insert(REMOTE_SUBNET, Default::default());
+        });
 
         // Set up the provided_canister_states.
         let provided_canister_states = canister_states_with_outputs(msgs.clone());
@@ -732,17 +734,20 @@ fn build_streams_with_best_effort_messages_impl(
         let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
         // Set the subnet types of the local and remote subnets.
-        provided_state.metadata.network_topology.set_subnets(btreemap! {
-            LOCAL_SUBNET => SubnetTopology {subnet_type: local_subnet_type, ..Default::default()},
-            REMOTE_SUBNET => SubnetTopology {subnet_type: remote_subnet_type, ..Default::default()},
+        provided_state.metadata.modify_network_topology(|nt| {
+            // Set the subnet types of the local and remote subnets.
+            nt.set_subnets(btreemap! {
+                LOCAL_SUBNET => SubnetTopology {subnet_type: local_subnet_type, ..Default::default()},
+                REMOTE_SUBNET => SubnetTopology {subnet_type: remote_subnet_type, ..Default::default()},
+            });
+            // Ensure that the routing table knows about `LOCAL_SUBNET` and `REMOTE_SUBNET`.
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                },
+            ).unwrap());
         });
-        // Ensure that the routing table knows about `LOCAL_SUBNET` and `REMOTE_SUBNET`.
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                CanisterIdRange{ start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-            },
-        ).unwrap());
 
         // Set up a canister with `msgs` in its output queues.
         let provided_canister_states = canister_states_with_outputs(msgs.clone());
@@ -820,17 +825,19 @@ fn build_streams_engine_src_rejects_guaranteed_response_request() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.network_topology.set_subnets(btreemap! {
-            LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
-            REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
+                REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                    CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                })
+                .unwrap(),
+            );
         });
-        provided_state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-            })
-            .unwrap(),
-        );
 
         let provided_canister_states = canister_states_with_outputs(vec![msg]);
         provided_state.put_canister_states(provided_canister_states);
@@ -887,17 +894,19 @@ fn build_streams_engine_src_rejects_cycles_request() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.network_topology.set_subnets(btreemap! {
-            LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
-            REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
+                REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                    CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                })
+                .unwrap(),
+            );
         });
-        provided_state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-            })
-            .unwrap(),
-        );
 
         let provided_canister_states = canister_states_with_outputs(vec![msg]);
         provided_state.put_canister_states(provided_canister_states);
@@ -957,17 +966,19 @@ fn build_streams_engine_src_drops_cycles_response() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.network_topology.set_subnets(btreemap! {
-            LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
-            REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
+                REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                    CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                })
+                .unwrap(),
+            );
         });
-        provided_state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-            })
-            .unwrap(),
-        );
 
         let provided_canister_states =
             canister_states_with_outputs(vec![RequestOrResponse::Response(response)]);
@@ -1027,17 +1038,19 @@ fn build_streams_engine_src_strips_and_routes_guaranteed_response() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         provided_state.metadata.own_subnet_type = SubnetType::CloudEngine;
-        provided_state.metadata.network_topology.set_subnets(btreemap! {
-            LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
-            REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
+                LOCAL_SUBNET => SubnetTopology { subnet_type: SubnetType::CloudEngine, ..Default::default() },
+                REMOTE_SUBNET => SubnetTopology { subnet_type: SubnetType::Application, ..Default::default() },
+            });
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                    CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                })
+                .unwrap(),
+            );
         });
-        provided_state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-            })
-            .unwrap(),
-        );
 
         let provided_canister_states =
             canister_states_with_outputs(vec![RequestOrResponse::Response(response)]);
@@ -1094,20 +1107,19 @@ fn build_streams_drops_refunds_at_engine_boundary() {
             let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
             provided_state.metadata.own_subnet_type = own_subnet_type;
-            provided_state
-                .metadata
-                .network_topology
-                .set_subnets(btreemap! {
+            provided_state.metadata.modify_network_topology(|nt| {
+                nt.set_subnets(btreemap! {
                     LOCAL_SUBNET => SubnetTopology { subnet_type: own_subnet_type, ..Default::default() },
                     REMOTE_SUBNET => SubnetTopology { subnet_type: remote_subnet_type, ..Default::default() },
                 });
-            provided_state.metadata.network_topology.set_routing_table(
-                RoutingTable::try_from(btreemap! {
-                    CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
-                    CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
-                })
-                .unwrap(),
-            );
+                nt.set_routing_table(
+                    RoutingTable::try_from(btreemap! {
+                        CanisterIdRange { start: local_canister_id, end: local_canister_id } => LOCAL_SUBNET,
+                        CanisterIdRange { start: remote_canister_id, end: remote_canister_id } => REMOTE_SUBNET,
+                    })
+                    .unwrap(),
+                );
+            });
 
             // Add a refund destined for the canister on the other side of the engine boundary.
             provided_state.add_refund(remote_canister_id, Cycles::new(100));
@@ -1205,22 +1217,20 @@ fn build_streams_with_refunds(
             system_subnet_stream_msg_limit,
         );
 
-        // Set the type of both subnets.
-        provided_state
-            .metadata
-            .network_topology
-            .set_subnets(btreemap! {
+        // Set the type of both subnets and map canisters to subnets.
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_subnets(btreemap! {
                 LOCAL_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
                 REMOTE_SUBNET => SubnetTopology {subnet_type, ..Default::default()},
             });
-
-        // Map local canisters to `LOCAL_SUBNET`, remote canisters to `REMOTE_SUBNET`.
-        provided_state.metadata.network_topology.set_routing_table(RoutingTable::try_from(
-            btreemap! {
-                CanisterIdRange{ start: first_local_canister, end: last_local_canister } => LOCAL_SUBNET,
-                CanisterIdRange{ start: first_remote_canister, end: last_remote_canister } => REMOTE_SUBNET,
-            },
-        ).unwrap());
+            // Map local canisters to `LOCAL_SUBNET`, remote canisters to `REMOTE_SUBNET`.
+            nt.set_routing_table(RoutingTable::try_from(
+                btreemap! {
+                    CanisterIdRange{ start: first_local_canister, end: last_local_canister } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: first_remote_canister, end: last_remote_canister } => REMOTE_SUBNET,
+                },
+            ).unwrap());
+        });
 
         // Loopback and remote streams pre-populated with `initial_refunds` and
         // `initial_messages` each.
@@ -1504,13 +1514,15 @@ fn build_streams_with_oversized_payloads() {
         let (stream_builder, mut provided_state, metrics_registry) = new_fixture(&log);
 
         // Map local canister to `LOCAL_SUBNET` and remote canister to `REMOTE_SUBNET`.
-        provided_state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
-                CanisterIdRange{ start: remote_canister, end: remote_canister } => REMOTE_SUBNET,
-            })
-            .unwrap(),
-        );
+        provided_state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: remote_canister, end: remote_canister } => REMOTE_SUBNET,
+                })
+                .unwrap(),
+            );
+        });
 
         // Provided_canister_states with oversized payload messages as outputs.
         let provided_canister_states = canister_states_with_outputs::<RequestOrResponse>(vec![
@@ -1617,26 +1629,27 @@ fn test_observe_misrouted_messages_on_splitting_subnet() {
 
         // Routing table: `migrating_canister` is still hosted by the local subnet;
         // `migrated_canister` has already migrated from the local subnet to B.
-        state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
-                CanisterIdRange{ start: migrating_canister, end: migrating_canister } => LOCAL_SUBNET,
-                CanisterIdRange{ start: migrated_canister, end: migrated_canister } => REMOTE_SUBNET_B,
-                CanisterIdRange{ start: canister_on_b, end: canister_on_b } => REMOTE_SUBNET_B,
-                CanisterIdRange{ start: canister_on_z, end: canister_on_z } => REMOTE_SUBNET_Z,
-            })
-            .unwrap(),
-        );
-
-        // Canister migrations: both `migrating_canister` and `migrated_canister` are
-        // migrating from the local subnet to B.
-        state.metadata.network_topology.canister_migrations = Arc::new(
-            CanisterMigrations::try_from(btreemap! {
-                CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
-                CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
-            })
-            .unwrap(),
-        );
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: migrating_canister, end: migrating_canister } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: migrated_canister, end: migrated_canister } => REMOTE_SUBNET_B,
+                    CanisterIdRange{ start: canister_on_b, end: canister_on_b } => REMOTE_SUBNET_B,
+                    CanisterIdRange{ start: canister_on_z, end: canister_on_z } => REMOTE_SUBNET_Z,
+                })
+                .unwrap(),
+            );
+            // Canister migrations: both `migrating_canister` and `migrated_canister` are
+            // migrating from the local subnet to B.
+            nt.canister_migrations = Arc::new(
+                CanisterMigrations::try_from(btreemap! {
+                    CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
+                    CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![LOCAL_SUBNET, REMOTE_SUBNET_B],
+                })
+                .unwrap(),
+            );
+        });
 
         let message_to = |receiver: CanisterId| {
             RequestBuilder::default()
@@ -1728,27 +1741,28 @@ fn test_observe_misrouted_messages_on_third_party_subnet() {
 
         // Routing table: `migrating_canister` is still hosted by subnet A;
         // `migrated_canister` has already migrated from A to B.
-        state.metadata.network_topology.set_routing_table(
-            RoutingTable::try_from(btreemap! {
-                CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
-                CanisterIdRange{ start: canister_on_a, end: canister_on_a } => REMOTE_SUBNET_A,
-                CanisterIdRange{ start: migrating_canister, end: migrating_canister } => REMOTE_SUBNET_A,
-                CanisterIdRange{ start: migrated_canister, end: migrated_canister } => REMOTE_SUBNET_B,
-                CanisterIdRange{ start: canister_on_b, end: canister_on_b } => REMOTE_SUBNET_B,
-                CanisterIdRange{ start: canister_on_z, end: canister_on_z } => REMOTE_SUBNET_Z,
-            })
-            .unwrap(),
-        );
-
-        // Canister migrations: both `migrating_canister` and `migrated_canister` are
-        // migrating from A to B.
-        state.metadata.network_topology.canister_migrations = Arc::new(
-            CanisterMigrations::try_from(btreemap! {
-                CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],
-                CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],
-            })
-            .unwrap(),
-        );
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(
+                RoutingTable::try_from(btreemap! {
+                    CanisterIdRange{ start: local_canister, end: local_canister } => LOCAL_SUBNET,
+                    CanisterIdRange{ start: canister_on_a, end: canister_on_a } => REMOTE_SUBNET_A,
+                    CanisterIdRange{ start: migrating_canister, end: migrating_canister } => REMOTE_SUBNET_A,
+                    CanisterIdRange{ start: migrated_canister, end: migrated_canister } => REMOTE_SUBNET_B,
+                    CanisterIdRange{ start: canister_on_b, end: canister_on_b } => REMOTE_SUBNET_B,
+                    CanisterIdRange{ start: canister_on_z, end: canister_on_z } => REMOTE_SUBNET_Z,
+                })
+                .unwrap(),
+            );
+            // Canister migrations: both `migrating_canister` and `migrated_canister` are
+            // migrating from A to B.
+            nt.canister_migrations = Arc::new(
+                CanisterMigrations::try_from(btreemap! {
+                    CanisterIdRange{ start: migrated_canister, end: migrated_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],
+                    CanisterIdRange{ start: migrating_canister, end: migrating_canister } => vec![REMOTE_SUBNET_A, REMOTE_SUBNET_B],
+                })
+                .unwrap(),
+            );
+        });
 
         let message_to = |receiver: CanisterId| {
             RequestBuilder::default()

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -11,7 +11,10 @@ use ic_registry_routing_table::{CanisterIdRange, CanisterIdRanges, RoutingTable}
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterStatus, ReplicatedState, Stream, SubnetTopology,
-    metadata_state::{StreamMap, testing::NetworkTopologyTesting},
+    metadata_state::{
+        StreamMap,
+        testing::{NetworkTopologyTesting, SystemMetadataTesting},
+    },
     replicated_state::LABEL_VALUE_OUT_OF_MEMORY,
     testing::{OutputRequestBuilder, ReplicatedStateTesting, StreamTesting, SystemStateTesting},
 };
@@ -38,6 +41,7 @@ use lazy_static::lazy_static;
 use maplit::btreemap;
 use pretty_assertions::assert_eq;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 const LOCAL_SUBNET: SubnetId = SUBNET_12; // g24bn-xymaa-aaaaa-aaaap-yai
 const REMOTE_SUBNET: SubnetId = SUBNET_23; // 5h3gz-qaxaa-aaaaa-aaaap-yai
@@ -2837,13 +2841,15 @@ fn induct_stream_slices_drops_refund_at_engine_boundary() {
             }],
             |stream_handler, mut state, slices, metrics| {
                 // Mark REMOTE_SUBNET as a CloudEngine.
-                state.metadata.network_topology.subnets_mut().insert(
-                    REMOTE_SUBNET,
-                    SubnetTopology {
-                        subnet_type: SubnetType::CloudEngine,
-                        ..Default::default()
-                    },
-                );
+                state.metadata.modify_network_topology(|nt| {
+                    nt.subnets_mut().insert(
+                        REMOTE_SUBNET,
+                        SubnetTopology {
+                            subnet_type: SubnetType::CloudEngine,
+                            ..Default::default()
+                        },
+                    );
+                });
 
                 // Expected state: a stream with one accept signal, no induction, cycles lost.
                 let refund = *refund_in_slice(slices.get(&REMOTE_SUBNET), 0);
@@ -3312,13 +3318,15 @@ fn induct_stream_slices_engine_src_guaranteed_response_request_critical_error() 
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // Expect a stream with a reject signal (EngineNotAllowed) for the guaranteed-response request.
             let mut expected_state = state.clone();
@@ -3361,13 +3369,15 @@ fn induct_stream_slices_engine_src_best_effort_request_inducted() {
         btreemap![],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // Build a best-effort request (deadline != NO_DEADLINE, payment = 0).
             let best_effort_request = RequestBuilder::new()
@@ -3412,13 +3422,15 @@ fn induct_stream_slices_engine_src_best_effort_request_with_cycles_rejected() {
         btreemap![],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // Build a best-effort request carrying cycles
             // (deadline != NO_DEADLINE, payment > 0).
@@ -3487,13 +3499,15 @@ fn induct_stream_slices_engine_src_best_effort_response_inducted() {
         }],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // Build a best-effort response with no cycles using the callback registered by setup.
             let best_effort_response = ResponseBuilder::new()
@@ -3552,13 +3566,15 @@ fn induct_stream_slices_engine_boundary_drops_forged_response() {
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // Expected state: response dropped (no induction), accept signal pushed,
             // cycles attached to the forged response observed as lost.
@@ -3615,13 +3631,15 @@ fn induct_stream_slices_engine_boundary_strips_and_inducts_guaranteed_response()
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // The framework attaches cycles to the response, so the stripping is meaningful.
             assert!(response_in_slice(slices.get(&REMOTE_SUBNET), 0).refund > Cycles::zero());
@@ -3682,13 +3700,15 @@ fn induct_stream_slices_engine_boundary_drops_best_effort_response_with_cycles()
         }],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.network_topology.subnets_mut().insert(
-                REMOTE_SUBNET,
-                SubnetTopology {
-                    subnet_type: SubnetType::CloudEngine,
-                    ..Default::default()
-                },
-            );
+            state.metadata.modify_network_topology(|nt| {
+                nt.subnets_mut().insert(
+                    REMOTE_SUBNET,
+                    SubnetTopology {
+                        subnet_type: SubnetType::CloudEngine,
+                        ..Default::default()
+                    },
+                );
+            });
 
             // A best-effort response carrying cycles, matching the callback registered by setup.
             let payment = Cycles::new(1_000);
@@ -3819,17 +3839,12 @@ fn with_test_setup_and_config(
             routing_table.lookup_entry(*REMOTE_CANISTER)
         );
         assert!(routing_table.lookup_entry(*UNKNOWN_CANISTER).is_none());
-        state
-            .metadata
-            .network_topology
-            .set_routing_table(routing_table);
-        for subnet in [LOCAL_SUBNET, REMOTE_SUBNET] {
-            state
-                .metadata
-                .network_topology
-                .subnets_mut()
-                .insert(subnet, Default::default());
-        }
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(routing_table);
+            for subnet in [LOCAL_SUBNET, REMOTE_SUBNET] {
+                nt.subnets_mut().insert(subnet, Default::default());
+            }
+        });
 
         // Generate testing canister using `LOCAL_CANISTER` as the canister ID.
         let mut canister_state = CanisterStateBuilder::new()
@@ -4377,7 +4392,9 @@ fn prepare_canister_migration(
     canister_migrations
         .insert_ranges(canister_id_ranges, from_subnet, to_subnet)
         .unwrap();
-    state.metadata.network_topology.canister_migrations = Arc::new(canister_migrations);
+    state.metadata.modify_network_topology(|nt| {
+        nt.canister_migrations = Arc::new(canister_migrations);
+    });
 
     state
 }
@@ -4404,10 +4421,9 @@ fn complete_canister_migration(
     routing_table
         .assign_ranges(canister_id_ranges, destination)
         .unwrap();
-    state
-        .metadata
-        .network_topology
-        .set_routing_table(routing_table);
+    state.metadata.modify_network_topology(|nt| {
+        nt.set_routing_table(routing_table);
+    });
 
     state
 }

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -2841,8 +2841,8 @@ fn induct_stream_slices_drops_refund_at_engine_boundary() {
             }],
             |stream_handler, mut state, slices, metrics| {
                 // Mark REMOTE_SUBNET as a CloudEngine.
-                state.metadata.modify_network_topology(|nt| {
-                    nt.subnets_mut().insert(
+                state.metadata.modify_network_topology(|network_topology| {
+                    network_topology.subnets_mut().insert(
                         REMOTE_SUBNET,
                         SubnetTopology {
                             subnet_type: SubnetType::CloudEngine,
@@ -3318,8 +3318,8 @@ fn induct_stream_slices_engine_src_guaranteed_response_request_critical_error() 
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3369,8 +3369,8 @@ fn induct_stream_slices_engine_src_best_effort_request_inducted() {
         btreemap![],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3422,8 +3422,8 @@ fn induct_stream_slices_engine_src_best_effort_request_with_cycles_rejected() {
         btreemap![],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3499,8 +3499,8 @@ fn induct_stream_slices_engine_src_best_effort_response_inducted() {
         }],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as CloudEngine.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3566,8 +3566,8 @@ fn induct_stream_slices_engine_boundary_drops_forged_response() {
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3631,8 +3631,8 @@ fn induct_stream_slices_engine_boundary_strips_and_inducts_guaranteed_response()
         }],
         |stream_handler, mut state, slices, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3700,8 +3700,8 @@ fn induct_stream_slices_engine_boundary_drops_best_effort_response_with_cycles()
         }],
         |stream_handler, mut state, _, metrics| {
             // Mark REMOTE_SUBNET as a CloudEngine to put us at the engine boundary.
-            state.metadata.modify_network_topology(|nt| {
-                nt.subnets_mut().insert(
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.subnets_mut().insert(
                     REMOTE_SUBNET,
                     SubnetTopology {
                         subnet_type: SubnetType::CloudEngine,
@@ -3839,10 +3839,12 @@ fn with_test_setup_and_config(
             routing_table.lookup_entry(*REMOTE_CANISTER)
         );
         assert!(routing_table.lookup_entry(*UNKNOWN_CANISTER).is_none());
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(routing_table);
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(routing_table);
             for subnet in [LOCAL_SUBNET, REMOTE_SUBNET] {
-                nt.subnets_mut().insert(subnet, Default::default());
+                network_topology
+                    .subnets_mut()
+                    .insert(subnet, Default::default());
             }
         });
 
@@ -4392,8 +4394,8 @@ fn prepare_canister_migration(
     canister_migrations
         .insert_ranges(canister_id_ranges, from_subnet, to_subnet)
         .unwrap();
-    state.metadata.modify_network_topology(|nt| {
-        nt.canister_migrations = Arc::new(canister_migrations);
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology.canister_migrations = Arc::new(canister_migrations);
     });
 
     state
@@ -4421,8 +4423,8 @@ fn complete_canister_migration(
     routing_table
         .assign_ranges(canister_id_ranges, destination)
         .unwrap();
-    state.metadata.modify_network_topology(|nt| {
-        nt.set_routing_table(routing_table);
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology.set_routing_table(routing_table);
     });
 
     state

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -15,6 +15,7 @@ use ic_registry_subnet_features::SubnetFeatures;
 use ic_replicated_state::{NetworkTopology, ReplicatedState};
 use ic_types::batch::{Batch, BatchContent};
 use ic_types::{ExecutionRound, NumBytes, SubnetId};
+use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
@@ -126,7 +127,7 @@ impl StateMachine for StateMachineImpl {
             )
         }
 
-        state.metadata.network_topology = network_topology;
+        state.metadata.network_topology = Arc::new(network_topology);
         state.metadata.own_subnet_features = subnet_features;
         state.metadata.own_resource_limits = resource_limits;
         state.metadata.node_public_keys = node_public_keys;

--- a/rs/messaging/src/state_machine/tests.rs
+++ b/rs/messaging/src/state_machine/tests.rs
@@ -179,7 +179,7 @@ fn state_machine_populates_network_topology() {
         ));
 
         assert_ne!(
-            &fixture.initial_state.metadata.network_topology,
+            fixture.initial_state.metadata.network_topology.as_ref(),
             &fixture.network_topology
         );
 
@@ -194,7 +194,10 @@ fn state_machine_populates_network_topology() {
             Default::default(),
         );
 
-        assert_eq!(&state.metadata.network_topology, &fixture.network_topology);
+        assert_eq!(
+            state.metadata.network_topology.as_ref(),
+            &fixture.network_topology
+        );
     });
 }
 

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -87,7 +87,7 @@ pub struct SystemMetadata {
     /// increasing).
     pub batch_time: Time,
 
-    pub network_topology: NetworkTopology,
+    pub network_topology: Arc<NetworkTopology>,
 
     pub own_subnet_id: SubnetId,
 
@@ -2067,6 +2067,21 @@ impl UnflushedCheckpointOps {
 
 pub mod testing {
     use super::*;
+
+    /// Exposes `SystemMetadata` internals for use in tests.
+    pub trait SystemMetadataTesting {
+        /// Mutates the network topology in place: clones the value out of the
+        /// `Arc`, applies `f`, and stores the result back.
+        fn modify_network_topology(&mut self, f: impl FnOnce(&mut NetworkTopology));
+    }
+
+    impl SystemMetadataTesting for SystemMetadata {
+        fn modify_network_topology(&mut self, f: impl FnOnce(&mut NetworkTopology)) {
+            let mut network_topology = (*self.network_topology).clone();
+            f(&mut network_topology);
+            self.network_topology = Arc::new(network_topology);
+        }
+    }
 
     /// Exposes `NetworkTopology` internals for use in tests.
     pub trait NetworkTopologyTesting {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -2070,16 +2070,12 @@ pub mod testing {
 
     /// Exposes `SystemMetadata` internals for use in tests.
     pub trait SystemMetadataTesting {
-        /// Mutates the network topology in place: clones the value out of the
-        /// `Arc`, applies `f`, and stores the result back.
         fn modify_network_topology(&mut self, f: impl FnOnce(&mut NetworkTopology));
     }
 
     impl SystemMetadataTesting for SystemMetadata {
         fn modify_network_topology(&mut self, f: impl FnOnce(&mut NetworkTopology)) {
-            let mut network_topology = (*self.network_topology).clone();
-            f(&mut network_topology);
-            self.network_topology = Arc::new(network_topology);
+            f(Arc::make_mut(&mut self.network_topology));
         }
     }
 

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -362,7 +362,7 @@ impl From<&SystemMetadata> for pb_metadata::SystemMetadata {
                     subnet_stream: Some(stream.into()),
                 })
                 .collect(),
-            network_topology: Some((&item.network_topology).into()),
+            network_topology: Some((&*item.network_topology).into()),
             subnet_call_context_manager: Some((&item.subnet_call_context_manager).into()),
             subnet_split_from: item.subnet_split_from.map(subnet_id_into_protobuf),
             state_sync_version: item.state_sync_version as u32,
@@ -543,10 +543,10 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
             ingress_history: Default::default(),
             streams: Arc::new(streams),
             subnet_schedule,
-            network_topology: try_from_option_field(
+            network_topology: Arc::new(try_from_option_field(
                 item.network_topology,
                 "SystemMetadata::network_topology",
-            )?,
+            )?),
             state_sync_version: item
                 .state_sync_version
                 .try_into()

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -749,8 +749,8 @@ fn system_metadata_online_split() {
     system_metadata.last_generated_canister_id = Some(CANISTER_2);
     system_metadata.prev_state_hash = Some(CryptoHash(vec![1, 2, 3]).into());
     system_metadata.batch_time = current_time();
-    system_metadata.modify_network_topology(|nt| {
-        nt.routing_table = Arc::new(routing_table);
+    system_metadata.modify_network_topology(|network_topology| {
+        network_topology.routing_table = Arc::new(routing_table);
     });
     system_metadata.subnet_metrics = SubnetMetrics {
         consumed_cycles_by_deleted_canisters: NominalCycles::new(2197),

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -181,7 +181,7 @@ fn init_allocation_ranges_if_empty() {
     };
 
     let mut system_metadata = SystemMetadata::new(own_subnet_id, SubnetType::Application);
-    system_metadata.network_topology = network_topology.into();
+    system_metadata.network_topology = Arc::new(network_topology);
 
     assert_eq!(
         CanisterIdRanges::try_from(vec![]).unwrap(),
@@ -262,7 +262,7 @@ fn peek_and_commit_new_canister_id() {
         nns_subnet_id: other_subnet_id,
         ..Default::default()
     };
-    system_metadata.network_topology = network_topology.into();
+    system_metadata.network_topology = Arc::new(network_topology);
 
     assert_eq!(None, system_metadata.last_generated_canister_id);
     assert_eq!(2, system_metadata.canister_allocation_ranges.len());
@@ -349,7 +349,7 @@ fn system_metadata_roundtrip_encoding() {
         nns_subnet_id: other_subnet_id,
         ..Default::default()
     };
-    system_metadata.network_topology = network_topology.into();
+    system_metadata.network_topology = Arc::new(network_topology);
 
     use ic_crypto_test_utils_keys::public_keys::valid_node_signing_public_key;
     let pk_der = ic_ed25519::PublicKey::deserialize_raw(&valid_node_signing_public_key().key_value)

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -4,6 +4,7 @@ use super::subnet_call_context_manager::{
     SubnetCallContext, SubnetCallContextManager, ThresholdArguments,
 };
 use super::*;
+use crate::metadata_state::testing::SystemMetadataTesting;
 use crate::testing::{CanisterQueuesTesting, StreamTesting};
 use crate::{CanisterPriority, InputQueueType};
 use assert_matches::assert_matches;
@@ -180,7 +181,7 @@ fn init_allocation_ranges_if_empty() {
     };
 
     let mut system_metadata = SystemMetadata::new(own_subnet_id, SubnetType::Application);
-    system_metadata.network_topology = network_topology;
+    system_metadata.network_topology = network_topology.into();
 
     assert_eq!(
         CanisterIdRanges::try_from(vec![]).unwrap(),
@@ -261,7 +262,7 @@ fn peek_and_commit_new_canister_id() {
         nns_subnet_id: other_subnet_id,
         ..Default::default()
     };
-    system_metadata.network_topology = network_topology;
+    system_metadata.network_topology = network_topology.into();
 
     assert_eq!(None, system_metadata.last_generated_canister_id);
     assert_eq!(2, system_metadata.canister_allocation_ranges.len());
@@ -348,7 +349,7 @@ fn system_metadata_roundtrip_encoding() {
         nns_subnet_id: other_subnet_id,
         ..Default::default()
     };
-    system_metadata.network_topology = network_topology;
+    system_metadata.network_topology = network_topology.into();
 
     use ic_crypto_test_utils_keys::public_keys::valid_node_signing_public_key;
     let pk_der = ic_ed25519::PublicKey::deserialize_raw(&valid_node_signing_public_key().key_value)
@@ -748,7 +749,9 @@ fn system_metadata_online_split() {
     system_metadata.last_generated_canister_id = Some(CANISTER_2);
     system_metadata.prev_state_hash = Some(CryptoHash(vec![1, 2, 3]).into());
     system_metadata.batch_time = current_time();
-    system_metadata.network_topology.routing_table = Arc::new(routing_table);
+    system_metadata.modify_network_topology(|nt| {
+        nt.routing_table = Arc::new(routing_table);
+    });
     system_metadata.subnet_metrics = SubnetMetrics {
         consumed_cycles_by_deleted_canisters: NominalCycles::new(2197),
         ..Default::default()

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -23,7 +23,7 @@ use ic_replicated_state::{
             BitcoinGetSuccessorsContext, BitcoinSendTransactionInternalContext, InstallCodeCallId,
             StopCanisterCall, SubnetCallContext,
         },
-        testing::NetworkTopologyTesting,
+        testing::{NetworkTopologyTesting, SystemMetadataTesting},
     },
     replicated_state::{
         MemoryTaken, PeekableOutputIterator, ReplicatedStateMessageRouting,
@@ -1276,11 +1276,9 @@ fn online_split() {
         CanisterIdRange {start: CanisterId::from_u64(CANISTER_2_U64 + 1), end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
     })
     .unwrap();
-    fixture
-        .state
-        .metadata
-        .network_topology
-        .set_routing_table(routing_table.clone());
+    fixture.state.metadata.modify_network_topology(|nt| {
+        nt.set_routing_table(routing_table.clone());
+    });
 
     // Stream with a couple of requests. The details don't matter, should be
     // retained unmodified on subnet A' only.

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1276,9 +1276,12 @@ fn online_split() {
         CanisterIdRange {start: CanisterId::from_u64(CANISTER_2_U64 + 1), end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
     })
     .unwrap();
-    fixture.state.metadata.modify_network_topology(|nt| {
-        nt.set_routing_table(routing_table.clone());
-    });
+    fixture
+        .state
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(routing_table.clone());
+        });
 
     // Stream with a couple of requests. The details don't matter, should be
     // retained unmodified on subnet A' only.

--- a/rs/state_manager/src/tree_hash.rs
+++ b/rs/state_manager/src/tree_hash.rs
@@ -80,7 +80,8 @@ mod tests {
             CustomSection, CustomSectionType, WasmBinary, WasmMetadata,
         },
         metadata_state::{
-            ApiBoundaryNodeEntry, Stream, SubnetMetrics, testing::NetworkTopologyTesting,
+            ApiBoundaryNodeEntry, Stream, SubnetMetrics,
+            testing::{NetworkTopologyTesting, SystemMetadataTesting},
         },
         page_map::{PAGE_SIZE, PageIndex},
         testing::{ReplicatedStateTesting, StreamTesting},
@@ -321,14 +322,13 @@ mod tests {
             })
             .unwrap();
 
-            state.metadata.network_topology.set_subnets(btreemap! {
-                own_subnet_id => Default::default(),
-                other_subnet_id => Default::default(),
+            state.metadata.modify_network_topology(|nt| {
+                nt.set_subnets(btreemap! {
+                    own_subnet_id => Default::default(),
+                    other_subnet_id => Default::default(),
+                });
+                nt.set_routing_table(routing_table);
             });
-            state
-                .metadata
-                .network_topology
-                .set_routing_table(routing_table);
             state.metadata.prev_state_hash =
                 Some(CryptoHashOfPartialState::new(CryptoHash(vec![3, 2, 1])));
 

--- a/rs/state_manager/src/tree_hash.rs
+++ b/rs/state_manager/src/tree_hash.rs
@@ -322,12 +322,12 @@ mod tests {
             })
             .unwrap();
 
-            state.metadata.modify_network_topology(|nt| {
-                nt.set_subnets(btreemap! {
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.set_subnets(btreemap! {
                     own_subnet_id => Default::default(),
                     other_subnet_id => Default::default(),
                 });
-                nt.set_routing_table(routing_table);
+                network_topology.set_routing_table(routing_table);
             });
             state.metadata.prev_state_hash =
                 Some(CryptoHashOfPartialState::new(CryptoHash(vec![3, 2, 1])));

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -28,7 +28,10 @@ use ic_replicated_state::{
     ReplicatedState, Stream, SubnetTopology,
     canister_state::canister_snapshots::CanisterSnapshot,
     canister_state::{execution_state::WasmBinary, system_state::wasm_chunk_store::WasmChunkStore},
-    metadata_state::{ApiBoundaryNodeEntry, testing::NetworkTopologyTesting},
+    metadata_state::{
+        ApiBoundaryNodeEntry,
+        testing::{NetworkTopologyTesting, SystemMetadataTesting},
+    },
     page_map::{PageIndex, Shard, StorageLayout},
     testing::{ReplicatedStateTesting, StreamTesting, SystemStateTesting},
 };
@@ -5533,7 +5536,7 @@ fn certified_read_can_certify_node_public_keys_since_v12() {
         network_topology.nns_subnet_id = subnet_test_id(42);
         network_topology.set_subnets(subnets);
 
-        state.metadata.network_topology = network_topology;
+        state.metadata.network_topology = network_topology.into();
         state.metadata.node_public_keys = node_public_keys;
 
         state_manager.commit_and_certify_sync(state, CertificationScope::Metadata, None);
@@ -5942,7 +5945,7 @@ fn certified_read_can_exclude_canister_ranges() {
         network_topology.set_subnets(subnets);
         network_topology.set_routing_table(routing_table);
 
-        state.metadata.network_topology = network_topology;
+        state.metadata.network_topology = network_topology.into();
 
         state_manager.commit_and_certify_sync(state, CertificationScope::Metadata, None);
 
@@ -8164,10 +8167,9 @@ fn can_split_with_inflight_restore_snapshot() {
                 CanisterIdRange {start: CANISTER_3, end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
             })
             .unwrap();
-            state
-                .metadata
-                .network_topology
-                .set_routing_table(routing_table.clone());
+            state.metadata.modify_network_topology(|nt| {
+                nt.set_routing_table(routing_table.clone());
+            });
 
             // Expected state after splitting.
             let mut expected = state.clone();

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -5536,7 +5536,7 @@ fn certified_read_can_certify_node_public_keys_since_v12() {
         network_topology.nns_subnet_id = subnet_test_id(42);
         network_topology.set_subnets(subnets);
 
-        state.metadata.network_topology = network_topology.into();
+        state.metadata.network_topology = Arc::new(network_topology);
         state.metadata.node_public_keys = node_public_keys;
 
         state_manager.commit_and_certify_sync(state, CertificationScope::Metadata, None);
@@ -5945,7 +5945,7 @@ fn certified_read_can_exclude_canister_ranges() {
         network_topology.set_subnets(subnets);
         network_topology.set_routing_table(routing_table);
 
-        state.metadata.network_topology = network_topology.into();
+        state.metadata.network_topology = Arc::new(network_topology);
 
         state_manager.commit_and_certify_sync(state, CertificationScope::Metadata, None);
 

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8167,8 +8167,8 @@ fn can_split_with_inflight_restore_snapshot() {
                 CanisterIdRange {start: CANISTER_3, end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
             })
             .unwrap();
-            state.metadata.modify_network_topology(|nt| {
-                nt.set_routing_table(routing_table.clone());
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.set_routing_table(routing_table.clone());
             });
 
             // Expected state after splitting.

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -57,7 +57,7 @@ use ic_replicated_state::{
     canister_state::{
         NextExecution, execution_state::SandboxMemory, execution_state::WasmExecutionMode,
     },
-    metadata_state::testing::NetworkTopologyTesting,
+    metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
     page_map::{
         PAGE_SIZE, PageMap, TestPageAllocatorFileDescriptorImpl,
         test_utils::base_only_storage_layout,
@@ -1285,7 +1285,7 @@ impl ExecutionTest {
         let compute_allocation_used = state.total_compute_allocation();
         let mut canister_arc = state.take_canister_state(&canister_id).unwrap();
         let canister = Arc::make_mut(&mut canister_arc);
-        let network_topology = Arc::new(state.metadata.network_topology.clone());
+        let network_topology = state.metadata.network_topology.clone();
         let mut round_limits = RoundLimits {
             instructions: RoundInstructions::from(i64::MAX),
             subnet_available_memory: self.subnet_available_memory,
@@ -1434,7 +1434,7 @@ impl ExecutionTest {
         let compute_allocation_used = state.total_compute_allocation();
         let canister = state.take_canister_state(&canister_id).unwrap();
         let mut canister = Arc::unwrap_or_clone(canister);
-        let network_topology = Arc::new(state.metadata.network_topology.clone());
+        let network_topology = state.metadata.network_topology.clone();
         let response_arc = Arc::new(response);
         // We push and then immediately pop the response from the canister queues
         // to ensure all invariants on the canister (system) state are preserved.
@@ -1852,7 +1852,7 @@ impl ExecutionTest {
             subnet_memory_reservation: self.subnet_memory_reservation,
         };
         for canister_id in canister_ids {
-            let network_topology = Arc::new(state.metadata.network_topology.clone());
+            let network_topology = state.metadata.network_topology.clone();
             let mut canister = canisters.remove(&canister_id).unwrap();
             loop {
                 match canister.next_execution() {
@@ -1922,7 +1922,7 @@ impl ExecutionTest {
         let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let mut canisters = state.take_canister_states();
-        let network_topology = Arc::new(state.metadata.network_topology.clone());
+        let network_topology = state.metadata.network_topology.clone();
         let mut canister = canisters.remove(&canister_id).unwrap();
         match canister.next_execution() {
             NextExecution::None => {
@@ -2937,7 +2937,7 @@ impl ExecutionTestBuilder {
         let mut state = ReplicatedState::new(self.own_subnet_id, self.subnet_type);
 
         if let Some(network_topology) = self.network_topology.take() {
-            state.metadata.network_topology = network_topology;
+            state.metadata.network_topology = Arc::new(network_topology);
         } else {
             let mut subnets = vec![self.own_subnet_id, self.nns_subnet_id];
             subnets.extend(self.caller_subnet_id.iter().copied());
@@ -2954,7 +2954,7 @@ impl ExecutionTestBuilder {
                 self.subnet_admins,
             ));
             network_topology.set_routing_table(routing_table);
-            state.metadata.network_topology = network_topology;
+            state.metadata.network_topology = Arc::new(network_topology);
         }
         state.metadata.init_allocation_ranges_if_empty().unwrap();
         state.metadata.bitcoin_get_successors_follow_up_responses =
@@ -3013,28 +3013,23 @@ impl ExecutionTestBuilder {
                 },
             );
 
-            if *is_enabled {
-                state
-                    .metadata
-                    .network_topology
-                    .chain_key_enabled_subnets
-                    .insert(key_id.clone(), vec![self.own_subnet_id]);
-            }
-            state
-                .metadata
-                .network_topology
-                .subnets_mut()
-                .get_mut(&self.own_subnet_id)
-                .unwrap()
-                .chain_keys_held
-                .insert(key_id.clone());
+            state.metadata.modify_network_topology(|nt| {
+                if *is_enabled {
+                    nt.chain_key_enabled_subnets
+                        .insert(key_id.clone(), vec![self.own_subnet_id]);
+                }
+                nt.subnets_mut()
+                    .get_mut(&self.own_subnet_id)
+                    .unwrap()
+                    .chain_keys_held
+                    .insert(key_id.clone());
+            });
         }
 
-        state.metadata.network_topology.bitcoin_mainnet_canister_id =
-            self.execution_config.bitcoin.mainnet_canister_id;
-
-        state.metadata.network_topology.bitcoin_testnet_canister_id =
-            self.execution_config.bitcoin.testnet_canister_id;
+        state.metadata.modify_network_topology(|nt| {
+            nt.bitcoin_mainnet_canister_id = self.execution_config.bitcoin.mainnet_canister_id;
+            nt.bitcoin_testnet_canister_id = self.execution_config.bitcoin.testnet_canister_id;
+        });
 
         let chain_key_subnet_public_keys = self
             .chain_keys_enabled_status

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1285,7 +1285,7 @@ impl ExecutionTest {
         let compute_allocation_used = state.total_compute_allocation();
         let mut canister_arc = state.take_canister_state(&canister_id).unwrap();
         let canister = Arc::make_mut(&mut canister_arc);
-        let network_topology = state.metadata.network_topology.clone();
+        let network_topology = Arc::clone(&state.metadata.network_topology);
         let mut round_limits = RoundLimits {
             instructions: RoundInstructions::from(i64::MAX),
             subnet_available_memory: self.subnet_available_memory,
@@ -1434,7 +1434,7 @@ impl ExecutionTest {
         let compute_allocation_used = state.total_compute_allocation();
         let canister = state.take_canister_state(&canister_id).unwrap();
         let mut canister = Arc::unwrap_or_clone(canister);
-        let network_topology = state.metadata.network_topology.clone();
+        let network_topology = Arc::clone(&state.metadata.network_topology);
         let response_arc = Arc::new(response);
         // We push and then immediately pop the response from the canister queues
         // to ensure all invariants on the canister (system) state are preserved.
@@ -1852,7 +1852,7 @@ impl ExecutionTest {
             subnet_memory_reservation: self.subnet_memory_reservation,
         };
         for canister_id in canister_ids {
-            let network_topology = state.metadata.network_topology.clone();
+            let network_topology = Arc::clone(&state.metadata.network_topology);
             let mut canister = canisters.remove(&canister_id).unwrap();
             loop {
                 match canister.next_execution() {
@@ -1922,7 +1922,7 @@ impl ExecutionTest {
         let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let mut canisters = state.take_canister_states();
-        let network_topology = state.metadata.network_topology.clone();
+        let network_topology = Arc::clone(&state.metadata.network_topology);
         let mut canister = canisters.remove(&canister_id).unwrap();
         match canister.next_execution() {
             NextExecution::None => {
@@ -3013,12 +3013,14 @@ impl ExecutionTestBuilder {
                 },
             );
 
-            state.metadata.modify_network_topology(|nt| {
+            state.metadata.modify_network_topology(|network_topology| {
                 if *is_enabled {
-                    nt.chain_key_enabled_subnets
+                    network_topology
+                        .chain_key_enabled_subnets
                         .insert(key_id.clone(), vec![self.own_subnet_id]);
                 }
-                nt.subnets_mut()
+                network_topology
+                    .subnets_mut()
                     .get_mut(&self.own_subnet_id)
                     .unwrap()
                     .chain_keys_held
@@ -3026,9 +3028,11 @@ impl ExecutionTestBuilder {
             });
         }
 
-        state.metadata.modify_network_topology(|nt| {
-            nt.bitcoin_mainnet_canister_id = self.execution_config.bitcoin.mainnet_canister_id;
-            nt.bitcoin_testnet_canister_id = self.execution_config.bitcoin.testnet_canister_id;
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.bitcoin_mainnet_canister_id =
+                self.execution_config.bitcoin.mainnet_canister_id;
+            network_topology.bitcoin_testnet_canister_id =
+                self.execution_config.bitcoin.testnet_canister_id;
         });
 
         let chain_key_subnet_public_keys = self

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -23,7 +23,7 @@ use ic_replicated_state::{
         subnet_call_context_manager::{
             BitcoinGetSuccessorsContext, BitcoinSendTransactionInternalContext, SubnetCallContext,
         },
-        testing::NetworkTopologyTesting,
+        testing::{NetworkTopologyTesting, SystemMetadataTesting},
     },
     page_map::PageMap,
     testing::{CanisterQueuesTesting, ReplicatedStateTesting, StreamTesting, SystemStateTesting},
@@ -148,22 +148,21 @@ impl ReplicatedStateBuilder {
             )
             .unwrap();
 
-        state
-            .metadata
-            .network_topology
-            .set_routing_table(routing_table);
-        state.metadata.network_topology.subnets_mut().insert(
-            self.subnet_id,
-            SubnetTopology {
-                public_key: vec![],
-                nodes: self.node_ids.into_iter().collect(),
-                subnet_type: self.subnet_type,
-                subnet_features: self.subnet_features,
-                chain_keys_held: BTreeSet::new(),
-                cost_schedule: CanisterCyclesCostSchedule::Normal,
-                subnet_admins: BTreeSet::new(),
-            },
-        );
+        state.metadata.modify_network_topology(|nt| {
+            nt.set_routing_table(routing_table);
+            nt.subnets_mut().insert(
+                self.subnet_id,
+                SubnetTopology {
+                    public_key: vec![],
+                    nodes: self.node_ids.into_iter().collect(),
+                    subnet_type: self.subnet_type,
+                    subnet_features: self.subnet_features,
+                    chain_keys_held: BTreeSet::new(),
+                    cost_schedule: CanisterCyclesCostSchedule::Normal,
+                    subnet_admins: BTreeSet::new(),
+                },
+            );
+        });
 
         state.metadata.batch_time = self.batch_time;
         state.metadata.own_subnet_features = self.subnet_features;
@@ -789,17 +788,19 @@ pub fn get_initial_state_with_balance(
 
         state.put_canister_state(canister_state_builder.build());
     }
-    state.metadata.network_topology.set_routing_table({
-        let mut rt = ic_registry_routing_table::RoutingTable::new();
-        rt.insert(
-            ic_registry_routing_table::CanisterIdRange {
-                start: CanisterId::from(0),
-                end: CanisterId::from(u64::MAX),
-            },
-            subnet_test_id(1),
-        )
-        .unwrap();
-        rt
+    state.metadata.modify_network_topology(|nt| {
+        nt.set_routing_table({
+            let mut rt = ic_registry_routing_table::RoutingTable::new();
+            rt.insert(
+                ic_registry_routing_table::CanisterIdRange {
+                    start: CanisterId::from(0),
+                    end: CanisterId::from(u64::MAX),
+                },
+                subnet_test_id(1),
+            )
+            .unwrap();
+            rt
+        });
     });
     state
 }
@@ -1224,10 +1225,9 @@ fn new_replicated_state_with_output_queues(
             own_subnet_id,
         )
         .unwrap();
-    replicated_state
-        .metadata
-        .network_topology
-        .set_routing_table(routing_table);
+    replicated_state.metadata.modify_network_topology(|nt| {
+        nt.set_routing_table(routing_table);
+    });
 
     replicated_state.put_canister_states(CanisterStates::new(canister_states));
     if let Some(subnet_queues) = subnet_queues {

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -148,9 +148,9 @@ impl ReplicatedStateBuilder {
             )
             .unwrap();
 
-        state.metadata.modify_network_topology(|nt| {
-            nt.set_routing_table(routing_table);
-            nt.subnets_mut().insert(
+        state.metadata.modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(routing_table);
+            network_topology.subnets_mut().insert(
                 self.subnet_id,
                 SubnetTopology {
                     public_key: vec![],
@@ -788,8 +788,8 @@ pub fn get_initial_state_with_balance(
 
         state.put_canister_state(canister_state_builder.build());
     }
-    state.metadata.modify_network_topology(|nt| {
-        nt.set_routing_table({
+    state.metadata.modify_network_topology(|network_topology| {
+        network_topology.set_routing_table({
             let mut rt = ic_registry_routing_table::RoutingTable::new();
             rt.insert(
                 ic_registry_routing_table::CanisterIdRange {
@@ -1225,9 +1225,11 @@ fn new_replicated_state_with_output_queues(
             own_subnet_id,
         )
         .unwrap();
-    replicated_state.metadata.modify_network_topology(|nt| {
-        nt.set_routing_table(routing_table);
-    });
+    replicated_state
+        .metadata
+        .modify_network_topology(|network_topology| {
+            network_topology.set_routing_table(routing_table);
+        });
 
     replicated_state.put_canister_states(CanisterStates::new(canister_states));
     if let Some(subnet_queues) = subnet_queues {


### PR DESCRIPTION
This PR follows on from #10594 by wrapping `SystemMetadata::network_topology` in an `Arc` which allows us to avoid deep cloning the full network topology in a few more scenarios:

Scenario | Frequency | Location
-- | -- | --
Scheduler hands the topology to message execution for the round | per execution round | scheduler.rs:528 → inner_round
Building a QueryContext | per query | query_context.rs:151 → QueryContext::new
Inspect message | per ingress message | execution_environment.rs:3468 → should_accept_ingress_message
Canister install / upgrade | per install/upgrade | execution_environment.rs:4133 → execute_install_code
Resumed install / upgrade (DTS continuation) | per resumed slice | execution_environment.rs:4311 → resume_install_code

The vast majority of the changes in this PR are simply updating tests to work with the new `Arc` wrapper.