### PR TITLE
fix: Try to lock the crypt device around FS creation

### DIFF
--- a/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
+++ b/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
@@ -80,4 +80,6 @@ else
         # and continue operating.
         cryptsetup luksClose old_var_crypt || echo "Failed to close old /var crypto partition"
     fi
+
+    udevadm trigger --settle --action=change /dev/mapper/var_crypt
 fi

--- a/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
+++ b/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
@@ -39,6 +39,7 @@ else
     /opt/ic/bin/guest_disk crypt-format var "$VAR_PARTITION"
     /opt/ic/bin/guest_disk crypt-open var "$VAR_PARTITION"
     echo "Populating /var filesystem in ${VAR_PARTITION} on first boot."
+    # Prevent udev from processing the device while we format it.
     udevadm lock --device=/dev/mapper/var_crypt mkfs.ext4 -F /dev/mapper/var_crypt -d /var
     # Fix root inode (mkfs fails to set correct security context).
     echo "ea_set / security.selinux system_u:object_r:var_t:s0\\000" | debugfs -w /dev/mapper/var_crypt
@@ -81,5 +82,6 @@ else
         cryptsetup luksClose old_var_crypt || echo "Failed to close old /var crypto partition"
     fi
 
+    # Explicitly trigger udev now that the device should be ready.
     udevadm trigger --settle --action=change /dev/mapper/var_crypt
 fi

--- a/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
+++ b/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
@@ -39,7 +39,7 @@ else
     /opt/ic/bin/guest_disk crypt-format var "$VAR_PARTITION"
     /opt/ic/bin/guest_disk crypt-open var "$VAR_PARTITION"
     echo "Populating /var filesystem in ${VAR_PARTITION} on first boot."
-    mkfs.ext4 -F /dev/mapper/var_crypt -d /var
+    udevadm lock --device=/dev/mapper/var_crypt mkfs.ext4 -F /dev/mapper/var_crypt -d /var
     # Fix root inode (mkfs fails to set correct security context).
     echo "ea_set / security.selinux system_u:object_r:var_t:s0\\000" | debugfs -w /dev/mapper/var_crypt
 

--- a/ic-os/components/upgrade/systemd-generators/mount-generator
+++ b/ic-os/components/upgrade/systemd-generators/mount-generator
@@ -134,6 +134,7 @@ function make_var_cryptsetup() {
     echo "Before=blockdev@dev-mapper-var_crypt.target"
     echo "Wants=blockdev@dev-mapper-var_crypt.target"
     echo "Before=var.mount"
+    echo "Before=systemd-fsck@dev-mapper-var_crypt.service"
     echo "Conflicts=umount.target"
     echo "Before=cryptsetup.target"
     echo "Requires=init-config.service"

--- a/ic-os/components/upgrade/systemd-generators/mount-generator
+++ b/ic-os/components/upgrade/systemd-generators/mount-generator
@@ -134,7 +134,6 @@ function make_var_cryptsetup() {
     echo "Before=blockdev@dev-mapper-var_crypt.target"
     echo "Wants=blockdev@dev-mapper-var_crypt.target"
     echo "Before=var.mount"
-    echo "Before=systemd-fsck@dev-mapper-var_crypt.service"
     echo "Conflicts=umount.target"
     echo "Before=cryptsetup.target"
     echo "Requires=init-config.service"


### PR DESCRIPTION
Locking and triggering udev within the script that creates var is hopefully a fix to the udev flakiness we've seen.