### PR TITLE
chore: Revert unnecessary `xnet_slo_120_subnets_staging_test` mitigation

### DIFF
--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -14,9 +14,8 @@ const OVERALL_TIMEOUT: Duration = Duration::from_secs(1400);
 
 fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE)
-        // Only best-effort calls with 30 seconds timeout, so the test doesn't hang for
-        // minutes in case we can't connect to some replica/subnet to pull.
-        .with_call_timeouts(&[Some(30)])
+        // Guaranteed-response calls and best-effort calls with 30 second timeout.
+        .with_call_timeouts(&[None, Some(30)])
         // With 120 single-node subnets colocated on shared performance hardware, the
         // per-subnet block production rate varies between runs. On loaded runs a few
         // "straggler" subnets dip just below the default 0.3 send rate threshold (down


### PR DESCRIPTION
Commit d2483fa applied a number of mitigations addressing `xnet_slo_120_subnets_staging_test` flakiness. Some of these still make sense (reduced timeouts, using `select_all()`), but now that the test is reliably passing, we should ideally revert to covering both best-effort and guaranteed-response calls.