### PR TITLE
feat(ICRC_Rosetta): Add ICRC Rosetta release 1.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10438,7 +10438,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.9"
+version = "1.2.10"
 dependencies = [
  "anyhow",
  "axum 0.8.8",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -10,7 +10,7 @@ load("//rs/tests:system_tests.bzl", "oci_tar")
 
 package(default_visibility = ["//visibility:public"])
 
-ROSETTA_VERSION = "1.2.9"
+ROSETTA_VERSION = "1.2.10"
 
 LOCAL_REPLICA_DATA = [
     "//rs/canister_sandbox",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.10] - 2026-07-01
+### Added
+- Add ICRC-122/152 support ([#9586](https://github.com/dfinity/ic/pull/9586))
+
+### Fixed
+- Enforce a 24h ingress window in `/construction/payloads` ([#10547](https://github.com/dfinity/ic/pull/10547))
+
 ## [1.2.9] - 2026-02-02
 ### Added
 - Add ICRC-107 fee collector block handling ([#7697](https://github.com/dfinity/ic/pull/7697))

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [1.2.10] - 2026-07-01
+## [1.2.10] - 2026-07-02
 ### Added
 - Add ICRC-122/152 support ([#9586](https://github.com/dfinity/ic/pull/9586))
 

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.9"
+version = "1.2.10"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.9";
+pub const ROSETTA_VERSION: &str = "1.2.10";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
Release information for ICRC Rosetta 1.2.10 with the following changes:

- Add ICRC-122/152 support.
- Enforce a 24h ingress window in `/construction/payloads`.