### PR TITLE
feat(ICP_Rosetta): Release ICP Rosetta 2.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13791,7 +13791,7 @@ dependencies = [
 
 [[package]]
 name = "ic-rosetta-api"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -10,7 +10,7 @@ load("//rs/tests:system_tests.bzl", "oci_tar")
 
 package(default_visibility = ["//visibility:public"])
 
-ROSETTA_VERSION = "2.1.9"
+ROSETTA_VERSION = "2.1.10"
 
 rust_library(
     name = "rosetta-api",

--- a/rs/rosetta-api/icp/CHANGELOG.md
+++ b/rs/rosetta-api/icp/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
+
+## [2.1.10] - 2026-07-01
 ### Changed
 - When no memo is specified for a transfer in `construction/payloads`, use a deterministic memo of 0 instead of a random one. Reconstructing the same transfer now produces the same transaction hash, so the ledger's `created_at_time` based deduplication catches retried transfers instead of applying them twice. ([#10537](https://github.com/dfinity/ic/pull/10537))
+- Optimize database query performance ([#8748](https://github.com/dfinity/ic/pull/8748)).
+
+### Fixed
+- Enforce a 24h ingress window in `construction/payloads` ([#10547](https://github.com/dfinity/ic/pull/10547)).
 
 ## [2.1.9] - 2026-02-02
 ### Added

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-rosetta-api"
-version = "2.1.9"
+version = "2.1.10"
 authors = ["The Internet Computer Project Developers"]
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 edition.workspace = true


### PR DESCRIPTION
Release ICP Rosetta v2.1.10 with the following changes:

- Use a deterministic memo of 0 instead of a random one for transfers without a specified memo in `construction/payloads`.
- Optimize database query performance.
- Enforce a 24h ingress window in `construction/payloads`.