### PR TITLE
refactor: Move `api_boundary_nodes` into `NetworkTopology`

### DIFF
--- a/rs/canonical_state/src/lazy_tree_conversion.rs
+++ b/rs/canonical_state/src/lazy_tree_conversion.rs
@@ -459,7 +459,7 @@ pub fn replicated_state_as_lazy_tree(state: &ReplicatedState, height: Height) ->
         FiniteMap::default()
             .with("api_boundary_nodes", move || {
                 api_boundary_nodes_as_tree(
-                    &state.metadata.api_boundary_nodes,
+                    &state.metadata.network_topology.api_boundary_nodes,
                     certification_version,
                 )
             })

--- a/rs/canonical_state/src/traversal.rs
+++ b/rs/canonical_state/src/traversal.rs
@@ -1282,7 +1282,7 @@ mod tests {
     #[test]
     fn test_traverse_api_boundary_nodes() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
-        state.metadata.api_boundary_nodes = btreemap! {
+        std::sync::Arc::make_mut(&mut state.metadata.network_topology).api_boundary_nodes = btreemap! {
             node_test_id(11) => ApiBoundaryNodeEntry {
                 domain: "api-bn11-example.com".to_string(),
                 ipv4_address: Some("127.0.0.1".to_string()),

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -257,6 +257,7 @@ pub fn default_get_latest_state() -> Labeled<Arc<ReplicatedState>> {
         None,
         None,
         None,
+        Default::default(),
     );
 
     metadata.network_topology = Arc::new(network_topology);

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -730,7 +730,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
         ResourceLimits,
         RegistryExecutionSettings,
         NodePublicKeys,
-        ApiBoundaryNodes,
     ) {
         loop {
             match self.try_to_read_registry(registry_version, own_subnet_id) {
@@ -777,7 +776,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             ResourceLimits,
             RegistryExecutionSettings,
             NodePublicKeys,
-            ApiBoundaryNodes,
         ),
         ReadRegistryError,
     > {
@@ -792,7 +790,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             .try_into()
             .unwrap_or(SubnetType::CloudEngine);
 
-        let api_boundary_nodes = self.try_to_populate_api_boundary_nodes(registry_version)?;
         let network_topology = self.try_to_populate_network_topology(
             registry_version,
             own_subnet_id,
@@ -914,7 +911,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
                 registry_version,
             },
             node_public_keys,
-            api_boundary_nodes,
         ))
     }
 
@@ -1156,6 +1152,8 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             None
         };
 
+        let api_boundary_nodes = self.try_to_populate_api_boundary_nodes(registry_version)?;
+
         Ok(NetworkTopology::new(
             subnets,
             Arc::new(routing_table),
@@ -1166,6 +1164,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             self.bitcoin_config.mainnet_canister_id,
             full_topology,
             default_initial_dkg_subnet_id,
+            api_boundary_nodes,
         ))
     }
 
@@ -1395,7 +1394,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
             resource_limits,
             registry_execution_settings,
             node_public_keys,
-            api_boundary_nodes,
         ) = self.read_registry(registry_version, state.metadata.own_subnet_id);
 
         self.metrics.blocks_proposed_total.inc();
@@ -1424,7 +1422,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
             resource_limits,
             &registry_execution_settings,
             node_public_keys,
-            api_boundary_nodes,
         );
 
         let garbage_collect_timer = self.metrics.start_phase_timer(PHASE_GARBAGE_COLLECT);

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -625,13 +625,11 @@ impl StateMachine for FakeStateMachine {
         resource_limits: ResourceLimits,
         registry_settings: &RegistryExecutionSettings,
         node_public_keys: NodePublicKeys,
-        api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState {
         state.metadata.network_topology = Arc::new(network_topology);
         state.metadata.own_subnet_features = subnet_features;
         state.metadata.own_resource_limits = resource_limits;
         state.metadata.node_public_keys = node_public_keys;
-        state.metadata.api_boundary_nodes = api_boundary_nodes;
         state.put_canister_state(
             CanisterStateBuilder::new()
                 .with_canister_id(canister_test_id(1))
@@ -696,7 +694,6 @@ fn try_to_read_registry(
         ResourceLimits,
         RegistryExecutionSettings,
         NodePublicKeys,
-        ApiBoundaryNodes,
     ),
     ReadRegistryError,
 > {
@@ -894,7 +891,6 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             own_resource_limits,
             registry_execution_settings,
             node_public_keys,
-            api_boundary_nodes,
         ) = batch_processor
             .try_to_read_registry(fixture.registry.get_latest_version(), own_subnet_id)
             .unwrap();
@@ -951,6 +947,30 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         assert_eq!(&routing_table, network_topology.routing_table().as_ref());
         assert_eq!(canister_migrations, *network_topology.canister_migrations);
 
+        // Check API Boundary Nodes.
+        let api_boundary_nodes = &network_topology.api_boundary_nodes;
+        assert_eq!(api_boundary_nodes.len(), 2);
+        let entry_1 = api_boundary_nodes.get(&node_test_id(11)).unwrap();
+        assert_eq!(
+            entry_1,
+            &ApiBoundaryNodeEntry {
+                domain: "api-bn11.example.org".to_string(),
+                ipv4_address: Some("127.0.0.1".to_string()),
+                ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334".to_string(),
+                pubkey: None,
+            }
+        );
+        let entry_2 = api_boundary_nodes.get(&node_test_id(12)).unwrap();
+        assert_eq!(
+            entry_2,
+            &ApiBoundaryNodeEntry {
+                domain: "api-bn12.example.org".to_string(),
+                ipv4_address: None,
+                ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7335".to_string(),
+                pubkey: None,
+            }
+        );
+
         // Check registry execution settings.
         assert_eq!(
             own_subnet_record.max_number_of_canisters,
@@ -989,29 +1009,6 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
                 *node_public_keys.get(&node_id).unwrap(),
             );
         }
-
-        // Check API Boundary Nodes.
-        assert_eq!(api_boundary_nodes.len(), 2);
-        let entry_1 = api_boundary_nodes.get(&node_test_id(11)).unwrap();
-        assert_eq!(
-            entry_1,
-            &ApiBoundaryNodeEntry {
-                domain: "api-bn11.example.org".to_string(),
-                ipv4_address: Some("127.0.0.1".to_string()),
-                ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334".to_string(),
-                pubkey: None,
-            }
-        );
-        let entry_2 = api_boundary_nodes.get(&node_test_id(12)).unwrap();
-        assert_eq!(
-            entry_2,
-            &ApiBoundaryNodeEntry {
-                domain: "api-bn12.example.org".to_string(),
-                ipv4_address: None,
-                ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7335".to_string(),
-                pubkey: None,
-            }
-        );
 
         // Commit a state with `own_subnet_id` in its metadata to ensure the latest
         // state corresponds to the registry records written above.
@@ -1128,7 +1125,7 @@ fn try_read_registry_succeeds_with_minimal_registry_records() {
         // critical error for `subnet_size` has incremented.
         assert_eq!(metrics.critical_error_missing_subnet_size.get(), 1);
         // Check the subnet size was set to the maximum for a small app subnet.
-        let (_, _, _, registry_execution_settings, _, _) = result.unwrap();
+        let (_, _, _, registry_execution_settings, _) = result.unwrap();
         assert_eq!(
             registry_execution_settings.subnet_size,
             SMALL_APP_SUBNET_MAX_SIZE
@@ -1453,7 +1450,7 @@ fn try_read_registry_can_skip_missing_or_invalid_node_public_keys() {
             2
         );
 
-        let (_, _, _, _, node_public_keys, _) = res.unwrap();
+        let (_, _, _, _, node_public_keys) = res.unwrap();
         assert_eq!(node_public_keys.len(), 1);
         assert!(!node_public_keys.contains_key(&node_test_id(1)));
         assert!(!node_public_keys.contains_key(&node_test_id(2)));
@@ -1592,7 +1589,8 @@ fn try_read_registry_can_skip_missing_or_invalid_fields_of_api_boundary_nodes() 
 
         // There are six API BNs in the registry. However, five nodes have missing or invalid fields of NodeRecord.
         // Hence, only one nodes are retrieved.
-        let (_, _, _, _, _, api_boundary_nodes) = res.unwrap();
+        let (network_topology, _, _, _, _) = res.unwrap();
+        let api_boundary_nodes = &network_topology.api_boundary_nodes;
         assert_eq!(api_boundary_nodes.len(), 1);
         assert!(api_boundary_nodes.contains_key(&node_test_id(11)));
 

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -1,5 +1,5 @@
 use crate::message_routing::{
-    ApiBoundaryNodes, CRITICAL_ERROR_INDUCT_RESPONSE_FAILED, MessageRoutingMetrics, NodePublicKeys,
+    CRITICAL_ERROR_INDUCT_RESPONSE_FAILED, MessageRoutingMetrics, NodePublicKeys,
 };
 use crate::routing::demux::Demux;
 use crate::routing::stream_builder::{
@@ -39,7 +39,6 @@ pub(crate) trait StateMachine: Send {
         resource_limits: ResourceLimits,
         registry_settings: &RegistryExecutionSettings,
         node_public_keys: NodePublicKeys,
-        api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState;
 }
 pub(crate) struct StateMachineImpl {
@@ -113,7 +112,6 @@ impl StateMachine for StateMachineImpl {
         resource_limits: ResourceLimits,
         registry_settings: &RegistryExecutionSettings,
         node_public_keys: NodePublicKeys,
-        api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState {
         let time_out_messages_timer = self.metrics.start_phase_timer(PHASE_TIME_OUT_MESSAGES);
 
@@ -133,7 +131,6 @@ impl StateMachine for StateMachineImpl {
         state.metadata.own_subnet_features = subnet_features;
         state.metadata.own_resource_limits = resource_limits;
         state.metadata.node_public_keys = node_public_keys;
-        state.metadata.api_boundary_nodes = api_boundary_nodes;
         if let Err(message) = state.metadata.init_allocation_ranges_if_empty() {
             self.metrics
                 .observe_no_canister_allocation_range(&self.log, message);

--- a/rs/messaging/src/state_machine/tests.rs
+++ b/rs/messaging/src/state_machine/tests.rs
@@ -193,7 +193,6 @@ fn state_machine_populates_network_topology() {
             Default::default(),
             &test_registry_settings(),
             Default::default(),
-            Default::default(),
         );
 
         assert_eq!(
@@ -226,7 +225,6 @@ fn test_delivered_batch(provided_batch: Batch) -> ReplicatedState {
             Default::default(),
             Default::default(),
             &test_registry_settings(),
-            Default::default(),
             Default::default(),
         )
     })
@@ -660,7 +658,6 @@ fn state_machine_handles_messages_to_deleted_subnet() {
             Default::default(),
             &test_registry_settings(),
             Default::default(),
-            Default::default(),
         );
 
         // Stream to the deleted subnet (8 messages) is gone — all dropped silently.
@@ -854,7 +851,6 @@ fn test_online_split(new_subnet_id: SubnetId, other_subnet_id: SubnetId) -> Repl
             Default::default(),
             &test_registry_settings(),
             Default::default(),
-            Default::default(),
         )
     });
 
@@ -971,7 +967,6 @@ fn test_batch_time_impl(
             Default::default(),
             Default::default(),
             &test_registry_settings(),
-            Default::default(),
             Default::default(),
         );
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -57,6 +57,7 @@ message NetworkTopology {
   repeated ChainKeySubnetEntry chain_key_enabled_subnets = 8;
   FullTopology full_topology = 9;
   types.v1.SubnetId default_initial_dkg_subnet_id = 10;
+  repeated ApiBoundaryNodeEntry api_boundary_nodes = 11;
 }
 
 message FullTopology {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -76,6 +76,8 @@ pub struct NetworkTopology {
     #[prost(message, optional, tag = "10")]
     pub default_initial_dkg_subnet_id:
         ::core::option::Option<super::super::super::types::v1::SubnetId>,
+    #[prost(message, repeated, tag = "11")]
+    pub api_boundary_nodes: ::prost::alloc::vec::Vec<ApiBoundaryNodeEntry>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FullTopology {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -100,8 +100,6 @@ pub struct SystemMetadata {
     /// DER-encoded public keys of the subnet's nodes.
     pub node_public_keys: BTreeMap<NodeId, Vec<u8>>,
 
-    pub api_boundary_nodes: BTreeMap<NodeId, ApiBoundaryNodeEntry>,
-
     /// "Subnet split in progress" marker: `Some(original_subnet_id)` if this
     /// replicated state is in the process of being split from `original_subnet_id`;
     /// `None` otherwise.
@@ -255,6 +253,9 @@ pub struct NetworkTopology {
     /// by default, i.e., when no subnet ID is specified explicitly in the
     /// request. If `None`, such requests are routed to the calling subnet.
     pub default_initial_dkg_subnet_id: Option<SubnetId>,
+
+    /// API boundary nodes, indexed by `NodeId`.
+    pub api_boundary_nodes: BTreeMap<NodeId, ApiBoundaryNodeEntry>,
 }
 
 /// Full description of the API Boundary Node, which is saved in the metadata.
@@ -284,6 +285,7 @@ impl Default for NetworkTopology {
             bitcoin_mainnet_canister_id: None,
             full_topology: None,
             default_initial_dkg_subnet_id: None,
+            api_boundary_nodes: Default::default(),
         }
     }
 }
@@ -300,6 +302,7 @@ impl NetworkTopology {
         bitcoin_mainnet_canister_id: Option<CanisterId>,
         full_topology: Option<FullTopology>,
         default_initial_dkg_subnet_id: Option<SubnetId>,
+        api_boundary_nodes: BTreeMap<NodeId, ApiBoundaryNodeEntry>,
     ) -> Self {
         Self {
             subnets,
@@ -311,6 +314,7 @@ impl NetworkTopology {
             bitcoin_mainnet_canister_id,
             full_topology,
             default_initial_dkg_subnet_id,
+            api_boundary_nodes,
         }
     }
 
@@ -555,7 +559,6 @@ impl SystemMetadata {
             own_subnet_features: SubnetFeatures::default(),
             own_resource_limits: Default::default(),
             node_public_keys: Default::default(),
-            api_boundary_nodes: Default::default(),
             split_from: None,
             subnet_split_from: None,
 
@@ -868,7 +871,6 @@ impl SystemMetadata {
             own_resource_limits: _,
             // Overwritten as soon as the round begins, no explicit action needed.
             node_public_keys: _,
-            api_boundary_nodes: _,
             ref mut split_from,
             subnet_split_from,
             subnet_call_context_manager: _,
@@ -976,7 +978,6 @@ impl SystemMetadata {
             own_subnet_features,
             own_resource_limits,
             node_public_keys,
-            api_boundary_nodes,
             split_from,
             mut subnet_split_from,
             mut subnet_call_context_manager,
@@ -1083,7 +1084,6 @@ impl SystemMetadata {
             own_resource_limits,
             // Already populated from the registry.
             node_public_keys,
-            api_boundary_nodes,
             split_from,
             subnet_split_from,
             subnet_call_context_manager,
@@ -2209,7 +2209,6 @@ pub mod testing {
             own_subnet_features: SubnetFeatures::default(),
             own_resource_limits: Default::default(),
             node_public_keys: Default::default(),
-            api_boundary_nodes: Default::default(),
             split_from: None,
             subnet_split_from: None,
             prev_state_hash: Default::default(),

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -69,6 +69,19 @@ impl From<&NetworkTopology> for pb_metadata::NetworkTopology {
             default_initial_dkg_subnet_id: item
                 .default_initial_dkg_subnet_id
                 .map(subnet_id_into_protobuf),
+            api_boundary_nodes: item
+                .api_boundary_nodes
+                .iter()
+                .map(
+                    |(node_id, api_boundary_node_entry)| pb_metadata::ApiBoundaryNodeEntry {
+                        node_id: Some(node_id_into_protobuf(*node_id)),
+                        domain: api_boundary_node_entry.domain.clone(),
+                        ipv4_address: api_boundary_node_entry.ipv4_address.clone(),
+                        ipv6_address: api_boundary_node_entry.ipv6_address.clone(),
+                        pubkey: api_boundary_node_entry.pubkey.clone(),
+                    },
+                )
+                .collect(),
         }
     }
 }
@@ -114,6 +127,19 @@ impl TryFrom<pb_metadata::NetworkTopology> for NetworkTopology {
             .map(subnet_id_try_from_protobuf)
             .transpose()?;
 
+        let mut api_boundary_nodes = BTreeMap::<NodeId, ApiBoundaryNodeEntry>::new();
+        for entry in item.api_boundary_nodes {
+            api_boundary_nodes.insert(
+                node_id_try_from_option(entry.node_id)?,
+                ApiBoundaryNodeEntry {
+                    domain: entry.domain,
+                    ipv4_address: entry.ipv4_address,
+                    ipv6_address: entry.ipv6_address,
+                    pubkey: entry.pubkey,
+                },
+            );
+        }
+
         Ok(Self {
             subnets,
             routing_table: try_from_option_field(
@@ -155,6 +181,7 @@ impl TryFrom<pb_metadata::NetworkTopology> for NetworkTopology {
                 }
             },
             default_initial_dkg_subnet_id,
+            api_boundary_nodes,
         })
     }
 }
@@ -391,6 +418,7 @@ impl From<&SystemMetadata> for pb_metadata::SystemMetadata {
                 })
                 .collect(),
             api_boundary_nodes: item
+                .network_topology
                 .api_boundary_nodes
                 .iter()
                 .map(
@@ -501,17 +529,23 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
             node_public_keys.insert(node_id_try_from_option(entry.node_id)?, entry.public_key);
         }
 
-        let mut api_boundary_nodes = BTreeMap::<NodeId, ApiBoundaryNodeEntry>::new();
-        for entry in item.api_boundary_nodes {
-            api_boundary_nodes.insert(
-                node_id_try_from_option(entry.node_id)?,
-                ApiBoundaryNodeEntry {
-                    domain: entry.domain,
-                    ipv4_address: entry.ipv4_address,
-                    ipv6_address: entry.ipv6_address,
-                    pubkey: entry.pubkey,
-                },
-            );
+        let mut network_topology: NetworkTopology =
+            try_from_option_field(item.network_topology, "SystemMetadata::network_topology")?;
+        // Backward compatibility: checkpoints written before `api_boundary_nodes`
+        // was moved into `NetworkTopology` stored it directly in `SystemMetadata`.
+        // Fall back to the old location when the new one is empty.
+        if network_topology.api_boundary_nodes.is_empty() {
+            for entry in item.api_boundary_nodes {
+                network_topology.api_boundary_nodes.insert(
+                    node_id_try_from_option(entry.node_id)?,
+                    ApiBoundaryNodeEntry {
+                        domain: entry.domain,
+                        ipv4_address: entry.ipv4_address,
+                        ipv6_address: entry.ipv6_address,
+                        pubkey: entry.pubkey,
+                    },
+                );
+            }
         }
 
         Ok(Self {
@@ -526,7 +560,6 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
             own_subnet_features: item.own_subnet_features.unwrap_or_default().into(),
             own_resource_limits: item.own_resource_limits.unwrap_or_default().into(),
             node_public_keys,
-            api_boundary_nodes,
             // Note: `load_checkpoint()` will set this to the contents of `split_marker.pbuf`,
             // when present.
             split_from: None,
@@ -543,10 +576,7 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
             ingress_history: Default::default(),
             streams: Arc::new(streams),
             subnet_schedule,
-            network_topology: Arc::new(try_from_option_field(
-                item.network_topology,
-                "SystemMetadata::network_topology",
-            )?),
+            network_topology: Arc::new(network_topology),
             state_sync_version: item
                 .state_sync_version
                 .try_into()

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -347,6 +347,14 @@ fn system_metadata_roundtrip_encoding() {
         routing_table,
         canister_migrations,
         nns_subnet_id: other_subnet_id,
+        api_boundary_nodes: btreemap! {
+            node_test_id(1) => ApiBoundaryNodeEntry {
+                domain: "api-example.com".to_string(),
+                ipv4_address: Some("127.0.0.1".to_string()),
+                ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334".to_string(),
+                pubkey: None,
+            },
+        },
         ..Default::default()
     };
     system_metadata.network_topology = Arc::new(network_topology);
@@ -358,14 +366,6 @@ fn system_metadata_roundtrip_encoding() {
 
     system_metadata.node_public_keys = btreemap! {
         node_test_id(1) => pk_der,
-    };
-    system_metadata.api_boundary_nodes = btreemap! {
-        node_test_id(1) => ApiBoundaryNodeEntry {
-            domain: "api-example.com".to_string(),
-            ipv4_address: Some("127.0.0.1".to_string()),
-            ipv6_address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334".to_string(),
-            pubkey: None,
-        },
     };
     system_metadata.bitcoin_get_successors_follow_up_responses =
         btreemap! { 10.into() => vec![vec![1], vec![2]] };
@@ -496,6 +496,7 @@ fn network_topology_roundtrip_encoding() {
         bitcoin_mainnet_canister_id,
         None,
         Some(app_subnet_id),
+        Default::default(),
     );
 
     let proto = pb::NetworkTopology::from(&network_topology);
@@ -519,6 +520,7 @@ fn network_topology_roundtrip_encoding() {
             routing_table: full_routing_table,
         }),
         Some(app_subnet_id),
+        Default::default(),
     );
 
     let proto = pb::NetworkTopology::from(&network_topology_with_full);

--- a/rs/state_manager/src/tree_hash.rs
+++ b/rs/state_manager/src/tree_hash.rs
@@ -288,7 +288,7 @@ mod tests {
                 node_test_id(2) => vec![2; 44],
             };
 
-            state.metadata.api_boundary_nodes = btreemap! {
+            std::sync::Arc::make_mut(&mut state.metadata.network_topology).api_boundary_nodes = btreemap! {
                 node_test_id(11) => ApiBoundaryNodeEntry {
                     domain: "api-bn11-example.com".to_string(),
                     ipv4_address: Some("127.0.0.1".to_string()),

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -5589,7 +5589,7 @@ fn certified_read_can_certify_api_boundary_nodes_since_v16() {
     state_manager_test(|_metrics, state_manager| {
         let (_, mut state) = state_manager.take_tip();
 
-        state.metadata.api_boundary_nodes = btreemap! {
+        std::sync::Arc::make_mut(&mut state.metadata.network_topology).api_boundary_nodes = btreemap! {
             node_test_id(11) => ApiBoundaryNodeEntry {
                 domain: "api-bn11-example.com".to_string(),
                 ipv4_address: Some("127.0.0.1".to_string()),


### PR DESCRIPTION
This is the first step of consolidating the various `SystemMetadata` fields populated from the registry, on the one hand, under `NetworkTopology` (for network-wide information); and, on the other, under a similar `SubnetTopology` (for subnet-related information).

Once this consolidation is complete, we can reuse the two structs (wrapped in `Arcs` in `SystemMetadata`) from one `ReplicatedState` to the next, iff they use the same registry version.