### PR TITLE
fix: correct dead e2fsprogs-1.47.4 source URL

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -754,9 +754,10 @@ http_archive(
     # reproducibility. See the patch for details.
     patch_strip = 1,
     patches = ["//bazel:e2fsprogs_no_external_config.patch"],
-    sha256 = "da274408bebbfd13a5a2fc3cfc66e3ffff17c48534673aa67f88d49b99123b96",
+    sha256 = "9f82eaa7002673291629077b80ee005cadfcd49854907a22007fed70b0ef596e",
     strip_prefix = "e2fsprogs-1.47.4",
-    urls = ["https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.4/e2fsprogs-1.47.4.tar.gz"],
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/tytso/e2fsprogs/tar.gz/refs/tags/v1.47.4"],
 )
 
 http_archive(


### PR DESCRIPTION
https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.4/e2fsprogs-1.47.4.tar.gz is a dead link so we point to the source code on GitHub at https://github.com/tytso/e2fsprogs/releases/tag/v1.47.4.