### PR TITLE
refactor: simplify code around CanisterCyclesCostSchedule

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -27,7 +27,7 @@ use ic_types::{
     messages::{CallContextId, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, RejectContext, SenderInfo},
     methods::{SystemMethod, WasmClosure},
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+use ic_types_cycles::Cycles;
 use ic_utils::deterministic_operations::deterministic_copy_from_slice;
 use ic_wasm_types::doc_ref;
 use request_in_prep::{RequestInPrep, into_output_request};
@@ -1281,10 +1281,6 @@ impl SystemApiImpl {
             instructions_executed_before_current_slice: 0,
             call_counters: SystemApiCallCounters::default(),
         }
-    }
-
-    pub fn get_cost_schedule(&self) -> CanisterCyclesCostSchedule {
-        self.sandbox_safe_system_state.cost_schedule()
     }
 
     /// Note that this function is made public only for the tests

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -31,9 +31,8 @@ use ic_types::{
     time::CoarseTime,
 };
 use ic_types_cycles::{
-    BurnedCycles, CanisterCyclesCostSchedule, CompoundCycles, Cycles,
-    CyclesAccountManagerSubnetConfig, CyclesUseCaseKind, Instructions,
-    RequestAndResponseTransmission,
+    BurnedCycles, CompoundCycles, Cycles, CyclesAccountManagerSubnetConfig, CyclesUseCaseKind,
+    Instructions, RequestAndResponseTransmission,
 };
 use ic_wasm_types::WasmEngineError;
 use serde::{Deserialize, Serialize};
@@ -877,8 +876,8 @@ impl SandboxSafeSystemState {
         &self.environment_variables
     }
 
-    pub fn cost_schedule(&self) -> CanisterCyclesCostSchedule {
-        self.subnet_cycles_config.cost_schedule
+    pub fn subnet_cycles_config(&self) -> CyclesAccountManagerSubnetConfig {
+        self.subnet_cycles_config
     }
 
     pub fn set_global_timer(&mut self, timer: CanisterTimer) {

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -8,7 +8,7 @@ use ic_base_types::{CanisterId, NumBytes, PrincipalId, SubnetId};
 use ic_config::{
     embedders::Config as HypervisorConfig,
     flag_status::FlagStatus,
-    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig, SubnetConfig},
+    subnet_config::{SchedulerConfig, SubnetConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 use ic_embedders::{
@@ -1072,10 +1072,7 @@ impl SchedulerTestBuilder {
             embedders_config: self.hypervisor_config.clone(),
             ..ic_config::execution_environment::Config::default()
         };
-        let wasm_executor = Arc::new(TestWasmExecutor::new(
-            Arc::clone(&cycles_account_manager),
-            registry_settings.subnet_size,
-        ));
+        let wasm_executor = Arc::new(TestWasmExecutor::new(Arc::clone(&cycles_account_manager)));
         let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);
         let state_manager = Arc::new(FakeStateManager::new());
 
@@ -1247,12 +1244,9 @@ struct TestWasmExecutor {
 }
 
 impl TestWasmExecutor {
-    fn new(cycles_account_manager: Arc<CyclesAccountManager>, subnet_size: usize) -> Self {
+    fn new(cycles_account_manager: Arc<CyclesAccountManager>) -> Self {
         Self {
-            core: Mutex::new(TestWasmExecutorCore::new(
-                cycles_account_manager,
-                subnet_size,
-            )),
+            core: Mutex::new(TestWasmExecutorCore::new(cycles_account_manager)),
         }
     }
 }
@@ -1312,12 +1306,11 @@ struct TestWasmExecutorCore {
     schedule: Vec<(ExecutionRound, CanisterId, NumInstructions)>,
     next_message_id: u32,
     round: ExecutionRound,
-    subnet_size: usize,
     cycles_account_manager: Arc<CyclesAccountManager>,
 }
 
 impl TestWasmExecutorCore {
-    fn new(cycles_account_manager: Arc<CyclesAccountManager>, subnet_size: usize) -> Self {
+    fn new(cycles_account_manager: Arc<CyclesAccountManager>) -> Self {
         Self {
             messages: HashMap::new(),
             system_tasks: HashMap::new(),
@@ -1325,7 +1318,6 @@ impl TestWasmExecutorCore {
             next_message_id: 0,
             round: ExecutionRound::new(0),
             cycles_account_manager,
-            subnet_size,
         }
     }
 
@@ -1499,11 +1491,7 @@ impl TestWasmExecutorCore {
         let call_message_id = self.next_message_id();
         let response_message_id = self.next_message_id();
         let closure = WasmClosure::new(0, response_message_id.into());
-        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
-            self.subnet_size,
-            system_state.cost_schedule(),
-            DEFAULT_REFERENCE_SUBNET_SIZE,
-        );
+        let subnet_cycles_config = system_state.subnet_cycles_config();
         let prepayment_for_response_execution = self
             .cycles_account_manager
             .prepayment_for_response_execution(

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1281,7 +1281,6 @@ impl ExecutionTest {
     /// Executes a canister task method of the given canister.
     pub fn canister_task(&mut self, canister_id: CanisterId, task: CanisterTask) {
         let mut state = self.state.take().unwrap();
-        let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let mut canister_arc = state.take_canister_state(&canister_id).unwrap();
         let canister = Arc::make_mut(&mut canister_arc);
@@ -1338,7 +1337,6 @@ impl ExecutionTest {
         self.update_execution_stats(
             canister_id,
             result.instructions_used.unwrap(),
-            cost_schedule,
             self.get_own_subnet_cycles_config(),
         );
         self.check_invariants();
@@ -1430,7 +1428,6 @@ impl ExecutionTest {
         response: Response,
     ) -> ExecutionResponse {
         let mut state = self.state.take().unwrap();
-        let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let canister = state.take_canister_state(&canister_id).unwrap();
         let mut canister = Arc::unwrap_or_clone(canister);
@@ -1501,7 +1498,6 @@ impl ExecutionTest {
         self.update_execution_stats(
             canister_id,
             instructions_used,
-            cost_schedule,
             state.get_own_subnet_cycles_config(),
         );
         state.put_canister_state(canister);
@@ -1718,7 +1714,6 @@ impl ExecutionTest {
     /// Return a progress flag indicating if the message was executed or not.
     pub fn execute_subnet_message(&mut self) -> bool {
         let mut state = self.state.take().unwrap();
-        let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let message = match state.pop_subnet_input() {
             Some(message) => message,
@@ -1795,7 +1790,6 @@ impl ExecutionTest {
                         self.update_execution_stats(
                             canister_id,
                             capped_slice_instructions_used,
-                            cost_schedule,
                             self.get_own_subnet_cycles_config(),
                         );
                     }
@@ -1840,7 +1834,6 @@ impl ExecutionTest {
             executed_any = true;
         }
         let mut state = self.state.take().unwrap();
-        let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let mut canisters = state.take_canister_states();
         let canister_ids: Vec<CanisterId> = canisters.all_keys().copied().collect();
@@ -1878,7 +1871,6 @@ impl ExecutionTest {
                     self.update_execution_stats(
                         canister_id,
                         instructions_used,
-                        cost_schedule,
                         state.get_own_subnet_cycles_config(),
                     );
                 }
@@ -1919,7 +1911,6 @@ impl ExecutionTest {
     /// Executes a slice of the given canister.
     pub fn execute_slice(&mut self, canister_id: CanisterId) {
         let mut state = self.state.take().unwrap();
-        let cost_schedule = state.get_own_cost_schedule();
         let compute_allocation_used = state.total_compute_allocation();
         let mut canisters = state.take_canister_states();
         let network_topology = Arc::clone(&state.metadata.network_topology);
@@ -1987,7 +1978,6 @@ impl ExecutionTest {
                         self.update_execution_stats(
                             canister_id,
                             capped_instructions_used,
-                            cost_schedule,
                             self.get_own_subnet_cycles_config(),
                         );
                     }
@@ -2029,7 +2019,6 @@ impl ExecutionTest {
                     self.update_execution_stats(
                         canister_id,
                         instructions_used,
-                        cost_schedule,
                         state.get_own_subnet_cycles_config(),
                     );
                 }
@@ -2066,7 +2055,6 @@ impl ExecutionTest {
         &mut self,
         canister_id: CanisterId,
         executed: NumInstructions,
-        cost_schedule: CanisterCyclesCostSchedule,
         subnet_cycles_config: CyclesAccountManagerSubnetConfig,
     ) {
         let mgr = &self.cycles_account_manager;
@@ -2082,7 +2070,10 @@ impl ExecutionTest {
         *self
             .execution_cost
             .entry(canister_id)
-            .or_insert(CompoundCycles::new(Cycles::new(0), cost_schedule)) += instruction_cost;
+            .or_insert(CompoundCycles::new(
+                Cycles::new(0),
+                subnet_cycles_config.cost_schedule,
+            )) += instruction_cost;
     }
 
     /// Inducts messages between canisters and pushes all cross-net messages to


### PR DESCRIPTION
`CanisterCyclesCostSchedule` is now passed in `CyclesAccountManagerSubnetConfig` and thus it does not have to be passed separately.