### PR TITLE
chore: prepare for rustc version bump to v1.95.0

### DIFF
--- a/packages/canlog/src/lib.rs
+++ b/packages/canlog/src/lib.rs
@@ -204,11 +204,11 @@ where
     }
 
     fn sort_asc(&mut self) {
-        self.entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        self.entries.sort_by_key(|a| a.timestamp);
     }
 
     fn sort_desc(&mut self) {
-        self.entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        self.entries.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     }
 }
 

--- a/rs/bitcoin/adapter/src/blockchainstate.rs
+++ b/rs/bitcoin/adapter/src/blockchainstate.rs
@@ -586,7 +586,7 @@ mod test {
         );
 
         let mut tips = crate::header_cache::test::get_tips(&state.header_cache);
-        tips.sort_by(|x, y| y.work.cmp(&x.work));
+        tips.sort_by_key(|y| std::cmp::Reverse(y.work));
         assert_eq!(tips.len(), 2);
         assert_eq!(tips[0].header.block_hash(), *last_fork_hash);
         assert_eq!(tips[1].header.block_hash(), *last_chain_hash);

--- a/rs/bitcoin/adapter/src/rpc_server.rs
+++ b/rs/bitcoin/adapter/src/rpc_server.rs
@@ -31,6 +31,7 @@ struct BtcServiceImpl<Network: BlockchainNetwork> {
 impl TryFrom<BtcServiceGetSuccessorsRequest> for GetSuccessorsRequest {
     type Error = Status;
 
+    #[allow(clippy::result_large_err)]
     fn try_from(request: BtcServiceGetSuccessorsRequest) -> Result<Self, Self::Error> {
         let anchor = BlockHash::from_slice(request.anchor.as_slice())
             .map_err(|_| Status::unknown("Failed to parse anchor hash!"))?;

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -305,7 +305,7 @@ fn reimburse_canceled_requests<R: CanisterRuntime>(
         requests.len(),
         state.retrieve_btc_min_amount
     );
-    for (request, fee) in requests.into_iter().zip(fees.into_iter()) {
+    for (request, fee) in requests.into_iter().zip(fees) {
         if let Some(account) = request.reimbursement_account {
             let amount = request.amount.saturating_sub(fee);
             if amount > 0 {

--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1503,7 +1503,7 @@ impl CkBtcSetup {
     pub fn print_minter_canister_logs(&self) {
         let log = self.env.canister_log(self.minter_id);
         let mut records = log.records().iter().collect::<Vec<_>>();
-        records.sort_by(|a, b| a.idx.cmp(&b.idx));
+        records.sort_by_key(|a| a.idx);
         for entry in records {
             println!(
                 "[{}] {}: {}",

--- a/rs/consensus/certification/src/certifier.rs
+++ b/rs/consensus/certification/src/certifier.rs
@@ -1044,7 +1044,7 @@ mod tests {
                     .collect();
 
                 // sort by heights
-                certs.sort_by(|s1, s2| s1.height.cmp(&s2.height));
+                certs.sort_by_key(|s| s.height);
 
                 assert_eq!(certs[0].height, Height::from(3));
                 assert_eq!(certs[1].height, Height::from(4));

--- a/rs/consensus/idkg/src/test_utils.rs
+++ b/rs/consensus/idkg/src/test_utils.rs
@@ -765,8 +765,8 @@ pub(crate) fn get_dealings_and_support(
 ) -> (BTreeMap<NodeId, SignedIDkgDealing>, Vec<IDkgDealingSupport>) {
     let dealings = env.nodes.create_and_verify_signed_dealings(params);
     let supports = dealings
-        .iter()
-        .flat_map(|(_, dealing)| {
+        .values()
+        .flat_map(|dealing| {
             env.nodes.filter_by_receivers(&params).map(|signer| {
                 let c: Arc<dyn ConsensusCrypto> = signer.crypto();
                 let sig_share = c

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_chunking.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_chunking.rs
@@ -295,9 +295,8 @@ pub fn prove_chunking<R: RngCore + CryptoRng>(
     let xpowers = Scalar::xpowers(&second_challenge, NUM_ZK_REPETITIONS);
 
     let mut z_r = Vec::with_capacity(first_challenge.len());
-    let mut delta_idx = 1;
 
-    for e_i in first_challenge.iter() {
+    for (delta_idx, e_i) in (1_usize..).zip(first_challenge.iter()) {
         let mut xpow_e_ij = Vec::with_capacity(e_i.len());
         for j in 0..e_i.len() {
             xpow_e_ij.push(Scalar::muln_usize_vartime(&xpowers, &e_i[j]));
@@ -306,8 +305,6 @@ pub fn prove_chunking<R: RngCore + CryptoRng>(
         let z_rk = Scalar::muln_vartime(&witness.scalars_r, &xpow_e_ij) + &delta[delta_idx];
 
         z_r.push(z_rk);
-
-        delta_idx += 1;
     }
 
     let z_beta = Scalar::muln_vartime(&beta, &xpowers) + &delta[0];

--- a/rs/crypto/tests/canister_threshold_idkg.rs
+++ b/rs/crypto/tests/canister_threshold_idkg.rs
@@ -3665,7 +3665,7 @@ mod reshare_key_transcript {
 
             let nodes_involved_in_resharing: Nodes = source_subnet_nodes
                 .into_filtered_by_receivers(&source_receivers)
-                .chain(target_subnet_nodes.into_iter())
+                .chain(target_subnet_nodes)
                 .collect();
             let initial_dealings = {
                 let signed_dealings = nodes_involved_in_resharing
@@ -3751,7 +3751,7 @@ mod reshare_key_transcript {
 
             let nodes_involved_in_resharing: Nodes = source_subnet_nodes
                 .into_filtered_by_receivers(&source_receivers)
-                .chain(target_subnet_nodes.into_iter())
+                .chain(target_subnet_nodes)
                 .collect();
             let reshared_key_transcript = nodes_involved_in_resharing
                 .run_idkg_and_create_and_verify_transcript(&reshare_params, rng);
@@ -3807,7 +3807,7 @@ mod reshare_key_transcript {
 
             let nodes_involved_in_resharing: Nodes = source_subnet_nodes
                 .into_filtered_by_receivers(&source_receivers)
-                .chain(target_subnet_nodes.into_iter())
+                .chain(target_subnet_nodes)
                 .collect();
             let reshared_key_transcript = nodes_involved_in_resharing
                 .run_idkg_and_create_and_verify_transcript(&reshare_params, rng);

--- a/rs/ethereum/cketh/minter/src/logs.rs
+++ b/rs/ethereum/cketh/minter/src/logs.rs
@@ -135,11 +135,11 @@ impl Log {
     }
 
     pub fn sort_asc(&mut self) {
-        self.entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        self.entries.sort_by_key(|a| a.timestamp);
     }
 
     pub fn sort_desc(&mut self) {
-        self.entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        self.entries.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     }
 }
 

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -701,7 +701,7 @@ impl CkEthSetup {
         let log = self.env.canister_log(self.minter_id);
 
         let mut records = log.records().iter().collect::<Vec<_>>();
-        records.sort_by(|a, b| a.idx.cmp(&b.idx));
+        records.sort_by_key(|a| a.idx);
         records
             .into_iter()
             .map(|log| CanisterLog {

--- a/rs/ethereum/ledger-suite-orchestrator/src/logs/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/logs/mod.rs
@@ -131,10 +131,10 @@ impl Log {
     }
 
     pub fn sort_asc(&mut self) {
-        self.entries.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        self.entries.sort_by_key(|a| a.timestamp);
     }
 
     pub fn sort_desc(&mut self) {
-        self.entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        self.entries.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     }
 }

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -725,11 +725,9 @@ fn scheduler_can_deplete_induction_pool_given_enough_execution_rounds(
         available_messages,
         instructions_per_round / instructions_per_message,
     );
-    let required_rounds = if minimum_executed_messages != 0 {
-        available_messages / minimum_executed_messages + 1
-    } else {
-        1
-    };
+    let required_rounds = available_messages
+        .checked_div(minimum_executed_messages)
+        .map_or(1, |v| v + 1);
     for _ in 0..required_rounds {
         test.execute_round(ExecutionRoundType::OrdinaryRound);
     }

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -2360,6 +2360,7 @@ pub mod test {
 
                 // `make_new_requests` will try to dispatch contexts to the adapter shim.
                 // Accept any number of `send` calls and treat them as no-ops.
+                #[allow(clippy::result_large_err)]
                 shim_mock.expect_send().returning(|_| Ok(()));
 
                 let mut sequence = Sequence::new();

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -17,6 +17,8 @@
 //! `VetKdArgs<'a>` (`'_` is forbidden, named lifetimes cannot be declared, and
 //! elision does not work inside the macro).
 
+#![allow(clippy::result_large_err)]
+
 use ic_crypto_interfaces_sig_verification::BasicSigVerifierByPublicKey;
 use ic_interfaces::crypto::{
     BasicSigVerifier, BasicSigner, CheckKeysWithRegistryError, CurrentNodePublicKeysError,

--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -460,6 +460,7 @@ fn append_blocks(new_blocks: Vec<EncodedBlock>) -> Result<(), String> {
     // the index of the next block that we
     // are going to append
     let mut block_index = with_blocks(|blocks| blocks.len());
+    #[allow(clippy::explicit_counter_loop)]
     for block in new_blocks {
         // append the encoded block to the block log
         with_blocks(|blocks| {

--- a/rs/ledger_suite/icp/index/tests/tests.rs
+++ b/rs/ledger_suite/icp/index/tests/tests.rs
@@ -525,9 +525,8 @@ fn assert_ledger_index_parity_query_blocks_and_query_encoded_blocks(
         //  - the `created_at_time` field of the unencoded block is set to the `timestamp` field
         //    of the block
         //  - all the other fields of the blocks match
-        for (ledger_block, unencoded_ledger_block) in ledger_blocks
-            .into_iter()
-            .zip(ledger_unencoded_blocks.into_iter())
+        for (ledger_block, unencoded_ledger_block) in
+            ledger_blocks.into_iter().zip(ledger_unencoded_blocks)
         {
             if ledger_block != unencoded_ledger_block {
                 if ledger_block.transaction.created_at_time.is_none() {

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -611,7 +611,7 @@ fn assert_candid_block_equals_icp_ledger_block(
     icp_ledger_blocks: Vec<Block>,
 ) {
     assert_eq!(candid_blocks.len(), icp_ledger_blocks.len());
-    for (cb, lb) in candid_blocks.into_iter().zip(icp_ledger_blocks.into_iter()) {
+    for (cb, lb) in candid_blocks.into_iter().zip(icp_ledger_blocks) {
         assert_eq!(
             cb.parent_hash.map(|x| x.to_vec()),
             lb.parent_hash.map(|x| x.as_slice().to_vec())
@@ -1209,9 +1209,8 @@ fn test_block_transformation() {
     assert_eq!(certificate_pre_upgrade, certificate_post_upgrade);
 
     //Go through all blocks and make sure the blocks fetched before the upgrade are the same as after the upgrade
-    for (block_pre_upgrade, block_post_upgrade) in resp_pre_upgrade
-        .into_iter()
-        .zip(resp_post_upgrade.into_iter())
+    for (block_pre_upgrade, block_post_upgrade) in
+        resp_pre_upgrade.into_iter().zip(resp_post_upgrade)
     {
         assert_eq!(block_pre_upgrade, block_post_upgrade);
         assert_eq!(

--- a/rs/ledger_suite/icrc1/archive/src/main.rs
+++ b/rs/ledger_suite/icrc1/archive/src/main.rs
@@ -372,6 +372,7 @@ fn icrc3_get_blocks(reqs: Vec<GetBlocksRequest>) -> GetBlocksResult {
         }
         let length = length.min(max_length);
         let decoded_block_range = decode_block_range(start, length, decode_icrc1_block);
+        #[allow(clippy::explicit_counter_loop)]
         for block in decoded_block_range {
             blocks.push(BlockWithId {
                 id: id.clone(),

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -946,6 +946,7 @@ fn append_blocks(new_blocks: Vec<GenericBlock>) -> Result<(), SyncError> {
     // the index of the next block that we
     // are going to append
     let mut block_index = with_blocks(|blocks| blocks.len());
+    #[allow(clippy::explicit_counter_loop)]
     for block in new_blocks {
         append_block(block_index, block)?;
         block_index += 1;

--- a/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
@@ -358,7 +358,7 @@ fn assert_ledger_index_parity(env: &StateMachine, ledger_id: CanisterId, index_i
     for (index, (ledger_block, index_block)) in ledger_blocks
         .blocks
         .into_iter()
-        .zip(index_blocks.blocks.into_iter())
+        .zip(index_blocks.blocks)
         .enumerate()
     {
         // If the hash matches then they are the same block.

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -1232,7 +1232,7 @@ fn test_icrc3_get_blocks() {
     for (local_index, (actual_block, expected_block)) in actual_res
         .blocks
         .into_iter()
-        .zip(expected_res.blocks.into_iter())
+        .zip(expected_res.blocks)
         .enumerate()
     {
         check_old_vs_icrc3_blocks(
@@ -1285,7 +1285,7 @@ fn test_icrc3_get_blocks() {
     for (block_index, (actual_block, expected_block)) in actual_archived_blocks
         .blocks
         .into_iter()
-        .zip(expected_archived_blocks.blocks.into_iter())
+        .zip(expected_archived_blocks.blocks)
         .enumerate()
     {
         check_old_vs_icrc3_blocks(block_index, expected_block.clone(), actual_block.clone());

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -1615,7 +1615,7 @@ where
     let mut prev_hash = None;
 
     // Check that the hash chain is correct.
-    for block in archived_blocks.into_iter().chain(resp.blocks.into_iter()) {
+    for block in archived_blocks.into_iter().chain(resp.blocks) {
         assert_eq!(
             prev_hash,
             get_phash(&block).expect("cannot get the hash of the previous block")
@@ -2069,7 +2069,7 @@ pub fn icrc1_test_block_transformation<T, Tokens>(
     for (block_pre_upgrade, block_post_upgrade) in resp_pre_upgrade
         .blocks
         .into_iter()
-        .zip(resp_post_upgrade.blocks.into_iter())
+        .zip(resp_post_upgrade.blocks)
     {
         assert!(
             equivalent_values(&block_pre_upgrade, &block_post_upgrade),

--- a/rs/monitoring/adapter_metrics/server/src/lib.rs
+++ b/rs/monitoring/adapter_metrics/server/src/lib.rs
@@ -28,6 +28,7 @@ impl Metrics {
 
 #[tonic::async_trait]
 impl AdapterMetricsService for Metrics {
+    #[allow(clippy::result_large_err)]
     async fn scrape(
         &self,
         _request: Request<ScrapeRequest>,

--- a/rs/nervous_system/agent/src/sns/swap.rs
+++ b/rs/nervous_system/agent/src/sns/swap.rs
@@ -78,7 +78,7 @@ impl SwapCanister {
             if new_sns_neuron_recipes.sns_neuron_recipes.is_empty() {
                 return Ok(sns_neuron_recipes);
             } else {
-                sns_neuron_recipes.extend(new_sns_neuron_recipes.sns_neuron_recipes.into_iter())
+                sns_neuron_recipes.extend(new_sns_neuron_recipes.sns_neuron_recipes)
             }
         }
         Err(ListAllSnsNeuronRecipesError::TooManyRecipes(

--- a/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_lifecycle.rs
@@ -294,7 +294,7 @@ async fn test_sns_lifecycle(
             .await
             .unwrap();
 
-        stream::iter(nns_neuron_controller_principal_ids.into_iter())
+        stream::iter(nns_neuron_controller_principal_ids)
             .then(|controller_principal_id| {
                 let pocket_ic = &pocket_ic;
                 async move {
@@ -1589,8 +1589,7 @@ async fn test_sns_lifecycle(
                             permissions: &[sns_pb::NeuronPermission],
                         ) -> Vec<sns_pb::NeuronPermission> {
                             let mut permissions = permissions.to_vec();
-                            permissions
-                                .sort_by(|x, y| y.principal.unwrap().cmp(&x.principal.unwrap()));
+                            permissions.sort_by_key(|y| std::cmp::Reverse(y.principal.unwrap()));
                             permissions
                         }
                         let claimer_permissions = nervous_system_parameters

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -964,15 +964,12 @@ fn compute_average_icp_xdr_rate_at_time(
     let size = filtered_rates.len() as u64;
     // If there are rates that meet the age requirement, compute the sum and compute
     // the average.
-    if size > 0 {
-        let sum: u64 = filtered_rates.into_iter().sum();
-        Some(IcpXdrConversionRate {
-            timestamp_seconds: day * 86_400,   // Start of the current day.
-            xdr_permyriad_per_icp: sum / size, // The average of the valid data points.
+    let sum: u64 = filtered_rates.into_iter().sum();
+    sum.checked_div(size)
+        .map(|xdr_permyriad_per_icp| IcpXdrConversionRate {
+            timestamp_seconds: day * 86_400, // Start of the current day.
+            xdr_permyriad_per_icp,           // The average of the valid data points.
         })
-    } else {
-        None
-    }
 }
 
 #[update(hidden = true)]

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4660,17 +4660,15 @@ impl Governance {
                     ));
                 }
             }
-            Command::Follow(follow) => {
-                if follow.followees.len() > MAX_FOLLOWEES_PER_TOPIC {
-                    return Err(GovernanceError::new_with_message(
-                        ErrorType::InvalidCommand,
-                        format!(
-                            "Too many followees: {} (max: {})",
-                            follow.followees.len(),
-                            MAX_FOLLOWEES_PER_TOPIC
-                        ),
-                    ));
-                }
+            Command::Follow(follow) if follow.followees.len() > MAX_FOLLOWEES_PER_TOPIC => {
+                return Err(GovernanceError::new_with_message(
+                    ErrorType::InvalidCommand,
+                    format!(
+                        "Too many followees: {} (max: {})",
+                        follow.followees.len(),
+                        MAX_FOLLOWEES_PER_TOPIC
+                    ),
+                ));
             }
             Command::SetFollowing(set_following) => {
                 set_following.validate_intrinsically()?;
@@ -4955,12 +4953,10 @@ impl Governance {
                 Self::validate_add_or_remove_data_centers_payload(&update.payload)
                     .map_err(invalid_proposal_error)?;
             }
-            ValidNnsFunction::SplitSubnet => {
-                if !are_subnet_splitting_proposals_enabled() {
-                    return Err(invalid_proposal_error(String::from(
-                        "Subnet Splitting proposals not yet enabled",
-                    )));
-                }
+            ValidNnsFunction::SplitSubnet if !are_subnet_splitting_proposals_enabled() => {
+                return Err(invalid_proposal_error(String::from(
+                    "Subnet Splitting proposals not yet enabled",
+                )));
             }
             _ => {}
         };

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4660,15 +4660,18 @@ impl Governance {
                     ));
                 }
             }
-            Command::Follow(follow) if follow.followees.len() > MAX_FOLLOWEES_PER_TOPIC => {
-                return Err(GovernanceError::new_with_message(
-                    ErrorType::InvalidCommand,
-                    format!(
-                        "Too many followees: {} (max: {})",
-                        follow.followees.len(),
-                        MAX_FOLLOWEES_PER_TOPIC
-                    ),
-                ));
+            #[allow(clippy::collapsible_match)]
+            Command::Follow(follow) => {
+                if follow.followees.len() > MAX_FOLLOWEES_PER_TOPIC {
+                    return Err(GovernanceError::new_with_message(
+                        ErrorType::InvalidCommand,
+                        format!(
+                            "Too many followees: {} (max: {})",
+                            follow.followees.len(),
+                            MAX_FOLLOWEES_PER_TOPIC
+                        ),
+                    ));
+                }
             }
             Command::SetFollowing(set_following) => {
                 set_following.validate_intrinsically()?;
@@ -4953,10 +4956,13 @@ impl Governance {
                 Self::validate_add_or_remove_data_centers_payload(&update.payload)
                     .map_err(invalid_proposal_error)?;
             }
-            ValidNnsFunction::SplitSubnet if !are_subnet_splitting_proposals_enabled() => {
-                return Err(invalid_proposal_error(String::from(
-                    "Subnet Splitting proposals not yet enabled",
-                )));
+            #[allow(clippy::collapsible_match)]
+            ValidNnsFunction::SplitSubnet => {
+                if !are_subnet_splitting_proposals_enabled() {
+                    return Err(invalid_proposal_error(String::from(
+                        "Subnet Splitting proposals not yet enabled",
+                    )));
+                }
             }
             _ => {}
         };

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -303,7 +303,7 @@ fn set_up_chain<R: Rng>(
         let previous_neuron_indices = (neuron_index - num_half_followees - 1)..neuron_index;
         let followee_neuron_ids = previous_neuron_indices
             .map(|index| neuron_ids[index as usize])
-            .chain(not_voting_neuron_ids.clone().into_iter())
+            .chain(not_voting_neuron_ids.clone())
             .collect::<Vec<_>>();
 
         let followees = hashmap! {topic.into() => Followees {followees: followee_neuron_ids}};

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -10931,8 +10931,7 @@ async fn test_known_neurons() {
         },
     ];
     let mut sorted_response_known_neurons = gov.list_known_neurons().known_neurons;
-    sorted_response_known_neurons
-        .sort_by(|a, b| a.id.as_ref().unwrap().id.cmp(&b.id.as_ref().unwrap().id));
+    sorted_response_known_neurons.sort_by_key(|a| a.id.as_ref().unwrap().id);
     assert_eq!(sorted_response_known_neurons, expected_known_neurons);
 
     // This proposal tries to name neuron 1 with the already existing name "Two", this should fail.
@@ -10959,8 +10958,7 @@ async fn test_known_neurons() {
 
     // Check that the state is the same as before the last proposal.
     let mut sorted_response_known_neurons = gov.list_known_neurons().known_neurons;
-    sorted_response_known_neurons
-        .sort_by(|a, b| a.id.as_ref().unwrap().id.cmp(&b.id.as_ref().unwrap().id));
+    sorted_response_known_neurons.sort_by_key(|a| a.id.as_ref().unwrap().id);
     assert_eq!(sorted_response_known_neurons, expected_known_neurons);
 
     // Update the name of neuron 2.

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -586,8 +586,8 @@ fn test_automated_node_provider_remuneration() {
     // All success failure rate is 0
     let node_metrics_daily: Vec<NodeMetricsDailyRaw> = nodes
         .clone()
-        .into_iter()
-        .flat_map(|(_, node_ids)| {
+        .into_values()
+        .flat_map(|node_ids| {
             node_ids.into_iter().map(|node_id| NodeMetricsDailyRaw {
                 node_id,
                 num_blocks_failed: 0,
@@ -841,8 +841,8 @@ fn test_automated_node_provider_remuneration() {
     // All success failure rate is 0
     let node_metrics_daily: Vec<NodeMetricsDailyRaw> = nodes
         .clone()
-        .into_iter()
-        .flat_map(|(_, node_ids)| {
+        .into_values()
+        .flat_map(|node_ids| {
             node_ids.into_iter().map(|node_id| NodeMetricsDailyRaw {
                 node_id,
                 num_blocks_failed: 0,
@@ -957,8 +957,8 @@ fn test_automated_node_provider_remuneration() {
     // All success failure rate is 0
     let node_metrics_daily: Vec<NodeMetricsDailyRaw> = nodes
         .clone()
-        .into_iter()
-        .flat_map(|(_, node_ids)| {
+        .into_values()
+        .flat_map(|node_ids| {
             node_ids.into_iter().map(|node_id| NodeMetricsDailyRaw {
                 node_id,
                 num_blocks_failed: 0,

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1810,9 +1810,7 @@ pub fn list_all_neurons_and_combine_responses(
         new_request.page_number = Some(page);
         let mut new_response = list_neurons(state_machine, sender, new_request);
         response.full_neurons.append(&mut new_response.full_neurons);
-        response
-            .neuron_infos
-            .extend(new_response.neuron_infos.into_iter());
+        response.neuron_infos.extend(new_response.neuron_infos);
     }
 
     response

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/stripper.rs
@@ -92,8 +92,8 @@ impl Strippable for &Option<IDkgPayload> {
     fn strip(self) -> Self::Output {
         let stripped_dealings = if let Some(idkg) = self {
             idkg.idkg_transcripts
-                .iter()
-                .flat_map(|(_id, transcript)| {
+                .values()
+                .flat_map(|transcript| {
                     transcript.verified_dealings.iter().map(
                         |(dealer_index, batch_signed_dealing)| {
                             (*dealer_index, batch_signed_dealing.content.message_id())

--- a/rs/p2p/consensus_manager/tests/test.rs
+++ b/rs/p2p/consensus_manager/tests/test.rs
@@ -354,7 +354,7 @@ fn load_test(
         node_advert_map.insert(node, processor);
     }
     let (nodes, topology_watcher) = fully_connected_localhost_subnet(rt.handle(), log, id, nodes);
-    for ((node1, transport), (node2, cm)) in nodes.into_iter().zip(cms.into_iter()) {
+    for ((node1, transport), (node2, cm)) in nodes.into_iter().zip(cms) {
         assert!(node1 == node2);
         cm.start(transport, topology_watcher.clone());
     }

--- a/rs/p2p/state_sync_manager/tests/common.rs
+++ b/rs/p2p/state_sync_manager/tests/common.rs
@@ -121,14 +121,8 @@ impl State {
         let other_state = other.0.lock().unwrap();
         other_state
             .chunks
-            .iter()
-            .filter_map(|(k, _)| {
-                if !this_state.chunks.contains_key(k) {
-                    Some(k)
-                } else {
-                    None
-                }
-            })
+            .keys()
+            .filter(|k| !this_state.chunks.contains_key(k))
             .cloned()
             .collect()
     }

--- a/rs/query_stats/src/payload_builder.rs
+++ b/rs/query_stats/src/payload_builder.rs
@@ -959,7 +959,7 @@ mod tests {
                 .stats
                 .entry(canister_id)
                 // NOTE: This assumes that there are no nodeids identical in stats1 and stats2
-                .and_modify(|entry| entry.extend(stat2.clone().into_iter()))
+                .and_modify(|entry| entry.extend(stat2.clone()))
                 .or_insert(stat2);
         }
 

--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -313,19 +313,17 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 wait_for_confirmation(&self.logger);
             }
 
-            StepType::DownloadConsensusPool => {
-                if self.params.download_pool_node.is_none() {
-                    // We could pick a node with highest finalization and CUP height automatically,
-                    // but we might have a preference between nodes of same heights.
-                    print_height_info(
-                        &self.logger,
-                        &self.recovery.registry_helper,
-                        self.params.subnet_id,
-                    );
+            StepType::DownloadConsensusPool if self.params.download_pool_node.is_none() => {
+                // We could pick a node with highest finalization and CUP height automatically,
+                // but we might have a preference between nodes of same heights.
+                print_height_info(
+                    &self.logger,
+                    &self.recovery.registry_helper,
+                    self.params.subnet_id,
+                );
 
-                    self.params.download_pool_node =
-                        Some(read(&self.logger, "Enter consensus pool download IP:"));
-                }
+                self.params.download_pool_node =
+                    Some(read(&self.logger, "Enter consensus pool download IP:"));
             }
 
             StepType::DownloadState => {
@@ -354,27 +352,21 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::ICReplay => {
-                if self.params.replay_until_height.is_none() {
-                    self.params.replay_until_height =
-                        read_optional(&self.logger, "Replay until height: ");
-                }
+            StepType::ICReplay if self.params.replay_until_height.is_none() => {
+                self.params.replay_until_height =
+                    read_optional(&self.logger, "Replay until height: ");
             }
 
-            StepType::ElectVersion => {
-                if self.params.upgrade_version.is_none() {
-                    self.params.upgrade_version =
-                        read_optional(&self.logger, "Version to bless (and upgrade to): ");
-                }
+            StepType::ElectVersion if self.params.upgrade_version.is_none() => {
+                self.params.upgrade_version =
+                    read_optional(&self.logger, "Version to bless (and upgrade to): ");
             }
 
-            StepType::UpgradeVersion => {
-                if self.params.upgrade_version.is_none() {
-                    self.params.upgrade_version = read_optional(
-                        &self.logger,
-                        "Version to upgrade to (WARN: it should already be blessed): ",
-                    );
-                }
+            StepType::UpgradeVersion if self.params.upgrade_version.is_none() => {
+                self.params.upgrade_version = read_optional(
+                    &self.logger,
+                    "Version to upgrade to (WARN: it should already be blessed): ",
+                );
             }
 
             StepType::ProposeCup => {
@@ -398,25 +390,21 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::UploadState => {
-                if self.params.upload_method.is_none() {
-                    self.params.upload_method = Some(read_data_location(
-                        &self.logger,
-                        "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
-                    ));
-                }
+            StepType::UploadState if self.params.upload_method.is_none() => {
+                self.params.upload_method = Some(read_data_location(
+                    &self.logger,
+                    "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
+                ));
             }
 
-            StepType::WaitForCUP => {
-                if self.params.wait_for_cup_node.is_none() {
-                    if let Some(DataLocation::Remote(ip)) = self.params.upload_method {
-                        self.params.wait_for_cup_node = Some(ip);
-                    } else {
-                        self.params.wait_for_cup_node = read_optional(
-                            &self.logger,
-                            "Enter IP of the node to be polled for the recovery CUP:",
-                        );
-                    }
+            StepType::WaitForCUP if self.params.wait_for_cup_node.is_none() => {
+                if let Some(DataLocation::Remote(ip)) = self.params.upload_method {
+                    self.params.wait_for_cup_node = Some(ip);
+                } else {
+                    self.params.wait_for_cup_node = read_optional(
+                        &self.logger,
+                        "Enter IP of the node to be polled for the recovery CUP:",
+                    );
                 }
             }
 

--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -313,17 +313,20 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 wait_for_confirmation(&self.logger);
             }
 
-            StepType::DownloadConsensusPool if self.params.download_pool_node.is_none() => {
-                // We could pick a node with highest finalization and CUP height automatically,
-                // but we might have a preference between nodes of same heights.
-                print_height_info(
-                    &self.logger,
-                    &self.recovery.registry_helper,
-                    self.params.subnet_id,
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::DownloadConsensusPool => {
+                if self.params.download_pool_node.is_none() {
+                    // We could pick a node with highest finalization and CUP height automatically,
+                    // but we might have a preference between nodes of same heights.
+                    print_height_info(
+                        &self.logger,
+                        &self.recovery.registry_helper,
+                        self.params.subnet_id,
+                    );
 
-                self.params.download_pool_node =
-                    Some(read(&self.logger, "Enter consensus pool download IP:"));
+                    self.params.download_pool_node =
+                        Some(read(&self.logger, "Enter consensus pool download IP:"));
+                }
             }
 
             StepType::DownloadState => {
@@ -352,21 +355,30 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::ICReplay if self.params.replay_until_height.is_none() => {
-                self.params.replay_until_height =
-                    read_optional(&self.logger, "Replay until height: ");
+            #[allow(clippy::collapsible_match)]
+            StepType::ICReplay => {
+                if self.params.replay_until_height.is_none() {
+                    self.params.replay_until_height =
+                        read_optional(&self.logger, "Replay until height: ");
+                }
             }
 
-            StepType::ElectVersion if self.params.upgrade_version.is_none() => {
-                self.params.upgrade_version =
-                    read_optional(&self.logger, "Version to bless (and upgrade to): ");
+            #[allow(clippy::collapsible_match)]
+            StepType::ElectVersion => {
+                if self.params.upgrade_version.is_none() {
+                    self.params.upgrade_version =
+                        read_optional(&self.logger, "Version to bless (and upgrade to): ");
+                }
             }
 
-            StepType::UpgradeVersion if self.params.upgrade_version.is_none() => {
-                self.params.upgrade_version = read_optional(
-                    &self.logger,
-                    "Version to upgrade to (WARN: it should already be blessed): ",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::UpgradeVersion => {
+                if self.params.upgrade_version.is_none() {
+                    self.params.upgrade_version = read_optional(
+                        &self.logger,
+                        "Version to upgrade to (WARN: it should already be blessed): ",
+                    );
+                }
             }
 
             StepType::ProposeCup => {
@@ -390,21 +402,27 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::UploadState if self.params.upload_method.is_none() => {
-                self.params.upload_method = Some(read_data_location(
-                    &self.logger,
-                    "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
-                ));
+            #[allow(clippy::collapsible_match)]
+            StepType::UploadState => {
+                if self.params.upload_method.is_none() {
+                    self.params.upload_method = Some(read_data_location(
+                        &self.logger,
+                        "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
+                    ));
+                }
             }
 
-            StepType::WaitForCUP if self.params.wait_for_cup_node.is_none() => {
-                if let Some(DataLocation::Remote(ip)) = self.params.upload_method {
-                    self.params.wait_for_cup_node = Some(ip);
-                } else {
-                    self.params.wait_for_cup_node = read_optional(
-                        &self.logger,
-                        "Enter IP of the node to be polled for the recovery CUP:",
-                    );
+            #[allow(clippy::collapsible_match)]
+            StepType::WaitForCUP => {
+                if self.params.wait_for_cup_node.is_none() {
+                    if let Some(DataLocation::Remote(ip)) = self.params.upload_method {
+                        self.params.wait_for_cup_node = Some(ip);
+                    } else {
+                        self.params.wait_for_cup_node = read_optional(
+                            &self.logger,
+                            "Enter IP of the node to be polled for the recovery CUP:",
+                        );
+                    }
                 }
             }
 

--- a/rs/recovery/src/nns_recovery_failover_nodes.rs
+++ b/rs/recovery/src/nns_recovery_failover_nodes.rs
@@ -184,27 +184,31 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
         // Depending on the next step we might require some user interaction before we can execute
         // it.
         match step_type {
-            StepType::StopReplica | StepType::DownloadConsensusPool | StepType::DownloadState
-                if self.params.download_node.is_none() =>
-            {
-                // We could pick a node with highest finalization and CUP height automatically,
-                // but we might have a preference between nodes of same heights.
-                print_height_info(
-                    &self.logger,
-                    &self.recovery.registry_helper,
-                    self.params.subnet_id,
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::StopReplica | StepType::DownloadConsensusPool | StepType::DownloadState => {
+                if self.params.download_node.is_none() {
+                    // We could pick a node with highest finalization and CUP height automatically,
+                    // but we might have a preference between nodes of same heights.
+                    print_height_info(
+                        &self.logger,
+                        &self.recovery.registry_helper,
+                        self.params.subnet_id,
+                    );
 
-                self.params.download_node = read_optional(&self.logger, "Enter download IP:");
+                    self.params.download_node = read_optional(&self.logger, "Enter download IP:");
+                }
             }
             _ => {}
         }
         match step_type {
-            StepType::DownloadState if self.params.download_state_height.is_none() => {
-                self.params.download_state_height = read_optional(
-                    &self.logger,
-                    "Enter the height of the checkpoint to download (leave empty for latest checkpoint):",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::DownloadState => {
+                if self.params.download_state_height.is_none() {
+                    self.params.download_state_height = read_optional(
+                        &self.logger,
+                        "Enter the height of the checkpoint to download (leave empty for latest checkpoint):",
+                    );
+                }
             }
             StepType::ProposeToCreateSubnet => {
                 if self.params.replica_version.is_none() {
@@ -221,16 +225,22 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
                 }
             }
 
-            StepType::DownloadParentNNSStore if self.params.parent_nns_host_ip.is_none() => {
-                self.params.parent_nns_host_ip = read_optional(
-                    &self.logger,
-                    "Enter parent NNS IP to download the registry store from:",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::DownloadParentNNSStore => {
+                if self.params.parent_nns_host_ip.is_none() {
+                    self.params.parent_nns_host_ip = read_optional(
+                        &self.logger,
+                        "Enter parent NNS IP to download the registry store from:",
+                    );
+                }
             }
 
-            StepType::ICReplayWithRegistryContent if self.params.replay_until_height.is_none() => {
-                self.params.replay_until_height =
-                    read_optional(&self.logger, "Replay until height: ");
+            #[allow(clippy::collapsible_match)]
+            StepType::ICReplayWithRegistryContent => {
+                if self.params.replay_until_height.is_none() {
+                    self.params.replay_until_height =
+                        read_optional(&self.logger, "Replay until height: ");
+                }
             }
 
             StepType::UploadAndHostTar => {
@@ -250,11 +260,14 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
                 }
             }
 
-            StepType::WaitForCUP if self.params.upload_method.is_none() => {
-                self.params.upload_method = read_optional_data_location(
-                    &self.logger,
-                    "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::WaitForCUP => {
+                if self.params.upload_method.is_none() {
+                    self.params.upload_method = read_optional_data_location(
+                        &self.logger,
+                        "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
+                    );
+                }
             }
             _ => {}
         }

--- a/rs/recovery/src/nns_recovery_failover_nodes.rs
+++ b/rs/recovery/src/nns_recovery_failover_nodes.rs
@@ -184,29 +184,27 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
         // Depending on the next step we might require some user interaction before we can execute
         // it.
         match step_type {
-            StepType::StopReplica | StepType::DownloadConsensusPool | StepType::DownloadState => {
-                if self.params.download_node.is_none() {
-                    // We could pick a node with highest finalization and CUP height automatically,
-                    // but we might have a preference between nodes of same heights.
-                    print_height_info(
-                        &self.logger,
-                        &self.recovery.registry_helper,
-                        self.params.subnet_id,
-                    );
+            StepType::StopReplica | StepType::DownloadConsensusPool | StepType::DownloadState
+                if self.params.download_node.is_none() =>
+            {
+                // We could pick a node with highest finalization and CUP height automatically,
+                // but we might have a preference between nodes of same heights.
+                print_height_info(
+                    &self.logger,
+                    &self.recovery.registry_helper,
+                    self.params.subnet_id,
+                );
 
-                    self.params.download_node = read_optional(&self.logger, "Enter download IP:");
-                }
+                self.params.download_node = read_optional(&self.logger, "Enter download IP:");
             }
             _ => {}
         }
         match step_type {
-            StepType::DownloadState => {
-                if self.params.download_state_height.is_none() {
-                    self.params.download_state_height = read_optional(
-                        &self.logger,
-                        "Enter the height of the checkpoint to download (leave empty for latest checkpoint):",
-                    );
-                }
+            StepType::DownloadState if self.params.download_state_height.is_none() => {
+                self.params.download_state_height = read_optional(
+                    &self.logger,
+                    "Enter the height of the checkpoint to download (leave empty for latest checkpoint):",
+                );
             }
             StepType::ProposeToCreateSubnet => {
                 if self.params.replica_version.is_none() {
@@ -223,20 +221,16 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
                 }
             }
 
-            StepType::DownloadParentNNSStore => {
-                if self.params.parent_nns_host_ip.is_none() {
-                    self.params.parent_nns_host_ip = read_optional(
-                        &self.logger,
-                        "Enter parent NNS IP to download the registry store from:",
-                    );
-                }
+            StepType::DownloadParentNNSStore if self.params.parent_nns_host_ip.is_none() => {
+                self.params.parent_nns_host_ip = read_optional(
+                    &self.logger,
+                    "Enter parent NNS IP to download the registry store from:",
+                );
             }
 
-            StepType::ICReplayWithRegistryContent => {
-                if self.params.replay_until_height.is_none() {
-                    self.params.replay_until_height =
-                        read_optional(&self.logger, "Replay until height: ");
-                }
+            StepType::ICReplayWithRegistryContent if self.params.replay_until_height.is_none() => {
+                self.params.replay_until_height =
+                    read_optional(&self.logger, "Replay until height: ");
             }
 
             StepType::UploadAndHostTar => {
@@ -256,13 +250,11 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
                 }
             }
 
-            StepType::WaitForCUP => {
-                if self.params.upload_method.is_none() {
-                    self.params.upload_method = read_optional_data_location(
-                        &self.logger,
-                        "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
-                    );
-                }
+            StepType::WaitForCUP if self.params.upload_method.is_none() => {
+                self.params.upload_method = read_optional_data_location(
+                    &self.logger,
+                    "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
+                );
             }
             _ => {}
         }

--- a/rs/recovery/src/nns_recovery_same_nodes.rs
+++ b/rs/recovery/src/nns_recovery_same_nodes.rs
@@ -244,32 +244,30 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
         // Depending on the next step we might require some user interaction before we can execute
         // it.
         match step_type {
-            StepType::StopReplica | StepType::DownloadState | StepType::UploadState => {
-                if self.params.admin_access_location.is_none() {
-                    self.params.admin_access_location = Some(read_data_location(
-                        &self.logger,
-                        "Enter state download/upload location (admin access required) [local/<ipv6>]:",
-                    ));
-                }
+            StepType::StopReplica | StepType::DownloadState | StepType::UploadState
+                if self.params.admin_access_location.is_none() =>
+            {
+                self.params.admin_access_location = Some(read_data_location(
+                    &self.logger,
+                    "Enter state download/upload location (admin access required) [local/<ipv6>]:",
+                ));
             }
             _ => {}
         }
         match step_type {
-            StepType::DownloadConsensusPool => {
-                if self.params.download_pool_node.is_none() {
-                    // We could pick a node with highest finalization and CUP height automatically,
-                    // but we might have a preference between nodes of same heights.
-                    print_height_info(
-                        &self.logger,
-                        &self.recovery.registry_helper,
-                        self.params.subnet_id,
-                    );
+            StepType::DownloadConsensusPool if self.params.download_pool_node.is_none() => {
+                // We could pick a node with highest finalization and CUP height automatically,
+                // but we might have a preference between nodes of same heights.
+                print_height_info(
+                    &self.logger,
+                    &self.recovery.registry_helper,
+                    self.params.subnet_id,
+                );
 
-                    self.params.download_pool_node = Some(read(
-                        &self.logger,
-                        "Enter consensus pool download IP (backup access required):",
-                    ));
-                }
+                self.params.download_pool_node = Some(read(
+                    &self.logger,
+                    "Enter consensus pool download IP (backup access required):",
+                ));
             }
 
             StepType::DownloadState => {
@@ -310,36 +308,32 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
                 }
             }
 
-            StepType::CreateArtifacts => {
-                if self.params.output_dir.is_none() {
-                    self.params.output_dir = read_optional(
-                        &self.logger,
-                        &format!(
-                            "Enter output directory for recovery artifacts (must be in a shared mount if doing local recovery, default: {}):",
-                            self.recovery.recovery_dir.join("output").display()
-                        ),
-                    );
-                }
+            StepType::CreateArtifacts if self.params.output_dir.is_none() => {
+                self.params.output_dir = read_optional(
+                    &self.logger,
+                    &format!(
+                        "Enter output directory for recovery artifacts (must be in a shared mount if doing local recovery, default: {}):",
+                        self.recovery.recovery_dir.join("output").display()
+                    ),
+                );
             }
 
-            StepType::UploadCUPAndRegistry => {
-                if self.params.wait_for_cup_node.is_none() {
-                    self.params.wait_for_cup_node = if let Some(DataLocation::Remote(ip)) =
-                        self.params.admin_access_location
-                    {
-                        consent_given(
+            StepType::UploadCUPAndRegistry if self.params.wait_for_cup_node.is_none() => {
+                self.params.wait_for_cup_node = if let Some(DataLocation::Remote(ip)) =
+                    self.params.admin_access_location
+                {
+                    consent_given(
                             &self.logger,
                             &format!(
                                 "Would you like to recover the admin node now, i.e. upload the CUP and registry local store to it? ({ip})"
                             ),
                         ).then_some(ip)
-                    } else {
-                        read_optional(
-                            &self.logger,
-                            "If you would like to recover the admin node now, i.e. upload the CUP and registry local store to it, enter its IP address:",
-                        )
-                    };
-                }
+                } else {
+                    read_optional(
+                        &self.logger,
+                        "If you would like to recover the admin node now, i.e. upload the CUP and registry local store to it, enter its IP address:",
+                    )
+                };
             }
 
             _ => {}

--- a/rs/recovery/src/nns_recovery_same_nodes.rs
+++ b/rs/recovery/src/nns_recovery_same_nodes.rs
@@ -244,30 +244,34 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
         // Depending on the next step we might require some user interaction before we can execute
         // it.
         match step_type {
-            StepType::StopReplica | StepType::DownloadState | StepType::UploadState
-                if self.params.admin_access_location.is_none() =>
-            {
-                self.params.admin_access_location = Some(read_data_location(
-                    &self.logger,
-                    "Enter state download/upload location (admin access required) [local/<ipv6>]:",
-                ));
+            #[allow(clippy::collapsible_match)]
+            StepType::StopReplica | StepType::DownloadState | StepType::UploadState => {
+                if self.params.admin_access_location.is_none() {
+                    self.params.admin_access_location = Some(read_data_location(
+                        &self.logger,
+                        "Enter state download/upload location (admin access required) [local/<ipv6>]:",
+                    ));
+                }
             }
             _ => {}
         }
         match step_type {
-            StepType::DownloadConsensusPool if self.params.download_pool_node.is_none() => {
-                // We could pick a node with highest finalization and CUP height automatically,
-                // but we might have a preference between nodes of same heights.
-                print_height_info(
-                    &self.logger,
-                    &self.recovery.registry_helper,
-                    self.params.subnet_id,
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::DownloadConsensusPool => {
+                if self.params.download_pool_node.is_none() {
+                    // We could pick a node with highest finalization and CUP height automatically,
+                    // but we might have a preference between nodes of same heights.
+                    print_height_info(
+                        &self.logger,
+                        &self.recovery.registry_helper,
+                        self.params.subnet_id,
+                    );
 
-                self.params.download_pool_node = Some(read(
-                    &self.logger,
-                    "Enter consensus pool download IP (backup access required):",
-                ));
+                    self.params.download_pool_node = Some(read(
+                        &self.logger,
+                        "Enter consensus pool download IP (backup access required):",
+                    ));
+                }
             }
 
             StepType::DownloadState => {
@@ -308,32 +312,38 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
                 }
             }
 
-            StepType::CreateArtifacts if self.params.output_dir.is_none() => {
-                self.params.output_dir = read_optional(
-                    &self.logger,
-                    &format!(
-                        "Enter output directory for recovery artifacts (must be in a shared mount if doing local recovery, default: {}):",
-                        self.recovery.recovery_dir.join("output").display()
-                    ),
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::CreateArtifacts => {
+                if self.params.output_dir.is_none() {
+                    self.params.output_dir = read_optional(
+                        &self.logger,
+                        &format!(
+                            "Enter output directory for recovery artifacts (must be in a shared mount if doing local recovery, default: {}):",
+                            self.recovery.recovery_dir.join("output").display()
+                        ),
+                    );
+                }
             }
 
-            StepType::UploadCUPAndRegistry if self.params.wait_for_cup_node.is_none() => {
-                self.params.wait_for_cup_node = if let Some(DataLocation::Remote(ip)) =
-                    self.params.admin_access_location
-                {
-                    consent_given(
+            #[allow(clippy::collapsible_match)]
+            StepType::UploadCUPAndRegistry => {
+                if self.params.wait_for_cup_node.is_none() {
+                    self.params.wait_for_cup_node = if let Some(DataLocation::Remote(ip)) =
+                        self.params.admin_access_location
+                    {
+                        consent_given(
                             &self.logger,
                             &format!(
                                 "Would you like to recover the admin node now, i.e. upload the CUP and registry local store to it? ({ip})"
                             ),
                         ).then_some(ip)
-                } else {
-                    read_optional(
-                        &self.logger,
-                        "If you would like to recover the admin node now, i.e. upload the CUP and registry local store to it, enter its IP address:",
-                    )
-                };
+                    } else {
+                        read_optional(
+                            &self.logger,
+                            "If you would like to recover the admin node now, i.e. upload the CUP and registry local store to it, enter its IP address:",
+                        )
+                    };
+                }
             }
 
             _ => {}

--- a/rs/recovery/subnet_splitting/src/subnet_splitting.rs
+++ b/rs/recovery/subnet_splitting/src/subnet_splitting.rs
@@ -445,20 +445,24 @@ impl RecoveryIterator<StepType, StepTypeIter> for SubnetSplitting {
                 ));
             }
 
-            StepType::UploadStateToSourceSubnet if self.params.upload_node_source.is_none() => {
-                self.params.upload_node_source = read_optional(
-                    &self.logger,
-                    "Enter IP of node in the Source Subnet with admin access: ",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::UploadStateToSourceSubnet => {
+                if self.params.upload_node_source.is_none() {
+                    self.params.upload_node_source = read_optional(
+                        &self.logger,
+                        "Enter IP of node in the Source Subnet with admin access: ",
+                    );
+                }
             }
 
-            StepType::UploadStateToDestinationSubnet
-                if self.params.upload_node_destination.is_none() =>
-            {
-                self.params.upload_node_destination = read_optional(
-                    &self.logger,
-                    "Enter IP of node in the Destination Subnet with admin access: ",
-                );
+            #[allow(clippy::collapsible_match)]
+            StepType::UploadStateToDestinationSubnet => {
+                if self.params.upload_node_destination.is_none() {
+                    self.params.upload_node_destination = read_optional(
+                        &self.logger,
+                        "Enter IP of node in the Destination Subnet with admin access: ",
+                    );
+                }
             }
 
             StepType::UnhaltDestinationSubnet | StepType::CompleteCanisterMigration => {

--- a/rs/recovery/subnet_splitting/src/subnet_splitting.rs
+++ b/rs/recovery/subnet_splitting/src/subnet_splitting.rs
@@ -445,22 +445,20 @@ impl RecoveryIterator<StepType, StepTypeIter> for SubnetSplitting {
                 ));
             }
 
-            StepType::UploadStateToSourceSubnet => {
-                if self.params.upload_node_source.is_none() {
-                    self.params.upload_node_source = read_optional(
-                        &self.logger,
-                        "Enter IP of node in the Source Subnet with admin access: ",
-                    );
-                }
+            StepType::UploadStateToSourceSubnet if self.params.upload_node_source.is_none() => {
+                self.params.upload_node_source = read_optional(
+                    &self.logger,
+                    "Enter IP of node in the Source Subnet with admin access: ",
+                );
             }
 
-            StepType::UploadStateToDestinationSubnet => {
-                if self.params.upload_node_destination.is_none() {
-                    self.params.upload_node_destination = read_optional(
-                        &self.logger,
-                        "Enter IP of node in the Destination Subnet with admin access: ",
-                    );
-                }
+            StepType::UploadStateToDestinationSubnet
+                if self.params.upload_node_destination.is_none() =>
+            {
+                self.params.upload_node_destination = read_optional(
+                    &self.logger,
+                    "Enter IP of node in the Destination Subnet with admin access: ",
+                );
             }
 
             StepType::UnhaltDestinationSubnet | StepType::CompleteCanisterMigration => {

--- a/rs/registry/canister/src/invariants/assignment.rs
+++ b/rs/registry/canister/src/invariants/assignment.rs
@@ -20,8 +20,8 @@ pub(crate) fn check_node_assignment_invariants(
 ) -> Result<(), InvariantCheckError> {
     // Replica
     let replicas: HashSet<NodeId> = get_subnet_records_map(snapshot)
-        .into_iter()
-        .flat_map(|(_, s)| s.membership)
+        .into_values()
+        .flat_map(|s| s.membership)
         .map(|v| NodeId::from(PrincipalId::try_from(v).unwrap()))
         .collect();
 

--- a/rs/registry/canister/src/mutations/firewall.rs
+++ b/rs/registry/canister/src/mutations/firewall.rs
@@ -156,7 +156,7 @@ pub fn add_firewall_rules_compute_entries(
         .collect();
 
     // Add entries from the front to back (sorting with stable sort)
-    tuples.sort_by(|a, b| a.0.cmp(&b.0));
+    tuples.sort_by_key(|a| a.0);
 
     for (already_inserted_above, (mut pos, rule)) in tuples.into_iter().enumerate() {
         // For every new entry we push the position down by the number of already-inserted entries.

--- a/rs/registry/regedit/src/lib.rs
+++ b/rs/registry/regedit/src/lib.rs
@@ -32,7 +32,7 @@ fn registry_spec_to_delta_pb(
 ) -> Result<(Vec<u8>, RegistryVersion)> {
     let (mut registry_changelogs, latest_registry_version) = source::get_changelog(source_spec)?;
     // Sort according to registry versions.
-    registry_changelogs.sort_by(|a, b| a.version.cmp(&b.version));
+    registry_changelogs.sort_by_key(|a| a.version);
     // Clip registry versions that are not within requested interval.
     registry_changelogs.retain(|a| {
         a.version >= start_version

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -663,10 +663,7 @@ impl CanisterQueues {
         F: FnMut(&CanisterId, &RequestOrResponse) -> Result<(), ()>,
     {
         for (canister_id, (_, queue)) in self.canister_queues.iter_mut() {
-            loop {
-                let Some(reference) = queue.peek() else {
-                    break;
-                };
+            while let Some(reference) = queue.peek() {
                 let queue = Arc::make_mut(queue);
                 let Some(msg) = self.store.pool.get(reference) else {
                     // Expired / dropped message. Pop it and advance.

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -1552,7 +1552,7 @@ impl Blocks {
                     .take()
                     .into_values()
                     .collect();
-                transactions.sort_by(|(idx1, _), (idx2, _)| idx1.cmp(idx2));
+                transactions.sort_by_key(|(idx1, _)| *idx1);
                 let rosetta_block = RosettaBlock {
                     index: *current_rosetta_block_index.borrow(),
                     parent_hash: current_rosetta_block_parent_hash

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -869,7 +869,7 @@ impl RosettaRequestHandler {
         });
 
         // Sort the transactions by block index in descending order
-        transactions.sort_by(|a, b| b.block_identifier.index.cmp(&a.block_identifier.index));
+        transactions.sort_by_key(|b| std::cmp::Reverse(b.block_identifier.index));
 
         // If rosetta blocks is empty that means the entire blockchain was traversed but no transactions were found that match the search criteria
         let last_traversed_block_index = blocks.iter().map(|block| block.index).min().unwrap_or(0);

--- a/rs/rosetta-api/icrc1/src/data_api/services.rs
+++ b/rs/rosetta-api/icrc1/src/data_api/services.rs
@@ -514,7 +514,7 @@ pub async fn search_transactions(
     });
 
     // Sort the transactions by block index in descending order
-    transactions.sort_by(|a, b| b.block_identifier.index.cmp(&a.block_identifier.index));
+    transactions.sort_by_key(|b| std::cmp::Reverse(b.block_identifier.index));
 
     // Is rosetta blocks is empty that means the entire blockchain was traversed but no transactions were found that match the search criteria
     let last_traversed_block_index = rosetta_blocks

--- a/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
@@ -1581,6 +1581,7 @@ fn test_account_balance() {
 
                     let mut all_involved_accounts = HashSet::new();
 
+                    #[allow(clippy::explicit_counter_loop)]
                     for ArgWithCaller {
                         caller,
                         arg,

--- a/rs/rosetta-api/icrc1/tests/system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/system_tests.rs
@@ -1312,6 +1312,7 @@ fn test_account_balance() {
 
                     let mut all_involved_accounts = HashSet::new();
 
+                    #[allow(clippy::explicit_counter_loop)]
                     for ArgWithCaller {
                         caller,
                         arg,

--- a/rs/rust_canisters/messaging_test/src/main.rs
+++ b/rs/rust_canisters/messaging_test/src/main.rs
@@ -71,7 +71,7 @@ async fn handle_call((msg, bytes_received_on_call, _): (CallMessage, u32, u32)) 
     // Perform and await the downstream calls; collect the responses.
     let downstream_replies = (futures::future::join_all(futures).await)
         .into_iter()
-        .zip(calls.into_iter())
+        .zip(calls)
         .map(|(reply, call)| match reply {
             Ok(reply) => {
                 let (reply, bytes_sent_on_reply, _) = decode::<ReplyMessage>(reply.into_bytes());

--- a/rs/sns/governance/src/following.rs
+++ b/rs/sns/governance/src/following.rs
@@ -490,7 +490,7 @@ impl TopicFollowees {
                         ValidatedFolloweesForTopic::try_from(followees_for_topic.clone())
                             .map_err(SetFollowingError::InvalidExistingFollowing)?;
 
-                    all_followees.extend(followees_for_topic.followees.into_iter());
+                    all_followees.extend(followees_for_topic.followees);
                 }
 
                 continue;

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1092,7 +1092,7 @@ async fn validate_and_render_upgrade_sns_controlled_canister(
         }
         Ok(wasm) => match wasm.validate(env, canister_upgrade_arg).await {
             Err(new_defects) => {
-                defects.extend(new_defects.into_iter());
+                defects.extend(new_defects);
                 None
             }
             Ok(_) => Some(wasm.description()),

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2763,7 +2763,7 @@ impl StateMachine {
         contents: Vec<CanisterHttpResponseContent>,
     ) {
         assert_eq!(contents.len(), self.nodes.len());
-        for (node, content) in std::iter::zip(self.nodes.iter(), contents.into_iter()) {
+        for (node, content) in std::iter::zip(self.nodes.iter(), contents) {
             let registry_version = self.registry_client.get_latest_version();
             let response = CanisterHttpResponse {
                 id: CanisterHttpRequestId::from(request_id),

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -586,8 +586,8 @@ impl CheckpointLoader {
             format!("Snapshot validation: failed to load list of snapshot ids: {err}")
         })?;
         let mut ref_snapshot_ids: Vec<_> = ref_canister_snapshots
-            .iter()
-            .flat_map(|(_, x)| x.iter().map(|x| *x.0))
+            .values()
+            .flat_map(|x| x.iter().map(|x| *x.0))
             .collect();
         on_disk_snapshot_ids.sort();
         ref_snapshot_ids.sort();

--- a/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
+++ b/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
@@ -307,11 +307,9 @@ async fn test_retrieve_doge_status<F: Fn(Txid) -> bool>(
             RetrieveDogeStatus::Confirmed { txid } => {
                 return txid;
             }
-            RetrieveDogeStatus::Submitted { txid } => {
-                if !blocks_generated {
-                    use bitcoin::hashes::Hash;
-                    blocks_generated = generate_blocks(Txid::from_byte_array(txid.into()));
-                }
+            RetrieveDogeStatus::Submitted { txid } if !blocks_generated => {
+                use bitcoin::hashes::Hash;
+                blocks_generated = generate_blocks(Txid::from_byte_array(txid.into()));
             }
             RetrieveDogeStatus::AmountTooLow => break,
             _ => {}

--- a/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
+++ b/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
@@ -307,9 +307,12 @@ async fn test_retrieve_doge_status<F: Fn(Txid) -> bool>(
             RetrieveDogeStatus::Confirmed { txid } => {
                 return txid;
             }
-            RetrieveDogeStatus::Submitted { txid } if !blocks_generated => {
-                use bitcoin::hashes::Hash;
-                blocks_generated = generate_blocks(Txid::from_byte_array(txid.into()));
+            #[allow(clippy::collapsible_match)]
+            RetrieveDogeStatus::Submitted { txid } => {
+                if !blocks_generated {
+                    use bitcoin::hashes::Hash;
+                    blocks_generated = generate_blocks(Txid::from_byte_array(txid.into()));
+                }
             }
             RetrieveDogeStatus::AmountTooLow => break,
             _ => {}

--- a/rs/tests/ckbtc/src/adapter.rs
+++ b/rs/tests/ckbtc/src/adapter.rs
@@ -228,7 +228,7 @@ impl<'a, T: IcRpcClientType> AdapterProxy<'a, T> {
 
         // Flatten the partial block into a single Vec
         let reconstructed_block = std::iter::once(partial_block)
-            .chain(results.into_iter())
+            .chain(results)
             .flatten()
             .collect::<Vec<_>>();
 

--- a/rs/tests/dre/utils/steps/update_subnet_type.rs
+++ b/rs/tests/dre/utils/steps/update_subnet_type.rs
@@ -225,11 +225,7 @@ async fn assert_version_on_all_nodes(
         })
     });
 
-    if join_all(threads.into_iter())
-        .await
-        .iter()
-        .any(|r| r.is_err())
-    {
+    if join_all(threads).await.iter().any(|r| r.is_err()) {
         anyhow::bail!(
             "Failed to ensure replica version {} on the current subnet",
             version

--- a/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
+++ b/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
@@ -444,8 +444,11 @@ pub fn check_success(
             &actual,
         );
 
-        if responses_received != 0 {
-            let avg_latency_millis = m.latency_distribution.sum_millis() / responses_received;
+        if let Some(avg_latency_millis) = m
+            .latency_distribution
+            .sum_millis()
+            .checked_div(responses_received)
+        {
             expect(
                 avg_latency_millis <= config.targeted_latency_seconds as usize * 1000,
                 i,

--- a/rs/tests/networking/http_endpoints_public_spec_test.rs
+++ b/rs/tests/networking/http_endpoints_public_spec_test.rs
@@ -301,7 +301,7 @@ fn malformed_http_request(env: TestEnv) {
                     Value::Text("request_type".to_string()) => Value::Text(request_type.to_string()),
                     Value::Text("sender".to_string()) => Value::Bytes(Principal::anonymous().as_slice().to_vec()),
                 };
-                valid_content.extend(content.into_iter());
+                valid_content.extend(content);
                 let envelope = |mut content: BTreeMap<Value, Value>| {
                     let ingress_expiry = SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
                         + Duration::from_secs(3 * 60);

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -228,8 +228,8 @@ impl IDkgPayload {
             .flat_map(MasterKeyTranscript::transcript_config_in_creation);
 
         self.pre_signatures_in_creation
-            .iter()
-            .flat_map(|(_, pre_sig)| pre_sig.iter_transcript_configs_in_creation())
+            .values()
+            .flat_map(|pre_sig| pre_sig.iter_transcript_configs_in_creation())
             .chain(key_transcripts)
             .chain(xnet_reshares_transcripts)
     }
@@ -240,8 +240,8 @@ impl IDkgPayload {
         &self,
     ) -> impl Iterator<Item = &IDkgTranscriptParamsRef> + '_ {
         self.pre_signatures_in_creation
-            .iter()
-            .flat_map(|(_, pre_sig)| pre_sig.iter_transcript_configs_in_creation())
+            .values()
+            .flat_map(|pre_sig| pre_sig.iter_transcript_configs_in_creation())
     }
 
     /// Return an iterator of the ongoing xnet reshare transcripts on the source side.

--- a/rs/xnet/payload_builder/src/proximity.rs
+++ b/rs/xnet/payload_builder/src/proximity.rs
@@ -160,11 +160,7 @@ impl ProximityMap {
         }
 
         // Mean weight to assign to nodes that we don't have explicit weights for.
-        let mean_weight = if weighted_nodes > 0 {
-            total_weight / weighted_nodes
-        } else {
-            1
-        };
+        let mean_weight = total_weight.checked_div(weighted_nodes).unwrap_or(1);
 
         // Cumulative node weights, to be used for weighted random selection.
         let cumulative_weights: Vec<u64> = node_weights


### PR DESCRIPTION
This PR prepares for a rustc version bump to v1.95.0 by making all the Rust changes required for the new version. It is a separate PR so that reverting the rustc version bump (if needed) does not create conflicts.