### PR TITLE
fix: build artifact_bundle locally to avoid dangling symlinks under BRE

### DIFF
--- a/publish/defs.bzl
+++ b/publish/defs.bzl
@@ -142,6 +142,13 @@ def _artifact_bundle_impl(ctx):
         },
         outputs = [bundle_root],
         tools = [ctx.executable._sha256],
+        # The bundle is a tree artifact whose children are absolute symlinks into the
+        # execroot (see `ln -s` below). Such symlinks only resolve on the machine that
+        # produced them, so the action must neither run remotely nor be served from the
+        # remote cache: either would materialize dangling symlinks under
+        # Build-without-the-Bytes (BwoB). Setting this here applies to every artifact_bundle
+        # target, so callers don't need `tags = ["no-remote"]` on each one.
+        execution_requirements = {"no-remote": ""},
         command = """
         set -euo pipefail
 


### PR DESCRIPTION
The `artifact_bundle` rule produces a tree artifact whose children are absolute symlinks into the execroot 
(via `ln -s "$(realpath ...)"`). Those symlinks only resolve on the machine that produced them. Under Bazel Remote Execution with build-without-the-bytes (BwoB), the bundle is produced remotely and validated locally, where the symlink targets aren't materialized, so Bazel fails with 'dangling symbolic link'  (e.g. for the testonly `types-test.gz`, which no local action pulls down).

Set `execution_requirements = {"no-remote": ""}` on the action so every `artifact_bundle` target builds locally and is not served from the remote cache, without needing per-target tags.