### PR TITLE
feat: management canister's endpoint list_canisters as inter-canister call

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
@@ -65,7 +65,8 @@ pub(super) fn resolve_destination(
     // Figure out the destination subnet based on the method and the payload.
     let method = Ic00Method::from_str(method_name);
     match method {
-        Ok(Ic00Method::CreateCanister)
+        Ok(Ic00Method::ListCanisters)
+        | Ok(Ic00Method::CreateCanister)
         | Ok(Ic00Method::RawRand)
         | Ok(Ic00Method::ProvisionalCreateCanisterWithCycles)
         | Ok(Ic00Method::HttpRequest)

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -314,6 +314,7 @@ impl SystemStateModifications {
             | Ok(Ic00Method::CanisterStatus)
             | Ok(Ic00Method::CanisterInfo)
             | Ok(Ic00Method::CanisterMetadata)
+            | Ok(Ic00Method::ListCanisters)
             | Ok(Ic00Method::StartCanister)
             | Ok(Ic00Method::StopCanister)
             | Ok(Ic00Method::DeleteCanister)

--- a/rs/execution_environment/benches/management_canister/list_canisters.rs
+++ b/rs/execution_environment/benches/management_canister/list_canisters.rs
@@ -1,0 +1,100 @@
+use crate::create_canisters::CreateCanistersArgs;
+use crate::utils::{CANISTERS_PER_BATCH, expect_reply, test_canister_wasm};
+use candid::{Encode, Principal};
+use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
+use ic_base_types::CanisterId;
+use ic_config::subnet_config::SubnetConfig;
+use ic_config::{execution_environment::Config as HypervisorConfig, flag_status::FlagStatus};
+use ic_registry_subnet_type::SubnetType;
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+
+/// Canister ID assigned to the subnet-admin test canister. On a fresh subnet
+/// the first created canister gets the first ID in the subnet's allocation
+/// range (i.e. `0`), so the test canister is created first (before the
+/// canisters populating the subnet) to receive this ID.
+fn admin_canister_id() -> CanisterId {
+    CanisterId::from_u64(0)
+}
+
+/// Builds a `StateMachine` whose subnet has subnet admins configured (which
+/// requires a `Free` cost schedule on an application subnet), installs the test
+/// canister as the sole subnet admin, and populates the subnet with
+/// `canisters_number` additional canisters.
+fn setup_with_canisters(canisters_number: u64) -> (StateMachine, CanisterId) {
+    let hypervisor_config = HypervisorConfig {
+        rate_limiting_of_heap_delta: FlagStatus::Disabled,
+        ..Default::default()
+    };
+    let admin = admin_canister_id();
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(SubnetType::Application),
+            hypervisor_config,
+        )))
+        .with_checkpoints_enabled(false)
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .build();
+
+    // Create the test canister first so that it receives the first canister ID
+    // in the subnet's allocation range, which matches the pre-configured
+    // subnet-admin ID.
+    let test_canister = env.create_canister_with_cycles(None, Cycles::new(u128::MAX / 2), None);
+    assert_eq!(test_canister, admin);
+    env.install_existing_canister(test_canister, test_canister_wasm(), vec![])
+        .expect("failed to install the test canister");
+
+    // Populate the subnet with `canisters_number` additional canisters via the
+    // test canister (batched inter-canister `create_canister` calls).
+    if canisters_number > 0 {
+        let result = env.execute_ingress(
+            test_canister,
+            "create_canisters",
+            Encode!(&CreateCanistersArgs {
+                canisters_number,
+                canisters_per_batch: CANISTERS_PER_BATCH,
+                initial_cycles: 0,
+            })
+            .unwrap(),
+        );
+        let created: Vec<Principal> = expect_reply(result);
+        assert_eq!(created.len(), canisters_number as usize);
+    }
+
+    (env, test_canister)
+}
+
+fn run_bench<M: criterion::measurement::Measurement>(
+    group: &mut BenchmarkGroup<M>,
+    bench_name: &str,
+    canisters_number: u64,
+) {
+    // `list_canisters` is read-only, so the environment (and its set of
+    // canisters) does not change across iterations and can be set up once.
+    let (env, test_canister) = setup_with_canisters(canisters_number);
+    group.bench_function(bench_name, |b| {
+        b.iter(|| {
+            let result = env.execute_ingress(test_canister, "list_canisters", Encode!().unwrap());
+            let ranges: u64 = expect_reply(result);
+            // At least the range covering the freshly created canisters.
+            assert!(ranges >= 1);
+        });
+    });
+}
+
+pub fn list_canisters_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("list_canisters");
+
+    run_bench(&mut group, "10", 10);
+    run_bench(&mut group, "100", 100);
+    run_bench(&mut group, "1k", 1_000);
+    run_bench(&mut group, "10k", 10_000);
+    run_bench(&mut group, "50k", 50_000);
+
+    group.finish();
+}
+
+criterion_group!(benchmarks, list_canisters_benchmark);
+criterion_main!(benchmarks);

--- a/rs/execution_environment/benches/management_canister/list_canisters.rs
+++ b/rs/execution_environment/benches/management_canister/list_canisters.rs
@@ -20,7 +20,8 @@ fn admin_canister_id() -> CanisterId {
 /// Builds a `StateMachine` whose subnet has subnet admins configured (which
 /// requires a `Free` cost schedule on an application subnet), installs the test
 /// canister as the sole subnet admin, and populates the subnet with
-/// `canisters_number` additional canisters.
+/// `canisters_number` additional canisters. Returns the `StateMachine` and the
+/// test canister ID.
 fn setup_with_canisters(canisters_number: u64) -> (StateMachine, CanisterId) {
     let hypervisor_config = HypervisorConfig {
         rate_limiting_of_heap_delta: FlagStatus::Disabled,

--- a/rs/execution_environment/benches/management_canister/list_canisters.rs
+++ b/rs/execution_environment/benches/management_canister/list_canisters.rs
@@ -86,9 +86,9 @@ fn run_bench<M: criterion::measurement::Measurement>(
         b.iter(|| {
             let result = env.execute_ingress(test_canister, "list_canisters", Encode!().unwrap());
             let ranges: u64 = expect_reply(result);
-            // The canisters are created with gaps, so there should be roughly
-            // one range per canister on the subnet.
-            assert!(ranges >= canisters_number / 2);
+            // The canisters are created with gaps, so there is exactly one
+            // range per canister on the subnet.
+            assert_eq!(ranges, canisters_number);
         });
     });
 }

--- a/rs/execution_environment/benches/management_canister/list_canisters.rs
+++ b/rs/execution_environment/benches/management_canister/list_canisters.rs
@@ -1,6 +1,6 @@
 use crate::create_canisters::CreateCanistersArgs;
 use crate::utils::{CANISTERS_PER_BATCH, expect_reply, test_canister_wasm};
-use candid::{Encode, Principal};
+use candid::Encode;
 use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use ic_base_types::CanisterId;
 use ic_config::subnet_config::SubnetConfig;
@@ -47,21 +47,33 @@ fn setup_with_canisters(canisters_number: u64) -> (StateMachine, CanisterId) {
         .expect("failed to install the test canister");
 
     // Populate the subnet with `canisters_number` additional canisters via the
-    // test canister (batched inter-canister `create_canister` calls).
-    if canisters_number > 0 {
+    // test canister (batched inter-canister calls). The canisters are created
+    // with gaps in between so that the subnet's canister IDs form roughly
+    // `canisters_number` distinct ranges, which `list_canisters` must report.
+    //
+    // The work is split into chunks so that no single ingress message exceeds
+    // the state machine's per-message tick budget (each chunk creates twice as
+    // many canisters and then deletes half of them). Gaps are preserved across
+    // chunk boundaries because each chunk ends with a deleted canister ID.
+    const CHUNK: u64 = 5_000;
+    let mut remaining_to_create = canisters_number;
+    let mut created_ranges = 0;
+    while remaining_to_create > 0 {
+        let chunk = remaining_to_create.min(CHUNK);
+        remaining_to_create -= chunk;
         let result = env.execute_ingress(
             test_canister,
-            "create_canisters",
+            "create_canisters_with_gaps",
             Encode!(&CreateCanistersArgs {
-                canisters_number,
+                canisters_number: chunk,
                 canisters_per_batch: CANISTERS_PER_BATCH,
                 initial_cycles: 0,
             })
             .unwrap(),
         );
-        let created: Vec<Principal> = expect_reply(result);
-        assert_eq!(created.len(), canisters_number as usize);
+        created_ranges += expect_reply::<u64>(result);
     }
+    assert_eq!(created_ranges, canisters_number);
 
     (env, test_canister)
 }
@@ -78,8 +90,9 @@ fn run_bench<M: criterion::measurement::Measurement>(
         b.iter(|| {
             let result = env.execute_ingress(test_canister, "list_canisters", Encode!().unwrap());
             let ranges: u64 = expect_reply(result);
-            // At least the range covering the freshly created canisters.
-            assert!(ranges >= 1);
+            // The canisters are created with gaps, so there should be roughly
+            // one range per canister on the subnet.
+            assert!(ranges >= canisters_number / 2);
         });
     });
 }

--- a/rs/execution_environment/benches/management_canister/list_canisters.rs
+++ b/rs/execution_environment/benches/management_canister/list_canisters.rs
@@ -3,8 +3,8 @@ use crate::utils::{CANISTERS_PER_BATCH, expect_reply, test_canister_wasm};
 use candid::Encode;
 use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use ic_base_types::CanisterId;
+use ic_config::execution_environment::Config as HypervisorConfig;
 use ic_config::subnet_config::SubnetConfig;
-use ic_config::{execution_environment::Config as HypervisorConfig, flag_status::FlagStatus};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
@@ -23,17 +23,12 @@ fn admin_canister_id() -> CanisterId {
 /// `canisters_number` additional canisters. Returns the `StateMachine` and the
 /// test canister ID.
 fn setup_with_canisters(canisters_number: u64) -> (StateMachine, CanisterId) {
-    let hypervisor_config = HypervisorConfig {
-        rate_limiting_of_heap_delta: FlagStatus::Disabled,
-        ..Default::default()
-    };
     let admin = admin_canister_id();
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
             SubnetConfig::new(SubnetType::Application),
-            hypervisor_config,
+            HypervisorConfig::default(),
         )))
-        .with_checkpoints_enabled(false)
         .with_subnet_type(SubnetType::Application)
         .with_cost_schedule(CanisterCyclesCostSchedule::Free)
         .with_subnet_admins(vec![admin.get()])

--- a/rs/execution_environment/benches/management_canister/main.rs
+++ b/rs/execution_environment/benches/management_canister/main.rs
@@ -5,6 +5,7 @@ mod create_execution_state;
 mod ecdsa;
 mod http_request;
 mod install_code;
+mod list_canisters;
 mod update_settings;
 mod utils;
 
@@ -18,6 +19,7 @@ fn all_benchmarks(c: &mut Criterion) {
     ecdsa::ecdsa_benchmark(c);
     http_request::http_request_benchmark(c);
     install_code::install_code_benchmark(c);
+    list_canisters::list_canisters_benchmark(c);
     update_settings::update_settings_benchmark(c);
 }
 

--- a/rs/execution_environment/benches/management_canister/test_canister/candid.did
+++ b/rs/execution_environment/benches/management_canister/test_canister/candid.did
@@ -38,6 +38,7 @@ type http_request_args = record {
 
 service : {
     "create_canisters" : (create_canisters_args) -> (vec principal);
+    "create_canisters_with_gaps" : (create_canisters_args) -> (nat64);
     "install_code" : (install_code_args) -> ();
     "update_settings" : (update_settings_args) -> ();
     "ecdsa_public_key" : (ecdsa_args) -> ();

--- a/rs/execution_environment/benches/management_canister/test_canister/candid.did
+++ b/rs/execution_environment/benches/management_canister/test_canister/candid.did
@@ -43,4 +43,5 @@ service : {
     "ecdsa_public_key" : (ecdsa_args) -> ();
     "sign_with_ecdsa" : (ecdsa_args) -> ();
     "http_request" : (http_request_args) -> ();
+    "list_canisters" : () -> (nat64);
 };

--- a/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
+++ b/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
@@ -10,9 +10,10 @@ use ic_cdk::api::management_canister::http_request::{
     http_request as ic_cdk_http_request,
 };
 use ic_cdk::api::management_canister::main::{
-    CanisterInstallMode, CanisterSettings, CreateCanisterArgument, InstallCodeArgument,
-    UpdateSettingsArgument, create_canister as ic_cdk_create_canister,
-    install_code as ic_cdk_install_code, update_settings as ic_cdk_update_settings,
+    CanisterIdRecord, CanisterInstallMode, CanisterSettings, CreateCanisterArgument,
+    InstallCodeArgument, UpdateSettingsArgument, create_canister as ic_cdk_create_canister,
+    delete_canister as ic_cdk_delete_canister, install_code as ic_cdk_install_code,
+    stop_canister as ic_cdk_stop_canister, update_settings as ic_cdk_update_settings,
 };
 use ic_cdk::call::Call;
 use ic_cdk::update;
@@ -58,6 +59,62 @@ async fn create_canisters(args: CreateCanistersArgs) -> Vec<Principal> {
         remaining_canisters -= batch_size;
     }
     result
+}
+
+/// Creates `2 * args.canisters_number` canisters and then deletes every other
+/// one (in canister ID order), leaving `args.canisters_number` canisters
+/// separated by gaps. As a result, the management canister's `list_canisters`
+/// method reports (roughly) one ID range per remaining canister. Returns the
+/// number of remaining canisters.
+#[update]
+async fn create_canisters_with_gaps(args: CreateCanistersArgs) -> u64 {
+    let mut canister_ids = create_canisters(CreateCanistersArgs {
+        canisters_number: args.canisters_number * 2,
+        canisters_per_batch: args.canisters_per_batch,
+        initial_cycles: args.initial_cycles,
+    })
+    .await;
+
+    // Canister ID principals encode the canister index in big-endian order, so
+    // sorting by the principal's bytes yields the numeric canister ID order.
+    canister_ids.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+
+    // Delete every other canister so that the remaining ones are separated by
+    // gaps (i.e. each remaining canister forms its own ID range).
+    let to_delete: Vec<Principal> = canister_ids.iter().skip(1).step_by(2).copied().collect();
+    let mut remaining = to_delete.as_slice();
+    while !remaining.is_empty() {
+        let batch_size = (args.canisters_per_batch as usize).min(remaining.len());
+        let (batch, rest) = remaining.split_at(batch_size);
+        remaining = rest;
+
+        // A canister must be stopped before it can be deleted.
+        let stop_futures: Vec<_> = batch
+            .iter()
+            .map(|canister_id| {
+                ic_cdk_stop_canister(CanisterIdRecord {
+                    canister_id: *canister_id,
+                })
+            })
+            .collect();
+        join_all(stop_futures).await.into_iter().for_each(|r| {
+            r.unwrap(); // Reject if there is an error.
+        });
+
+        let delete_futures: Vec<_> = batch
+            .iter()
+            .map(|canister_id| {
+                ic_cdk_delete_canister(CanisterIdRecord {
+                    canister_id: *canister_id,
+                })
+            })
+            .collect();
+        join_all(delete_futures).await.into_iter().for_each(|r| {
+            r.unwrap(); // Reject if there is an error.
+        });
+    }
+
+    (canister_ids.len() - to_delete.len()) as u64
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Serialize)]

--- a/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
+++ b/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
@@ -14,6 +14,7 @@ use ic_cdk::api::management_canister::main::{
     UpdateSettingsArgument, create_canister as ic_cdk_create_canister,
     install_code as ic_cdk_install_code, update_settings as ic_cdk_update_settings,
 };
+use ic_cdk::call::Call;
 use ic_cdk::update;
 use serde::{Deserialize, Serialize};
 
@@ -218,6 +219,31 @@ async fn http_request(args: HttpRequestArgs) {
     results.into_iter().for_each(|r| {
         r.unwrap(); // Reject if there is an error.
     });
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
+pub struct CanisterIdRange {
+    pub start: Principal,
+    pub end: Principal,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
+pub struct ListCanistersResult {
+    pub canisters: Vec<CanisterIdRange>,
+}
+
+/// Calls the management canister's `list_canisters` method (which takes no
+/// arguments) and returns the number of canister ID ranges reported for the
+/// subnet. This canister must be a subnet admin for the call to succeed.
+#[update]
+async fn list_canisters() -> u64 {
+    let result: ListCanistersResult =
+        Call::unbounded_wait(Principal::management_canister(), "list_canisters")
+            .await
+            .expect("list_canisters call failed")
+            .candid()
+            .expect("failed to decode list_canisters response");
+    result.canisters.len() as u64
 }
 
 fn main() {}

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -138,6 +138,8 @@ impl CanisterManager {
             Err(_)
             | Ok(Ic00Method::CanisterInfo)
             | Ok(Ic00Method::CanisterMetadata)
+            // `list_canisters` can only be called via inter-canister calls by subnet admins.
+            | Ok(Ic00Method::ListCanisters)
             | Ok(Ic00Method::ECDSAPublicKey)
             | Ok(Ic00Method::SetupInitialDKG)
             | Ok(Ic00Method::SignWithECDSA)

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -465,11 +465,13 @@ pub(crate) fn list_canisters(
 /// The cost model was derived from the `list_canisters` benchmark using the
 /// conversion `2B instructions = 1 second` (i.e. `2M instructions = 1 ms`):
 ///   - a base cost of 20M instructions (≈10ms), and
-///   - a variable cost of 10K instructions per canister hosted on the subnet
+///   - a variable cost of 16K instructions per canister hosted on the subnet
 ///     (`list_canisters` iterates over all of them to build the ID ranges).
+///     The variable cost reflects the worst case where the canister IDs form
+///     gaps so that each canister becomes its own ID range.
 pub(crate) fn list_canisters_instructions(state: &ReplicatedState) -> NumInstructions {
     const BASE_INSTRUCTIONS: u64 = 20_000_000;
-    const INSTRUCTIONS_PER_CANISTER: u64 = 10_000;
+    const INSTRUCTIONS_PER_CANISTER: u64 = 16_000;
     let num_canisters = state.num_canisters() as u64;
     NumInstructions::new(BASE_INSTRUCTIONS + INSTRUCTIONS_PER_CANISTER * num_canisters)
 }

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -6,6 +6,7 @@ use crate::{
     ExecuteMessageResult, HypervisorMetrics, RoundLimits, as_round_instructions,
     canister_manager::types::CanisterManagerError, metrics::CallTreeMetrics,
 };
+use candid::Encode;
 use ic_base_types::{CanisterId, NumBytes, SubnetId};
 use ic_embedders::{
     wasm_executor::{CanisterStateChanges, ExecutionStateChanges, SliceExecutionOutput},
@@ -18,11 +19,14 @@ use ic_interfaces::execution_environment::{
     HypervisorError, HypervisorResult, SubnetAvailableMemory, WasmExecutionOutput,
 };
 use ic_logger::{ReplicaLogger, error, fatal, info, warn};
-use ic_management_canister_types_private::CanisterStatusType;
+use ic_management_canister_types_private::{
+    CanisterIdRange, CanisterStatusType, EmptyBlob, ListCanistersResponse, Payload as _,
+};
+use ic_registry_routing_table::canister_id_into_u64;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CallContext, CallContextAction, CallOrigin, CanisterState, ExecutionState, NetworkTopology,
-    SystemState,
+    ReplicatedState, SystemState,
 };
 use ic_types::ingress::{IngressState, IngressStatus, WasmResult};
 use ic_types::messages::{
@@ -415,6 +419,53 @@ pub(crate) fn validate_controller_or_subnet_admin(
             controller_provided: *sender,
         })
     }
+}
+
+/// Computes the response to the `list_canisters` management canister method.
+///
+/// The method takes no arguments and is only available on subnets with subnet
+/// admins configured, in which case the caller must be a subnet admin. On
+/// success, it returns the Candid-encoded `ListCanistersResponse` listing the
+/// ranges of canister IDs hosted on this subnet.
+pub(crate) fn list_canisters(
+    state: &ReplicatedState,
+    caller: &PrincipalId,
+    payload: &[u8],
+) -> Result<Vec<u8>, UserError> {
+    EmptyBlob::decode(payload)?;
+    match state.get_own_subnet_admins() {
+        Some(ref admins) => validate_subnet_admin(admins, caller).map_err(UserError::from)?,
+        None => {
+            return Err(UserError::new(
+                ErrorCode::CanisterRejectedMessage,
+                "list_canisters is only available on subnets with subnet admins",
+            ));
+        }
+    }
+    let mut canisters: Vec<CanisterIdRange> = Vec::new();
+    for id in state.canister_states().all_keys() {
+        let id_u64 = canister_id_into_u64(*id);
+        match canisters.last_mut() {
+            Some(last) if canister_id_into_u64(last.end).checked_add(1) == Some(id_u64) => {
+                last.end = *id;
+            }
+            _ => canisters.push(CanisterIdRange {
+                start: *id,
+                end: *id,
+            }),
+        }
+    }
+    let response = ListCanistersResponse { canisters };
+    Ok(Encode!(&response).unwrap())
+}
+
+/// Computes the number of round instructions consumed by executing the
+/// `list_canisters` management method against the given state.
+///
+/// TODO: Replace this placeholder with an actual cost model (e.g. proportional
+/// to the number of canisters hosted on the subnet).
+pub(crate) fn list_canisters_instructions(_state: &ReplicatedState) -> NumInstructions {
+    NumInstructions::new(1)
 }
 
 /// Unregisters the callback corresponding to the given response.

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -469,6 +469,8 @@ pub(crate) fn list_canisters(
 ///     (`list_canisters` iterates over all of them to build the ID ranges).
 ///     The variable cost reflects the worst case where the canister IDs form
 ///     gaps so that each canister becomes its own ID range.
+// Keep in sync with `list_canisters_respects_round_instruction_limit` in
+// `execution_test.rs`.
 pub(crate) fn list_canisters_instructions(state: &ReplicatedState) -> NumInstructions {
     const BASE_INSTRUCTIONS: u64 = 20_000_000;
     const INSTRUCTIONS_PER_CANISTER: u64 = 16_000;

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -462,10 +462,16 @@ pub(crate) fn list_canisters(
 /// Computes the number of round instructions consumed by executing the
 /// `list_canisters` management method against the given state.
 ///
-/// TODO: Replace this placeholder with an actual cost model (e.g. proportional
-/// to the number of canisters hosted on the subnet).
-pub(crate) fn list_canisters_instructions(_state: &ReplicatedState) -> NumInstructions {
-    NumInstructions::new(1)
+/// The cost model was derived from the `list_canisters` benchmark using the
+/// conversion `2B instructions = 1 second` (i.e. `2M instructions = 1 ms`):
+///   - a base cost of 20M instructions (≈10ms), and
+///   - a variable cost of 10K instructions per canister hosted on the subnet
+///     (`list_canisters` iterates over all of them to build the ID ranges).
+pub(crate) fn list_canisters_instructions(state: &ReplicatedState) -> NumInstructions {
+    const BASE_INSTRUCTIONS: u64 = 20_000_000;
+    const INSTRUCTIONS_PER_CANISTER: u64 = 10_000;
+    let num_canisters = state.num_canisters() as u64;
+    NumInstructions::new(BASE_INSTRUCTIONS + INSTRUCTIONS_PER_CANISTER * num_canisters)
 }
 
 /// Unregisters the callback corresponding to the given response.

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -426,12 +426,13 @@ pub(crate) fn validate_controller_or_subnet_admin(
 /// The method takes no arguments and is only available on subnets with subnet
 /// admins configured, in which case the caller must be a subnet admin. On
 /// success, it returns the Candid-encoded `ListCanistersResponse` listing the
-/// ranges of canister IDs hosted on this subnet.
+/// ranges of canister IDs hosted on this subnet, together with the number of
+/// round instructions the caller must deduct for computing it.
 pub(crate) fn list_canisters(
     state: &ReplicatedState,
     caller: &PrincipalId,
     payload: &[u8],
-) -> Result<Vec<u8>, UserError> {
+) -> Result<(Vec<u8>, NumInstructions), UserError> {
     EmptyBlob::decode(payload)?;
     match state.get_own_subnet_admins() {
         Some(ref admins) => validate_subnet_admin(admins, caller).map_err(UserError::from)?,
@@ -456,7 +457,10 @@ pub(crate) fn list_canisters(
         }
     }
     let response = ListCanistersResponse { canisters };
-    Ok(Encode!(&response).unwrap())
+    Ok((
+        Encode!(&response).unwrap(),
+        list_canisters_instructions(state),
+    ))
 }
 
 /// Computes the number of round instructions consumed by executing the
@@ -471,7 +475,7 @@ pub(crate) fn list_canisters(
 ///     gaps so that each canister becomes its own ID range.
 // Keep in sync with `list_canisters_respects_round_instruction_limit` in
 // `execution_test.rs`.
-pub(crate) fn list_canisters_instructions(state: &ReplicatedState) -> NumInstructions {
+fn list_canisters_instructions(state: &ReplicatedState) -> NumInstructions {
     const BASE_INSTRUCTIONS: u64 = 20_000_000;
     const INSTRUCTIONS_PER_CANISTER: u64 = 16_000;
     let num_canisters = state.num_canisters() as u64;

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -6,7 +6,7 @@ use crate::canister_manager::types::{
 };
 use crate::canister_settings::CanisterSettings;
 use crate::execution::call_or_task::execute_call_or_task;
-use crate::execution::common::validate_controller;
+use crate::execution::common::{list_canisters, list_canisters_instructions, validate_controller};
 use crate::execution::inspect_message;
 use crate::execution::response::execute_response;
 use crate::execution_environment_metrics::{
@@ -1082,6 +1082,21 @@ impl ExecutionEnvironment {
                     refund: msg.take_cycles(),
                 }
             }
+
+            Ok(Ic00Method::ListCanisters) => match &msg {
+                CanisterCall::Request(_) => {
+                    round_limits.instructions -=
+                        as_round_instructions(list_canisters_instructions(&state));
+                    let res = list_canisters(&state, msg.sender(), payload).map(|res| (res, None));
+                    ExecuteSubnetMessageResult::Finished {
+                        response: res,
+                        refund: msg.take_cycles(),
+                    }
+                }
+                CanisterCall::Ingress(_) => {
+                    self.reject_unexpected_ingress(Ic00Method::ListCanisters)
+                }
+            },
 
             Ok(Ic00Method::CanisterInfo) => match &msg {
                 CanisterCall::Request(_) => {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -6,7 +6,7 @@ use crate::canister_manager::types::{
 };
 use crate::canister_settings::CanisterSettings;
 use crate::execution::call_or_task::execute_call_or_task;
-use crate::execution::common::{list_canisters, list_canisters_instructions, validate_controller};
+use crate::execution::common::{list_canisters, validate_controller};
 use crate::execution::inspect_message;
 use crate::execution::response::execute_response;
 use crate::execution_environment_metrics::{
@@ -1085,15 +1085,15 @@ impl ExecutionEnvironment {
 
             Ok(Ic00Method::ListCanisters) => match &msg {
                 CanisterCall::Request(_) => {
-                    let res = list_canisters(&state, msg.sender(), payload).map(|res| (res, None));
                     // Only deduct round instructions for building the response
                     // (i.e. the canister ID range computation) when access
                     // control succeeds; a rejected call must not consume round
                     // instructions.
-                    if res.is_ok() {
-                        round_limits.instructions -=
-                            as_round_instructions(list_canisters_instructions(&state));
-                    }
+                    let res =
+                        list_canisters(&state, msg.sender(), payload).map(|(res, instructions)| {
+                            round_limits.instructions -= as_round_instructions(instructions);
+                            (res, None)
+                        });
                     ExecuteSubnetMessageResult::Finished {
                         response: res,
                         refund: msg.take_cycles(),

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1086,9 +1086,10 @@ impl ExecutionEnvironment {
             Ok(Ic00Method::ListCanisters) => match &msg {
                 CanisterCall::Request(_) => {
                     let res = list_canisters(&state, msg.sender(), payload).map(|res| (res, None));
-                    // Only charge for the cost of building the response (i.e. the
-                    // canister ID range computation) when access control succeeds;
-                    // a rejected call must not consume round instructions.
+                    // Only deduct round instructions for building the response
+                    // (i.e. the canister ID range computation) when access
+                    // control succeeds; a rejected call must not consume round
+                    // instructions.
                     if res.is_ok() {
                         round_limits.instructions -=
                             as_round_instructions(list_canisters_instructions(&state));

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1085,9 +1085,14 @@ impl ExecutionEnvironment {
 
             Ok(Ic00Method::ListCanisters) => match &msg {
                 CanisterCall::Request(_) => {
-                    round_limits.instructions -=
-                        as_round_instructions(list_canisters_instructions(&state));
                     let res = list_canisters(&state, msg.sender(), payload).map(|res| (res, None));
+                    // Only charge for the cost of building the response (i.e. the
+                    // canister ID range computation) when access control succeeds;
+                    // a rejected call must not consume round instructions.
+                    if res.is_ok() {
+                        round_limits.instructions -=
+                            as_round_instructions(list_canisters_instructions(&state));
+                    }
                     ExecuteSubnetMessageResult::Finished {
                         response: res,
                         refund: msg.take_cycles(),

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -30,6 +30,7 @@ use ic_test_utilities_execution_environment::{
     get_reject, get_reply,
 };
 use ic_test_utilities_metrics::{fetch_histogram_vec_count, metric_vec};
+use ic_test_utilities_state::CanisterStateBuilder;
 use ic_types::{
     CanisterId, CountBytes, PrincipalId, RegistryVersion,
     canister_http::{CanisterHttpMethod, PricingVersion, Replication, Transform},
@@ -5833,4 +5834,86 @@ fn stopping_canister_not_controlled_by_caller_refunds_cycles() {
     );
     let res = stop_canister_refunds_cycles(&mut test, proxy, canister_id);
     let _ = get_reject(res);
+}
+
+// A subnet admin canister can call `list_canisters` via an inter-canister call
+// and receives the coalesced ranges of canister IDs hosted on the subnet.
+#[test]
+fn list_canisters_via_inter_canister_call_succeeds() {
+    let own_subnet = subnet_test_id(1);
+    let caller_subnet = subnet_test_id(2);
+    let caller_canister = canister_test_id(1);
+    let mut test = ExecutionTestBuilder::new()
+        .with_own_subnet_id(own_subnet)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![caller_canister.get()])
+        .with_caller(caller_subnet, caller_canister)
+        .build();
+
+    // IDs 5, 6, 7 are consecutive (coalesce into [5,7]) and ID 10 is isolated.
+    for raw_id in [5_u64, 6, 7, 10] {
+        test.state_mut().put_canister_state(
+            CanisterStateBuilder::new()
+                .with_canister_id(CanisterId::from(raw_id))
+                .build(),
+        );
+    }
+
+    test.inject_call_to_ic00(Method::ListCanisters, EmptyBlob.encode(), Cycles::new(0));
+    test.execute_all();
+
+    let RequestOrResponse::Response(response) = test.xnet_messages()[0].clone() else {
+        panic!("Type should be RequestOrResponse::Response");
+    };
+    assert_eq!(response.originator, caller_canister);
+    let Payload::Data(data) = &response.response_payload else {
+        panic!(
+            "list_canisters was rejected: {:?}",
+            response.response_payload
+        );
+    };
+    let list = ic00::ListCanistersResponse::decode(data).unwrap();
+    assert_eq!(
+        list.canisters,
+        vec![
+            ic00::CanisterIdRange {
+                start: CanisterId::from(5_u64),
+                end: CanisterId::from(7_u64),
+            },
+            ic00::CanisterIdRange {
+                start: CanisterId::from(10_u64),
+                end: CanisterId::from(10_u64),
+            },
+        ]
+    );
+}
+
+// A non-admin canister calling `list_canisters` via an inter-canister call is
+// rejected.
+#[test]
+fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
+    let own_subnet = subnet_test_id(1);
+    let caller_subnet = subnet_test_id(2);
+    let admin = canister_test_id(1);
+    let non_admin = canister_test_id(2);
+    let mut test = ExecutionTestBuilder::new()
+        .with_own_subnet_id(own_subnet)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .with_caller(caller_subnet, non_admin)
+        .build();
+
+    test.inject_call_to_ic00(Method::ListCanisters, EmptyBlob.encode(), Cycles::new(0));
+    test.execute_all();
+
+    let RequestOrResponse::Response(response) = test.xnet_messages()[0].clone() else {
+        panic!("Type should be RequestOrResponse::Response");
+    };
+    let Payload::Reject(context) = &response.response_payload else {
+        panic!(
+            "Expected a reject response, got: {:?}",
+            response.response_payload
+        );
+    };
+    assert_eq!(context.code(), RejectCode::CanisterReject);
 }

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -5917,3 +5917,27 @@ fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
     };
     assert_eq!(context.code(), RejectCode::CanisterReject);
 }
+
+// `list_canisters` can only be called via an inter-canister call; an ingress
+// message is rejected by the ingress filter before execution, since
+// `list_canisters` is not among the ic00 methods allowed via ingress, even if
+// the caller is a subnet admin.
+#[test]
+fn list_canisters_via_ingress_fails() {
+    let admin = user_test_id(1);
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .build();
+    test.set_user_id(admin);
+
+    let result =
+        test.should_accept_ingress_message(IC_00, Method::ListCanisters, EmptyBlob.encode());
+    assert_eq!(
+        result,
+        Err(UserError::new(
+            ErrorCode::CanisterRejectedMessage,
+            "ic00 method list_canisters can not be called via ingress messages"
+        ))
+    );
+}

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -5923,7 +5923,7 @@ fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
 // `list_canisters` is not among the ic00 methods allowed via ingress, even if
 // the caller is a subnet admin.
 #[test]
-fn list_canisters_via_ingress_fails() {
+fn list_canisters_via_ingress_fails_at_ingress_filter() {
     let admin = user_test_id(1);
     let mut test = ExecutionTestBuilder::new()
         .with_cost_schedule(CanisterCyclesCostSchedule::Free)
@@ -5939,5 +5939,27 @@ fn list_canisters_via_ingress_fails() {
             ErrorCode::CanisterRejectedMessage,
             "ic00 method list_canisters can not be called via ingress messages"
         ))
+    );
+}
+
+// Even if an ingress message reaches `execute_subnet_message`, `list_canisters`
+// is still rejected: it can only be called via an inter-canister call, even by
+// a subnet admin.
+#[test]
+fn list_canisters_via_ingress_fails_at_execution() {
+    let admin = user_test_id(1);
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .build();
+    test.set_user_id(admin);
+
+    let err = test
+        .subnet_message(Method::ListCanisters, EmptyBlob.encode())
+        .unwrap_err();
+    assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
+    assert!(
+        err.description()
+            .contains("list_canisters cannot be called by a user")
     );
 }

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -30,7 +30,6 @@ use ic_test_utilities_execution_environment::{
     get_reject, get_reply,
 };
 use ic_test_utilities_metrics::{fetch_histogram_vec_count, metric_vec};
-use ic_test_utilities_state::CanisterStateBuilder;
 use ic_types::{
     CanisterId, CountBytes, PrincipalId, RegistryVersion,
     canister_http::{CanisterHttpMethod, PricingVersion, Replication, Transform},
@@ -5834,88 +5833,6 @@ fn stopping_canister_not_controlled_by_caller_refunds_cycles() {
     );
     let res = stop_canister_refunds_cycles(&mut test, proxy, canister_id);
     let _ = get_reject(res);
-}
-
-// A subnet admin canister can call `list_canisters` via an inter-canister call
-// and receives the coalesced ranges of canister IDs hosted on the subnet.
-#[test]
-fn list_canisters_via_inter_canister_call_succeeds() {
-    let own_subnet = subnet_test_id(1);
-    let caller_subnet = subnet_test_id(2);
-    let caller_canister = canister_test_id(1);
-    let mut test = ExecutionTestBuilder::new()
-        .with_own_subnet_id(own_subnet)
-        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
-        .with_subnet_admins(vec![caller_canister.get()])
-        .with_caller(caller_subnet, caller_canister)
-        .build();
-
-    // IDs 5, 6, 7 are consecutive (coalesce into [5,7]) and ID 10 is isolated.
-    for raw_id in [5_u64, 6, 7, 10] {
-        test.state_mut().put_canister_state(
-            CanisterStateBuilder::new()
-                .with_canister_id(CanisterId::from(raw_id))
-                .build(),
-        );
-    }
-
-    test.inject_call_to_ic00(Method::ListCanisters, EmptyBlob.encode(), Cycles::new(0));
-    test.execute_all();
-
-    let RequestOrResponse::Response(response) = test.xnet_messages()[0].clone() else {
-        panic!("Type should be RequestOrResponse::Response");
-    };
-    assert_eq!(response.originator, caller_canister);
-    let Payload::Data(data) = &response.response_payload else {
-        panic!(
-            "list_canisters was rejected: {:?}",
-            response.response_payload
-        );
-    };
-    let list = ic00::ListCanistersResponse::decode(data).unwrap();
-    assert_eq!(
-        list.canisters,
-        vec![
-            ic00::CanisterIdRange {
-                start: CanisterId::from(5_u64),
-                end: CanisterId::from(7_u64),
-            },
-            ic00::CanisterIdRange {
-                start: CanisterId::from(10_u64),
-                end: CanisterId::from(10_u64),
-            },
-        ]
-    );
-}
-
-// A non-admin canister calling `list_canisters` via an inter-canister call is
-// rejected.
-#[test]
-fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
-    let own_subnet = subnet_test_id(1);
-    let caller_subnet = subnet_test_id(2);
-    let admin = canister_test_id(1);
-    let non_admin = canister_test_id(2);
-    let mut test = ExecutionTestBuilder::new()
-        .with_own_subnet_id(own_subnet)
-        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
-        .with_subnet_admins(vec![admin.get()])
-        .with_caller(caller_subnet, non_admin)
-        .build();
-
-    test.inject_call_to_ic00(Method::ListCanisters, EmptyBlob.encode(), Cycles::new(0));
-    test.execute_all();
-
-    let RequestOrResponse::Response(response) = test.xnet_messages()[0].clone() else {
-        panic!("Type should be RequestOrResponse::Response");
-    };
-    let Payload::Reject(context) = &response.response_payload else {
-        panic!(
-            "Expected a reject response, got: {:?}",
-            response.response_payload
-        );
-    };
-    assert_eq!(context.code(), RejectCode::CanisterReject);
 }
 
 // `list_canisters` can only be called via an inter-canister call; an ingress

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -295,6 +295,7 @@ impl ExecutionEnvironmentMetrics {
                     ic00::Method::CanisterStatus
                     | ic00::Method::CanisterInfo
                     | ic00::Method::CanisterMetadata
+                    | ic00::Method::ListCanisters
                     | ic00::Method::CreateCanister
                     | ic00::Method::DeleteCanister
                     | ic00::Method::DepositCycles

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -37,6 +37,12 @@ impl Ic00MethodPermissions {
             Ic00Method::CanisterStatus
             | Ic00Method::CanisterInfo
             | Ic00Method::CanisterMetadata
+            // NOTE: `ListCanisters` does consume round instructions, but it has
+            // no effective canister ID and therefore never reaches
+            // `can_be_executed` (see `can_execute_subnet_msg` in `scheduler.rs`),
+            // so `counts_toward_round_limit` is not consulted for it. Its
+            // round-instruction deferral is handled by a dedicated special case
+            // in `can_execute_subnet_msg` instead.
             | Ic00Method::ListCanisters
             | Ic00Method::DepositCycles
             | Ic00Method::ECDSAPublicKey

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -37,6 +37,7 @@ impl Ic00MethodPermissions {
             Ic00Method::CanisterStatus
             | Ic00Method::CanisterInfo
             | Ic00Method::CanisterMetadata
+            | Ic00Method::ListCanisters
             | Ic00Method::DepositCycles
             | Ic00Method::ECDSAPublicKey
             | Ic00Method::SignWithECDSA

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -55,12 +55,10 @@ use tokio::sync::oneshot;
 use tower::{Service, util::BoxCloneService};
 
 pub(crate) use self::query_scheduler::QueryScheduler;
-use crate::execution::common::validate_subnet_admin;
+use crate::execution::common::list_canisters;
 use ic_management_canister_types_private::{
-    CanisterIdRange, CanisterIdRecord, CanisterMetricsArgs, EmptyBlob, FetchCanisterLogsRequest,
-    ListCanistersResponse, Payload, QueryMethod,
+    CanisterIdRecord, CanisterMetricsArgs, FetchCanisterLogsRequest, Payload, QueryMethod,
 };
-use ic_registry_routing_table::canister_id_into_u64;
 
 pub struct DataCertificateWithDelegationMetadata {
     pub data_certificate: Vec<u8>,
@@ -176,47 +174,6 @@ impl InternalHttpQueryHandler {
         self.local_query_execution_stats.set_epoch(epoch);
     }
 
-    fn list_canisters(
-        &self,
-        state: &ReplicatedState,
-        caller: &ic_types::PrincipalId,
-        payload: &[u8],
-    ) -> Result<WasmResult, UserError> {
-        match EmptyBlob::decode(payload) {
-            Err(err) => Err(err),
-            Ok(EmptyBlob) => {
-                match state.get_own_subnet_admins() {
-                    Some(ref admins) => {
-                        validate_subnet_admin(admins, caller).map_err(UserError::from)?
-                    }
-                    None => {
-                        return Err(UserError::new(
-                            ErrorCode::CanisterRejectedMessage,
-                            "list_canisters is only available on subnets with subnet admins",
-                        ));
-                    }
-                }
-                let mut canisters: Vec<CanisterIdRange> = Vec::new();
-                for id in state.canister_states().all_keys() {
-                    let id_u64 = canister_id_into_u64(*id);
-                    match canisters.last_mut() {
-                        Some(last)
-                            if canister_id_into_u64(last.end).checked_add(1) == Some(id_u64) =>
-                        {
-                            last.end = *id;
-                        }
-                        _ => canisters.push(CanisterIdRange {
-                            start: *id,
-                            end: *id,
-                        }),
-                    }
-                }
-                let response = ListCanistersResponse { canisters };
-                Ok(WasmResult::Reply(Encode!(&response).unwrap()))
-            }
-        }
-    }
-
     /// Handle a query of type `Query`.
     pub fn query(
         &self,
@@ -295,8 +252,8 @@ impl InternalHttpQueryHandler {
                 Ok(QueryMethod::ListCanisters) => {
                     let since = Instant::now();
                     let caller = query.source();
-                    let result =
-                        self.list_canisters(state.get_ref(), &caller, &query.method_payload);
+                    let result = list_canisters(state.get_ref(), &caller, &query.method_payload)
+                        .map(WasmResult::Reply);
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::ListCanisters,
                         since.elapsed().as_secs_f64(),

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -253,7 +253,7 @@ impl InternalHttpQueryHandler {
                     let since = Instant::now();
                     let caller = query.source();
                     let result = list_canisters(state.get_ref(), &caller, &query.method_payload)
-                        .map(WasmResult::Reply);
+                        .map(|(res, _instructions)| WasmResult::Reply(res));
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::ListCanisters,
                         since.elapsed().as_secs_f64(),

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1832,6 +1832,22 @@ fn can_execute_subnet_msg(
     canister_states: &CanisterStates,
     round_limits: &mut RoundLimits,
 ) -> bool {
+    let msg_method = match msg {
+        SubnetMessage::Ingress(ingress) => Ic00Method::from_str(ingress.method_name.as_str()).ok(),
+        SubnetMessage::Request(request) => Ic00Method::from_str(request.method_name.as_str()).ok(),
+        SubnetMessage::Response { .. } => None,
+    };
+
+    // Some heavy methods use round instructions.
+    let instructions_reached = round_limits.instructions_reached();
+
+    // `list_canisters` iterates over the subnet's canisters and thus consumes
+    // round instructions, even though it has no effective canister ID. Defer it
+    // to a later round if the round instruction limit has already been reached.
+    if let Some(Ic00Method::ListCanisters) = msg_method {
+        return !instructions_reached;
+    }
+
     let Some(effective_canister_id) = msg.effective_canister_id() else {
         // If there is no effective canister ID, execute the subnet message.
         return true;
@@ -1840,12 +1856,7 @@ fn can_execute_subnet_msg(
         // If there is no effective canister state, execute the subnet message.
         return true;
     };
-    let maybe_method = match msg {
-        SubnetMessage::Ingress(ingress) => Ic00Method::from_str(ingress.method_name.as_str()).ok(),
-        SubnetMessage::Request(request) => Ic00Method::from_str(request.method_name.as_str()).ok(),
-        SubnetMessage::Response { .. } => None,
-    };
-    let Some(method) = maybe_method else {
+    let Some(method) = msg_method else {
         // If this is a response or the method name is not valid, execute the message.
         return true;
     };
@@ -1870,9 +1881,6 @@ fn can_execute_subnet_msg(
                 return false;
             }
         };
-
-    // Some heavy methods use round instructions.
-    let instructions_reached = round_limits.instructions_reached();
 
     let permissions = Ic00MethodPermissions::new(method);
     permissions.can_be_executed(
@@ -1908,6 +1916,7 @@ fn get_instruction_limits_for_subnet_message(
             CanisterStatus
             | CanisterInfo
             | CanisterMetadata
+            | ListCanisters
             | CreateCanister
             | DeleteCanister
             | DepositCycles

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2832,6 +2832,115 @@ fn canister_status_via_query_call_by_subnet_admin_succeeds() {
     assert_eq!(canister_status_count(&env), 1);
 }
 
+// `list_canisters` consumes round instructions according to its cost model (a
+// base cost plus a per-canister cost). This test checks that the round
+// instruction limit is respected: when many `list_canisters` calls are pending
+// at once, the per-round subnet-message instruction budget only allows some of
+// them to execute per round, so the rest are deferred to later rounds (i.e. not
+// all calls execute in the same round).
+#[test]
+fn list_canisters_respects_round_instruction_limit() {
+    // Keep in sync with `list_canisters_instructions` in `execution/common.rs`.
+    const BASE_INSTRUCTIONS: u64 = 20_000_000;
+    const INSTRUCTIONS_PER_CANISTER: u64 = 16_000;
+    // Number of concurrent `list_canisters` calls. Chosen large enough that they
+    // cannot all fit within a single round's subnet-message instruction budget
+    // (`max_instructions_per_round / 16`, which with the default configuration
+    // fits at most ~12 calls of ~20M instructions each).
+    const NUM_CALLS: u64 = 30;
+
+    // The admin canister is created first so that it gets the first canister ID
+    // in the subnet's range, matching the configured subnet admin.
+    let admin = CanisterId::from_u64(0);
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(SubnetType::Application),
+            HypervisorConfig::default(),
+        )))
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .build();
+
+    let admin_canister = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+    assert_eq!(admin_canister, admin);
+
+    let num_canisters = env.get_latest_state().num_canisters() as u64;
+    let cost_per_call = BASE_INSTRUCTIONS + INSTRUCTIONS_PER_CANISTER * num_canisters;
+
+    // Build an update that fires `NUM_CALLS` concurrent `list_canisters`
+    // inter-canister calls (ignoring their responses) and then replies. After
+    // this single message executes, all `NUM_CALLS` calls are pending as subnet
+    // messages at the same time.
+    let mut update = wasm();
+    for _ in 0..NUM_CALLS {
+        update = update.call_simple(
+            CanisterId::ic_00(),
+            "list_canisters",
+            call_args()
+                .other_side(EmptyBlob.encode())
+                .on_reply(wasm().noop())
+                .on_reject(wasm().noop()),
+        );
+    }
+    let update = update.reply().build();
+
+    // `send_ingress` executes a single round in which the update runs and
+    // enqueues all `NUM_CALLS` calls; they are only drained in subsequent rounds.
+    let baseline = env.subnet_message_instructions();
+    let msg_id = env.send_ingress(
+        PrincipalId::new_anonymous(),
+        admin_canister,
+        "update",
+        update,
+    );
+
+    // Execute rounds one at a time, tracking after each round how many
+    // `list_canisters` calls have been executed so far. Each executed call
+    // consumes exactly `cost_per_call` round instructions in the subnet-message
+    // phase (the number of canisters on the subnet does not change), so the
+    // cumulative charge divided by `cost_per_call` yields the number of executed
+    // calls.
+    let executed_so_far =
+        || ((env.subnet_message_instructions() - baseline) / cost_per_call as f64).round() as u64;
+    let mut executed_per_round = vec![];
+    for _ in 0..100 {
+        env.tick();
+        executed_per_round.push(executed_so_far());
+        if executed_so_far() == NUM_CALLS {
+            break;
+        }
+    }
+
+    // The update itself succeeded.
+    assert_matches!(
+        env.ingress_status(&msg_id),
+        IngressStatus::Known {
+            state: IngressState::Completed(_),
+            ..
+        }
+    );
+
+    // Not all `list_canisters` calls were executed in the same round: there is a
+    // round after which some but not all of them had been executed.
+    assert!(
+        executed_per_round.iter().any(|&n| n > 0 && n < NUM_CALLS),
+        "expected list_canisters calls to be spread across rounds, got progression {:?}",
+        executed_per_round,
+    );
+    // Eventually all of them were executed, each charged exactly per the cost
+    // model, confirming the round instruction accounting.
+    assert_eq!(*executed_per_round.last().unwrap(), NUM_CALLS);
+    assert_eq!(
+        env.subnet_message_instructions() - baseline,
+        (NUM_CALLS * cost_per_call) as f64
+    );
+}
+
 #[test]
 fn canister_status_via_query_call_by_neither_controller_nor_subnet_admin_fails() {
     let subnet_config = SubnetConfig::new(SubnetType::Application);

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2907,6 +2907,7 @@ fn list_canisters_respects_round_instruction_limit() {
     // enqueues all `NUM_CALLS` calls; they are only drained in subsequent rounds.
     let instructions_baseline = env.subnet_message_instructions();
     let calls_baseline = list_canisters_count(&env);
+    assert_eq!(calls_baseline, 0);
     env.send_ingress(
         PrincipalId::new_anonymous(),
         admin_canister,

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2832,6 +2832,20 @@ fn canister_status_via_query_call_by_subnet_admin_succeeds() {
     assert_eq!(canister_status_count(&env), 1);
 }
 
+fn list_canisters_count(env: &StateMachine) -> u64 {
+    fetch_histogram_vec_stats(
+        env.metrics_registry(),
+        "execution_subnet_message_duration_seconds",
+    )
+    .get(&labels(&[
+        ("method_name", "ic00_list_canisters"),
+        ("outcome", "finished"),
+        ("status", "success"),
+        ("speed", "fast"),
+    ]))
+    .map_or(0, |stats| stats.count)
+}
+
 // `list_canisters` consumes round instructions according to its cost model (a
 // base cost plus a per-canister cost). This test checks that the round
 // instruction limit is respected: when many `list_canisters` calls are pending
@@ -2891,7 +2905,8 @@ fn list_canisters_respects_round_instruction_limit() {
 
     // `send_ingress` executes a single round in which the update runs and
     // enqueues all `NUM_CALLS` calls; they are only drained in subsequent rounds.
-    let baseline = env.subnet_message_instructions();
+    let instructions_baseline = env.subnet_message_instructions();
+    let calls_baseline = list_canisters_count(&env);
     let msg_id = env.send_ingress(
         PrincipalId::new_anonymous(),
         admin_canister,
@@ -2900,13 +2915,10 @@ fn list_canisters_respects_round_instruction_limit() {
     );
 
     // Execute rounds one at a time, tracking after each round how many
-    // `list_canisters` calls have been executed so far. Each executed call
-    // consumes exactly `cost_per_call` round instructions in the subnet-message
-    // phase (the number of canisters on the subnet does not change), so the
-    // cumulative charge divided by `cost_per_call` yields the number of executed
-    // calls.
-    let executed_so_far =
-        || ((env.subnet_message_instructions() - baseline) / cost_per_call as f64).round() as u64;
+    // `list_canisters` calls have been executed so far, using the
+    // `execution_subnet_message_duration_seconds` metric to count them
+    // explicitly (rather than inferring the count from consumed instructions).
+    let executed_so_far = || list_canisters_count(&env) - calls_baseline;
     let mut executed_per_round = vec![];
     for _ in 0..100 {
         env.tick();
@@ -2932,11 +2944,12 @@ fn list_canisters_respects_round_instruction_limit() {
         "expected list_canisters calls to be spread across rounds, got progression {:?}",
         executed_per_round,
     );
-    // Eventually all of them were executed, each charged exactly per the cost
-    // model, confirming the round instruction accounting.
+    // Eventually all of them were executed.
     assert_eq!(*executed_per_round.last().unwrap(), NUM_CALLS);
+    // Each executed call was charged exactly per the cost model, confirming the
+    // round instruction accounting.
     assert_eq!(
-        env.subnet_message_instructions() - baseline,
+        env.subnet_message_instructions() - instructions_baseline,
         (NUM_CALLS * cost_per_call) as f64
     );
 }

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -13,15 +13,15 @@ use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterInstallModeV2, CanisterMetadataRequest, CanisterMetadataResponse,
     CanisterMetricsArgs, CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2,
     CreateCanisterArgs, DerivationPath, EcdsaKeyId, EmptyBlob, IC_00, InstallCodeArgsV2,
-    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method, Payload, SignWithECDSAArgs,
-    TakeCanisterSnapshotArgs, UpdateSettingsArgs,
+    ListCanistersResponse, LoadCanisterSnapshotArgs, MasterPublicKeyId, Method, Payload,
+    SignWithECDSAArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
 };
 use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{
     ErrorCode, StateMachine, StateMachineBuilder, StateMachineConfig, UserError,
 };
-use ic_test_utilities_execution_environment::get_reply;
+use ic_test_utilities_execution_environment::{get_reject, get_reply};
 use ic_test_utilities_metrics::{
     fetch_gauge, fetch_histogram_vec_stats, fetch_int_counter, labels,
 };
@@ -2952,6 +2952,95 @@ fn list_canisters_respects_round_instruction_limit() {
         env.subnet_message_instructions() - instructions_baseline,
         (NUM_CALLS * cost_per_call) as f64
     );
+}
+
+// A subnet admin canister can call `list_canisters` via an inter-canister
+// call and receives a successful response. Coalescing of the returned
+// canister ID ranges is tested separately by `test_list_canisters_success` in
+// `query_handler/tests.rs`.
+#[test]
+fn list_canisters_via_inter_canister_call_succeeds() {
+    // The admin canister is created first so that it gets the first canister ID
+    // in the subnet's range, matching the configured subnet admin.
+    let admin = CanisterId::from_u64(0);
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(SubnetType::Application),
+            HypervisorConfig::default(),
+        )))
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin.get()])
+        .build();
+
+    let admin_canister = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+    assert_eq!(admin_canister, admin);
+
+    let list_canisters = wasm()
+        .call_simple(
+            CanisterId::ic_00(),
+            "list_canisters",
+            call_args().other_side(EmptyBlob.encode()),
+        )
+        .build();
+    let msg_id = env.send_ingress(
+        PrincipalId::new_anonymous(),
+        admin_canister,
+        "update",
+        list_canisters,
+    );
+    let reply = get_reply(env.await_ingress(msg_id, 100));
+    ListCanistersResponse::decode(&reply).unwrap();
+}
+
+// A non-admin canister calling `list_canisters` via an inter-canister call is
+// rejected, and the rejected call must not consume any round instructions:
+// only a successful call pays for computing the response, per the cost model
+// checked by `list_canisters_respects_round_instruction_limit` above.
+#[test]
+fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
+    let admin = user_test_id(100).get();
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(SubnetType::Application),
+            HypervisorConfig::default(),
+        )))
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin])
+        .build();
+
+    let non_admin_canister = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+
+    let list_canisters = wasm()
+        .call_simple(
+            CanisterId::ic_00(),
+            "list_canisters",
+            call_args()
+                .other_side(EmptyBlob.encode())
+                .on_reject(wasm().reject_message().reject()),
+        )
+        .build();
+
+    let instructions_baseline = env.subnet_message_instructions();
+    let msg_id = env.send_ingress(
+        PrincipalId::new_anonymous(),
+        non_admin_canister,
+        "update",
+        list_canisters,
+    );
+    let reject = get_reject(env.await_ingress(msg_id, 100));
+    assert!(reject.contains("Only the subnet admins can perform certain actions"));
+
+    assert_eq!(env.subnet_message_instructions(), instructions_baseline);
 }
 
 #[test]

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2907,7 +2907,7 @@ fn list_canisters_respects_round_instruction_limit() {
     // enqueues all `NUM_CALLS` calls; they are only drained in subsequent rounds.
     let instructions_baseline = env.subnet_message_instructions();
     let calls_baseline = list_canisters_count(&env);
-    let msg_id = env.send_ingress(
+    env.send_ingress(
         PrincipalId::new_anonymous(),
         admin_canister,
         "update",
@@ -2927,15 +2927,6 @@ fn list_canisters_respects_round_instruction_limit() {
             break;
         }
     }
-
-    // The update itself succeeded.
-    assert_matches!(
-        env.ingress_status(&msg_id),
-        IngressStatus::Known {
-            state: IngressState::Completed(_),
-            ..
-        }
-    );
 
     // Not all `list_canisters` calls were executed in the same round: there is a
     // round after which some but not all of them had been executed.

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2883,7 +2883,16 @@ fn list_canisters_respects_round_instruction_limit() {
     );
     assert_eq!(admin_canister, admin);
 
+    // Create an additional canister so that the subnet hosts more than just
+    // the admin canister, exercising the per-canister cost of `list_canisters`.
+    create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+
     let num_canisters = env.get_latest_state().num_canisters() as u64;
+    assert_eq!(num_canisters, 2);
     let cost_per_call = BASE_INSTRUCTIONS + INSTRUCTIONS_PER_CANISTER * num_canisters;
 
     // Build an update that fires `NUM_CALLS` concurrent `list_canisters`

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2987,13 +2987,7 @@ fn list_canisters_via_inter_canister_call_succeeds() {
             call_args().other_side(EmptyBlob.encode()),
         )
         .build();
-    let msg_id = env.send_ingress(
-        PrincipalId::new_anonymous(),
-        admin_canister,
-        "update",
-        list_canisters,
-    );
-    let reply = get_reply(env.await_ingress(msg_id, 100));
+    let reply = get_reply(env.execute_ingress(admin_canister, "update", list_canisters));
     ListCanistersResponse::decode(&reply).unwrap();
 }
 
@@ -3032,13 +3026,7 @@ fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
         .build();
 
     let instructions_baseline = env.subnet_message_instructions();
-    let msg_id = env.send_ingress(
-        PrincipalId::new_anonymous(),
-        non_admin_canister,
-        "update",
-        list_canisters,
-    );
-    let reject = get_reject(env.await_ingress(msg_id, 100));
+    let reject = get_reject(env.execute_ingress(non_admin_canister, "update", list_canisters));
     assert!(reject.contains("Only the subnet admins can perform certain actions"));
 
     assert_eq!(env.subnet_message_instructions(), instructions_baseline);

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2999,8 +2999,9 @@ fn list_canisters_via_inter_canister_call_succeeds() {
 
 // A non-admin canister calling `list_canisters` via an inter-canister call is
 // rejected, and the rejected call must not consume any round instructions:
-// only a successful call pays for computing the response, per the cost model
-// checked by `list_canisters_respects_round_instruction_limit` above.
+// instructions are only deducted from the round limits for a successful call,
+// per the cost model checked by `list_canisters_respects_round_instruction_limit`
+// above.
 #[test]
 fn list_canisters_via_inter_canister_call_rejected_for_non_admin() {
     let admin = user_test_id(100).get();

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1724,6 +1724,7 @@ impl ExecutionTest {
         };
         let maybe_canister_id = get_effective_canister_id(message.clone());
         let is_install_code = check_is_install_code(message.clone());
+        let is_list_canisters = check_is_list_canisters(message.clone());
         let mut round_limits = RoundLimits {
             instructions: RoundInstructions::from(i64::MAX),
             subnet_available_memory: self.subnet_available_memory,
@@ -1808,7 +1809,9 @@ impl ExecutionTest {
                         .insert(canister_id, paused_subnet_message);
                 }
             }
-        } else {
+        } else if !is_list_canisters {
+            // `list_canisters` has no effective canister ID but still consumes
+            // round instructions, so it is exempt from this assertion.
             assert_eq!(slice_instructions_used.get(), 0);
         }
         self.check_invariants();
@@ -3290,6 +3293,15 @@ fn check_is_install_code(message: SubnetMessage) -> bool {
         SubnetMessage::Ingress(ingress) => CanisterCall::Ingress(ingress),
     };
     message.method_name() == "install_code" || message.method_name() == "install_chunked_code"
+}
+
+fn check_is_list_canisters(message: SubnetMessage) -> bool {
+    let message = match message {
+        SubnetMessage::Response(_) => return false,
+        SubnetMessage::Request(request) => CanisterCall::Request(request),
+        SubnetMessage::Ingress(ingress) => CanisterCall::Ingress(ingress),
+    };
+    message.method_name() == "list_canisters"
 }
 
 pub fn wat_compilation_cost(wat: &str) -> NumInstructions {

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -77,6 +77,7 @@ pub enum Method {
     CanisterStatus,
     CanisterInfo,
     CanisterMetadata,
+    ListCanisters,
     CreateCanister,
     DeleteCanister,
     DepositCycles,

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -678,7 +678,8 @@ pub fn extract_effective_canister_id(
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },
 
-        Ok(Method::SetupInitialDKG)
+        Ok(Method::ListCanisters)
+        | Ok(Method::SetupInitialDKG)
         | Ok(Method::DepositCycles)
         | Ok(Method::HttpRequest)
         | Ok(Method::FlexibleHttpRequest)

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -263,7 +263,8 @@ impl Request {
                     Err(_) => None,
                 }
             }
-            Ok(Method::CreateCanister)
+            Ok(Method::ListCanisters)
+            | Ok(Method::CreateCanister)
             | Ok(Method::SetupInitialDKG)
             | Ok(Method::HttpRequest)
             | Ok(Method::FlexibleHttpRequest)


### PR DESCRIPTION
This PR allows the management canister's endpoint `list_canisters` to be called as an inter-canister call by subnet admins. The endpoint is evaluated on the same subnet as the calling canister.