### PR TITLE
fix(ic-replay): unset default initial DKG record when overwriting subnet list record

### DIFF
--- a/rs/replay/src/ingress.rs
+++ b/rs/replay/src/ingress.rs
@@ -325,6 +325,7 @@ pub(crate) fn cmd_add_ledger_account(
 
 /// Creates an ingress message that updates the subnet list record in the registry to contain only
 /// the player's subnet id.
+///
 /// It also unsets the default Initial DKG subnet ID such that the invariant checking that the
 /// latter is present in the subnet list is satisfied.
 pub(crate) fn cmd_overwrite_subnet_list_with_singleton(
@@ -332,12 +333,12 @@ pub(crate) fn cmd_overwrite_subnet_list_with_singleton(
     player: &crate::player::Player,
     time: Time,
 ) -> Result<Vec<SignedIngress>, String> {
+    let initial_dkg_msg = unset_default_initial_dkg_subnet_id(agent, time)?;
+
     let subnet_list_record = SubnetListRecord {
         subnets: vec![player.subnet_id.get().into_vec()],
     };
-
     let subnet_list_msg = update_subnet_list_record(agent, subnet_list_record, time)?;
-    let initial_dkg_msg = unset_default_initial_dkg_subnet_id(agent, time)?;
 
     Ok(vec![initial_dkg_msg, subnet_list_msg])
 }

--- a/rs/replay/src/ingress.rs
+++ b/rs/replay/src/ingress.rs
@@ -27,7 +27,8 @@ use ic_protobuf::registry::{
 };
 use ic_registry_client_helpers::subnet::get_node_ids_from_subnet_record;
 use ic_registry_keys::{
-    make_replica_version_key, make_subnet_list_record_key, make_subnet_record_key,
+    make_default_initial_dkg_subnet_id_key, make_replica_version_key, make_subnet_list_record_key,
+    make_subnet_record_key,
 };
 use ic_registry_transport::{
     pb::v1::{Precondition, RegistryMutation, registry_mutation},
@@ -324,6 +325,8 @@ pub(crate) fn cmd_add_ledger_account(
 
 /// Creates an ingress message that updates the subnet list record in the registry to contain only
 /// the player's subnet id.
+/// It also unsets the default Initial DKG subnet ID such that the invariant checking that the
+/// latter is present in the subnet list is satisfied.
 pub(crate) fn cmd_overwrite_subnet_list_with_singleton(
     agent: &Agent,
     player: &crate::player::Player,
@@ -333,8 +336,10 @@ pub(crate) fn cmd_overwrite_subnet_list_with_singleton(
         subnets: vec![player.subnet_id.get().into_vec()],
     };
 
-    let msg = update_subnet_list_record(agent, subnet_list_record, time)?;
-    Ok(vec![msg])
+    let subnet_list_msg = update_subnet_list_record(agent, subnet_list_record, time)?;
+    let initial_dkg_msg = unset_default_initial_dkg_subnet_id(agent, time)?;
+
+    Ok(vec![initial_dkg_msg, subnet_list_msg])
 }
 
 /// Creates signed ingress messages to potentially add a new replica
@@ -549,6 +554,24 @@ fn update_subnet_list_record(
         Ok(_) => mutation.value = buf,
         Err(error) => panic!("Error encoding the value to protobuf: {error:?}"),
     }
+    atomic_mutate(
+        agent,
+        REGISTRY_CANISTER_ID,
+        vec![mutation],
+        vec![],
+        context_time,
+    )
+}
+
+/// Unset default initial DKG subnet ID.
+fn unset_default_initial_dkg_subnet_id(
+    agent: &Agent,
+    context_time: Time,
+) -> Result<SignedIngress, String> {
+    let mut mutation = RegistryMutation::default();
+    mutation.set_mutation_type(registry_mutation::Type::Delete);
+    mutation.key = make_default_initial_dkg_subnet_id_key().as_bytes().to_vec();
+
     atomic_mutate(
         agent,
         REGISTRY_CANISTER_ID,

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -80,13 +80,12 @@ const MAINNET_NNS_DAPP_CANISTER_ID: &str = "qoctq-giaaa-aaaaa-aaaea-cai";
 // made on top of the current mainnet version and not including the incompatible changes.
 // After switching to `Head`/`Commit` it is then advised to switch back to `Mainnet` when the
 // changes reach mainnet NNS to avoid compatibility bugs.
-const IC_REPLAY_VERSION: BinaryVersion = BinaryVersion::Mainnet;
+const IC_REPLAY_VERSION: BinaryVersion = BinaryVersion::Head;
 const IC_RECOVERY_VERSION: BinaryVersion = BinaryVersion::Mainnet;
+#[allow(dead_code)]
 enum BinaryVersion {
     Mainnet,
-    #[allow(dead_code)]
     Head,
-    #[allow(dead_code)]
     Commit(&'static str),
 }
 


### PR DESCRIPTION
The system test setup to spin up an IC with mainnet state performs some registry mutations on mainnet state before using it. One of them is overwriting the subnet list record to a single subnet (the NNS of the test IC). This is to prevent opening XNet connections to real mainnet nodes.

The newly introduced `default_initial_dkg_subnet_id` registry record has an invariant that this subnet ID must be part of the subnet list, which breaks when overwriting it in this setup. This PR thus also unsets this record prior to patching the subnet list.