### PR TITLE
chore: deduplicate hickory-resolver

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f78d53f7469ce9942ae6b5291f59924ee6a7937f946111f9b53c1cbbb9e83e25",
+  "checksum": "d36b6f62a49fb36997ade69ef1aad99494c289a40f2934b9f271d3fb3e4829e8",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -22734,7 +22734,7 @@
               "target": "hex_literal"
             },
             {
-              "id": "hickory-resolver 0.25.2",
+              "id": "hickory-resolver 0.26.1",
               "target": "hickory_resolver"
             },
             {
@@ -24093,7 +24093,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -25787,66 +25787,6 @@
         },
         "edition": "2018",
         "version": "0.5.1"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "enum-as-inner 0.6.0": {
-      "name": "enum-as-inner",
-      "version": "0.6.0",
-      "package_url": "https://github.com/bluejekyll/enum-as-inner",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/enum-as-inner/0.6.0/download",
-          "sha256": "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "enum_as_inner",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "enum_as_inner",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.4.1",
-              "target": "heck"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.42",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.110",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -33702,127 +33642,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hickory-proto 0.25.2": {
-      "name": "hickory-proto",
-      "version": "0.25.2",
-      "package_url": "https://github.com/hickory-dns/hickory-dns",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hickory-proto/0.25.2/download",
-          "sha256": "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hickory_proto",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "hickory_proto",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "futures-io",
-            "std",
-            "tokio"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "data-encoding 2.11.0",
-              "target": "data_encoding"
-            },
-            {
-              "id": "futures-channel 0.3.31",
-              "target": "futures_channel"
-            },
-            {
-              "id": "futures-io 0.3.31",
-              "target": "futures_io"
-            },
-            {
-              "id": "futures-util 0.3.31",
-              "target": "futures_util"
-            },
-            {
-              "id": "idna 1.0.3",
-              "target": "idna"
-            },
-            {
-              "id": "ipnet 2.10.1",
-              "target": "ipnet"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "rand 0.9.4",
-              "target": "rand"
-            },
-            {
-              "id": "thiserror 2.0.18",
-              "target": "thiserror"
-            },
-            {
-              "id": "tinyvec 1.6.0",
-              "target": "tinyvec"
-            },
-            {
-              "id": "tokio 1.50.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tracing 0.1.44",
-              "target": "tracing"
-            },
-            {
-              "id": "url 2.5.4",
-              "target": "url"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.89",
-              "target": "async_trait"
-            },
-            {
-              "id": "enum-as-inner 0.6.0",
-              "target": "enum_as_inner"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.25.2"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "hickory-proto 0.26.1": {
       "name": "hickory-proto",
       "version": "0.26.1",
@@ -33940,106 +33759,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hickory-resolver 0.25.2": {
-      "name": "hickory-resolver",
-      "version": "0.25.2",
-      "package_url": "https://github.com/hickory-dns/hickory-dns",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hickory-resolver/0.25.2/download",
-          "sha256": "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hickory_resolver",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "hickory_resolver",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "system-config",
-            "tokio"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "futures-util 0.3.31",
-              "target": "futures_util"
-            },
-            {
-              "id": "hickory-proto 0.25.2",
-              "target": "hickory_proto"
-            },
-            {
-              "id": "moka 0.12.15",
-              "target": "moka"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "parking_lot 0.12.5",
-              "target": "parking_lot"
-            },
-            {
-              "id": "rand 0.9.4",
-              "target": "rand"
-            },
-            {
-              "id": "resolv-conf 0.7.0",
-              "target": "resolv_conf"
-            },
-            {
-              "id": "smallvec 1.15.1",
-              "target": "smallvec"
-            },
-            {
-              "id": "thiserror 2.0.18",
-              "target": "thiserror"
-            },
-            {
-              "id": "tokio 1.50.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tracing 0.1.44",
-              "target": "tracing"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.25.2"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "hickory-resolver 0.26.1": {
       "name": "hickory-resolver",
       "version": "0.26.1",
@@ -34074,30 +33793,15 @@
             "__dnssec",
             "__https",
             "__tls",
+            "default",
             "dnssec-aws-lc-rs",
             "https-aws-lc-rs",
+            "system-config",
             "tls-aws-lc-rs",
             "tokio",
             "webpki-roots"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "default",
-              "system-config"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "default",
-              "system-config"
-            ],
-            "x86_64-apple-darwin": [
-              "default",
-              "system-config"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "default",
-              "system-config"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -34138,6 +33842,10 @@
               "target": "rand"
             },
             {
+              "id": "resolv-conf 0.7.0",
+              "target": "resolv_conf"
+            },
+            {
               "id": "rustls 0.23.27",
               "target": "rustls"
             },
@@ -34169,34 +33877,14 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "resolv-conf 0.7.0",
-                "target": "resolv_conf"
-              },
-              {
                 "id": "system-configuration 0.7.0",
                 "target": "system_configuration"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "resolv-conf 0.7.0",
-                "target": "resolv_conf"
               }
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "resolv-conf 0.7.0",
-                "target": "resolv_conf"
-              },
-              {
                 "id": "system-configuration 0.7.0",
                 "target": "system_configuration"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "resolv-conf 0.7.0",
-                "target": "resolv_conf"
               }
             ]
           }
@@ -71941,7 +71629,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ],
@@ -72897,7 +72585,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -73012,7 +72700,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -83352,7 +83040,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ],
@@ -103438,7 +103126,7 @@
     "hashlink 0.8.3",
     "hex 0.4.3",
     "hex-literal 0.4.1",
-    "hickory-resolver 0.25.2",
+    "hickory-resolver 0.26.1",
     "hkdf 0.12.4",
     "hmac 0.12.1",
     "hpke 0.12.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3874,7 +3874,7 @@ dependencies = [
  "hashlink 0.8.3",
  "hex",
  "hex-literal 0.4.1",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "hkdf",
  "hmac",
  "hpke",
@@ -4193,7 +4193,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4474,18 +4474,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -5754,7 +5742,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2 0.4.4",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "http 1.3.1",
  "idna 1.0.3",
  "ipnet",
@@ -5772,31 +5760,6 @@ dependencies = [
  "tracing",
  "url",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.6.0",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 1.0.3",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring 0.17.14",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -5825,27 +5788,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot 0.12.5",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -5853,7 +5795,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -6285,8 +6227,8 @@ dependencies = [
  "futures-util",
  "governor 0.10.2",
  "hex",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -6359,8 +6301,8 @@ dependencies = [
  "clap 4.5.53",
  "derive-new",
  "fqdn",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "http 1.3.1",
  "humantime",
  "hyper 1.8.1",
@@ -11704,7 +11646,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.4",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -12116,7 +12058,7 @@ dependencies = [
  "errno 0.3.10",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12259,7 +12201,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12280,7 +12222,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13988,7 +13930,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15017,7 +14959,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.5.1",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2584,7 +2584,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4229,7 +4229,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4523,18 +4523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,7 +4622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6063,7 +6051,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2 0.4.13",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "http 1.4.0",
  "idna",
  "ipnet",
@@ -6081,31 +6069,6 @@ dependencies = [
  "tracing",
  "url",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.3",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -6134,27 +6097,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.3",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -6162,7 +6104,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -6414,7 +6356,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6931,8 +6873,8 @@ dependencies = [
  "futures-util",
  "governor 0.10.4",
  "hex",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7005,8 +6947,8 @@ dependencies = [
  "clap 4.6.0",
  "derive-new",
  "fqdn",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "http 1.4.0",
  "humantime",
  "hyper 1.8.1",
@@ -12303,7 +12245,7 @@ dependencies = [
  "axum-server 0.7.3",
  "criterion",
  "futures",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -17171,7 +17113,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19131,7 +19073,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -20942,7 +20884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -20962,7 +20904,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -22043,7 +21985,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.13",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -22584,7 +22526,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -22693,7 +22635,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -22714,7 +22656,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -23651,7 +23593,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -23928,7 +23870,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -24024,7 +23966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -24598,7 +24540,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -24629,7 +24571,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -26834,7 +26776,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -663,7 +663,7 @@ getrandom = { version = "0.2", features = ["custom"] }
 goldenfile = "1.8.0"
 gpt = "4.1"
 hex = { version = "0.4.3", features = ["serde"] }
-hickory-resolver = "0.25.2"
+hickory-resolver = "0.26.1"
 hkdf = "^0.12"
 http = "1.3.1"
 http-body = "1.0.1"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -588,7 +588,7 @@ crate.spec(
 )
 crate.spec(
     package = "hickory-resolver",
-    version = "0.25.2",
+    version = "0.26.1",
 )
 crate.spec(
     package = "hkdf",

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -472,7 +472,7 @@ async fn connect(
                 dns_resolver.options_mut().attempts = 1;
             }
             let ip_addr = dns_resolver
-                .build()
+                .build()?
                 .lookup_ip(domain.as_str())
                 .await?
                 .iter()
@@ -1276,7 +1276,7 @@ mod tests {
         // Since the API BN is configured with a domain that does not resolve, we expect the
         // connection to fail with a name resolution error, which indicates that we indeed tried to
         // connect to the API BN instead of an NNS node.
-        assert_matches!(response, Err(err) if format!("{err:?}").contains("ResolveError"));
+        assert_matches!(response, Err(err) if format!("{err:?}").contains("NoRecordsFound"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
The old 0.25.2 was removed and the codebase migrated to 0.26.1, aligning the explicit dep with the other transitive dependency.