### PR TITLE
chore: bump secp256k1-sys and bitcoin

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d6ca6745ef7d17f984d40625f0b27f428a21f181dd060a7ff6d1e93f4bd3c320",
+  "checksum": "536d712e718236b3a04344298bbf77c9e8e7b30260976936342398646d6185ef",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -22874,7 +22874,7 @@
               "target": "scrypt"
             },
             {
-              "id": "secp256k1 0.22.2",
+              "id": "secp256k1 0.29.0",
               "target": "secp256k1"
             },
             {
@@ -23563,7 +23563,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.59.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
@@ -70471,7 +70471,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.59.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ],
@@ -71427,7 +71427,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.59.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
@@ -71542,7 +71542,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.59.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
@@ -73047,8 +73047,6 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "global-context",
             "rand",
             "rand-std",
             "recovery",
@@ -73115,6 +73113,8 @@
         "crate_features": {
           "common": [
             "alloc",
+            "default",
+            "global-context",
             "hashes",
             "rand",
             "recovery",
@@ -73301,10 +73301,12 @@
         },
         "edition": "2021",
         "rustc_flags": {
-          "common": [
-            "--cfg=rust_secp_no_symbol_renaming"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "--cfg=rust_secp_no_symbol_renaming"
+            ]
+          }
         },
         "version": "0.10.0"
       },
@@ -81681,7 +81683,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.59.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ],
@@ -101808,7 +101810,7 @@
     "scopeguard 1.2.0",
     "scraper 0.17.1",
     "scrypt 0.11.0",
-    "secp256k1 0.22.2",
+    "secp256k1 0.29.0",
     "securefmt 0.1.5",
     "security-framework 3.5.1",
     "semver 1.0.27",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3946,7 +3946,7 @@ dependencies = [
  "scopeguard",
  "scraper",
  "scrypt",
- "secp256k1 0.22.2",
+ "secp256k1 0.29.0",
  "securefmt",
  "security-framework 3.5.1",
  "semver",
@@ -4093,7 +4093,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11848,7 +11848,7 @@ dependencies = [
  "errno 0.3.10",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11991,7 +11991,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12012,7 +12012,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13686,7 +13686,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -927,15 +927,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -2440,15 +2431,6 @@ dependencies = [
  "futures",
  "ic-cdk 0.19.0",
  "serde",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5007,7 +4989,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "tokio",
 ]
 
@@ -5016,12 +4998,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -8704,7 +8680,7 @@ name = "ic-crypto-internal-threshold-sig-canister-threshold-sig-test-utils"
 version = "0.9.0"
 dependencies = [
  "assert_matches",
- "bitcoin",
+ "bitcoin-dogecoin",
  "ed25519-dalek",
  "hex",
  "ic-crypto-internal-threshold-sig-canister-threshold-sig",
@@ -8713,7 +8689,7 @@ dependencies = [
  "k256",
  "p256",
  "rand 0.8.6",
- "secp256k1 0.22.2",
+ "secp256k1 0.29.1",
  "sha2 0.10.9",
 ]
 
@@ -13826,7 +13802,7 @@ name = "ic-secp256k1"
 version = "0.3.0"
 dependencies = [
  "bip32",
- "bitcoin",
+ "bitcoin-dogecoin",
  "hex",
  "hex-literal 0.4.1",
  "hmac",
@@ -13836,7 +13812,7 @@ dependencies = [
  "pem",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
- "secp256k1 0.22.2",
+ "secp256k1 0.29.1",
  "sha2 0.10.9",
  "simple_asn1",
  "wycheproof",
@@ -16679,7 +16655,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -18094,7 +18070,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -18103,7 +18079,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -18116,7 +18092,7 @@ dependencies = [
  "ic-test-utilities",
  "ic-types",
  "rand 0.8.6",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "serde",
  "serde_json",
 ]
@@ -18908,7 +18884,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -19002,7 +18978,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -19024,7 +19000,7 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "libm",
 ]
 
@@ -20498,7 +20474,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg",
  "indexmap 1.9.3",
 ]
 
@@ -20614,7 +20590,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand_xorshift",
  "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
@@ -21018,25 +20994,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg 0.1.2",
- "rand_xorshift 0.1.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -21069,16 +21026,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -21096,21 +21043,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -21147,74 +21079,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -21404,15 +21274,6 @@ dependencies = [
  "time",
  "x509-parser 0.18.1",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -22194,7 +22055,7 @@ dependencies = [
  "ic-types",
  "on_wire",
  "rand 0.8.6",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "serde",
  "serde_json",
 ]
@@ -22733,7 +22594,6 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "295642060261c80709ac034f52fca8e5a9fa2c7d341ded5cdb164b7c33768b2a"
 dependencies = [
- "rand 0.6.5",
  "secp256k1-sys 0.5.2",
 ]
 
@@ -27121,7 +26981,7 @@ dependencies = [
  "ic-dummy-getrandom-for-wasm",
  "ic-management-canister-types 0.7.1",
  "rand 0.8.6",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "serde",
  "serde_bytes",
 ]

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1496,10 +1496,11 @@ crate.spec(
 crate.spec(
     features = [
         "global-context",
-        "rand-std",
+        "rand",
+        "std",
     ],
     package = "secp256k1",
-    version = "^0.22",
+    version = "^0.29",
 )
 crate.spec(
     package = "security-framework",
@@ -2195,13 +2196,15 @@ crate.annotation_select(
     rustc_flags = DEFAULT_RUSTC_FLAGS_FOR_FUZZING,
     triples = ["@@//bazel:fuzzing_code_enabled"],
 )
-crate.annotation(
+
+# cfg flag to avoid linking issues. The cfg is scoped to wasm32 (the canister
+# target) because on native targets the vendored C library exports
+# version-renamed symbols, and the cfg makes the Rust bindings reference the
+# un-renamed names, breaking linking.
+crate.annotation_select(
     crate = "secp256k1-sys",
     rustc_flags = ["--cfg=rust_secp_no_symbol_renaming"],
-    # This specific version is used by ic-btc-kyt canister, which
-    # requires an extra cfg flag to avoid linking issues.
-    # Applying the same cfg to other versions of secp256k1-sys
-    # may break other programs or tests.
+    triples = ["wasm32-unknown-unknown"],
     version = "0.10.0",
 )
 crate.annotation(

--- a/packages/ic-secp256k1/BUILD.bazel
+++ b/packages/ic-secp256k1/BUILD.bazel
@@ -35,7 +35,7 @@ rust_doc_test(
         # Keep sorted.
         ":ic-secp256k1",
         "@crate_index//:bip32",
-        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:bitcoin_dogecoin",
         "@crate_index//:hex",
         "@crate_index//:hex-literal",
         "@crate_index//:hmac",
@@ -58,7 +58,7 @@ rust_test(
     deps = [
         # Keep sorted.
         "@crate_index//:bip32",
-        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:bitcoin_dogecoin",
         "@crate_index//:hex",
         "@crate_index//:hex-literal",
         "@crate_index//:hmac",
@@ -82,7 +82,7 @@ rust_test_suite(
         # Keep sorted.
         ":ic-secp256k1",
         "@crate_index//:bip32",
-        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:bitcoin_dogecoin",
         "@crate_index//:hex",
         "@crate_index//:hex-literal",
         "@crate_index//:hmac",

--- a/packages/ic-secp256k1/Cargo.toml
+++ b/packages/ic-secp256k1/Cargo.toml
@@ -27,8 +27,8 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 bip32 = "0.5"
-bitcoin = { version = "0.28.2" }
+bitcoin = { workspace = true }
 hex = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false, features = ["convert"] }
-secp256k1 = { version = "0.22", features = ["global-context", "rand-std"] }
+secp256k1 = { version = "0.29", features = ["global-context", "std", "rand"] }
 wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }

--- a/packages/ic-secp256k1/tests/tests.rs
+++ b/packages/ic-secp256k1/tests/tests.rs
@@ -151,12 +151,10 @@ fn should_accept_ecdsa_signatures_that_we_generate() {
 
 #[test]
 fn bitcoin_library_accepts_our_bip341_signatures() {
-    use bitcoin::{
-        hashes::hex::FromHex,
-        schnorr::TapTweak,
-        secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature},
-        util::taproot::TapBranchHash,
-    };
+    use bitcoin::hashes::Hash;
+    use bitcoin::key::TapTweak;
+    use bitcoin::secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature};
+    use bitcoin::taproot::TapNodeHash;
 
     let secp256k1 = Secp256k1::new();
 
@@ -172,13 +170,13 @@ fn bitcoin_library_accepts_our_bip341_signatures() {
 
         let pk = XOnlyPublicKey::from_slice(&sk.public_key().serialize_sec1(true)[1..]).unwrap();
 
-        let tbh = TapBranchHash::from_hex(&hex::encode(ttr)).unwrap();
+        let tbh = TapNodeHash::from_slice(&ttr).unwrap();
 
-        let tweaked_key = pk.tap_tweak(&secp256k1, Some(tbh)).0.to_inner();
+        let tweaked_key = pk.tap_tweak(&secp256k1, Some(tbh)).0.to_x_only_public_key();
 
-        let msg = Message::from_slice(&msg).unwrap();
+        let msg = Message::from_digest_slice(&msg).unwrap();
         let sig = Signature::from_slice(&sig).unwrap();
-        assert!(sig.verify(&msg, &tweaked_key).is_ok());
+        assert!(secp256k1.verify_schnorr(&sig, &msg, &tweaked_key).is_ok());
     }
 }
 

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/BUILD.bazel
@@ -14,8 +14,7 @@ rust_library(
         "//rs/crypto/sha2",
         "//rs/types/types",
         "@crate_index//:assert_matches",
-        #TODO(BTC-CRATE-UPGRADE): Migrate this to bitcoin.
-        "@crate_index//:bitcoin_0_28",
+        "@crate_index//:bitcoin_dogecoin",
         "@crate_index//:ed25519-dalek",
         "@crate_index//:hex",
         "@crate_index//:k256",

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/Cargo.toml
@@ -9,10 +9,9 @@ documentation.workspace = true
 [dependencies]
 assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
-#TODO: try migrating this to the latest bitcoin crate. 
-bitcoin = { version = "0.28.2" }
+bitcoin = { workspace = true }
 hex = "0.4"
-secp256k1 = { version = "0.22", features = ["global-context", "rand-std"] }
+secp256k1 = { version = "0.29", features = ["global-context", "std", "rand"] }
 ic-crypto-internal-threshold-sig-canister-threshold-sig = { path = ".." }
 ic-crypto-sha2 = { path = "../../../../../sha2" }
 ic-types = { path = "../../../../../../types/types" }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/src/lib.rs
@@ -49,27 +49,26 @@ pub fn verify_taproot_signature_using_third_party(
     msg: &[u8],
     taproot_hash: &[u8],
 ) -> bool {
-    use bitcoin::hashes::hex::FromHex;
-
     if msg.len() != 32 {
         // The bitcoin Rust library doesn't support arbitrary hash inputs yet
         // https://github.com/rust-bitcoin/rust-secp256k1/issues/702
         return true;
     }
-    use bitcoin::schnorr::TapTweak;
+    use bitcoin::hashes::Hash;
+    use bitcoin::key::TapTweak;
     use bitcoin::secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature};
-    use bitcoin::util::taproot::TapBranchHash;
+    use bitcoin::taproot::TapNodeHash;
 
     let secp256k1 = Secp256k1::new();
     let pk = XOnlyPublicKey::from_slice(&sec1_pk[1..]).unwrap();
 
-    let tnh = TapBranchHash::from_hex(&hex::encode(taproot_hash)).unwrap();
+    let tnh = TapNodeHash::from_slice(taproot_hash).unwrap();
 
-    let dk = pk.tap_tweak(&secp256k1, Some(tnh)).0.to_inner();
+    let dk = pk.tap_tweak(&secp256k1, Some(tnh)).0.to_x_only_public_key();
 
-    let msg = Message::from_slice(msg).unwrap();
+    let msg = Message::from_digest_slice(msg).unwrap();
     let sig = Signature::from_slice(sig).unwrap();
-    sig.verify(&msg, &dk).is_ok()
+    secp256k1.verify_schnorr(&sig, &msg, &dk).is_ok()
 }
 
 pub fn verify_ed25519_signature_using_third_party(pk: &[u8], sig: &[u8], msg: &[u8]) -> bool {


### PR DESCRIPTION
This bumps some crates and allows us to remove some duplication in the lockfile.