### PR TITLE
fix: restore Python setup in Container Scan Nightly

### DIFF
--- a/.github/workflows/container-scan-nightly.yml
+++ b/.github/workflows/container-scan-nightly.yml
@@ -21,6 +21,10 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
       - name: Setup environment deps
         id: setup-environment-deps
         shell: bash


### PR DESCRIPTION
## Summary
- The nightly [Container Scan Nightly](https://github.com/dfinity/ic/actions/workflows/container-scan-nightly.yml) workflow has failed every run since 2026-06-04 with `pip3: command not found` (exit 127) in the "Setup environment deps" step.
- Root cause: [#10208](https://github.com/dfinity/ic/pull/10208) migrated the `ic-build` container image to Ubuntu 26.04 and, as part of that cleanup, removed the `actions/setup-python` step from this workflow on the assumption the new base image ships `pip` alongside `python3`. It doesn't — Debian/Ubuntu splits `pip` into the separate `python3-pip` package, which isn't installed in `ic-build`.
- This restores the `Set up Python` step (same as before #10208, and matching the still-present pattern in [`ci/actions/dependencies/periodic/action.yml`](https://github.com/dfinity/ic/blob/master/ci/actions/dependencies/periodic/action.yml)), which provides its own self-contained Python + pip and unblocks `pip3 install -r requirements.txt`.

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch`) on this branch and confirm `Setup environment deps` and `Run Container Scan Nightly` both pass.