### PR TITLE
ci(arm64): experiment — use Namespace cache as Bazel remote downloader

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -323,6 +323,25 @@ jobs:
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
           nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
           cat /tmp/bazel-cache.bazelrc
+
+          # EXPERIMENT: reuse the Namespace cache endpoint as a Bazel remote
+          # downloader (Remote Asset API) so repository downloads (e.g. apt .debs
+          # from snapshot.ubuntu.com) are proxied/cached instead of hitting the
+          # origin on every fetch (which gets rate-limited with 503s). Only valid
+          # for a gRPC endpoint; the local fallback keeps the build working if the
+          # endpoint doesn't implement the Remote Asset API's FetchBlob.
+          cache_endpoint="$(sed -n 's/.*--remote_cache=\([^ ]*\).*/\1/p' /tmp/bazel-cache.bazelrc | head -n1)"
+          case "$cache_endpoint" in
+            grpc://*|grpcs://*)
+              {
+                echo "build --experimental_remote_downloader=$cache_endpoint"
+                echo "build --experimental_remote_downloader_local_fallback"
+              } >> /tmp/bazel-cache.bazelrc
+              echo "::notice::Configured remote downloader -> $cache_endpoint" ;;
+            *)
+              echo "::notice::Cache endpoint '$cache_endpoint' is not gRPC; Remote Asset API needs gRPC — skipping remote downloader experiment." ;;
+          esac
+          cat /tmp/bazel-cache.bazelrc
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/netrc
       - name: Build and Test


### PR DESCRIPTION
## What

Experiment: point `--experimental_remote_downloader` at the Namespace Bazel cache endpoint in the `bazel-test-arm64` job, so repository-rule downloads (e.g. apt `.deb`s from `snapshot.ubuntu.com`) are proxied/cached instead of hitting the origin on every cache-cold fetch.

## Why

`bazel-test-arm64` frequently fails fetching `.deb`s from `snapshot.ubuntu.com` with `503 Service Unavailable` (rate limiting), e.g. https://github.com/dfinity/ic/actions/runs/28729685558/job/85193105952.

Root cause: a Bazel remote **cache** only caches *action outputs*, not repository-rule downloads. Repository downloads are only cached remotely via a remote **downloader** (Remote Asset API, `--experimental_remote_downloader`). The job runs with `--noworkspace_rc` and therefore does not load `bazel/conf/.bazelrc.internal`, the only place that configures DFINITY's remote downloader — and Namespace runners can't reach that internal endpoint anyway. So every cache-cold fetch goes straight to `snapshot.ubuntu.com`.

## How

In the `Set up Bazel cache` step we derive the `--remote_cache=` endpoint that `nsc bazel cache setup` generated and, **if it's a gRPC endpoint**, append `--experimental_remote_downloader=<endpoint>` + `--experimental_remote_downloader_local_fallback` to `/tmp/bazel-cache.bazelrc` (already passed to every `bazel` invocation in the job).

Safe by design:
- Guarded to `grpc(s)://` endpoints (the Remote Asset API is gRPC-only).
- `--experimental_remote_downloader_local_fallback` falls back to direct download if Namespace doesn't implement the Remote Asset API's `FetchBlob`.

## What to check

In the `bazel-test-arm64` logs:
- If it worked: repository fetches no longer hit `snapshot.ubuntu.com` (or the `503`s disappear).
- If unsupported: `UNIMPLEMENTED`/`NOT_FOUND` for the asset service, or fetches still hit `snapshot.ubuntu.com` — then we fall back to retries / a mirror / a persistent repository cache.

## Notes

Namespace's Bazel docs advertise remote caching (and early-access RBE) but do not mention a Remote Asset / remote-downloader service, so this may be a no-op (safe due to the fallback). The definitive check is whether their cache endpoint implements `build.bazel.remote.asset.v1.Fetch`.