### PR TITLE
fix: enable the Namespace Remote Asset API

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
-          nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
+          nsc bazel cache setup --enable_remote_asset_api --bazelrc=/tmp/bazel-cache.bazelrc
           cat /tmp/bazel-cache.bazelrc
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/netrc

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -5,6 +5,9 @@
 # lockfile for MODULE.bazel
 common --lockfile_mode=off
 
+# If the download via the Remote Asset API on the bazel-remote cache failed, try it again locally.
+common --remote_downloader_local_fallback
+
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558
 # (Removing this still builds, but reverts to compiling protoc/libprotoc from source.)

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -6,7 +6,7 @@
 common --lockfile_mode=off
 
 # If the download via the Remote Asset API on the bazel-remote cache failed, try it again locally.
-common --remote_downloader_local_fallback
+common --experimental_remote_downloader_local_fallback
 
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558


### PR DESCRIPTION
To work around the frequent rate limits of the snapshot.ubuntu.com web-servers when bazel downloads packages from it during external‑repository fetching (loading-phase) we'll cache these downloads using Namespace's [Remote Asset API](https://namespace.so/docs/integrations/bazel#remote-asset-api). This option has also been enabled on the `namespace-profile-darwin` and  `namespace-profile-arm64-linux` profiles.