### PR TITLE
fix: little fixes and tests for replicated canister log fetching

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -11,7 +11,7 @@ const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
-const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Disabled;
+const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Enabled;
 
 const FLEXIBLE_HTTP_REQUESTS_FEATURE: FlagStatus = FlagStatus::Disabled;
 

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -11,7 +11,7 @@ const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
-const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Enabled;
+const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Disabled;
 
 const FLEXIBLE_HTTP_REQUESTS_FEATURE: FlagStatus = FlagStatus::Disabled;
 

--- a/rs/cycles_account_manager/src/cycles_account_manager/tests.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager/tests.rs
@@ -251,3 +251,67 @@ fn test_convert_instructions_to_cycles() {
     // `convert_instructions_to_cycles(u64::MAX) != 10 * (u64::MAX / 10)`
     assert_ne!(u64_max_cycles, (10 * (u128::from(u64::MAX) / 10)).into());
 }
+
+#[test]
+fn test_fetch_canister_logs_fee() {
+    let subnet_size: usize = 13;
+    let reference_subnet_size: usize = 13;
+    let cycles_account_manager = create_cycles_account_manager();
+
+    // Base and per-byte fees for the application subnet configuration.
+    let base_fee = Cycles::new(5_000_000);
+    let per_byte_fee = Cycles::new(80);
+
+    let normal = |subnet_size: usize| {
+        CyclesAccountManagerSubnetConfig::new(
+            subnet_size,
+            CanisterCyclesCostSchedule::Normal,
+            reference_subnet_size,
+        )
+    };
+    let free = |subnet_size: usize| {
+        CyclesAccountManagerSubnetConfig::new(
+            subnet_size,
+            CanisterCyclesCostSchedule::Free,
+            reference_subnet_size,
+        )
+    };
+
+    // Fetching logs is free on a subnet with a free cost schedule.
+    assert_eq!(
+        cycles_account_manager.fetch_canister_logs_fee(NumBytes::new(1_000), free(subnet_size)),
+        Cycles::zero()
+    );
+    assert_eq!(
+        cycles_account_manager.max_fetch_canister_logs_fee(free(subnet_size)),
+        Cycles::zero()
+    );
+
+    // An empty response only costs the base fee, scaled by the subnet size.
+    assert_eq!(
+        cycles_account_manager.fetch_canister_logs_fee(NumBytes::new(0), normal(subnet_size)),
+        base_fee * subnet_size
+    );
+
+    // A non-empty response costs the base fee plus the per-byte fee for each
+    // response byte, scaled by the subnet size.
+    let response_size = 1_000_u64;
+    assert_eq!(
+        cycles_account_manager
+            .fetch_canister_logs_fee(NumBytes::new(response_size), normal(subnet_size)),
+        (base_fee + per_byte_fee * response_size) * subnet_size
+    );
+
+    // The fee scales linearly with the subnet size.
+    assert_eq!(
+        cycles_account_manager
+            .fetch_canister_logs_fee(NumBytes::new(response_size), normal(2 * subnet_size)),
+        (base_fee + per_byte_fee * response_size) * (2 * subnet_size)
+    );
+
+    // The maximum fee is the fee for a maximum-size response.
+    assert_eq!(
+        cycles_account_manager.max_fetch_canister_logs_fee(normal(subnet_size)),
+        (base_fee + per_byte_fee * MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES as u64) * subnet_size
+    );
+}

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -163,6 +163,7 @@ rust_ic_test_suite(
         "//rs/interfaces",
         "//rs/interfaces/state_manager",
         "//rs/interfaces/state_manager/mocks",
+        "//rs/limits",
         "//rs/monitoring/metrics",
         "//rs/nns/constants",
         "//rs/registry/resource_limits",

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -5,6 +5,7 @@ use ic_config::execution_environment::{
 };
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SubnetConfig;
+use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 use ic_execution_environment::units::{KIB, MIB};
 use ic_interfaces_state_manager::{CertificationScope, StateManager};
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
@@ -24,9 +25,9 @@ use ic_test_utilities_execution_environment::{
     ExecutionTestBuilder, get_reject, get_reply, wat_canister, wat_fn,
 };
 use ic_test_utilities_metrics::{fetch_histogram_stats, fetch_histogram_vec_stats, labels};
-use ic_types::canister_log::MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES;
-use ic_types::{CanisterId, CanisterLog, NumInstructions, ingress::WasmResult};
-use ic_types_cycles::Cycles;
+use ic_test_utilities_types::ids::subnet_test_id;
+use ic_types::{CanisterId, CanisterLog, NumBytes, NumInstructions, ingress::WasmResult};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use more_asserts::{assert_gt, assert_le, assert_lt};
 use proptest::{prelude::ProptestConfig, prop_assume};
 use std::time::{Duration, SystemTime};
@@ -118,6 +119,27 @@ fn setup_env_with(replicated_inter_canister_log_fetch: FlagStatus) -> StateMachi
 fn setup_env() -> StateMachine {
     let replicated_inter_canister_log_fetch = FlagStatus::Enabled;
     setup_env_with(replicated_inter_canister_log_fetch)
+}
+
+/// A [`CyclesAccountManager`] and subnet config mirroring the default application
+/// subnet used by these tests, so that the production fee functions can be reused
+/// to compute the expected `fetch_canister_logs` fees instead of recomputing the
+/// fee formula inline.
+fn cycles_account_manager() -> CyclesAccountManager {
+    CyclesAccountManager::new(
+        NumInstructions::new(0),
+        SubnetType::Application,
+        subnet_test_id(0),
+        SubnetConfig::new(SubnetType::Application).cycles_account_manager_config,
+    )
+}
+
+fn subnet_cycles_config() -> CyclesAccountManagerSubnetConfig {
+    CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        CanisterCyclesCostSchedule::Normal,
+        SMALL_APP_SUBNET_MAX_SIZE,
+    )
 }
 
 fn create_canister(env: &StateMachine, settings: CanisterSettingsArgs) -> CanisterId {
@@ -2670,14 +2692,8 @@ fn test_fetch_canister_logs_update_call_cycles_threshold_is_exact() {
     );
     let _ = env.execute_ingress(canister_b, "test", vec![]);
 
-    // The required payment is the fee for a maximum-size response, scaled by the
-    // subnet size (the default `StateMachine` subnet has `SMALL_APP_SUBNET_MAX_SIZE`
-    // nodes).
-    let cam_config = SubnetConfig::new(SubnetType::Application).cycles_account_manager_config;
-    let max_fee = (cam_config.fetch_canister_logs_base_fee
-        + cam_config.fetch_canister_logs_per_byte_fee
-            * MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES as u64)
-        * SMALL_APP_SUBNET_MAX_SIZE;
+    // The required payment is the fee for a maximum-size response.
+    let max_fee = cycles_account_manager().max_fetch_canister_logs_fee(subnet_cycles_config());
 
     // One cycle below the required max fee is rejected, and the reject message
     // reports the exact required amount.
@@ -2695,7 +2711,7 @@ fn test_fetch_canister_logs_update_call_cycles_threshold_is_exact() {
 }
 
 #[test]
-fn test_fetch_canister_logs_update_call_deducts_cycles() {
+fn test_fetch_canister_logs_update_call_deducts_and_refunds_cycles() {
     let user_controller = PrincipalId::new_user_test_id(42);
     let env = setup_env();
     let canister_a = create_and_install_canister(
@@ -2717,30 +2733,55 @@ fn test_fetch_canister_logs_update_call_deducts_cycles() {
     );
     let _ = env.execute_ingress(canister_b, "test", vec![]);
 
-    let balance_before = env.cycle_balance(canister_a);
-
-    // Provide more than enough cycles for the fetch.
-    let cycles_sent = Cycles::new(5_000_000_000);
-    let records = fetch_log_records_intercanister(&env, canister_a, canister_b, cycles_sent);
+    // Fetch the logs via a query (canister_a is a controller of canister_b) to
+    // learn the exact size of the encoded response. The inter-canister update
+    // call returns the same encoded response, so its fee is computed from this
+    // length.
+    let reply = get_reply(fetch_canister_logs_query(
+        &env,
+        canister_a.get(),
+        canister_b,
+    ));
+    let records = FetchCanisterLogsResponse::decode(&reply)
+        .unwrap()
+        .canister_log_records;
     assert_eq!(records.len(), 1);
+    let response_size = reply.len() as u64;
 
-    let balance_after = env.cycle_balance(canister_a);
-    let cycles_spent = balance_before - balance_after;
-
-    // Some cycles must have been deducted (fetch fee + execution overhead).
+    // The fetch fee is charged for the actual response size; everything above it
+    // must be refunded to the caller.
+    let expected_fee = cycles_account_manager()
+        .fetch_canister_logs_fee(NumBytes::new(response_size), subnet_cycles_config());
+    let cycles_sent = Cycles::new(5_000_000_000);
     assert!(
-        cycles_spent > 0,
-        "Expected some cycles to be spent, but balance is unchanged"
+        cycles_sent > expected_fee,
+        "Test setup error: sent {cycles_sent} cycles, but the fee is {expected_fee}"
     );
-    // The refund should have returned most of the overpayment.
-    // cycles_sent was 5B, and the actual fetch fee for a small response
-    // plus execution overhead should be well under 2B.
-    assert_lt!(
-        cycles_spent,
-        2_000_000_000,
-        "Expected most cycles to be refunded, but {} were spent",
-        cycles_spent
+    let expected_refund = cycles_sent - expected_fee;
+
+    // Perform the inter-canister fetch with more than enough cycles, capturing
+    // the cycles refunded to the caller in the reply callback.
+    let result = env.execute_ingress(
+        canister_a,
+        "update",
+        wasm()
+            .call_with_cycles(
+                CanisterId::ic_00(),
+                "fetch_canister_logs",
+                call_args()
+                    .other_side(FetchCanisterLogsRequest::new(canister_b).encode())
+                    .on_reply(wasm().msg_cycles_refunded().reply_int64().build())
+                    .on_reject(wasm().reject_message().reject()),
+                cycles_sent,
+            )
+            .build(),
     );
+    let refunded_bytes = get_reply(result);
+    let refunded = Cycles::new(u64::from_le_bytes(refunded_bytes[..8].try_into().unwrap()) as u128);
+
+    // Exactly the unused cycles (sent minus the fee for the actual response
+    // size) are refunded.
+    assert_eq!(refunded, expected_refund);
 }
 
 #[test]

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -2705,9 +2705,19 @@ fn test_fetch_canister_logs_update_call_cycles_threshold_is_exact() {
         "Expected insufficient cycles error mentioning the exact max fee, got: {reject_message}"
     );
 
-    // Exactly the required max fee is accepted.
+    // Exactly the required max fee is accepted. Even though the caller attaches the
+    // full max fee, only the fee for the actual (small) response is charged and the
+    // rest is refunded, so the caller spends strictly less than the attached max fee.
+    let balance_before = env.cycle_balance(canister_a);
     let records = fetch_log_records_intercanister(&env, canister_a, canister_b, max_fee);
     assert_eq!(records.len(), 1);
+    let cycles_spent = balance_before - env.cycle_balance(canister_a);
+    assert!(cycles_spent > 0, "expected some cycles to be spent");
+    assert_lt!(
+        cycles_spent,
+        max_fee.get(),
+        "expected the unused portion of the max fee to be refunded"
+    );
 }
 
 #[test]

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -7,6 +7,7 @@ use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SubnetConfig;
 use ic_execution_environment::units::{KIB, MIB};
 use ic_interfaces_state_manager::{CertificationScope, StateManager};
+use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_management_canister_types_private::{
     self as ic00, BoundedAllowedViewers, CanisterIdRecord, CanisterInstallMode, CanisterLogRecord,
     CanisterSettingsArgs, CanisterSettingsArgsBuilder, DataSize, EmptyBlob,
@@ -23,6 +24,7 @@ use ic_test_utilities_execution_environment::{
     ExecutionTestBuilder, get_reject, get_reply, wat_canister, wat_fn,
 };
 use ic_test_utilities_metrics::{fetch_histogram_stats, fetch_histogram_vec_stats, labels};
+use ic_types::canister_log::MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES;
 use ic_types::{CanisterId, CanisterLog, NumInstructions, ingress::WasmResult};
 use ic_types_cycles::Cycles;
 use more_asserts::{assert_gt, assert_le, assert_lt};
@@ -2643,6 +2645,53 @@ fn test_fetch_canister_logs_update_call_rejected_insufficient_cycles() {
         reject_message.contains("cycles are required"),
         "Expected insufficient cycles error, got: {reject_message}"
     );
+}
+
+#[test]
+fn test_fetch_canister_logs_update_call_cycles_threshold_is_exact() {
+    let user_controller = PrincipalId::new_user_test_id(42);
+    let env = setup_env();
+    let canister_a = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_controllers(vec![user_controller])
+            .build(),
+        UNIVERSAL_CANISTER_WASM.to_vec(),
+    );
+    let canister_b = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Controllers)
+            .with_controllers(vec![canister_a.get()])
+            .build(),
+        wat_canister()
+            .update("test", wat_fn().debug_print(b"message"))
+            .build_wasm(),
+    );
+    let _ = env.execute_ingress(canister_b, "test", vec![]);
+
+    // The required payment is the fee for a maximum-size response, scaled by the
+    // subnet size (the default `StateMachine` subnet has `SMALL_APP_SUBNET_MAX_SIZE`
+    // nodes).
+    let cam_config = SubnetConfig::new(SubnetType::Application).cycles_account_manager_config;
+    let max_fee = (cam_config.fetch_canister_logs_base_fee
+        + cam_config.fetch_canister_logs_per_byte_fee
+            * MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES as u64)
+        * SMALL_APP_SUBNET_MAX_SIZE;
+
+    // One cycle below the required max fee is rejected, and the reject message
+    // reports the exact required amount.
+    let result =
+        fetch_canister_logs_intercanister(&env, canister_a, canister_b, max_fee - Cycles::new(1));
+    let reject_message = get_reject(result);
+    assert!(
+        reject_message.contains(&format!("{max_fee} cycles are required")),
+        "Expected insufficient cycles error mentioning the exact max fee, got: {reject_message}"
+    );
+
+    // Exactly the required max fee is accepted.
+    let records = fetch_log_records_intercanister(&env, canister_a, canister_b, max_fee);
+    assert_eq!(records.len(), 1);
 }
 
 #[test]

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -2638,38 +2638,6 @@ fn test_canister_log_resize_no_extra_charge_feature_disabled() {
 }
 
 #[test]
-fn test_fetch_canister_logs_update_call_rejected_insufficient_cycles() {
-    let user_controller = PrincipalId::new_user_test_id(42);
-    let env = setup_env();
-    let canister_a = create_and_install_canister(
-        &env,
-        CanisterSettingsArgsBuilder::new()
-            .with_controllers(vec![user_controller])
-            .build(),
-        UNIVERSAL_CANISTER_WASM.to_vec(),
-    );
-    let canister_b = create_and_install_canister(
-        &env,
-        CanisterSettingsArgsBuilder::new()
-            .with_log_visibility(LogVisibilityV2::Controllers)
-            .with_controllers(vec![canister_a.get()])
-            .build(),
-        wat_canister()
-            .update("test", wat_fn().debug_print(b"message"))
-            .build_wasm(),
-    );
-    let _ = env.execute_ingress(canister_b, "test", vec![]);
-
-    // Send with 1 cycle — far below the required max fee.
-    let result = fetch_canister_logs_intercanister(&env, canister_a, canister_b, Cycles::new(1));
-    let reject_message = get_reject(result);
-    assert!(
-        reject_message.contains("cycles are required"),
-        "Expected insufficient cycles error, got: {reject_message}"
-    );
-}
-
-#[test]
 fn test_fetch_canister_logs_update_call_cycles_threshold_is_exact() {
     let user_controller = PrincipalId::new_user_test_id(42);
     let env = setup_env();

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
@@ -6,6 +6,7 @@ use crate::canister_state::system_state::log_memory_store::{
 };
 use crate::page_map::PageMap;
 use ic_management_canister_types_private::{CanisterLogRecord, DataSize, FetchCanisterLogsFilter};
+use ic_types::canister_log::MAX_FETCH_CANISTER_LOGS_RESULT_BYTES;
 use more_asserts::assert_le;
 
 // PageMap file layout.
@@ -26,8 +27,15 @@ pub(super) const DATA_REGION_OFFSET: MemoryAddress = INDEX_TABLE_OFFSET.add_size
 // Ring buffer constraints.
 
 /// Maximum total size of log records returned in a single message.
-pub(super) const RESULT_MAX_SIZE: MemorySize = MemorySize::new(2_000_000);
-const _: () = assert!(RESULT_MAX_SIZE.get() <= 2_000_000, "Exceeds 2 MB");
+///
+/// This bounds the stored data size of the records returned by `records()`, and in
+/// turn the size of the Candid-encoded `fetch_canister_logs` response. It is defined
+/// from `MAX_FETCH_CANISTER_LOGS_RESULT_BYTES`, and the fee for fetching logs is
+/// prepaid against `MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES` (that value plus a Candid
+/// framing margin); the `fetch_canister_logs_response_within_limit` test verifies the
+/// encoded response stays within it.
+pub(super) const RESULT_MAX_SIZE: MemorySize =
+    MemorySize::new(MAX_FETCH_CANISTER_LOGS_RESULT_BYTES as u64);
 
 // With index table of 1 page (4 KiB) and 28 bytes per entry -> 146 entries max.
 // With 2 MB result max size limit we want each index entry segment to be under

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -388,19 +388,24 @@ fn fetch_canister_logs_response_within_limit() {
     // stored data size (`CanisterLogRecord::data_size()` = 40 B + content per
     // record), while Candid encodes each record's fixed fields in fewer bytes (two
     // `nat64` = 16 B). The worst case is therefore the fewest/largest records, so we
-    // sweep record sizes from empty up to a single near-maximal record and assert the
-    // encoded response fits within the constant (with margin for Candid framing).
+    // sweep record sizes up to a single near-maximal record and assert the encoded
+    // response fits within the constant (with margin for Candid framing). The sizes
+    // are kept large enough that a full buffer exceeds `RESULT_MAX_SIZE`: the ring
+    // buffer holds only a few hundred records (its index table is one page), so tiny
+    // records could never fill it past the cap.
     let aggregate_capacity = 3 * RESULT_MAX_SIZE.get() as usize;
     for content_len in [
-        0,
-        100,
-        4 * KIB,
-        100 * KIB,
+        16 * KIB,
+        128 * KIB,
         RESULT_MAX_SIZE.get() as usize - CanisterLogRecord::default().data_size(),
     ] {
         let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
         s.resize_for_testing(aggregate_capacity);
-        // Fill well past `RESULT_MAX_SIZE` so the response is trimmed to the cap.
+        // Append records into store `s`, starting at record index `0`, until at least
+        // `2 * RESULT_MAX_SIZE` bytes have been added (twice the result cap, so the
+        // buffer ends up larger than what can be returned in a single result), packing
+        // each delta up to `MAX_DELTA_LOG_MEMORY_LIMIT` with records whose content is
+        // `content_len` bytes.
         append_deltas(
             &mut s,
             0,
@@ -408,6 +413,8 @@ fn fetch_canister_logs_response_within_limit() {
             MAX_DELTA_LOG_MEMORY_LIMIT,
             content_len,
         );
+        // The buffer now holds more than the result cap, so `records()` must trim.
+        assert_gt!(s.bytes_used(), RESULT_MAX_SIZE.get() as usize);
 
         let records = s.records(None);
         // The returned records are trimmed to `RESULT_MAX_SIZE` by stored data size.

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -1,8 +1,9 @@
 use super::super::ring_buffer::RESULT_MAX_SIZE;
 use super::super::*;
 use ic_management_canister_types_private::{
-    DataSize, FetchCanisterLogsFilter, FetchCanisterLogsRange,
+    DataSize, FetchCanisterLogsFilter, FetchCanisterLogsRange, FetchCanisterLogsResponse, Payload,
 };
+use ic_types::canister_log::{MAX_DELTA_LOG_MEMORY_LIMIT, MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES};
 use more_asserts::{assert_gt, assert_le, assert_lt};
 
 const KIB: usize = 1024;
@@ -377,6 +378,52 @@ fn max_response_size_respected_with_filtering_by_timestamp() {
     assert_le!(total_size(&result), RESULT_MAX_SIZE.get() as usize);
     // Oldest records (head) must be present.
     assert_eq!(result.first().unwrap().timestamp_nanos, partial_start_ts);
+}
+
+#[test]
+fn fetch_canister_logs_response_within_limit() {
+    // The `fetch_canister_logs` fee is prepaid based on
+    // `MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES`, so the Candid-encoded response must
+    // never exceed it. `records()` trims the returned set to `RESULT_MAX_SIZE` by
+    // stored data size (`CanisterLogRecord::data_size()` = 40 B + content per
+    // record), while Candid encodes each record's fixed fields in fewer bytes (two
+    // `nat64` = 16 B). The worst case is therefore the fewest/largest records, so we
+    // sweep record sizes from empty up to a single near-maximal record and assert the
+    // encoded response fits within the constant (with margin for Candid framing).
+    let aggregate_capacity = 3 * RESULT_MAX_SIZE.get() as usize;
+    for content_len in [
+        0,
+        100,
+        4 * KIB,
+        100 * KIB,
+        RESULT_MAX_SIZE.get() as usize - CanisterLogRecord::default().data_size(),
+    ] {
+        let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+        s.resize_for_testing(aggregate_capacity);
+        // Fill well past `RESULT_MAX_SIZE` so the response is trimmed to the cap.
+        append_deltas(
+            &mut s,
+            0,
+            2 * RESULT_MAX_SIZE.get() as usize,
+            MAX_DELTA_LOG_MEMORY_LIMIT,
+            content_len,
+        );
+
+        let records = s.records(None);
+        // The returned records are trimmed to `RESULT_MAX_SIZE` by stored data size.
+        assert_le!(total_size(&records), RESULT_MAX_SIZE.get() as usize);
+
+        let response = FetchCanisterLogsResponse {
+            canister_log_records: records,
+        };
+        let encoded_len = response.encode().len();
+        assert_le!(
+            encoded_len,
+            MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES,
+            "content_len={content_len}: encoded response of {encoded_len} bytes exceeds \
+             MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES ({MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES})"
+        );
+    }
 }
 
 #[test]

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -18,8 +18,25 @@ pub const DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT: usize = 4 * KIB;
 /// The maximum size of a delta (per message) canister log buffer.
 pub const MAX_DELTA_LOG_MEMORY_LIMIT: usize = 2 * MIB;
 
+/// Maximum stored data size (in bytes) of the log records returned by a single
+/// `fetch_canister_logs` request.
+///
+/// The log memory store's ring buffer trims its result to this limit, measured by
+/// `CanisterLogRecord::data_size()`. This is the single source of truth for that
+/// limit: `RESULT_MAX_SIZE` in `ic-replicated-state` is defined from it.
+pub const MAX_FETCH_CANISTER_LOGS_RESULT_BYTES: usize = 2_000_000;
+
 /// Maximum number of response bytes for a fetch canister logs request.
-pub const MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES: usize = 2_000_000;
+///
+/// The `fetch_canister_logs` fee is prepaid based on this value, so it must be an
+/// upper bound on the size of a Candid-encoded `FetchCanisterLogsResponse`. The
+/// returned records are trimmed to `MAX_FETCH_CANISTER_LOGS_RESULT_BYTES` by their
+/// stored data size; this adds a page for the fixed Candid framing (magic bytes and
+/// type table) that is not counted towards the record data size. The
+/// `fetch_canister_logs_response_within_limit` test in `ic-replicated-state` verifies
+/// that the worst-case encoded response fits within this bound.
+pub const MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES: usize =
+    MAX_FETCH_CANISTER_LOGS_RESULT_BYTES + 4 * KIB;
 
 // Compile-time assertions to ensure the constants are within valid ranges.
 const _: () = assert!(DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT <= MAX_AGGREGATE_LOG_MEMORY_LIMIT);

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -27,6 +27,9 @@ pub const MAX_DELTA_LOG_MEMORY_LIMIT: usize = 2 * MIB;
 pub const MAX_FETCH_CANISTER_LOGS_RESULT_BYTES: usize = 2_000_000;
 
 /// Maximum number of response bytes for a fetch canister logs request.
+/// This must not exceed the maximum update call response size
+/// (`MAX_INTER_CANISTER_PAYLOAD_IN_BYTES`), otherwise a `fetch_canister_logs`
+/// response of this size could not be returned to the caller.
 ///
 /// The `fetch_canister_logs` fee is prepaid based on this value, so it must be an
 /// upper bound on the size of a Candid-encoded `FetchCanisterLogsResponse`. The
@@ -41,6 +44,10 @@ pub const MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES: usize =
 // Compile-time assertions to ensure the constants are within valid ranges.
 const _: () = assert!(DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT <= MAX_AGGREGATE_LOG_MEMORY_LIMIT);
 const _: () = assert!(MAX_DELTA_LOG_MEMORY_LIMIT <= MAX_AGGREGATE_LOG_MEMORY_LIMIT);
+const _: () = assert!(
+    MAX_FETCH_CANISTER_LOGS_RESPONSE_BYTES
+        <= crate::messages::MAX_INTER_CANISTER_PAYLOAD_IN_BYTES_U64 as usize
+);
 
 /// Truncates the content of a log record so that the record fits within the allowed size.
 fn truncate_content(byte_capacity: usize, mut record: CanisterLogRecord) -> CanisterLogRecord {


### PR DESCRIPTION
This PR implements the following fix: separates the maximum size when computing a `fetch_canister_logs` response (checked w.r.t. estimated Rust in-memory data size) from the maximum Candid-encode size of the response (relevant for computing the cycles amount that must be attached to the call) - the latter is larger by the Candid-encoding overhead (approximated by 4KiB).

This PR also adds new tests:
- unit tests of the fee formula;
- checking that a call is rejected if too few cycles are attached (attaching just one cycle less than required to be as tight as possible);
- checking that unused cycles are refunded exactly;
- checking that the result is trimmed to be within the maximum result size and its Candid-encoded size does not exceed the corresponding constant accounting for up to 4KiB overhead.