### PR TITLE
fix: upload canister wasms under their intended CDN filenames

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -124,6 +124,16 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.update(SNS_CANISTER_NAME_TO_MAX_COMPRESSE
         name = "copy_" + compressed_file_name,
         src = target,
         out = compressed_file_name,
+        # Force a hard copy instead of a symlink. `copy_file` defaults
+        # `allow_symlink` to True (when not executable), which makes `out` a
+        # symlink to `src`. `artifact_bundle` resolves inputs with `realpath` and
+        # the uploader (ci/src/artifacts/upload.sh) names the uploaded object
+        # after the *resolved* basename. A symlink therefore resolves to the
+        # underlying target's filename (e.g. `governance-canister-test.wasm.gz`)
+        # instead of the intended CDN name (e.g. `governance-canister_test.wasm.gz`).
+        # A hard copy keeps the `out` name so the object is uploaded under the
+        # correct filename. See also the `.did` copy below.
+        allow_symlink = False,
     )
     for (compressed_file_name, target) in CANISTERS.items() + COMPRESSED_CANISTERS.items()
     if compressed_file_name.endswith(".wasm.gz")


### PR DESCRIPTION
## Problem

`governance-canister_test.wasm.gz` (and other canisters) stopped being available on the CDN under their intended names, e.g. for a recent commit:

- ❌ `…/canisters/governance-canister_test.wasm.gz` → 404
- ✅ `…/canisters/governance-canister-test.wasm.gz` → present (note the **dash**)
- ✅ `…/canisters/governance-canister_test.wasm.gz.did` → present (underscore)

The upload log even reports uploading the underscore name, yet the object lands under the underlying target's dash name.

## Root cause

1. In `publish/canisters/BUILD.bazel`, each `.wasm.gz` is produced by `copy_file` **without** `allow_symlink = False`. bazel_skylib defaults `allow_symlink` to `True` for non-executable outputs, so the output is a **symlink** to the underlying canister artifact (e.g. `//rs/nns/governance:governance-canister-test` → `governance-canister-test.wasm.gz`, dash).
2. `artifact_bundle` (`publish/defs.bzl`) records `ln -s "$(realpath "$input")"` — the fully-resolved (dash) path.
3. `ci/src/artifacts/upload.sh` names the uploaded object after `basename "$(readlink -f …)"` — the resolved (dash) basename — **not** the bundle entry (underscore) shown in the log line and `bucket_path`.

The `.did` files use `allow_symlink = False` (hard copy), which is exactly why they keep uploading under the correct underscore name.

This was latent until #10641 pinned `artifact_bundle` to run locally (`no-remote`). Running remotely materialized inputs by content at their declared (correct) path; running locally stages the `copy_file` symlink, so `realpath` now follows it through to the dash-named artifact.

## Fix

Force a hard copy (`allow_symlink = False`) for the `.wasm.gz` copies, mirroring the existing `.did` copy. The bundle then resolves to the real file carrying the intended name, restoring `governance-canister_test.wasm.gz` and the other affected canisters — **without reverting #10641**.

## Notes

The deeper issue is that `ci/src/artifacts/upload.sh` names objects by the *resolved* basename rather than the bundle-relative name (`rclone copyto "$bucket_path"` would be the general fix). This PR is the minimal, low-risk fix consistent with the existing `.did` handling.
