### PR TITLE
chore: bump foundry container image to v1.7.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -197,7 +197,7 @@ use_repo(oci, "ic_gatewayd", "ic_gatewayd_linux_amd64")
 # foundry container used in test
 oci.pull(
     name = "foundry",
-    image = "ghcr.io/foundry-rs/foundry@sha256:8f9dd6d4c498538b3aa3999758520bca24a41273163b0c7295ed53b1a6062f30",  # v0.3.0 https://github.com/foundry-rs/foundry/pkgs/container/foundry/391862899?tag=v0.3.0
+    image = "ghcr.io/foundry-rs/foundry@sha256:8347b728d5d393dac1c018691b36f506d23b9dcd78341d40ea0fcb11c3a19cdd",  # v1.7.1 https://github.com/foundry-rs/foundry/pkgs/container/foundry?tag=v1.7.1
     platforms = [
         "linux/amd64",
     ],

--- a/rs/tests/cross_chain/ic_xc_cketh_test.rs
+++ b/rs/tests/cross_chain/ic_xc_cketh_test.rs
@@ -845,9 +845,12 @@ fn deploy_smart_contract(
     // `--use /{solc}` points `forge` at the vendored `solc` binary bind-mounted
     // from the UVM (see `setup_anvil`), so compilation happens offline instead of
     // `forge` downloading `solc` from the internet.
+    // `-w /tmp` gives `forge` a writable working directory for its `out`/`cache`
+    // compilation artifacts: since foundry v1, the container runs as the non-root
+    // `foundry` user, which cannot write to the default working directory `/`.
     let cmd = format!(
         "\
-        docker run --net {DOCKER_NETWORK_NAME} --rm \
+        docker run --net {DOCKER_NETWORK_NAME} --rm -w /tmp \
         -v /config/{filename}:/contracts/{filename} \
         -v /tmp/{solc}:/{solc} \
         foundry \"forge create --json --use /{solc} --rpc-url http://anvil:{FOUNDRY_PORT} --broadcast --private-key {sender_private_key} /contracts/{filename}:{contract_name} --constructor-args {constructor_args}\"\


### PR DESCRIPTION
Bumps the foundry OCI image pinned in `MODULE.bazel` (used to build the ckETH cross-chain system test's UVM config image) from **v0.3.0** to the latest stable release **v1.7.1**.

Besides keeping the toolchain current, v1.x ships an `anvil` whose default hardfork includes Pectra (EIP-7702). That is a prerequisite for exercising the deposit-from-CEX sweep design (DEFI-2096) in a system test, which relies on EIP-7702 delegation.

The image is pinned by digest (multi-arch index `sha256:8347b728…`, which contains the `linux/amd64` manifest that `oci.pull` selects).

Since foundry v1 the container image runs as the non-root `foundry` user, so `forge create` can no longer write its `out`/`cache` compilation artifacts to the default working directory `/`. The ckETH cross-chain test is updated to run the container with `-w /tmp` so those artifacts land in a writable location.

Verified by running the farm-based `//rs/tests/cross_chain:ic_xc_cketh_test` to completion against the v1.7.1 image.