### PR TITLE
fix(ci): upload CDN artifacts under their bundle (intended) name

### DIFF
--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -48,6 +48,7 @@ upload() {
         --s3-region=eu-central-1 \
         --s3-env-auth \
         copy \
+        --copy-links \
         --files-from <(echo "$(basename "$artifact_localpath")") \
         --no-traverse \
         --immutable \
@@ -69,6 +70,7 @@ upload() {
         --s3-endpoint=https://64059940cc95339fc7e5888f431876ee.r2.cloudflarestorage.com \
         --s3-env-auth \
         copy \
+        --copy-links \
         --files-from <(echo "$(basename "$artifact_localpath")") \
         --no-traverse \
         --immutable \
@@ -98,11 +100,8 @@ for fullrelpath in $(find -L "$BUNDLE" -type f); do
     log
     log "-- uploading '$artifact_basename' (remote path: '$bucket_path') --"
 
-    # rclone reads the $(dirname $f) to get file attributes.
-    # Therefore symlink should be resolved.
-    artifact_fullpath="$(readlink -f "$fullrelpath")"
-    upload "$artifact_fullpath" "$bucket_path"
+    upload "$fullrelpath" "$bucket_path"
 
-    artifact_checksum="$(sha256sum "$artifact_fullpath" | cut -d' ' -f1)"
+    artifact_checksum="$(sha256sum "$fullrelpath" | cut -d' ' -f1)"
     echo "$artifact_checksum,https://download.dfinity.systems/$bucket_path"
 done


### PR DESCRIPTION
## What

Upload each CDN artifact under its **bundle entry (intended) name** instead of the resolved symlink target's basename.

## Why

[`ci/src/artifacts/upload.sh`](https://github.com/dfinity/ic/blob/master/ci/src/artifacts/upload.sh) resolved each bundle entry with `readlink -f` and named the uploaded S3 object after the *resolved* basename. For bundles whose entries are symlinks with a different (intended) name than their target, this produced the wrong CDN filename — e.g. `governance-canister-test.wasm.gz` instead of `governance-canister_test.wasm.gz`.

## How

- **Loop:** stop resolving with `readlink -f`; pass the bundle entry `$fullrelpath` (a symlink whose own name is already the intended CDN name) directly to `upload()`, and hash it with `sha256sum` (which follows symlinks, so the bytes are unchanged).
- **`upload()`:** add `--copy-links` to **both** the AWS and Cloudflare `rclone copy` invocations, so rclone follows the symlink and uploads the target's bytes under the `--files-from` (bundle entry) name.
- **Keep** the directory + `--files-from` + `--immutable` pattern (the [rclone#4921](https://github.com/rclone/rclone/issues/4921) immutable workaround). `copyto` is intentionally avoided because `--immutable` is silently ignored for single-file transfers, which would reintroduce the risk of overwriting published artifacts.

This is defense-in-depth that fixes the latent symlink-rename issue for *all* bundles, not just canisters.

## Testing

Dry run in the dev container against a synthetic bundle (symlink with intended name → real file with wrong name) confirms:
- `--copy-links` present in both AWS + Cloudflare `rclone copy` calls;
- `--files-from` resolves to the intended name (`governance-canister_test.wasm.gz`, `SHA256SUMS`);
- the wrong resolved names never appear;
- `--immutable` / `--no-traverse` / directory-source preserved;
- checksum line uses symlink-followed bytes and the intended-name URL.
