### PR TITLE
fix: Don't count flexible HTTP outcall timeouts towards maximum responses during validation

### DIFF
--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -420,6 +420,64 @@ fn timeouts_bypass_max_responses_per_block() {
     );
 }
 
+#[test]
+fn flexible_timeouts_bypass_max_responses_per_block() {
+    let subnet_size = 4;
+    let num_contexts = CANISTER_HTTP_MAX_RESPONSES_PER_BLOCK + 50;
+
+    test_config_with_http_feature(
+        true,
+        subnet_size,
+        |mut payload_builder, _canister_http_pool| {
+            let committee: BTreeSet<_> = (0..subnet_size as u64).map(node_test_id).collect();
+
+            // `num_contexts` flexible request contexts, all at time = UNIX_EPOCH.
+            let contexts: Vec<_> = (0..num_contexts as u64)
+                .map(|id| {
+                    (
+                        CallbackId::new(id),
+                        flexible_request_context(committee.clone(), 1, subnet_size as u32),
+                    )
+                })
+                .collect();
+            inject_request_contexts(&mut payload_builder, contexts);
+
+            // Validation time past the timeout interval so every context times out.
+            let validation_context = ValidationContext {
+                registry_version: RegistryVersion::new(1),
+                certified_height: Height::new(0),
+                time: UNIX_EPOCH + CANISTER_HTTP_TIMEOUT_INTERVAL + Duration::from_secs(1),
+            };
+
+            let payload = payload_builder.build_payload(
+                Height::new(1),
+                TEST_MAX_PAYLOAD_BYTES,
+                &[],
+                &validation_context,
+            );
+
+            let parsed = bytes_to_payload(&payload).expect("Failed to parse payload");
+
+            // The builder emits all timed-out flexible requests, ungated by the cap.
+            assert_eq!(parsed.flexible_errors.len(), num_contexts);
+            assert!(parsed.responses.is_empty());
+            assert!(parsed.timeouts.is_empty());
+            // Flexible timeouts must not count against the per-block response cap.
+            assert_eq!(parsed.num_non_timeout_responses(), 0);
+
+            // The builder's own honest payload must pass validation.
+            payload_builder
+                .validate_payload(
+                    Height::new(1),
+                    &test_proposal_context(&validation_context),
+                    &payload,
+                    &[],
+                )
+                .unwrap();
+        },
+    );
+}
+
 /// Divergence responses must be counted by num_non_timeout_responses() and
 /// therefore be subject to the CANISTER_HTTP_MAX_RESPONSES_PER_BLOCK limit
 /// during validation.

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -174,7 +174,10 @@ impl CanisterHttpPayload {
         responses.len()
             + divergence_responses.len()
             + flexible_responses.len()
-            + flexible_errors.len()
+            + flexible_errors
+                .iter()
+                .filter(|error| !matches!(error, FlexibleCanisterHttpError::Timeout { .. }))
+                .count()
     }
 
     /// Returns true, if this is an empty payload


### PR DESCRIPTION
To limit the effect on the finalization rate, we limit the number of (non-timeout) HTTP outcalls responses that are allowed to be included into a single payload.
https://github.com/dfinity/ic/blob/38556a3a0f8445310a9fd7323e28e6fb2eae2d30/rs/types/types/src/canister_http.rs#L81-L85

The exception are timeout responses, which are very cheap to verify. Therefore, they do not count towards this limit during payload building:
https://github.com/dfinity/ic/blob/38556a3a0f8445310a9fd7323e28e6fb2eae2d30/rs/https_outcalls/consensus/src/payload_builder.rs#L206-L227

However, before this PR, flexible timeouts did count towards the limit during payload validation. A honest block maker could therefore generate a payload with more the 500 flexible timeouts, which would be rejected by other honest block makers.

Note that the flexible outcalls feature isn't enabled yet.