### PR TITLE
fix: Validate in-memory size of ingress payload

### DIFF
--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -104,9 +104,18 @@ impl IngressSelector for IngressManager {
         let max_expiry = context.time + MAX_INGRESS_TTL;
         let expiry_range = min_expiry..=max_expiry;
 
-        let settings = self
-            .get_ingress_message_settings(context.registry_version)
-            .expect("Couldn't fetch ingress message parameters from the registry.");
+        let settings = match self.get_ingress_message_settings(context.registry_version) {
+            Ok(settings) => settings,
+            Err(err) => {
+                warn!(
+                    every_n_seconds => 5,
+                    self.log,
+                    "Failed to get the ingress message settings from the registry: {err}"
+                );
+
+                return PayloadWithSizeEstimate::default();
+            }
+        };
 
         // Select valid ingress messages and stop once the total size
         // becomes greater than byte_limit.
@@ -332,9 +341,26 @@ impl IngressSelector for IngressManager {
             .start_timer();
 
         let certified_height = context.certified_height;
-        let settings = self
-            .get_ingress_message_settings(context.registry_version)
-            .expect("Couldn't get IngressMessageSettings from the registry.");
+        let settings = match self.get_ingress_message_settings(context.registry_version) {
+            Ok(settings) => settings,
+            Err(err) => {
+                warn!(
+                    every_n_seconds => 30,
+                    self.log,
+                    "Failed to get the ingress message settings from the registry \
+                    at version {}: {:?}",
+                    context.registry_version,
+                    err
+                );
+
+                return Err(ValidationError::ValidationFailed(
+                    IngressPayloadValidationFailure::GetIngressMessageSettingsFailed(
+                        context.registry_version,
+                        err,
+                    ),
+                ));
+            }
+        };
 
         let past_ingress = match IngressSetChain::new(context.time, past_ingress, || {
             IngressHistorySet::new(self.ingress_hist_reader.as_ref(), certified_height)

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -379,6 +379,16 @@ impl IngressSelector for IngressManager {
             ));
         }
 
+        let size_estimates = self.payload_size_estimates(payload);
+        if size_estimates.memory.get() > settings.max_ingress_bytes_per_block as u64 {
+            return Err(ValidationError::InvalidArtifact(
+                InvalidIngressPayloadReason::IngressPayloadTooBig(
+                    size_estimates.memory.get() as usize,
+                    settings.max_ingress_bytes_per_block,
+                ),
+            ));
+        }
+
         // Tracks the sum of cycles needed per canister.
         let mut cycles_needed: BTreeMap<CanisterId, Cycles> = BTreeMap::new();
 
@@ -415,17 +425,6 @@ impl IngressSelector for IngressManager {
                 0, // message count is checked above.
                 &mut cycles_needed,
             )?;
-        }
-
-        let size_estimates = self.payload_size_estimates(payload);
-
-        if size_estimates.memory.get() > settings.max_ingress_bytes_per_block as u64 {
-            return Err(ValidationError::InvalidArtifact(
-                InvalidIngressPayloadReason::IngressPayloadTooBig(
-                    size_estimates.memory.get() as usize,
-                    settings.max_ingress_bytes_per_block,
-                ),
-            ));
         }
 
         Ok(size_estimates.wire)
@@ -900,21 +899,48 @@ pub(crate) mod tests {
     ) {
         let subnet_id = subnet_test_id(0);
 
-        // Tiny per-block byte cap (4 KiB); generous per-message (4 MiB) and
-        // per-block message-count (1000) caps.
-        const BLOCK_BYTE_CAP: usize = 4 * 1024;
+        const MAX_INGRESS_BYTES_PER_MESSAGE: usize = 4 * 1024 * 1024;
+
+        // Two payloads differing by exactly one ~1 KiB message. We set the
+        // per-block byte cap to the exact in-memory size of the smaller one, so
+        // the larger one is one message over it.
+        let build_message = |nonce: u64| {
+            SignedIngressBuilder::new()
+                .canister_id(canister_test_id(0))
+                .method_name("update")
+                .method_payload(vec![0_u8; 1024])
+                .nonce(nonce)
+                .expiry_time(UNIX_EPOCH + MAX_INGRESS_TTL)
+                .build()
+        };
+        let at_limit_msgs: Vec<_> = (0..4_u64).map(build_message).collect();
+        let over_limit_msgs: Vec<_> = (0..5_u64).map(build_message).collect();
+
+        // Each message individually respects the per-message size cap, so only
+        // the *cumulative* per-block cap is exercised below.
+        for msg in over_limit_msgs.iter() {
+            assert!(msg.count_bytes() <= MAX_INGRESS_BYTES_PER_MESSAGE);
+        }
+
+        let at_limit = IngressPayload::from(at_limit_msgs);
+        let over_limit = IngressPayload::from(over_limit_msgs);
+        // The in-memory size estimate is independent of the hashes-in-blocks
+        // feature, so the cap can be derived without an `IngressManager`.
+        let block_byte_cap = (at_limit.total_messages_size_estimate()
+            + at_limit.total_ids_size_estimate())
+        .get() as usize;
+
         let registry = set_up_registry(
             subnet_id,
-            Some(BLOCK_BYTE_CAP), // max_ingress_bytes_per_block
+            Some(block_byte_cap), // max_ingress_bytes_per_block == `at_limit`'s size
             1000,                 // max_ingress_messages_per_block
-            4 * 1024 * 1024,      // max_ingress_bytes_per_message
+            MAX_INGRESS_BYTES_PER_MESSAGE,
         );
 
         setup_with_params(
             None,
             Some((registry, subnet_id)),
             None,
-            // Well-funded Running canister so each ingress passes full validation.
             Some(
                 ReplicatedStateBuilder::new()
                     .with_subnet_id(subnet_id)
@@ -930,65 +956,45 @@ pub(crate) mod tests {
             |mut ingress_manager, _| {
                 ingress_manager.hashes_in_blocks_enabled_in_tests = hashes_in_blocks_enabled;
 
-                let settings = ingress_manager
-                    .get_ingress_message_settings(RegistryVersion::from(1))
-                    .unwrap();
                 let context = ValidationContext {
                     time: UNIX_EPOCH,
                     registry_version: RegistryVersion::from(1),
                     certified_height: Height::from(0),
                 };
-                let build_message = |nonce: u64| {
-                    SignedIngressBuilder::new()
-                        .canister_id(canister_test_id(0))
-                        .method_name("update")
-                        .method_payload(vec![0_u8; 1024])
-                        .nonce(nonce)
-                        .expiry_time(UNIX_EPOCH + MAX_INGRESS_TTL)
-                        .build()
-                };
 
-                // A single ~1 KiB message stays below the 4 KiB per-block cap and
-                // must still validate successfully (i.e. we don't over-reject).
-                let small_payload = IngressPayload::from(vec![build_message(0)]);
+                // A payload whose cumulative in-memory size is *exactly* the cap
+                // must validate. Validation returns the payload's wire size
+                // estimate, which with hashes-in-blocks enabled is just the
+                // message ids.
+                assert_eq!(
+                    ingress_manager
+                        .payload_size_estimates(&at_limit)
+                        .memory
+                        .get() as usize,
+                    block_byte_cap
+                );
+                let expected_wire = ingress_manager.payload_size_estimates(&at_limit).wire;
+                assert_eq!(
+                    ingress_manager.validate_ingress_payload(&at_limit, &HashSet::new(), &context),
+                    Ok(expected_wire)
+                );
+
+                // One additional message pushes the payload just over the cap,
+                // so it must be rejected regardless of the hashes-in-blocks
+                // feature.
                 assert!(
                     ingress_manager
-                        .payload_size_estimates(&small_payload)
+                        .payload_size_estimates(&over_limit)
                         .memory
                         .get() as usize
-                        <= settings.max_ingress_bytes_per_block
+                        > block_byte_cap
                 );
                 assert_matches!(
                     ingress_manager.validate_ingress_payload(
-                        &small_payload,
+                        &over_limit,
                         &HashSet::new(),
-                        &context,
+                        &context
                     ),
-                    Ok(_)
-                );
-
-                // 16 messages of ~1 KiB each => far above the 4 KiB per-block cap,
-                // even though each message individually respects the per-message
-                // size cap.
-                let mut msgs = Vec::new();
-                for i in 0..16_u64 {
-                    let ingress = build_message(i);
-                    assert!(ingress.count_bytes() <= settings.max_ingress_bytes_per_message);
-                    msgs.push(ingress);
-                }
-                let payload = IngressPayload::from(msgs);
-                assert!(
-                    ingress_manager
-                        .payload_size_estimates(&payload)
-                        .memory
-                        .get() as usize
-                        > settings.max_ingress_bytes_per_block
-                );
-
-                // The oversized block must be rejected regardless of whether the
-                // hashes-in-blocks feature is enabled.
-                assert_matches!(
-                    ingress_manager.validate_ingress_payload(&payload, &HashSet::new(), &context),
                     Err(ValidationError::InvalidArtifact(
                         InvalidIngressPayloadReason::IngressPayloadTooBig(_, _),
                     ))

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -419,6 +419,15 @@ impl IngressSelector for IngressManager {
 
         let size_estimates = self.payload_size_estimates(payload);
 
+        if size_estimates.memory.get() > settings.max_ingress_bytes_per_block as u64 {
+            return Err(ValidationError::InvalidArtifact(
+                InvalidIngressPayloadReason::IngressPayloadTooBig(
+                    size_estimates.memory.get() as usize,
+                    settings.max_ingress_bytes_per_block,
+                ),
+            ));
+        }
+
         Ok(size_estimates.wire)
     }
 
@@ -883,6 +892,109 @@ pub(crate) mod tests {
                 ),)
             );
         })
+    }
+
+    #[rstest]
+    fn test_validate_ingress_payload_max_block_bytes(
+        #[values[true, false]] hashes_in_blocks_enabled: bool,
+    ) {
+        let subnet_id = subnet_test_id(0);
+
+        // Tiny per-block byte cap (4 KiB); generous per-message (4 MiB) and
+        // per-block message-count (1000) caps.
+        const BLOCK_BYTE_CAP: usize = 4 * 1024;
+        let registry = set_up_registry(
+            subnet_id,
+            Some(BLOCK_BYTE_CAP), // max_ingress_bytes_per_block
+            1000,                 // max_ingress_messages_per_block
+            4 * 1024 * 1024,      // max_ingress_bytes_per_message
+        );
+
+        setup_with_params(
+            None,
+            Some((registry, subnet_id)),
+            None,
+            // Well-funded Running canister so each ingress passes full validation.
+            Some(
+                ReplicatedStateBuilder::new()
+                    .with_subnet_id(subnet_id)
+                    .with_canister(
+                        CanisterStateBuilder::new()
+                            .with_canister_id(canister_test_id(0))
+                            .with_cycles(u128::MAX)
+                            .build(),
+                    )
+                    .build(),
+            ),
+            /*ingress_pool_max_count=*/ None,
+            |mut ingress_manager, _| {
+                ingress_manager.hashes_in_blocks_enabled_in_tests = hashes_in_blocks_enabled;
+
+                let settings = ingress_manager
+                    .get_ingress_message_settings(RegistryVersion::from(1))
+                    .unwrap();
+                let context = ValidationContext {
+                    time: UNIX_EPOCH,
+                    registry_version: RegistryVersion::from(1),
+                    certified_height: Height::from(0),
+                };
+                let build_message = |nonce: u64| {
+                    SignedIngressBuilder::new()
+                        .canister_id(canister_test_id(0))
+                        .method_name("update")
+                        .method_payload(vec![0_u8; 1024])
+                        .nonce(nonce)
+                        .expiry_time(UNIX_EPOCH + MAX_INGRESS_TTL)
+                        .build()
+                };
+
+                // A single ~1 KiB message stays below the 4 KiB per-block cap and
+                // must still validate successfully (i.e. we don't over-reject).
+                let small_payload = IngressPayload::from(vec![build_message(0)]);
+                assert!(
+                    ingress_manager
+                        .payload_size_estimates(&small_payload)
+                        .memory
+                        .get() as usize
+                        <= settings.max_ingress_bytes_per_block
+                );
+                assert_matches!(
+                    ingress_manager.validate_ingress_payload(
+                        &small_payload,
+                        &HashSet::new(),
+                        &context,
+                    ),
+                    Ok(_)
+                );
+
+                // 16 messages of ~1 KiB each => far above the 4 KiB per-block cap,
+                // even though each message individually respects the per-message
+                // size cap.
+                let mut msgs = Vec::new();
+                for i in 0..16_u64 {
+                    let ingress = build_message(i);
+                    assert!(ingress.count_bytes() <= settings.max_ingress_bytes_per_message);
+                    msgs.push(ingress);
+                }
+                let payload = IngressPayload::from(msgs);
+                assert!(
+                    ingress_manager
+                        .payload_size_estimates(&payload)
+                        .memory
+                        .get() as usize
+                        > settings.max_ingress_bytes_per_block
+                );
+
+                // The oversized block must be rejected regardless of whether the
+                // hashes-in-blocks feature is enabled.
+                assert_matches!(
+                    ingress_manager.validate_ingress_payload(&payload, &HashSet::new(), &context),
+                    Err(ValidationError::InvalidArtifact(
+                        InvalidIngressPayloadReason::IngressPayloadTooBig(_, _),
+                    ))
+                );
+            },
+        );
     }
 
     #[test]

--- a/rs/interfaces/src/ingress_manager.rs
+++ b/rs/interfaces/src/ingress_manager.rs
@@ -5,7 +5,7 @@ use crate::{
     validation::ValidationError,
 };
 use ic_types::{
-    CanisterId, Height, NumBytes,
+    CanisterId, Height, NumBytes, RegistryVersion,
     artifact::IngressMessageId,
     batch::{IngressPayload, ValidationContext},
     consensus::Payload,
@@ -80,6 +80,7 @@ pub enum InvalidIngressPayloadReason {
 pub enum IngressPayloadValidationFailure {
     StateManagerError(Height, StateManagerError),
     IngressHistoryError(Height, IngressHistoryError),
+    GetIngressMessageSettingsFailed(RegistryVersion, String),
 }
 
 pub type IngressPayloadValidationError =

--- a/rs/interfaces/src/ingress_manager.rs
+++ b/rs/interfaces/src/ingress_manager.rs
@@ -63,6 +63,9 @@ pub enum InvalidIngressPayloadReason {
     IngressValidationError(MessageId, String),
     IngressExpired(MessageId, String),
     IngressMessageTooBig(usize, usize),
+    /// The cumulative in-memory size of the ingress payload (`.0`) exceeds the
+    /// per-block limit `max_ingress_bytes_per_block` (`.1`).
+    IngressPayloadTooBig(usize, usize),
     IngressPayloadTooManyMessages(usize, usize),
     DuplicatedIngressMessage(MessageId),
     InsufficientCycles(CanisterOutOfCyclesError),


### PR DESCRIPTION
Due to the hashes-in-blocks feature, ingress payloads have both an in-memory and an on-wire size limit (if hashes-in-blocks is disabled, both are the same). 

During payload building, both limits are enforced while selecting new ingress messages to be included:
https://github.com/dfinity/ic/blob/0f0a8d48219d90b10c2aad869217f96926d4b149/rs/ingress_manager/src/ingress_selector.rs#L210-L220

With this PR, we also enforce the in-memory limit during payload validation.