### PR TITLE
chore: allow symlinks for canister did files

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -153,7 +153,6 @@ artifact_bundle(
         testonly = True,
         src = target + ".didfile",
         out = name + ".did",
-        allow_symlink = False,
     )
     for (name, target) in CANISTERS.items()
     if (


### PR DESCRIPTION
After e293044d60e868b081b922cbf0346b5c6ef30e0e we support symlinks in artifact_bundles so we should no longer need `allow_symlink = False` for canister did files.