### PR TITLE
fix: deflake //rs/http_endpoints/nns_delegation_manager:nns_delegation_manager_test

### DIFF
--- a/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
+++ b/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
@@ -48,6 +48,15 @@ rust_library(
 rust_test(
     name = "nns_delegation_manager_test",
     crate = ":nns_delegation_manager",
+    # Each test establishes a real TLS connection to an in-process mock server. The Rust test
+    # harness runs the tests in parallel (one thread per test), so on a busy machine the connection
+    # setup can be starved of CPU and exceed `CONNECTION_TIMEOUT`. Limit the number of concurrent
+    # test threads and reserve enough CPU cores so the connections are established in time,
+    # preventing flaky connection timeouts.
+    env = {
+        "RUST_TEST_THREADS": "4",
+    },
+    tags = ["cpu:4"],
     deps = [
         "//rs/certification/test-utils",
         "//rs/crypto/tls_interfaces",

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -1270,19 +1270,8 @@ mod tests {
         )
         .await;
 
-        // Since the API BN is configured with a domain that does not resolve, we expect the
-        // connection to fail with a name resolution error, which indicates that we indeed tried to
-        // connect to the API BN instead of an NNS node. Depending on the environment the resolver
-        // either reports `NoRecordsFound` (a DNS server answered that the domain does not exist) or
-        // `Timeout` (no DNS server answered within the resolver timeout); both prove that we went
-        // through the API BN DNS-resolution path rather than connecting to an NNS node by IP.
-        assert_matches!(
-            response,
-            Err(err) if {
-                let err = format!("{err:?}");
-                err.contains("NoRecordsFound") || err.contains("Timeout")
-            }
-        );
+        // connect to the API BN instead of an NNS node.
+        assert_matches!(response, Err(err) if format!("{err:?}").contains("NoRecordsFound"));
     }
 
     #[tokio::test]

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -59,11 +59,6 @@ const DELEGATION_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 
 const DELEGATION_RETRY_MAX_BACKOFF_SECONDS: u64 = 15;
 
-// Unlike the send/receive timeouts below (which we deliberately lower in test mode), the
-// connection timeout uses the same value in production and in tests. Establishing the TLS
-// connection to the in-process mock server can take a while under load, and a low connection
-// timeout would spuriously fire before the connection is established and mask the
-// send/receive/DNS-resolution errors that the tests assert on.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(not(test))]

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -1270,6 +1270,8 @@ mod tests {
         )
         .await;
 
+        // Since the API BN is configured with a domain that does not resolve, we expect the
+        // connection to fail with a name resolution error, which indicates that we indeed tried to
         // connect to the API BN instead of an NNS node.
         assert_matches!(response, Err(err) if format!("{err:?}").contains("NoRecordsFound"));
     }

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -213,7 +213,6 @@ async fn load_root_delegation(
 
         match try_fetch_delegation_from_nns(
             config,
-            CONNECTION_TIMEOUT,
             log,
             rt_handle,
             subnet_id,
@@ -248,7 +247,6 @@ async fn load_root_delegation(
 /// Returns a BoxError if any step of the process fails.
 async fn try_fetch_delegation_from_nns(
     config: &Config,
-    connection_timeout: Duration,
     log: &ReplicaLogger,
     rt_handle: &tokio::runtime::Handle,
     subnet_id: SubnetId,
@@ -296,7 +294,7 @@ async fn try_fetch_delegation_from_nns(
     let registry_version = registry_client.get_latest_version();
 
     let mut request_sender = timeout(
-        connection_timeout,
+        CONNECTION_TIMEOUT,
         connect(
             log.clone(),
             rt_handle,
@@ -308,7 +306,7 @@ async fn try_fetch_delegation_from_nns(
     )
     .await
     .map_err(|_| {
-        format!("Timed out while connecting to the node after {connection_timeout:?}")
+        format!("Timed out while connecting to the node after {CONNECTION_TIMEOUT:?}")
     })??;
 
     let uri = format!("/api/v2/subnet/{nns_subnet_id}/read_state");
@@ -1266,7 +1264,6 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
-            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             CLOUD_ENGINE_SUBNET_ID,
@@ -1304,10 +1301,6 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
-            // Use a short connection timeout here: this test deliberately makes the mock server
-            // hang before accepting the connection, so we want the connection timeout to fire
-            // quickly instead of waiting for the full `CONNECTION_TIMEOUT`.
-            Duration::from_secs(1),
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,
@@ -1333,7 +1326,6 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
-            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,
@@ -1359,7 +1351,6 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
-            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -59,10 +59,15 @@ const DELEGATION_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 
 const DELEGATION_RETRY_MAX_BACKOFF_SECONDS: u64 = 15;
 
-#[cfg(not(test))]
+// Unlike the send/receive timeouts below (which we deliberately lower in test mode), the
+// connection timeout uses the same value in production and in tests. Establishing the TLS
+// connection to the in-process mock server can take a while under load, and a low connection
+// timeout would spuriously fire before the connection is established and mask the
+// send/receive/DNS-resolution errors that the tests assert on. To keep this timeout meaningful in
+// tests, the concurrency of the test binary is limited (see `RUST_TEST_THREADS` and the `cpu:4`
+// tag in `BUILD.bazel`), and the test that specifically exercises the connection timeout passes
+// its own short timeout instead.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
-#[cfg(test)]
-const CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[cfg(not(test))]
 const NNS_DELEGATION_BODY_RECEIVE_TIMEOUT: Duration = Duration::from_secs(300);
@@ -211,6 +216,7 @@ async fn load_root_delegation(
 
         match try_fetch_delegation_from_nns(
             config,
+            CONNECTION_TIMEOUT,
             log,
             rt_handle,
             subnet_id,
@@ -245,6 +251,7 @@ async fn load_root_delegation(
 /// Returns a BoxError if any step of the process fails.
 async fn try_fetch_delegation_from_nns(
     config: &Config,
+    connection_timeout: Duration,
     log: &ReplicaLogger,
     rt_handle: &tokio::runtime::Handle,
     subnet_id: SubnetId,
@@ -292,7 +299,7 @@ async fn try_fetch_delegation_from_nns(
     let registry_version = registry_client.get_latest_version();
 
     let mut request_sender = timeout(
-        CONNECTION_TIMEOUT,
+        connection_timeout,
         connect(
             log.clone(),
             rt_handle,
@@ -304,7 +311,7 @@ async fn try_fetch_delegation_from_nns(
     )
     .await
     .map_err(|_| {
-        format!("Timed out while connecting to the node after {CONNECTION_TIMEOUT:?}")
+        format!("Timed out while connecting to the node after {connection_timeout:?}")
     })??;
 
     let uri = format!("/api/v2/subnet/{nns_subnet_id}/read_state");
@@ -1262,6 +1269,7 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
+            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             CLOUD_ENGINE_SUBNET_ID,
@@ -1275,8 +1283,17 @@ mod tests {
 
         // Since the API BN is configured with a domain that does not resolve, we expect the
         // connection to fail with a name resolution error, which indicates that we indeed tried to
-        // connect to the API BN instead of an NNS node.
-        assert_matches!(response, Err(err) if format!("{err:?}").contains("NoRecordsFound"));
+        // connect to the API BN instead of an NNS node. Depending on the environment the resolver
+        // either reports `NoRecordsFound` (a DNS server answered that the domain does not exist) or
+        // `Timeout` (no DNS server answered within the resolver timeout); both prove that we went
+        // through the API BN DNS-resolution path rather than connecting to an NNS node by IP.
+        assert_matches!(
+            response,
+            Err(err) if {
+                let err = format!("{err:?}");
+                err.contains("NoRecordsFound") || err.contains("Timeout")
+            }
+        );
     }
 
     #[tokio::test]
@@ -1290,6 +1307,10 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
+            // Use a short connection timeout here: this test deliberately makes the mock server
+            // hang before accepting the connection, so we want the connection timeout to fire
+            // quickly instead of waiting for the full `CONNECTION_TIMEOUT`.
+            Duration::from_secs(1),
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,
@@ -1315,6 +1336,7 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
+            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,
@@ -1340,6 +1362,7 @@ mod tests {
 
         let response = try_fetch_delegation_from_nns(
             &Config::default(),
+            CONNECTION_TIMEOUT,
             &no_op_logger(),
             &rt_handle,
             APP_SUBNET_ID,

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -63,10 +63,7 @@ const DELEGATION_RETRY_MAX_BACKOFF_SECONDS: u64 = 15;
 // connection timeout uses the same value in production and in tests. Establishing the TLS
 // connection to the in-process mock server can take a while under load, and a low connection
 // timeout would spuriously fire before the connection is established and mask the
-// send/receive/DNS-resolution errors that the tests assert on. To keep this timeout meaningful in
-// tests, the concurrency of the test binary is limited (see `RUST_TEST_THREADS` and the `cpu:4`
-// tag in `BUILD.bazel`), and the test that specifically exercises the connection timeout passes
-// its own short timeout instead.
+// send/receive/DNS-resolution errors that the tests assert on.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(not(test))]


### PR DESCRIPTION
## Summary

`//rs/http_endpoints/nns_delegation_manager:nns_delegation_manager_test` was flaky. Over the past week it flaked in 7 CI runs, with three subtests failing intermittently:

- `load_root_delegation_times_out_on_send_request_test`
- `load_root_delegation_times_out_on_receive_body_test`
- `load_root_delegation_on_cloud_engine_should_contact_api_bn_test`

## Root cause

In test mode `CONNECTION_TIMEOUT`, `NNS_DELEGATION_REQUEST_SEND_TIMEOUT` and `NNS_DELEGATION_BODY_RECEIVE_TIMEOUT` were all set to `1s`. `try_fetch_delegation_from_nns` runs three sequential, wall-clock-timed stages, and the **connect** stage runs first with the same `1s` budget as the stage each test actually targets:

1. `timeout(CONNECTION_TIMEOUT, connect(...))` — a real TCP + TLS handshake to an in-process mock server (or a DNS lookup for the API BN case).
2. `timeout(NNS_DELEGATION_REQUEST_SEND_TIMEOUT, send_request(...))`
3. `timeout(NNS_DELEGATION_BODY_RECEIVE_TIMEOUT, collect body)`

The Rust test harness runs the tests in parallel (one thread per test), and each test drives the client and the spawned mock server on the same `current_thread` Tokio runtime. Under CPU contention on CI, the connect stage exceeds `1s`, so the connection timeout fires and returns `"Timed out while connecting to the node after 1s"` — pre-empting and masking the send/receive/DNS error each test asserts on. In every observed CI failure the actual error was this connection-timeout string.

## Fix

- Use the same `10s` `CONNECTION_TIMEOUT` in production and tests (removed the `#[cfg(test)]` `1s` override). A generous connect budget means a slow TLS handshake no longer pre-empts the send/receive/DNS errors the tests actually assert on, while the `1s` send/receive timeouts those tests target are unchanged.
- Limit the test binary's concurrency (`RUST_TEST_THREADS=4` and `tags = ["cpu:4"]`) so connection setup isn't starved of CPU and completes within the timeout. This directly addresses the CPU-contention root cause.

## Verification

- `rustfmt` and `cargo clippy` (incl. `--tests`) are clean.
- Stress-ran `bazel test --runs_per_test=10 --jobs=10 --nocache_test_results //rs/http_endpoints/nns_delegation_manager:nns_delegation_manager_test`; with the connect stage no longer sharing a `1s` budget it stops timing out spuriously.
- Downstream `//rs/http_endpoints/public:*` and `//rs/replica:*` tests pass.

Created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
