### PR TITLE
feat(HTTP handler): return 503 on outdated delegation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9827,6 +9827,7 @@ dependencies = [
  "ic-base-types",
  "ic-btc-interface",
  "ic-canister-sandbox-backend-lib",
+ "ic-canonical-state",
  "ic-config",
  "ic-crypto-prng",
  "ic-crypto-sha2",

--- a/rs/canonical_state/BUILD.bazel
+++ b/rs/canonical_state/BUILD.bazel
@@ -38,6 +38,7 @@ rust_test(
     crate = ":canonical_state",
     deps = [
         # Keep sorted.
+        "//rs/canonical_state/tree_hash/test_utils",
         "//rs/crypto/sha2",
         "//rs/registry/subnet_features",
         "//rs/sys",

--- a/rs/canonical_state/src/delegation.rs
+++ b/rs/canonical_state/src/delegation.rs
@@ -1,0 +1,474 @@
+//! Validation of an NNS [`CertificateDelegation`] against a [`ReplicatedState`].
+//!
+//! A subnet delegation issued by the NNS certifies, for a given subnet, its
+//! threshold public key and the set of canister ID ranges assigned to it. This
+//! module checks that the contents of such a delegation agree with the subnet
+//! information recorded in a [`ReplicatedState`] (as it is exposed in the
+//! certified state tree): the certified public key must match the one in the
+//! state, and the certified canister ranges must match the ranges the state
+//! assigns to that subnet.
+//!
+//! In some cases, the delegation fetched from the NNS could mismatch the information
+//! stored in the state, for example right after a subnet split: the subnet starts
+//! certifying with a fresh threshold key while the cached NNS delegation may still
+//! carry the previous key for up to a few minutes. Similarly, right before a subnet
+//! split, the delegation might already carry the new key while the certified state
+//! still carries the old key.
+use ic_crypto_tree_hash::{LabeledTree, lookup_path};
+use ic_replicated_state::ReplicatedState;
+use ic_types::{
+    PrincipalId, SubnetId,
+    messages::{Certificate, CertificateDelegation, CertificateDelegationFormat},
+};
+use std::fmt;
+
+/// An error encountered while checking a delegation against a replicated state.
+///
+/// These indicate that validity could *not be determined* (e.g. a malformed
+/// certificate), as opposed to the delegation being found inconsistent with the
+/// state.
+#[derive(Debug, Eq, PartialEq)]
+pub enum DelegationValidationError {
+    /// The delegation's `subnet_id` is not a valid principal.
+    InvalidSubnetId(String),
+    /// The embedded certificate could not be CBOR-decoded.
+    MalformedCertificate(String),
+    /// The certificate's mixed hash tree could not be converted into a labeled tree.
+    MalformedHashTree(String),
+    /// An expected path was missing from the certificate or had an unexpected shape.
+    UnexpectedTreeShape(String),
+    /// A certified canister-ranges leaf could not be CBOR-decoded.
+    MalformedCanisterRanges(String),
+    /// The state has no topology for the delegated subnet.
+    UnknownSubnet(SubnetId),
+}
+
+impl fmt::Display for DelegationValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSubnetId(err) => write!(f, "invalid subnet id in delegation: {err}"),
+            Self::MalformedCertificate(err) => {
+                write!(f, "failed to decode delegation certificate: {err}")
+            }
+            Self::MalformedHashTree(err) => {
+                write!(f, "invalid hash tree in delegation certificate: {err}")
+            }
+            Self::UnexpectedTreeShape(err) => write!(f, "unexpected certificate tree shape: {err}"),
+            Self::MalformedCanisterRanges(err) => {
+                write!(f, "failed to decode certified canister ranges: {err}")
+            }
+            Self::UnknownSubnet(subnet_id) => {
+                write!(f, "state has no topology for subnet {subnet_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DelegationValidationError {}
+
+/// Checks whether `delegation` is consistent with `state`.
+///
+/// Returns `Ok(true)` if, for the subnet the delegation refers to, both:
+/// * the threshold public key certified by the delegation matches the subnet's
+///   public key in `state`; and
+/// * the canister ID ranges certified by the delegation match the ranges
+///   assigned to the subnet in `state`.
+///
+/// Returns `Ok(false)` if either of those does not match. Any error that
+/// prevents the comparison (malformed certificate, missing tree paths, unknown
+/// subnet, ...) is returned as `Err`.
+///
+/// `format` indicates where the certified canister ranges are located in the
+/// delegation's certificate (it must match the format the delegation was built
+/// with):
+/// * [`CertificateDelegationFormat::Flat`]: under `/subnet/<subnet_id>/canister_ranges`;
+/// * [`CertificateDelegationFormat::Tree`]: under `/canister_ranges/<subnet_id>`;
+/// * [`CertificateDelegationFormat::Pruned`]: the ranges are pruned out of the
+///   certificate, so only the public key is checked.
+///
+/// Both sides are compared using the *certification* view of the state's
+/// network topology ([`subnets_for_certification`] and
+/// [`routing_table_for_certification`]), i.e. exactly the data that the
+/// certified state tree (and hence a delegation) is derived from.
+///
+/// [`subnets_for_certification`]: ic_replicated_state::metadata_state::NetworkTopology::subnets_for_certification
+/// [`routing_table_for_certification`]: ic_replicated_state::metadata_state::NetworkTopology::routing_table_for_certification
+pub fn is_delegation_valid_with_respect_to_state(
+    delegation: &CertificateDelegation,
+    format: CertificateDelegationFormat,
+    state: &ReplicatedState,
+) -> Result<bool, DelegationValidationError> {
+    let subnet_id_bytes = delegation.subnet_id.0.as_slice();
+    let subnet_id = SubnetId::from(
+        PrincipalId::try_from(subnet_id_bytes)
+            .map_err(|err| DelegationValidationError::InvalidSubnetId(err.to_string()))?,
+    );
+
+    let certificate: Certificate = serde_cbor::from_slice(delegation.certificate.0.as_slice())
+        .map_err(|err| DelegationValidationError::MalformedCertificate(err.to_string()))?;
+    let tree = LabeledTree::try_from(certificate.tree)
+        .map_err(|err| DelegationValidationError::MalformedHashTree(format!("{err:?}")))?;
+
+    let network_topology = &state.metadata.network_topology;
+    let subnet_topology = network_topology
+        .subnets_for_certification()
+        .get(&subnet_id)
+        .ok_or(DelegationValidationError::UnknownSubnet(subnet_id))?;
+
+    // 1. The certified public key must match the one recorded in the state.
+    let certified_public_key =
+        match lookup_path(&tree, &[b"subnet", subnet_id_bytes, b"public_key"]) {
+            Some(LabeledTree::Leaf(public_key)) => public_key,
+            _ => {
+                return Err(DelegationValidationError::UnexpectedTreeShape(format!(
+                    "missing /subnet/{subnet_id}/public_key leaf"
+                )));
+            }
+        };
+    if certified_public_key.as_slice() != subnet_topology.public_key.as_slice() {
+        return Ok(false);
+    }
+
+    // 2. The certified canister ranges must match the ranges the state assigns
+    //    to the subnet. Pruned delegations carry no ranges, so there is nothing
+    //    left to compare once the public key matches.
+    let certified_ranges =
+        match certified_canister_ranges(&tree, format, subnet_id_bytes, subnet_id)? {
+            Some(mut ranges) => {
+                ranges.sort();
+                ranges
+            }
+            None => return Ok(true),
+        };
+
+    let expected_ranges: Vec<(PrincipalId, PrincipalId)> = network_topology
+        .routing_table_for_certification()
+        .ranges(subnet_id)
+        .iter()
+        .map(|range| (range.start.get(), range.end.get()))
+        .collect();
+
+    Ok(certified_ranges == expected_ranges)
+}
+
+/// Extracts the canister ID ranges certified for `subnet_id` from the
+/// delegation's certificate `tree`, according to `format`.
+///
+/// Returns `Ok(None)` for [`CertificateDelegationFormat::Pruned`] (the ranges
+/// are absent, so there is nothing to compare), and `Ok(Some(ranges))`
+/// otherwise. The returned ranges are not necessarily sorted.
+fn certified_canister_ranges(
+    tree: &LabeledTree<Vec<u8>>,
+    format: CertificateDelegationFormat,
+    subnet_id_bytes: &[u8],
+    subnet_id: SubnetId,
+) -> Result<Option<Vec<(PrincipalId, PrincipalId)>>, DelegationValidationError> {
+    // Canister ranges are stored as self-describing CBOR of `(start, end)`
+    // principal pairs (see `encoding::encode_subnet_canister_ranges`).
+    let decode = |bytes: &[u8]| {
+        serde_cbor::from_slice::<Vec<(PrincipalId, PrincipalId)>>(bytes)
+            .map_err(|err| DelegationValidationError::MalformedCanisterRanges(err.to_string()))
+    };
+
+    match format {
+        // A single leaf at /subnet/<subnet_id>/canister_ranges.
+        CertificateDelegationFormat::Flat => {
+            match lookup_path(tree, &[b"subnet", subnet_id_bytes, b"canister_ranges"]) {
+                Some(LabeledTree::Leaf(bytes)) => Ok(Some(decode(bytes)?)),
+                _ => Err(DelegationValidationError::UnexpectedTreeShape(format!(
+                    "missing /subnet/{subnet_id}/canister_ranges leaf"
+                ))),
+            }
+        }
+        // Ranges split across the leaves of the /canister_ranges/<subnet_id> subtree.
+        CertificateDelegationFormat::Tree => {
+            match lookup_path(tree, &[b"canister_ranges", subnet_id_bytes]) {
+                Some(LabeledTree::SubTree(children)) => {
+                    let mut ranges = Vec::new();
+                    for (_label, child) in children.iter() {
+                        match child {
+                            LabeledTree::Leaf(bytes) => ranges.extend(decode(bytes)?),
+                            LabeledTree::SubTree(_) => {
+                                return Err(DelegationValidationError::UnexpectedTreeShape(
+                                    format!(
+                                        "unexpected subtree under /canister_ranges/{subnet_id}"
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                    Ok(Some(ranges))
+                }
+                _ => Err(DelegationValidationError::UnexpectedTreeShape(format!(
+                    "missing /canister_ranges/{subnet_id} subtree"
+                ))),
+            }
+        }
+        CertificateDelegationFormat::Pruned => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DelegationValidationError, is_delegation_valid_with_respect_to_state};
+    use crate::encoding::encode_subnet_canister_ranges;
+    use assert_matches::assert_matches;
+    use ic_canonical_state_tree_hash_test_utils::build_witness_gen;
+    use ic_crypto_tree_hash::{Label, LabeledTree, WitnessGenerator, flatmap};
+    use ic_registry_routing_table::CanisterIdRange;
+    use ic_registry_subnet_type::SubnetType;
+    use ic_replicated_state::{
+        ReplicatedState, SubnetTopology, metadata_state::testing::NetworkTopologyTesting,
+    };
+    use ic_test_utilities_types::ids::SUBNET_1;
+    use ic_types::{
+        CanisterId, PrincipalId, SubnetId,
+        messages::{Blob, Certificate, CertificateDelegation, CertificateDelegationFormat},
+    };
+    use serde::Serialize;
+
+    fn range(start: u64, end: u64) -> CanisterIdRange {
+        CanisterIdRange {
+            start: CanisterId::from_u64(start),
+            end: CanisterId::from_u64(end),
+        }
+    }
+
+    /// Encodes canister ranges into a leaf, exactly as the canonical state does
+    /// (see [`encode_subnet_canister_ranges`]).
+    fn ranges_leaf(ranges: &[CanisterIdRange]) -> LabeledTree<Vec<u8>> {
+        let pairs: Vec<(PrincipalId, PrincipalId)> = ranges
+            .iter()
+            .map(|r| (r.start.get(), r.end.get()))
+            .collect();
+        LabeledTree::Leaf(encode_subnet_canister_ranges(Some(&pairs)))
+    }
+
+    /// `/subnet/<subnet_id>/{canister_ranges, public_key}` (the `Flat` layout).
+    fn flat_tree(
+        subnet_id: SubnetId,
+        public_key: &[u8],
+        ranges: &[CanisterIdRange],
+    ) -> LabeledTree<Vec<u8>> {
+        LabeledTree::SubTree(flatmap![
+            Label::from("subnet") => LabeledTree::SubTree(flatmap![
+                Label::from(subnet_id.get().to_vec()) => LabeledTree::SubTree(flatmap![
+                    Label::from("canister_ranges") => ranges_leaf(ranges),
+                    Label::from("public_key") => LabeledTree::Leaf(public_key.to_vec()),
+                ]),
+            ]),
+        ])
+    }
+
+    /// `/subnet/<subnet_id>/public_key` plus a `/canister_ranges/<subnet_id>`
+    /// subtree whose leaves hold the ranges split into two chunks (the `Tree`
+    /// layout).
+    fn tree_layout(
+        subnet_id: SubnetId,
+        public_key: &[u8],
+        chunk_a: &[CanisterIdRange],
+        chunk_b: &[CanisterIdRange],
+    ) -> LabeledTree<Vec<u8>> {
+        LabeledTree::SubTree(flatmap![
+            Label::from("canister_ranges") => LabeledTree::SubTree(flatmap![
+                Label::from(subnet_id.get().to_vec()) => LabeledTree::SubTree(flatmap![
+                    Label::from(chunk_a[0].start.get().to_vec()) => ranges_leaf(chunk_a),
+                    Label::from(chunk_b[0].start.get().to_vec()) => ranges_leaf(chunk_b),
+                ]),
+            ]),
+            Label::from("subnet") => LabeledTree::SubTree(flatmap![
+                Label::from(subnet_id.get().to_vec()) => LabeledTree::SubTree(flatmap![
+                    Label::from("public_key") => LabeledTree::Leaf(public_key.to_vec()),
+                ]),
+            ]),
+        ])
+    }
+
+    /// `/subnet/<subnet_id>/public_key` only (the `Pruned` layout).
+    fn pruned_tree(subnet_id: SubnetId, public_key: &[u8]) -> LabeledTree<Vec<u8>> {
+        LabeledTree::SubTree(flatmap![
+            Label::from("subnet") => LabeledTree::SubTree(flatmap![
+                Label::from(subnet_id.get().to_vec()) => LabeledTree::SubTree(flatmap![
+                    Label::from("public_key") => LabeledTree::Leaf(public_key.to_vec()),
+                ]),
+            ]),
+        ])
+    }
+
+    /// Wraps `tree` into a delegation for `subnet_id`. The signature is
+    /// irrelevant: the validator never verifies it.
+    fn delegation(subnet_id: SubnetId, tree: &LabeledTree<Vec<u8>>) -> CertificateDelegation {
+        let certificate = Certificate {
+            tree: build_witness_gen(tree)
+                .mixed_hash_tree(tree)
+                .expect("failed to build a MixedHashTree"),
+            signature: Blob(vec![]),
+            delegation: None,
+        };
+        let mut serializer = serde_cbor::Serializer::new(Vec::new());
+        serializer.self_describe().unwrap();
+        certificate.serialize(&mut serializer).unwrap();
+        CertificateDelegation {
+            subnet_id: Blob(subnet_id.get().to_vec()),
+            certificate: Blob(serializer.into_inner()),
+        }
+    }
+
+    /// A replicated state whose certification view maps `subnet_id` to
+    /// `public_key` and `ranges`.
+    fn state_with(
+        subnet_id: SubnetId,
+        public_key: Vec<u8>,
+        ranges: &[CanisterIdRange],
+    ) -> ReplicatedState {
+        let mut state = ReplicatedState::new(subnet_id, SubnetType::Application);
+        state.metadata.network_topology.subnets_mut().insert(
+            subnet_id,
+            SubnetTopology {
+                public_key,
+                ..SubnetTopology::default()
+            },
+        );
+        let routing_table = state.metadata.network_topology.routing_table_mut();
+        for range in ranges {
+            routing_table.insert(*range, subnet_id).unwrap();
+        }
+        state
+    }
+
+    #[test]
+    fn flat_delegation_matching_public_key_and_ranges_is_valid() {
+        let public_key = vec![1, 2, 3];
+        let ranges = [range(10, 20), range(100, 200)];
+        let state = state_with(SUBNET_1, public_key.clone(), &ranges);
+        let delegation = delegation(SUBNET_1, &flat_tree(SUBNET_1, &public_key, &ranges));
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Flat,
+                &state,
+            ),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn tree_delegation_matching_public_key_and_ranges_is_valid() {
+        let public_key = vec![1, 2, 3];
+        // The state holds both ranges; the delegation splits them across two leaves.
+        let state = state_with(
+            SUBNET_1,
+            public_key.clone(),
+            &[range(10, 20), range(100, 200)],
+        );
+        let delegation = delegation(
+            SUBNET_1,
+            &tree_layout(SUBNET_1, &public_key, &[range(10, 20)], &[range(100, 200)]),
+        );
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Tree,
+                &state,
+            ),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn pruned_delegation_ignores_ranges_and_only_checks_public_key() {
+        let public_key = vec![1, 2, 3];
+        // The state has ranges, but a pruned delegation carries none: they must
+        // not be compared, so a matching public key is enough. The tree only
+        // contains the public key.
+        let state = state_with(SUBNET_1, public_key.clone(), &[range(10, 20)]);
+        let delegation = delegation(SUBNET_1, &pruned_tree(SUBNET_1, &public_key));
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Pruned,
+                &state,
+            ),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn mismatching_public_key_is_invalid() {
+        let ranges = [range(10, 20)];
+        let state = state_with(SUBNET_1, vec![1, 2, 3], &ranges);
+        // Same ranges, different public key.
+        let delegation = delegation(SUBNET_1, &flat_tree(SUBNET_1, &[9, 9, 9], &ranges));
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Flat,
+                &state,
+            ),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn mismatching_canister_ranges_are_invalid() {
+        let public_key = vec![1, 2, 3];
+        let state = state_with(SUBNET_1, public_key.clone(), &[range(10, 20)]);
+        // Same public key, but the delegation certifies a different range.
+        let delegation = delegation(
+            SUBNET_1,
+            &flat_tree(SUBNET_1, &public_key, &[range(10, 999)]),
+        );
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Flat,
+                &state,
+            ),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn unknown_subnet_is_an_error() {
+        // The state does not know about SUBNET_1.
+        let state = ReplicatedState::new(SUBNET_1, SubnetType::Application);
+        let delegation = delegation(SUBNET_1, &flat_tree(SUBNET_1, &[1, 2, 3], &[range(10, 20)]));
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Flat,
+                &state,
+            ),
+            Err(DelegationValidationError::UnknownSubnet(_))
+        );
+    }
+
+    #[test]
+    fn public_key_missing_from_delegation_is_an_error() {
+        let state = state_with(SUBNET_1, vec![1, 2, 3], &[range(10, 20)]);
+        // A tree that has canister ranges but no public_key leaf.
+        let tree = LabeledTree::SubTree(flatmap![
+            Label::from("subnet") => LabeledTree::SubTree(flatmap![
+                Label::from(SUBNET_1.get().to_vec()) => LabeledTree::SubTree(flatmap![
+                    Label::from("canister_ranges") => ranges_leaf(&[range(10, 20)]),
+                ]),
+            ]),
+        ]);
+        let delegation = delegation(SUBNET_1, &tree);
+
+        assert_matches!(
+            is_delegation_valid_with_respect_to_state(
+                &delegation,
+                CertificateDelegationFormat::Flat,
+                &state,
+            ),
+            Err(DelegationValidationError::UnexpectedTreeShape(_))
+        );
+    }
+}

--- a/rs/canonical_state/src/delegation.rs
+++ b/rs/canonical_state/src/delegation.rs
@@ -133,12 +133,8 @@ pub fn is_delegation_valid_with_respect_to_state(
     // 2. The certified canister ranges must match the ranges the state assigns
     //    to the subnet. Pruned delegations carry no ranges, so there is nothing
     //    left to compare once the public key matches.
-    let certified_ranges = match certified_canister_ranges(&tree, format, subnet_id)? {
-        Some(mut ranges) => {
-            ranges.sort();
-            ranges
-        }
-        None => return Ok(true),
+    let Some(certified_ranges) = certified_canister_ranges(&tree, format, subnet_id)? else {
+        return Ok(true);
     };
 
     let expected_ranges: Vec<(PrincipalId, PrincipalId)> = network_topology
@@ -156,7 +152,7 @@ pub fn is_delegation_valid_with_respect_to_state(
 ///
 /// Returns `Ok(None)` for [`CertificateDelegationFormat::Pruned`] (the ranges
 /// are absent, so there is nothing to compare), and `Ok(Some(ranges))`
-/// otherwise. The returned ranges are not necessarily sorted.
+/// otherwise.
 fn certified_canister_ranges(
     tree: &LabeledTree<Vec<u8>>,
     format: CertificateDelegationFormat,

--- a/rs/canonical_state/src/delegation.rs
+++ b/rs/canonical_state/src/delegation.rs
@@ -214,7 +214,8 @@ mod tests {
     use ic_registry_routing_table::CanisterIdRange;
     use ic_registry_subnet_type::SubnetType;
     use ic_replicated_state::{
-        ReplicatedState, SubnetTopology, metadata_state::testing::NetworkTopologyTesting,
+        ReplicatedState, SubnetTopology,
+        metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
     };
     use ic_test_utilities_types::ids::SUBNET_1;
     use ic_types::{
@@ -318,17 +319,19 @@ mod tests {
         ranges: &[CanisterIdRange],
     ) -> ReplicatedState {
         let mut state = ReplicatedState::new(subnet_id, SubnetType::Application);
-        state.metadata.network_topology.subnets_mut().insert(
-            subnet_id,
-            SubnetTopology {
-                public_key,
-                ..SubnetTopology::default()
-            },
-        );
-        let routing_table = state.metadata.network_topology.routing_table_mut();
-        for range in ranges {
-            routing_table.insert(*range, subnet_id).unwrap();
-        }
+        state.metadata.modify_network_topology(|topology| {
+            topology.subnets_mut().insert(
+                subnet_id,
+                SubnetTopology {
+                    public_key,
+                    ..SubnetTopology::default()
+                },
+            );
+            let routing_table = topology.routing_table_mut();
+            for range in ranges {
+                routing_table.insert(*range, subnet_id).unwrap();
+            }
+        });
         state
     }
 

--- a/rs/canonical_state/src/delegation.rs
+++ b/rs/canonical_state/src/delegation.rs
@@ -98,9 +98,8 @@ pub fn is_delegation_valid_with_respect_to_state(
     format: CertificateDelegationFormat,
     state: &ReplicatedState,
 ) -> Result<bool, DelegationValidationError> {
-    let subnet_id_bytes = delegation.subnet_id.0.as_slice();
     let subnet_id = SubnetId::from(
-        PrincipalId::try_from(subnet_id_bytes)
+        PrincipalId::try_from(delegation.subnet_id.0.as_slice())
             .map_err(|err| DelegationValidationError::InvalidSubnetId(err.to_string()))?,
     );
 
@@ -116,15 +115,17 @@ pub fn is_delegation_valid_with_respect_to_state(
         .ok_or(DelegationValidationError::UnknownSubnet(subnet_id))?;
 
     // 1. The certified public key must match the one recorded in the state.
-    let certified_public_key =
-        match lookup_path(&tree, &[b"subnet", subnet_id_bytes, b"public_key"]) {
-            Some(LabeledTree::Leaf(public_key)) => public_key,
-            _ => {
-                return Err(DelegationValidationError::UnexpectedTreeShape(format!(
-                    "missing /subnet/{subnet_id}/public_key leaf"
-                )));
-            }
-        };
+    let certified_public_key = match lookup_path(
+        &tree,
+        &[b"subnet", subnet_id.get_ref().as_slice(), b"public_key"],
+    ) {
+        Some(LabeledTree::Leaf(public_key)) => public_key,
+        _ => {
+            return Err(DelegationValidationError::UnexpectedTreeShape(format!(
+                "missing /subnet/{subnet_id}/public_key leaf"
+            )));
+        }
+    };
     if certified_public_key.as_slice() != subnet_topology.public_key.as_slice() {
         return Ok(false);
     }
@@ -132,14 +133,13 @@ pub fn is_delegation_valid_with_respect_to_state(
     // 2. The certified canister ranges must match the ranges the state assigns
     //    to the subnet. Pruned delegations carry no ranges, so there is nothing
     //    left to compare once the public key matches.
-    let certified_ranges =
-        match certified_canister_ranges(&tree, format, subnet_id_bytes, subnet_id)? {
-            Some(mut ranges) => {
-                ranges.sort();
-                ranges
-            }
-            None => return Ok(true),
-        };
+    let certified_ranges = match certified_canister_ranges(&tree, format, subnet_id)? {
+        Some(mut ranges) => {
+            ranges.sort();
+            ranges
+        }
+        None => return Ok(true),
+    };
 
     let expected_ranges: Vec<(PrincipalId, PrincipalId)> = network_topology
         .routing_table_for_certification()
@@ -160,9 +160,9 @@ pub fn is_delegation_valid_with_respect_to_state(
 fn certified_canister_ranges(
     tree: &LabeledTree<Vec<u8>>,
     format: CertificateDelegationFormat,
-    subnet_id_bytes: &[u8],
     subnet_id: SubnetId,
 ) -> Result<Option<Vec<(PrincipalId, PrincipalId)>>, DelegationValidationError> {
+    let subnet_id_bytes = subnet_id.get_ref().as_slice();
     // Canister ranges are stored as self-describing CBOR of `(start, end)`
     // principal pairs (see `encoding::encode_subnet_canister_ranges`).
     let decode = |bytes: &[u8]| {

--- a/rs/canonical_state/src/lib.rs
+++ b/rs/canonical_state/src/lib.rs
@@ -128,6 +128,7 @@
 //! `CURRENT_CERTIFICATION_VERSION+1` it will panic, in order to avoid undefined
 //! behavior.
 
+pub mod delegation;
 pub mod encoding;
 pub mod lazy_tree_conversion;
 pub mod size_limit_visitor;

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -14,6 +14,7 @@ rust_library(
         "//packages/ic-error-types",
         "//packages/ic-heap-bytes",
         "//rs/canister_sandbox:backend_lib",
+        "//rs/canonical_state",
         "//rs/config",
         "//rs/crypto/prng",
         "//rs/crypto/tree_hash",

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 candid = { workspace = true }
 ic-base-types = { path = "../types/base_types" }
 ic-canister-sandbox-backend-lib = { path = "../canister_sandbox" }
+ic-canonical-state = { path = "../canonical_state" }
 ic-config = { path = "../config" }
 ic-crypto-prng = { path = "../crypto/prng" }
 ic-crypto-tree-hash = { path = "../crypto/tree_hash" }

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -16,6 +16,7 @@ use crate::{
     metrics::{MeasurementScope, QueryHandlerMetrics},
 };
 use candid::Encode;
+use ic_canonical_state::delegation::is_delegation_valid_with_respect_to_state;
 use ic_config::execution_environment::Config;
 use ic_config::flag_status::FlagStatus;
 use ic_crypto_tree_hash::{Label, LabeledTree, LabeledTree::SubTree, flatmap};
@@ -537,17 +538,40 @@ impl Service<QueryExecutionInput> for HttpQueryHandler {
                 // with a reference to older states which can cause out-of-memory crashes.
 
                 let (certificate_delegation, certificate_delegation_metadata) =
-                    match certificate_delegation_with_metadata {
+                    match certificate_delegation_with_metadata.clone() {
                         Some((delegation, metadata)) => (Some(delegation), Some(metadata)),
                         None => (None, None),
                     };
 
-                let result = match get_latest_certified_state_and_data_certificate(
+                let result = get_latest_certified_state_and_data_certificate(
                     state_reader,
                     certificate_delegation,
                     query.receiver,
-                ) {
-                    Some((state, cert)) => {
+                )
+                .map_or_else(
+                    || Err(QueryExecutionError::CertifiedStateUnavailable),
+                    |(state, cert)| {
+                        // Make sure NNS delegation is valid with respect to the certified state.
+                        // Otherwise the client would not be able to verify the query response against the delegation.
+                        if let Some((delegation, metadata)) = &certificate_delegation_with_metadata
+                        {
+                            match is_delegation_valid_with_respect_to_state(
+                                delegation,
+                                metadata.format,
+                                state.get_ref(),
+                            ) {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    return Err(QueryExecutionError::OutdatedDelegation);
+                                }
+                                Err(err) => {
+                                    return Err(QueryExecutionError::InvalidDelegation(
+                                        err.to_string(),
+                                    ));
+                                }
+                            }
+                        }
+
                         let time = state.get_ref().metadata.batch_time;
 
                         let certified_height_used_for_execution = state.height();
@@ -574,9 +598,8 @@ impl Service<QueryExecutionInput> for HttpQueryHandler {
                         );
 
                         Ok((response, time))
-                    }
-                    None => Err(QueryExecutionError::CertifiedStateUnavailable),
-                };
+                    },
+                );
 
                 let _ = tx.send(Ok(result));
             }

--- a/rs/http_endpoints/public/BUILD.bazel
+++ b/rs/http_endpoints/public/BUILD.bazel
@@ -31,6 +31,7 @@ rust_library(
     deps = [
         # Keep sorted.
         "//packages/ic-error-types",
+        "//rs/canonical_state",
         "//rs/config",
         "//rs/crypto/interfaces/sig_verification",
         "//rs/crypto/tls_interfaces",

--- a/rs/http_endpoints/public/Cargo.toml
+++ b/rs/http_endpoints/public/Cargo.toml
@@ -23,6 +23,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 ic-http-endpoints-async-utils = { path = "../../http_endpoints/async_utils" }
 ic-nns-delegation-manager = { path = "../../http_endpoints/nns_delegation_manager" }
+ic-canonical-state = { path = "../../canonical_state" }
 ic-config = { path = "../../config" }
 ic-crypto-interfaces-sig-verification = { path = "../../crypto/interfaces/sig_verification" }
 ic-crypto-tls-interfaces = { path = "../../crypto/tls_interfaces" }
@@ -63,7 +64,6 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 ic-canister-client = { path = "../../canister_client" }
 ic-canister-client-sender = { path = "../../canister_client/sender" }
-ic-canonical-state = { path = "../../canonical_state" }
 ic-canonical-state-tree-hash = { path = "../../canonical_state/tree_hash" }
 ic-certification-test-utils = { path = "../../certification/test-utils" }
 ic-crypto-temp-crypto = { path = "../../crypto/temp_crypto" }

--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     HttpError,
-    common::{Cbor, WithTimeout, into_cbor},
+    common::{Cbor, WithTimeout, into_cbor, verify_delegation_matches_certified_state},
     metrics::{
         CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS, HttpHandlerMetrics,
         SYNC_CALL_EARLY_RESPONSE_CERTIFICATION_TIMEOUT,
@@ -36,7 +36,9 @@ use ic_replicated_state::ReplicatedState;
 use ic_types::{
     CanisterId, PrincipalId, SubnetId,
     consensus::certification::Certification,
-    messages::{Blob, Certificate, HttpCallContent, HttpRequestEnvelope, MessageId},
+    messages::{
+        Blob, Certificate, CertificateDelegation, HttpCallContent, HttpRequestEnvelope, MessageId,
+    },
 };
 use serde_cbor::Value as CBOR;
 use std::{collections::BTreeMap, convert::Infallible, sync::Arc, time::Duration};
@@ -237,23 +239,35 @@ async fn call_sync(
     // Check if the message is already known.
     // If it is known, we can return the certificate without re-submitting the message
     // to the ingress pool.
-    if let Some((tree, certification)) =
-        tree_and_certificate_for_message(state_reader.clone(), message_id.clone()).await
-        && let ParsedMessageStatus::Known(_) = parsed_message_status(&tree, &message_id)
+    match tree_cert_deleg_for_message(
+        (&nns_delegation_reader, delegation_filter),
+        state_reader.clone(),
+        message_id.clone(),
+    )
+    .await
     {
-        let signature = certification.signed.signature.signature.get().0;
+        Ok(Some((tree, certification, delegation)))
+            if matches!(
+                parsed_message_status(&tree, &message_id),
+                ParsedMessageStatus::Known(_)
+            ) =>
+        {
+            let signature = certification.signed.signature.signature.get().0;
 
-        metrics
-            .sync_call_early_response_trigger_total
-            .with_label_values(&[SYNC_CALL_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE])
-            .inc();
+            metrics
+                .sync_call_early_response_trigger_total
+                .with_label_values(&[SYNC_CALL_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE])
+                .inc();
 
-        return SyncCallResponse::Certificate(Certificate {
-            tree,
-            signature: Blob(signature),
-            delegation: nns_delegation_reader.get_delegation(delegation_filter),
-        });
-    };
+            return SyncCallResponse::Certificate(Certificate {
+                tree,
+                signature: Blob(signature),
+                delegation,
+            });
+        }
+        Ok(None) | Ok(Some(_)) => (),
+        Err(err) => return SyncCallResponse::HttpError(err),
+    }
 
     let certification_subscriber = match ingress_watcher_handle
         .subscribe_for_certification(message_id.clone())
@@ -326,12 +340,20 @@ async fn call_sync(
         }
     }
 
-    let Some((tree, certification)) =
-        tree_and_certificate_for_message(state_reader, message_id.clone()).await
-    else {
-        return SyncCallResponse::Accepted(
-            "Certified state is not available. Please try /read_state.",
-        );
+    let (tree, certification, delegation) = match tree_cert_deleg_for_message(
+        (&nns_delegation_reader, delegation_filter),
+        state_reader,
+        message_id.clone(),
+    )
+    .await
+    {
+        Ok(Some((tree, certification, delegation))) => (tree, certification, delegation),
+        Ok(None) => {
+            return SyncCallResponse::Accepted(
+                "Certified state is not available. Please try /read_state.",
+            );
+        }
+        Err(err) => return SyncCallResponse::HttpError(err),
     };
 
     let message_status = parsed_message_status(&tree, &message_id);
@@ -366,7 +388,7 @@ async fn call_sync(
     SyncCallResponse::Certificate(Certificate {
         tree,
         signature: Blob(signature),
-        delegation: nns_delegation_reader.get_delegation(delegation_filter),
+        delegation,
     })
 }
 
@@ -390,18 +412,27 @@ fn parsed_message_status(tree: &MixedHashTree, message_id: &MessageId) -> Parsed
     }
 }
 
-async fn tree_and_certificate_for_message(
+async fn tree_cert_deleg_for_message(
+    (nns_delegation_reader, delegation_filter): (&NNSDelegationReader, CanisterRangesFilter),
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     message_id: MessageId,
-) -> Option<(MixedHashTree, Certification)> {
+) -> Result<Option<(MixedHashTree, Certification, Option<CertificateDelegation>)>, HttpError> {
     let certified_state_reader = match tokio::task::spawn_blocking(move || {
         state_reader.get_certified_state_snapshot()
     })
     .await
     {
-        Ok(Some(certified_state_reader)) => Some(certified_state_reader),
-        Ok(None) | Err(_) => None,
-    }?;
+        Ok(Some(certified_state_reader)) => certified_state_reader,
+        Ok(None) | Err(_) => return Ok(None),
+    };
+    let delegation_metadata = nns_delegation_reader.get_delegation_with_metadata(delegation_filter);
+    if let Some((delegation, metadata)) = delegation_metadata.as_ref() {
+        verify_delegation_matches_certified_state(
+            delegation,
+            metadata,
+            certified_state_reader.as_ref(),
+        )?
+    }
 
     // We always add time path to comply with the IC spec.
     let time_path = Path::from(Label::from("time"));
@@ -414,5 +445,12 @@ async fn tree_and_certificate_for_message(
         sparse_labeled_tree_from_paths(&[time_path, request_status_path])
             .expect("Path is within length bound.");
 
-    certified_state_reader.read_certified_state(&tree)
+    let Some((tree, certification)) = certified_state_reader.read_certified_state(&tree) else {
+        return Ok(None);
+    };
+    Ok(Some((
+        tree,
+        certification,
+        delegation_metadata.map(|(delegation, _metadata)| delegation),
+    )))
 }

--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -243,6 +243,7 @@ async fn call_sync(
         (&nns_delegation_reader, delegation_filter),
         state_reader.clone(),
         message_id.clone(),
+        &metrics,
     )
     .await
     {
@@ -344,6 +345,7 @@ async fn call_sync(
         (&nns_delegation_reader, delegation_filter),
         state_reader,
         message_id.clone(),
+        &metrics,
     )
     .await
     {
@@ -416,6 +418,7 @@ async fn tree_cert_deleg_for_message(
     (nns_delegation_reader, delegation_filter): (&NNSDelegationReader, CanisterRangesFilter),
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     message_id: MessageId,
+    metrics: &HttpHandlerMetrics,
 ) -> Result<Option<(MixedHashTree, Certification, Option<CertificateDelegation>)>, HttpError> {
     let certified_state_reader = match tokio::task::spawn_blocking(move || {
         state_reader.get_certified_state_snapshot()
@@ -431,6 +434,7 @@ async fn tree_cert_deleg_for_message(
             delegation,
             metadata,
             certified_state_reader.as_ref(),
+            metrics,
         )?
     }
 

--- a/rs/http_endpoints/public/src/common.rs
+++ b/rs/http_endpoints/public/src/common.rs
@@ -7,11 +7,12 @@ use http::{
 };
 use http_body_util::BodyExt;
 use hyper::{Response, StatusCode, header};
+use ic_canonical_state::delegation::is_delegation_valid_with_respect_to_state;
 use ic_crypto_interfaces_sig_verification::IngressSigVerifier;
 use ic_crypto_tree_hash::{Label, Path, TooLongPathError, sparse_labeled_tree_from_paths};
 use ic_error_types::UserError;
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateReader;
+use ic_interfaces_state_manager::{CertifiedStateSnapshot, StateReader};
 use ic_logger::{ReplicaLogger, info, warn};
 use ic_registry_client_helpers::crypto::{
     CryptoRegistry, root_of_trust::RegistryRootOfTrustProvider,
@@ -21,7 +22,9 @@ use ic_types::{
     RegistryVersion, SubnetId, Time,
     crypto::threshold_sig::ThresholdSigPublicKey,
     malicious_flags::MaliciousFlags,
-    messages::{HttpRequest, HttpRequestContent},
+    messages::{
+        CertificateDelegation, CertificateDelegationMetadata, HttpRequest, HttpRequestContent,
+    },
 };
 use ic_utils::str::StrEllipsize;
 use ic_validator::{
@@ -274,6 +277,18 @@ pub(crate) fn certified_state_unavailable_error() -> HttpError {
     HttpError { status, message }
 }
 
+pub(crate) fn outdated_delegation_error() -> HttpError {
+    let status = StatusCode::SERVICE_UNAVAILABLE;
+    let message = "This replica has an outdated NNS delegation. Please try again.".to_string();
+    HttpError { status, message }
+}
+
+pub(crate) fn invalid_delegation_error() -> HttpError {
+    let status = StatusCode::SERVICE_UNAVAILABLE;
+    let message = "This replica has an invalid NNS delegation. Please try again.".to_string();
+    HttpError { status, message }
+}
+
 pub(crate) async fn get_latest_certified_state(
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
 ) -> Option<Arc<ReplicatedState>> {
@@ -316,6 +331,22 @@ where
         Arc::new(DisabledHttpRequestVerifier) as Arc<_>
     } else {
         Arc::new(HttpRequestVerifierImpl::new(ingress_verifier)) as Arc<_>
+    }
+}
+
+pub(crate) fn verify_delegation_matches_certified_state(
+    delegation: &CertificateDelegation,
+    metadata: &CertificateDelegationMetadata,
+    certified_state_reader: &dyn CertifiedStateSnapshot<State = ReplicatedState>,
+) -> Result<(), HttpError> {
+    match is_delegation_valid_with_respect_to_state(
+        delegation,
+        metadata.format,
+        certified_state_reader.get_state(),
+    ) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(outdated_delegation_error()),
+        Err(_err) => Err(invalid_delegation_error()),
     }
 }
 

--- a/rs/http_endpoints/public/src/common.rs
+++ b/rs/http_endpoints/public/src/common.rs
@@ -1,4 +1,4 @@
-use crate::HttpError;
+use crate::{HttpError, metrics::HttpHandlerMetrics};
 use axum::{body::Body, extract::FromRequest, response::IntoResponse};
 use bytes::Bytes;
 use http::{
@@ -338,7 +338,13 @@ pub(crate) fn verify_delegation_matches_certified_state(
     delegation: &CertificateDelegation,
     metadata: &CertificateDelegationMetadata,
     certified_state_reader: &dyn CertifiedStateSnapshot<State = ReplicatedState>,
+    metrics: &HttpHandlerMetrics,
 ) -> Result<(), HttpError> {
+    let _timer = metrics
+        .verify_delegation_duration
+        .with_label_values(&[metadata.format.to_string()])
+        .start_timer();
+
     match is_delegation_valid_with_respect_to_state(
         delegation,
         metadata.format,

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -42,6 +42,8 @@ pub const LABEL_IO_ERROR: &str = "io";
 pub const LABEL_TLS_ERROR: &str = "tls_handshake_failed";
 pub const LABEL_TIMEOUT_ERROR: &str = "timeout";
 
+pub const LABEL_DELEGATION_FORMAT: &str = "delegation_format";
+
 pub const REQUESTS_NUM_LABELS: usize = 2;
 pub const REQUESTS_LABEL_NAMES: [&str; REQUESTS_NUM_LABELS] =
     [LABEL_REQUEST_TYPE, LABEL_HTTP_STATUS_CODE];
@@ -59,6 +61,7 @@ pub struct HttpHandlerMetrics {
     pub health_status_transitions_total: IntCounterVec,
     pub connection_setup_duration: HistogramVec,
     pub connection_duration: HistogramVec,
+    pub verify_delegation_duration: HistogramVec,
 
     // Ingress watcher metrics
     pub ingress_watcher_tracked_messages: IntGauge,
@@ -147,6 +150,13 @@ impl HttpHandlerMetrics {
                 // 10ms, 20ms, ... 50000s
                 decimal_buckets(-2, 4),
                 &[LABEL_PROTOCOL],
+            ),
+            verify_delegation_duration: metrics_registry.histogram_vec(
+                "replica_http_verify_delegation_duration_seconds",
+                "Duration of verifying delegation, by delegation format.",
+                // 1ms, 2ms, ... 5s
+                decimal_buckets(-4, 0),
+                &[LABEL_DELEGATION_FORMAT],
             ),
             // Ingress watcher metrics
             ingress_watcher_subscriptions_total: metrics_registry.int_counter(

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -154,7 +154,7 @@ impl HttpHandlerMetrics {
             verify_delegation_duration: metrics_registry.histogram_vec(
                 "replica_http_verify_delegation_duration_seconds",
                 "Duration of verifying delegation, by delegation format.",
-                // 1ms, 2ms, ... 5s
+                // 0.1ms, 0.2ms, ... 5s
                 decimal_buckets(-4, 0),
                 &[LABEL_DELEGATION_FORMAT],
             ),

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -100,7 +100,6 @@ impl QueryService {
 }
 
 impl QueryServiceBuilder {
-    #[allow(clippy::too_many_arguments)]
     pub fn builder(
         log: ReplicaLogger,
         node_id: NodeId,

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -4,7 +4,7 @@ use crate::{
     ReplicaHealthStatus,
     common::{
         Cbor, WithTimeout, build_validator, certified_state_unavailable_error,
-        validation_error_to_http_error,
+        invalid_delegation_error, outdated_delegation_error, validation_error_to_http_error,
     },
 };
 
@@ -100,6 +100,7 @@ impl QueryService {
 }
 
 impl QueryServiceBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn builder(
         log: ReplicaLogger,
         node_id: NodeId,
@@ -320,6 +321,12 @@ pub(crate) async fn query(
     let (response, timestamp) = match query_execution_response {
         Err(QueryExecutionError::CertifiedStateUnavailable) => {
             return certified_state_unavailable_error().into_response();
+        }
+        Err(QueryExecutionError::InvalidDelegation(_)) => {
+            return invalid_delegation_error().into_response();
+        }
+        Err(QueryExecutionError::OutdatedDelegation) => {
+            return outdated_delegation_error().into_response();
         }
         Ok((response, time)) => (response, time),
     };

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -301,6 +301,7 @@ pub(crate) async fn read_state(
             nns_delegation_reader.get_delegation_with_metadata(canister_ranges_filter),
             certified_state_reader.as_ref(),
             maybe_nns_subnet_filter,
+            &metrics,
         )
     })
     .await;
@@ -358,6 +359,7 @@ fn get_certificate_and_create_response(
     delegation_from_nns: Option<(CertificateDelegation, CertificateDelegationMetadata)>,
     certified_state_reader: &dyn CertifiedStateSnapshot<State = ReplicatedState>,
     deprecated_canister_ranges_filter: DeprecatedCanisterRangesFilter,
+    metrics: &HttpHandlerMetrics,
 ) -> axum::response::Response {
     // Create labeled tree. This may be an expensive operation and by
     // creating the labeled tree after verifying the paths we know that
@@ -397,8 +399,12 @@ fn get_certificate_and_create_response(
     // Make sure the public key in the NNS delegation matches the one in the certified state we are
     // about to serve. Otherwise the client would not be able to verify the certificate.
     if let Some((delegation, metadata)) = &delegation_from_nns
-        && let Err(HttpError { status, message }) =
-            verify_delegation_matches_certified_state(delegation, metadata, certified_state_reader)
+        && let Err(HttpError { status, message }) = verify_delegation_matches_certified_state(
+            delegation,
+            metadata,
+            certified_state_reader,
+            metrics,
+        )
     {
         return (status, message).into_response();
     }
@@ -731,6 +737,7 @@ mod test {
             /*delegation_from_nns=*/ None,
             &reader,
             DeprecatedCanisterRangesFilter::KeepAll,
+            &HttpHandlerMetrics::new(&MetricsRegistry::new()),
         );
         assert_eq!(response.status(), StatusCode::OK);
     }
@@ -745,6 +752,7 @@ mod test {
             /*delegation_from_nns=*/ None,
             &reader,
             DeprecatedCanisterRangesFilter::KeepOnlyNNS(NNS_SUBNET_ID),
+            &HttpHandlerMetrics::new(&MetricsRegistry::new()),
         );
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -396,8 +396,8 @@ fn get_certificate_and_create_response(
 
     let signature = certification.signed.signature.signature.get().0;
 
-    // Make sure the public key in the NNS delegation matches the one in the certified state we are
-    // about to serve. Otherwise the client would not be able to verify the certificate.
+    // Make sure the NNS delegation matches the certified state we are about to serve. Otherwise the
+    // client would reject the certificate.
     if let Some((delegation, metadata)) = &delegation_from_nns
         && let Err(HttpError { status, message }) = verify_delegation_matches_certified_state(
             delegation,

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     HttpError, ReplicaHealthStatus,
-    common::{Cbor, WithTimeout, build_validator, into_cbor, validation_error_to_http_error},
+    common::{
+        Cbor, WithTimeout, build_validator, into_cbor, validation_error_to_http_error,
+        verify_delegation_matches_certified_state,
+    },
     metrics::HttpHandlerMetrics,
 };
 use axum::{
@@ -30,8 +33,9 @@ use ic_types::{
     crypto::threshold_sig::IcRootOfTrust,
     malicious_flags::MaliciousFlags,
     messages::{
-        Blob, Certificate, CertificateDelegation, EXPECTED_MESSAGE_ID_LENGTH, HttpReadStateContent,
-        HttpReadStateResponse, HttpRequest, HttpRequestEnvelope, MessageId, ReadState,
+        Blob, Certificate, CertificateDelegation, CertificateDelegationMetadata,
+        EXPECTED_MESSAGE_ID_LENGTH, HttpReadStateContent, HttpReadStateResponse, HttpRequest,
+        HttpRequestEnvelope, MessageId, ReadState,
     },
 };
 use ic_validator::{CanisterIdSet, HttpRequestVerifier};
@@ -281,13 +285,10 @@ pub(crate) async fn read_state(
             return (status, message).into_response();
         }
 
-        let delegation_from_nns = match (version, target) {
-            (Version::V2, _) => nns_delegation_reader.get_delegation(CanisterRangesFilter::Flat),
-            (Version::V3, Target::Canister) => nns_delegation_reader
-                .get_delegation(CanisterRangesFilter::Tree(effective_canister_id)),
-            (Version::V3, Target::Subnet) => {
-                nns_delegation_reader.get_delegation(CanisterRangesFilter::None)
-            }
+        let canister_ranges_filter = match (version, target) {
+            (Version::V2, _) => CanisterRangesFilter::Flat,
+            (Version::V3, Target::Canister) => CanisterRangesFilter::Tree(effective_canister_id),
+            (Version::V3, Target::Subnet) => CanisterRangesFilter::None,
         };
 
         let maybe_nns_subnet_filter = match version {
@@ -297,7 +298,7 @@ pub(crate) async fn read_state(
 
         get_certificate_and_create_response(
             read_state.paths,
-            delegation_from_nns,
+            nns_delegation_reader.get_delegation_with_metadata(canister_ranges_filter),
             certified_state_reader.as_ref(),
             maybe_nns_subnet_filter,
         )
@@ -354,7 +355,7 @@ enum DeprecatedCanisterRangesFilter {
 
 fn get_certificate_and_create_response(
     mut paths: Vec<Path>,
-    delegation_from_nns: Option<CertificateDelegation>,
+    delegation_from_nns: Option<(CertificateDelegation, CertificateDelegationMetadata)>,
     certified_state_reader: &dyn CertifiedStateSnapshot<State = ReplicatedState>,
     deprecated_canister_ranges_filter: DeprecatedCanisterRangesFilter,
 ) -> axum::response::Response {
@@ -393,11 +394,20 @@ fn get_certificate_and_create_response(
 
     let signature = certification.signed.signature.signature.get().0;
 
+    // Make sure the public key in the NNS delegation matches the one in the certified state we are
+    // about to serve. Otherwise the client would not be able to verify the certificate.
+    if let Some((delegation, metadata)) = &delegation_from_nns
+        && let Err(HttpError { status, message }) =
+            verify_delegation_matches_certified_state(delegation, metadata, certified_state_reader)
+    {
+        return (status, message).into_response();
+    }
+
     Cbor(HttpReadStateResponse {
         certificate: Blob(into_cbor(&Certificate {
             tree,
             signature: Blob(signature),
-            delegation: delegation_from_nns,
+            delegation: delegation_from_nns.map(|(delegation, _metadata)| delegation),
         })),
     })
     .into_response()

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -48,7 +48,7 @@ use ic_replicated_state::{
 };
 use ic_test_utilities_types::ids::{canister_test_id, node_test_id, subnet_test_id};
 use ic_types::{
-    CryptoHashOfPartialState, Height, PrincipalId, RegistryVersion,
+    CanisterId, CryptoHashOfPartialState, Height, PrincipalId, RegistryVersion,
     artifact::UnvalidatedArtifactMutation,
     batch::RawQueryStats,
     consensus::certification::{Certification, CertificationContent},

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -46,9 +46,9 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterQueues, NetworkTopology, RefundPool, ReplicatedState, SystemMetadata,
 };
-use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+use ic_test_utilities_types::ids::{canister_test_id, node_test_id, subnet_test_id};
 use ic_types::{
-    CanisterId, CryptoHashOfPartialState, Height, PrincipalId, RegistryVersion,
+    CryptoHashOfPartialState, Height, PrincipalId, RegistryVersion,
     artifact::UnvalidatedArtifactMutation,
     batch::RawQueryStats,
     consensus::certification::{Certification, CertificationContent},
@@ -109,7 +109,8 @@ impl UpdateEndpoint {
 
     pub fn default_ingress_message(&self) -> ic_http_endpoints_test_agent::IngressMessage {
         match self {
-            UpdateEndpoint::Canister(_) => ic_http_endpoints_test_agent::IngressMessage::default(),
+            UpdateEndpoint::Canister(_) => ic_http_endpoints_test_agent::IngressMessage::default()
+                .with_canister_id(canister_test_id(0).get(), canister_test_id(0).get()),
             UpdateEndpoint::Subnet(_) => ic_http_endpoints_test_agent::IngressMessage::default()
                 .with_canister_id(CanisterId::ic_00().get(), CanisterId::ic_00().get())
                 .with_method_name("create_canister".to_string()),
@@ -433,6 +434,10 @@ pub struct HttpEndpointHandles {
     pub query_execution: QueryExecutionHandle,
     pub terminal_state_ingress_messages: Sender<(MessageId, Height)>,
     pub certified_height_watcher: watch::Sender<Height>,
+    /// Sender feeding the NNS delegation the endpoint serves. Sending a new
+    /// value swaps the delegation the running endpoint uses, which lets tests
+    /// simulate the NNS delegation changing at runtime.
+    pub nns_delegation_watcher: watch::Sender<Option<NNSDelegationBuilder>>,
 }
 
 pub struct HttpEndpointBuilder {
@@ -535,9 +540,18 @@ impl HttpEndpointBuilder {
         let builder = self.delegation_from_nns.map(|delegation| {
             NNSDelegationBuilder::try_new(delegation.certificate, subnet_id, &log).unwrap()
         });
-        let (_nns_delegation_watcher_tx, nns_delegation_watcher_rx) = watch::channel(builder);
+        // Start the channel empty and *publish* the initial delegation below.
+        // Publishing (rather than seeding the channel with the initial value)
+        // triggers a change notification, which is what `wait_until_initialized`
+        // waits for before the endpoint becomes healthy. This lets us keep the
+        // sender alive (and hand it back to the test) so that tests can swap the
+        // delegation at runtime, instead of dropping it.
+        let (nns_delegation_watcher_tx, nns_delegation_watcher_rx) = watch::channel(None);
         let nns_delegation_reader =
             NNSDelegationReader::new(nns_delegation_watcher_rx, log.clone());
+        nns_delegation_watcher_tx
+            .send(builder)
+            .expect("The NNS delegation receiver should be alive.");
 
         let (terminal_state_ingress_messages_tx, terminal_state_ingress_messages_rx) = channel(100);
 
@@ -582,6 +596,7 @@ impl HttpEndpointBuilder {
             query_execution: query_exe_handler,
             terminal_state_ingress_messages: terminal_state_ingress_messages_tx,
             certified_height_watcher: certified_height_watcher_tx,
+            nns_delegation_watcher: nns_delegation_watcher_tx,
         }
     }
 }

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -2147,13 +2147,10 @@ fn test_call_v4_subnet_wrong_canister_or_method(
 // certified state. This can happen around subnet splits and canister migrations.
 // ---------------------------------------------------------------------------
 
-/// Builds an NNS delegation for `subnet_test_id(1)` certifying a fresh random
-/// subnet public key and the given canister ranges (in both the flat and the tree
-/// layout, so it works with every
-/// [`ic_nns_delegation_manager::CanisterRangesFilter`]). Returns the delegation
-/// together with the exact bytes of the certified public key, so a caller can
-/// install a matching (or, by using different bytes, a mismatching) key in the
-/// certified state.
+/// Builds an NNS delegation for `subnet_test_id(1)` certifying the given public key
+/// and the given canister ranges (in both the flat and the tree layout, so it works
+/// with every [`ic_nns_delegation_manager::CanisterRangesFilter`]). If no public key
+/// is given, a fresh one is generated.
 fn nns_delegation_and_public_key(
     existing_public_key: Option<ThresholdSigPublicKey>,
     ranges: &[(CanisterId, CanisterId)],
@@ -2179,8 +2176,6 @@ fn nns_delegation_and_public_key(
 
     let (_certificate, _root_pk, cbor) =
         CertificateBuilder::new(CertificateData::CustomTree(certificate_tree)).build();
-
-    println!("{:?}", _certificate.tree());
 
     let delegation = CertificateDelegation {
         subnet_id: Blob(subnet_id.get().to_vec()),

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -19,12 +19,14 @@ use ic_canister_client::prepare_read_state;
 use ic_canister_client_sender::Sender;
 use ic_canonical_state::encoding::types::{Cycles, SubnetMetrics};
 use ic_certification_test_utils::{
-    Certificate as TestCertificate, CertificateBuilder, CertificateData, serialize_to_cbor,
+    Certificate as TestCertificate, CertificateBuilder, CertificateData,
+    create_certificate_labeled_tree, serialize_to_cbor,
 };
 use ic_config::http_handler::Config;
 use ic_crypto_temp_crypto::{NodeKeysToGenerate, TempCryptoComponent};
 use ic_crypto_tree_hash::{
     Digest, Label, LabeledTree, MatchPatternPath, MixedHashTree, Path, Witness, flatmap,
+    lookup_path,
 };
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_http_endpoints_public::{query, read_state};
@@ -38,13 +40,20 @@ use ic_interfaces_registry_mocks::MockRegistryClient;
 use ic_interfaces_state_manager::CertifiedStateSnapshot;
 use ic_interfaces_state_manager::Labeled;
 use ic_interfaces_state_manager_mocks::MockStateManager;
+use ic_logger::replica_logger::no_op_logger;
+use ic_nns_delegation_manager::NNSDelegationBuilder;
 use ic_protobuf::registry::crypto::v1::{
     AlgorithmId as AlgorithmIdProto, PublicKey as PublicKeyProto,
 };
 use ic_read_state_response_parser::parse_subnet_read_state_response;
 use ic_registry_keys::make_crypto_threshold_signing_pubkey_key;
-use ic_replicated_state::ReplicatedState;
-use ic_test_utilities_state::ReplicatedStateBuilder;
+use ic_registry_routing_table::CanisterIdRange;
+use ic_registry_routing_table::RoutingTable;
+use ic_registry_subnet_type::SubnetType;
+use ic_replicated_state::metadata_state::testing::SystemMetadataTesting;
+use ic_replicated_state::{
+    ReplicatedState, SubnetTopology, metadata_state::testing::NetworkTopologyTesting,
+};
 use ic_test_utilities_types::ids::{NODE_1, canister_test_id, subnet_test_id, user_test_id};
 use ic_types::{
     CanisterId, CryptoHashOfPartialState, Height, NumBytes, PrincipalId, RegistryVersion,
@@ -80,13 +89,14 @@ use std::{
     convert::Infallible,
     net::TcpStream,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
 };
 use tokio::{
     net::TcpSocket,
     runtime::Runtime,
+    sync::watch,
     time::{Duration, sleep},
 };
 use tokio_rustls::TlsConnector;
@@ -782,10 +792,37 @@ fn can_retrieve_subnet_metrics(
         .with_delegation(delegation_from_nns)
         .build();
 
-    let mock_certified_state = |certificate: TestCertificate| {
+    let mock_certified_state = move |certificate: TestCertificate| {
         let hash_tree = certificate.clone().tree();
 
-        let state: Arc<ReplicatedState> = Arc::new(ReplicatedStateBuilder::new().build());
+        // The certified state must certify the same subnet public key and canister
+        // ranges as the delegation embedded in `certificate`; otherwise the
+        // delegation-vs-certified-state check rejects the request with 503.
+        let delegation = certificate
+            .delegation()
+            .map(|d| CertificateDelegation {
+                subnet_id: d.subnet_id,
+                certificate: d.certificate,
+            })
+            .expect("Delegation should be present.");
+        let mut replicated_state = ReplicatedState::new(subnet_id, SubnetType::Application);
+        replicated_state
+            .metadata
+            .modify_network_topology(|topology| {
+                topology.subnets_mut().insert(
+                    subnet_id,
+                    SubnetTopology {
+                        public_key: certified_subnet_public_key(&delegation),
+                        ..SubnetTopology::default()
+                    },
+                );
+                let routing_table = topology.routing_table_mut();
+                for (start, end) in [(canister_test_id(0), canister_test_id(10))] {
+                    routing_table
+                        .insert(CanisterIdRange { start, end }, subnet_id)
+                        .unwrap();
+                }
+            });
         let certification = Certification {
             height: Height::from(1),
             height_witness: Some(Witness::new_for_testing(Digest([0; 32]))),
@@ -807,7 +844,7 @@ fn can_retrieve_subnet_metrics(
             },
         };
 
-        (state, hash_tree, certification)
+        (Arc::new(replicated_state), hash_tree, certification)
     };
 
     let mut mock_state_manager = MockStateManager::new();
@@ -2095,5 +2132,459 @@ fn test_call_v4_subnet_wrong_canister_or_method(
                 method_name,
             )
         );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// NNS delegation vs. certified state: the `call`, `read_state` and `query`
+// endpoints must reply with `503 SERVICE_UNAVAILABLE` when the NNS delegation the
+// replica would serve does not match its certified state. Otherwise the client
+// would receive a certificate whose delegation it cannot verify against the
+// certified state. This can happen around subnet splits and canister migrations.
+// ---------------------------------------------------------------------------
+
+/// Builds an NNS delegation for `subnet_test_id(1)` certifying a fresh random
+/// subnet public key and the given canister ranges (in both the flat and the tree
+/// layout, so it works with every
+/// [`ic_nns_delegation_manager::CanisterRangesFilter`]). Returns the delegation
+/// together with the exact bytes of the certified public key, so a caller can
+/// install a matching (or, by using different bytes, a mismatching) key in the
+/// certified state.
+fn nns_delegation_and_public_key(
+    existing_public_key: Option<ThresholdSigPublicKey>,
+    ranges: &[(CanisterId, CanisterId)],
+) -> (CertificateDelegation, ThresholdSigPublicKey) {
+    let subnet_id = subnet_test_id(1);
+
+    let subnet_public_key = existing_public_key.unwrap_or_else(|| {
+        // Any threshold public key works here; reuse the random root key of a
+        // throw-away certificate builder so we don't depend on the crypto crates.
+        CertificateBuilder::new(CertificateData::CustomTree(LabeledTree::Leaf(vec![])))
+            .get_root_public_key()
+    });
+
+    let certificate_tree = create_certificate_labeled_tree(
+        &ranges.to_vec(),
+        subnet_id,
+        subnet_public_key.clone(),
+        /*max_ranges_per_routing_table_leaf=*/ 5,
+        /*time=*/ 42,
+        /*with_tree_canister_ranges=*/ true,
+        /*with_flat_canister_ranges=*/ true,
+    );
+
+    let (_certificate, _root_pk, cbor) =
+        CertificateBuilder::new(CertificateData::CustomTree(certificate_tree)).build();
+
+    println!("{:?}", _certificate.tree());
+
+    let delegation = CertificateDelegation {
+        subnet_id: Blob(subnet_id.get().to_vec()),
+        certificate: Blob(cbor),
+    };
+
+    (delegation, subnet_public_key)
+}
+
+/// Returns the raw bytes of the `/subnet/<subnet_test_id(1)>/public_key` leaf
+/// certified by `delegation`, i.e. exactly what
+/// `verify_delegation_matches_certified_state` compares against the subnet's
+/// public key in the certified state.
+fn certified_subnet_public_key(delegation: &CertificateDelegation) -> Vec<u8> {
+    let subnet_id_bytes = subnet_test_id(1).get().to_vec();
+    let certificate: Certificate =
+        serde_cbor::from_slice(delegation.certificate.0.as_slice()).unwrap();
+    let tree = LabeledTree::try_from(certificate.tree).unwrap();
+    match lookup_path(
+        &tree,
+        &[b"subnet", subnet_id_bytes.as_slice(), b"public_key"],
+    ) {
+        Some(LabeledTree::Leaf(public_key)) => public_key.clone(),
+        other => panic!("unexpected `public_key` path in delegation: {other:?}"),
+    }
+}
+
+/// Rewrites the state behind `latest_state` so that the certification view of the
+/// network topology assigns `subnet_test_id(1)` the given `public_key` and the
+/// given canister `ranges`. Installing the delegation's certified key and ranges
+/// makes the delegation match; installing different bytes makes it mismatch.
+fn set_certified_subnet_topology(
+    latest_state: &Arc<Mutex<Labeled<Arc<ReplicatedState>>>>,
+    public_key: Option<Vec<u8>>,
+    ranges: Option<&[(CanisterId, CanisterId)]>,
+) {
+    let subnet_id = subnet_test_id(1);
+    let mut guard = latest_state.lock().unwrap();
+    let height = guard.height();
+    let mut state = (**guard.get_ref()).clone();
+    state.metadata.modify_network_topology(|topology| {
+        if let Some(public_key) = public_key {
+            // `insert` overwrites the previous entry, so this also serves to *change* the
+            // certified public key on a subsequent call.
+            topology.subnets_mut().insert(
+                subnet_id,
+                SubnetTopology {
+                    public_key,
+                    ..SubnetTopology::default()
+                },
+            );
+        }
+        if let Some(ranges) = ranges {
+            let mut routing_table = RoutingTable::new();
+            for (start, end) in ranges {
+                routing_table
+                    .insert(
+                        CanisterIdRange {
+                            start: *start,
+                            end: *end,
+                        },
+                        subnet_id,
+                    )
+                    .unwrap();
+            }
+            topology.set_routing_table(routing_table);
+        }
+    });
+    *guard = Labeled::new(height, Arc::new(state));
+}
+
+/// Which side of the delegation/certified-state pair drifts to trigger the
+/// mismatch in the transition tests below.
+#[derive(Copy, Clone, Debug)]
+enum DelegationDrift {
+    /// The NNS starts handing out a delegation certifying a different subnet key.
+    DelegationKeyChanges,
+    /// The NNS starts handing out a delegation certifying different canister ranges.
+    DelegationCanisterRangesChange,
+    /// The certified state starts certifying a different subnet key.
+    StateKeyChanges,
+    /// The certified state starts certifying different canister ranges.
+    StateCanisterRangesChange,
+}
+
+/// Makes the delegation the endpoint serves stop matching its certified state,
+/// according to `drift`, so that subsequent requests must return `503`.
+fn drift_delegation_away_from_certified_state(
+    drift: DelegationDrift,
+    nns_delegation_watcher: &watch::Sender<Option<NNSDelegationBuilder>>,
+    latest_state: &Arc<Mutex<Labeled<Arc<ReplicatedState>>>>,
+    existing_public_key: ThresholdSigPublicKey,
+    existing_ranges: &[(CanisterId, CanisterId)],
+) {
+    match drift {
+        DelegationDrift::DelegationKeyChanges => {
+            // The NNS pushes a fresh delegation certifying a new (random) key that
+            // no longer matches the key in the certified state.
+            let (new_delegation, _new_public_key) =
+                nns_delegation_and_public_key(None, existing_ranges);
+            let builder = NNSDelegationBuilder::try_new(
+                new_delegation.certificate,
+                subnet_test_id(1),
+                &no_op_logger(),
+            )
+            .unwrap();
+            nns_delegation_watcher.send(Some(builder)).unwrap();
+        }
+        DelegationDrift::DelegationCanisterRangesChange => {
+            // The NNS pushes a fresh delegation certifying different canister ranges
+            // that no longer match the routing table in the certified state.
+            let new_ranges = [(canister_test_id(0), canister_test_id(20))];
+            let (new_delegation, _new_public_key) =
+                nns_delegation_and_public_key(Some(existing_public_key), &new_ranges);
+            let builder = NNSDelegationBuilder::try_new(
+                new_delegation.certificate,
+                subnet_test_id(1),
+                &no_op_logger(),
+            )
+            .unwrap();
+            nns_delegation_watcher.send(Some(builder)).unwrap();
+        }
+        DelegationDrift::StateKeyChanges => {
+            // The certified state starts certifying a different key (the routing
+            // table is left untouched, only the public key changes).
+            set_certified_subnet_topology(latest_state, Some(vec![0xff; 10]), None);
+        }
+        DelegationDrift::StateCanisterRangesChange => {
+            // The certified state starts certifying different canister ranges (the
+            // subnet's public key is left untouched, only the routing table changes).
+            let new_ranges = [(canister_test_id(0), canister_test_id(20))];
+            set_certified_subnet_topology(latest_state, None, Some(&new_ranges));
+        }
+    }
+}
+
+/// The `read_state` endpoints answer a request while the NNS delegation matches
+/// the certified state, but reply with `503 SERVICE_UNAVAILABLE` once the two
+/// drift apart -- whether it is the delegation's key that changes or the certified
+/// state's key.
+#[rstest]
+fn test_read_state_endpoint_becomes_unavailable_when_delegation_drifts_from_state(
+    #[values(read_state::Version::V2, read_state::Version::V3)] version: read_state::Version,
+    #[values(
+        DelegationDrift::DelegationKeyChanges,
+        DelegationDrift::DelegationCanisterRangesChange,
+        DelegationDrift::StateKeyChanges,
+        DelegationDrift::StateCanisterRangesChange
+    )]
+    drift: DelegationDrift,
+) {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    let ranges = [(canister_test_id(0), canister_test_id(10))];
+    let (delegation, public_key) = nns_delegation_and_public_key(None, &ranges);
+
+    let (state_manager, latest_state) = basic_state_manager_mock();
+    // Start from a certified state that matches the delegation.
+    set_certified_subnet_topology(
+        &latest_state,
+        Some(certified_subnet_public_key(&delegation)),
+        Some(&ranges),
+    );
+
+    let handlers = HttpEndpointBuilder::new(rt.handle().clone(), config)
+        .with_state_manager(state_manager)
+        .with_delegation_from_nns(delegation)
+        .run();
+
+    // We always read the `/time` path of `canister_test_id(0)`, which is covered by
+    // the delegation's canister ranges.
+    let read_state_request = || {
+        CanisterReadState::new(
+            vec![Path::from(Label::from("time"))],
+            canister_test_id(0).get(),
+            version,
+        )
+        .read_state(addr)
+    };
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+
+        // While the delegation matches the certified state, the request succeeds.
+        let response = read_state_request().await;
+        assert_eq!(
+            StatusCode::OK,
+            response.status(),
+            "{:?}",
+            response.text().await
+        );
+
+        // The delegation and the certified state drift apart.
+        drift_delegation_away_from_certified_state(
+            drift,
+            &handlers.nns_delegation_watcher,
+            &latest_state,
+            public_key,
+            &ranges,
+        );
+
+        // The same request now fails, because the delegation no longer matches.
+        let response = read_state_request().await;
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+        assert_eq!(
+            "This replica has an outdated NNS delegation. Please try again.",
+            response.text().await.unwrap(),
+        );
+    });
+}
+
+/// The synchronous `call` endpoints accept a request while the NNS delegation
+/// matches the certified state, but reply with `503 SERVICE_UNAVAILABLE` once the
+/// two drift apart -- whether it is the delegation's key that changes or the
+/// certified state's key.
+#[rstest]
+/// The message is certified after certified state transition.
+#[case(Height::from(0), Some(Height::from(1)), Height::from(1))]
+/// The message is already certified.
+#[case(Height::from(1), None, Height::from(1))]
+#[case(Height::from(1), Some(Height::from(0)), Height::from(1))]
+fn test_sync_call_endpoint_becomes_unavailable_when_delegation_drifts_from_state(
+    #[values(
+        UpdateEndpoint::Canister(Call::V3),
+        UpdateEndpoint::Canister(Call::V4),
+        UpdateEndpoint::Subnet(CallSubnet::V4(subnet_test_id(1).get())),
+    )]
+    endpoint: UpdateEndpoint,
+    #[values(
+        DelegationDrift::DelegationKeyChanges,
+        DelegationDrift::DelegationCanisterRangesChange,
+        DelegationDrift::StateKeyChanges,
+        DelegationDrift::StateCanisterRangesChange
+    )]
+    drift: DelegationDrift,
+    #[case] initial_certified_height: Height,
+    #[case] transitioned_certified_height: Option<Height>,
+    #[case] message_finalization_height: Height,
+) {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    let ranges = [(canister_test_id(0), canister_test_id(10))];
+    let (delegation, public_key) = nns_delegation_and_public_key(None, &ranges);
+
+    let (state_manager, latest_state) = basic_state_manager_mock();
+    // Start from a certified state that matches the delegation.
+    set_certified_subnet_topology(
+        &latest_state,
+        Some(certified_subnet_public_key(&delegation)),
+        Some(&ranges),
+    );
+
+    let mut handlers = HttpEndpointBuilder::new(rt.handle().clone(), config)
+        .with_certified_height(initial_certified_height)
+        .with_state_manager(state_manager)
+        .with_delegation_from_nns(delegation)
+        .run();
+
+    let message = endpoint.default_ingress_message();
+
+    // Accept every ingress message so that the handler reaches the delegation check.
+    rt.spawn(async move {
+        loop {
+            let (_, resp) = handlers.ingress_filter.next_request().await.unwrap();
+            resp.send_response(Ok(Ok(())))
+        }
+    });
+
+    let message_id = message.message_id();
+    let message_clone = message.clone();
+    let latest_state_clone = latest_state.clone();
+    rt.spawn(async move {
+        let new_ingress = handlers.ingress_rx.recv().await.unwrap();
+        let UnvalidatedArtifactMutation::Insert((sent_message, _)) = new_ingress else {
+            panic!("Expected Insert");
+        };
+        assert_eq!(sent_message.id(), message_clone.message_id());
+
+        // set the ingress to the terminal state in the certified state
+        // this is needed since the HTTP handler would return 202 otherwise
+        let (_height, mut state) = {
+            let state_and_height = latest_state_clone.lock().unwrap();
+            (
+                state_and_height.height(),
+                (**state_and_height.get_ref()).clone(),
+            )
+        };
+        state.set_ingress_status(
+            message_clone.message_id(),
+            message_clone.known_ingress_status(),
+            NumBytes::new(4 << 30), // INGRESS_HISTORY_MEMORY_CAPACITY
+            |_| {},
+        );
+        *latest_state_clone.lock().unwrap() =
+            Labeled::new(message_finalization_height, Arc::new(state));
+
+        handlers
+            .terminal_state_ingress_messages
+            .try_send((message_id, message_finalization_height))
+            .unwrap();
+
+        if let Some(transitioned_certified_height) = transitioned_certified_height {
+            handlers
+                .certified_height_watcher
+                .send(transitioned_certified_height)
+                .unwrap();
+        }
+    });
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+
+        // While the delegation matches the certified state, the message is accepted.
+        let response = endpoint.call(addr, message.clone()).await;
+        assert_eq!(
+            StatusCode::OK,
+            response.status(),
+            "{:?}",
+            response.text().await
+        );
+
+        // The delegation and the certified state drift apart.
+        drift_delegation_away_from_certified_state(
+            drift,
+            &handlers.nns_delegation_watcher,
+            &latest_state,
+            public_key,
+            &ranges,
+        );
+
+        let response = endpoint.call(addr, message).await;
+        if matches!(endpoint, UpdateEndpoint::Subnet(CallSubnet::V4(_)))
+            && matches!(
+                drift,
+                DelegationDrift::DelegationCanisterRangesChange
+                    | DelegationDrift::StateCanisterRangesChange
+            )
+        {
+            // The subnet v4 endpoint does not check the canister ranges
+            assert_eq!(
+                StatusCode::OK,
+                response.status(),
+                "{:?}",
+                response.text().await
+            );
+        } else {
+            // The same request now fails, because the delegation no longer matches.
+            assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+            assert_eq!(
+                "This replica has an outdated NNS delegation. Please try again.",
+                response.text().await.unwrap(),
+            );
+        }
+    });
+}
+
+/// The `query` endpoints reply with `503 SERVICE_UNAVAILABLE` when the query
+/// handler reports that the delegation does not match the certified state, i.e.
+/// when the [`QueryExecutionService`](ic_interfaces::execution_environment::QueryExecutionService)
+/// returns [`QueryExecutionError::OutdatedDelegation`] or
+/// [`QueryExecutionError::InvalidDelegation`].
+#[rstest]
+#[case::outdated(
+    QueryExecutionError::OutdatedDelegation,
+    "This replica has an outdated NNS delegation. Please try again."
+)]
+#[case::invalid(
+    QueryExecutionError::InvalidDelegation("delegation does not match certified state".to_string()),
+    "This replica has an invalid NNS delegation. Please try again."
+)]
+fn test_query_endpoint_returns_service_unavailable_on_delegation_mismatch(
+    #[values(query::Version::V2, query::Version::V3, query::Version::SubnetV3)]
+    version: query::Version,
+    #[case] query_execution_error: QueryExecutionError,
+    #[case] expected_message: &str,
+) {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    let mut handlers = HttpEndpointBuilder::new(rt.handle().clone(), config).run();
+
+    // The query execution service reports that the delegation is out of sync with
+    // the certified state.
+    rt.spawn(async move {
+        let (_, resp) = handlers.query_execution.next_request().await.unwrap();
+        resp.send_response(Err(query_execution_error));
+    });
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+
+        let response = query_endpoint(version, addr).await;
+
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+        assert_eq!(expected_message, response.text().await.unwrap());
     });
 }

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -816,12 +816,16 @@ fn can_retrieve_subnet_metrics(
                         ..SubnetTopology::default()
                     },
                 );
-                let routing_table = topology.routing_table_mut();
-                for (start, end) in [(canister_test_id(0), canister_test_id(10))] {
-                    routing_table
-                        .insert(CanisterIdRange { start, end }, subnet_id)
-                        .unwrap();
-                }
+                let routing_table = topology
+                    .routing_table_mut()
+                    .insert(
+                        CanisterIdRange {
+                            start: canister_test_id(0),
+                            end: canister_test_id(10),
+                        },
+                        subnet_id,
+                    )
+                    .unwrap();
             });
         let certification = Certification {
             height: Height::from(1),
@@ -2166,7 +2170,7 @@ fn nns_delegation_and_public_key(
     let certificate_tree = create_certificate_labeled_tree(
         &ranges.to_vec(),
         subnet_id,
-        subnet_public_key.clone(),
+        subnet_public_key,
         /*max_ranges_per_routing_table_leaf=*/ 5,
         /*time=*/ 42,
         /*with_tree_canister_ranges=*/ true,

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -816,7 +816,7 @@ fn can_retrieve_subnet_metrics(
                         ..SubnetTopology::default()
                     },
                 );
-                let routing_table = topology
+                topology
                     .routing_table_mut()
                     .insert(
                         CanisterIdRange {

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -585,6 +585,10 @@ pub type IngressFilterService =
 pub enum QueryExecutionError {
     #[error("Certified state is not available yet")]
     CertifiedStateUnavailable,
+    #[error("Invalid delegation: {0}")]
+    InvalidDelegation(String),
+    #[error("Outdated delegation with respect to the current certified state")]
+    OutdatedDelegation,
 }
 
 /// The response type to a `call()` request in [`QueryExecutionService`].

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -917,6 +917,10 @@ impl Player {
             Err(QueryExecutionError::CertifiedStateUnavailable) => {
                 panic!("Certified state unavailable for query call.")
             }
+            Err(QueryExecutionError::InvalidDelegation(_))
+            | Err(QueryExecutionError::OutdatedDelegation) => {
+                unreachable!("QueryExecutionErrors above only found when a delegation is given")
+            }
         }
     }
 
@@ -1270,6 +1274,10 @@ async fn get_changes_since(
         Err(QueryExecutionError::CertifiedStateUnavailable) => {
             Err("Certified state unavailable for query call.".to_string())
         }
+        Err(QueryExecutionError::InvalidDelegation(_))
+        | Err(QueryExecutionError::OutdatedDelegation) => {
+            unreachable!("QueryExecutionErrors above only found when a delegation is given")
+        }
     }
 }
 
@@ -1314,6 +1322,10 @@ impl<PerformQueryImpl: PerformQuery + Sync> GetChunk for GetChunkImpl<'_, Perfor
                      call with key={:?}.",
                     String::from_utf8_lossy(chunk_content_sha256),
                 ));
+            }
+            Err(QueryExecutionError::InvalidDelegation(_))
+            | Err(QueryExecutionError::OutdatedDelegation) => {
+                unreachable!("QueryExecutionErrors above only found when a delegation is given")
             }
         };
 

--- a/rs/replica_tests/src/lib.rs
+++ b/rs/replica_tests/src/lib.rs
@@ -5,7 +5,7 @@ use ic_config::{Config, crypto::CryptoConfig, transport::TransportConfig};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_execution_environment::IngressHistoryReaderImpl;
 use ic_interfaces::execution_environment::{
-    IngressHistoryReader, QueryExecutionError, QueryExecutionInput, QueryExecutionService,
+    IngressHistoryReader, QueryExecutionInput, QueryExecutionService,
 };
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
@@ -612,8 +612,8 @@ impl LocalTestRuntime {
         };
         let result = match query_svc.oneshot(input).await.unwrap() {
             Ok((result, _)) => result,
-            Err(QueryExecutionError::CertifiedStateUnavailable) => {
-                panic!("Certified state unavailable for query call.")
+            Err(err) => {
+                panic!("Query failed with error: {:?}", err);
             }
         };
         if let Ok(WasmResult::Reply(result)) = result.clone() {

--- a/rs/replica_tests/src/lib.rs
+++ b/rs/replica_tests/src/lib.rs
@@ -5,7 +5,7 @@ use ic_config::{Config, crypto::CryptoConfig, transport::TransportConfig};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_execution_environment::IngressHistoryReaderImpl;
 use ic_interfaces::execution_environment::{
-    IngressHistoryReader, QueryExecutionInput, QueryExecutionService,
+    IngressHistoryReader, QueryExecutionError, QueryExecutionInput, QueryExecutionService,
 };
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
@@ -612,8 +612,12 @@ impl LocalTestRuntime {
         };
         let result = match query_svc.oneshot(input).await.unwrap() {
             Ok((result, _)) => result,
-            Err(err) => {
-                panic!("Query failed with error: {:?}", err);
+            Err(QueryExecutionError::CertifiedStateUnavailable) => {
+                panic!("Certified state unavailable for query call.")
+            }
+            Err(QueryExecutionError::InvalidDelegation(_))
+            | Err(QueryExecutionError::OutdatedDelegation) => {
+                unreachable!("QueryExecutionErrors above only found when a delegation is given.")
             }
         };
         if let Ok(WasmResult::Reply(result)) = result.clone() {

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -848,6 +848,16 @@ pub enum CertificateDelegationFormat {
     Pruned,
 }
 
+impl fmt::Display for CertificateDelegationFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CertificateDelegationFormat::Flat => write!(f, "flat"),
+            CertificateDelegationFormat::Tree => write!(f, "tree"),
+            CertificateDelegationFormat::Pruned => write!(f, "pruned"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct CertificateDelegationMetadata {
     pub format: CertificateDelegationFormat,


### PR DESCRIPTION
During canister migrations and soon subnet splitting, the public key of a subnet and/or its canister ranges are modified. Because the delegation manager fetches new delegations independently from the state, it can happen that a replica serves a response that is invalid w.r.t. the latest delegation in the following cases:
- The public key/canister ranges have been modified on the NNS, the replica fetched a delegation for the new ones, but its state has not reached the registry version triggering those changes yet: the replica serves a "new" delegation for an "old" state.
- The public key/canister ranges have been modified on the NNS, the state has reached the registry version, but the replica has not fetched a delegation yet: the replica serves an "old" delegation for a "new" state.

In both cases, agents will reject the response either with a `CertificateVerificationFailed` or a `CertificateNotAuthorized`, which should be observed normally only in instances of malicious behaviour.

This PR makes the HTTP handler check that the delegation it is about to serve correctly matches the state (for queries, call_sync and read_state). If not, it returns a 503 HTTP error code, similar to `Certified state is not available yet`, suggesting that retrying later should work. 

Note: for each request, the HTTP handler's hot path now iterates through the entire routing table to find the ranges it is responsible for and compares them with the ones in the delegation. This could potentially take some time if the routing table is heavily fragmented. Thus, a new metric is added to measure the time spent on that check. In my tests with a single subnet (obviously not representative), it takes less than 0.1ms, but I am planning to carefully monitor that metric in production.

In a future PR, the delegation manager can also use the building blocks introduced here to reactively fetch a new delegation when it detects that the latest state is not compatible with the latest delegation.