### PR TITLE
feat(registry): allow deleting non-System subnets

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -663,7 +663,8 @@ fn delete_subnet() {
 
 #[candid_method(update, rename = "delete_subnet")]
 fn delete_subnet_(payload: DeleteSubnetPayload) -> Result<(), String> {
-    registry_mut().do_delete_subnet(payload)?;
+    let caller = dfn_core::api::caller();
+    registry_mut().do_delete_subnet(caller, payload)?;
     recertify_registry();
     Ok(())
 }

--- a/rs/registry/canister/src/mutations/do_delete_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_delete_subnet.rs
@@ -1,6 +1,7 @@
 use candid::{CandidType, Principal};
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
+use ic_nns_constants::ENGINE_CONTROLLER_CANISTER_ID;
 use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetType};
 use ic_registry_keys::{
     make_catch_up_package_contents_key, make_crypto_threshold_signing_pubkey_key,
@@ -14,10 +15,6 @@ use serde::{Deserialize, Serialize};
 use crate::{common::LOG_PREFIX, registry::Registry};
 
 impl Registry {
-    /// Note: The method name implies general subnet deletion. Currently, however, only CloudEngine subnets
-    ///       can be deleted. The reason is that general subnet deletion requires changes in the deterministic
-    ///       state machine, which are planned in the near future.  
-    ///
     /// Deleting a subnet means to:
     /// - Remove its subnet ID from the key `subnet_list`.
     /// - Remove its subnet record.
@@ -29,16 +26,34 @@ impl Registry {
     /// consumers that must take deleted subnets into account do so via old registry versions (the
     /// registry client method `get_versioned_value` allows the caller to distinguish between deleted
     /// and non-existing values via `version ?= 0`).
-    pub fn do_delete_subnet(&mut self, payload: DeleteSubnetPayload) -> Result<(), String> {
-        println!("{LOG_PREFIX}do_delete_subnet: {payload:?}");
+    ///
+    /// Authorization by subnet type (the calling principal is already restricted to governance or the
+    /// engine controller at the endpoint):
+    /// - System subnets (e.g. the NNS) may never be deleted.
+    /// - The engine controller may only delete CloudEngine subnets.
+    /// - Governance may delete any non-System subnet.
+    pub fn do_delete_subnet(
+        &mut self,
+        caller: PrincipalId,
+        payload: DeleteSubnetPayload,
+    ) -> Result<(), String> {
+        println!("{LOG_PREFIX}do_delete_subnet: caller={caller}, payload={payload:?}");
 
         let DeleteSubnetPayload { subnet_id } = payload;
         let subnet_id_ = SubnetId::from(PrincipalId::from(subnet_id));
         let subnet_record = self.get_subnet(subnet_id_, self.latest_version())?;
 
-        // Currently, only CloudEngines can be deleted.
-        if subnet_record.subnet_type != i32::from(SubnetType::CloudEngine) {
-            return Err("Only CloudEngines may be deleted".to_string());
+        // System subnets (e.g. the NNS) may never be deleted.
+        if subnet_record.subnet_type == i32::from(SubnetType::System) {
+            return Err("System subnets may not be deleted".to_string());
+        }
+
+        // The engine controller may only delete CloudEngine subnets; governance may
+        // delete any non-System subnet.
+        if caller == ENGINE_CONTROLLER_CANISTER_ID.get()
+            && subnet_record.subnet_type != i32::from(SubnetType::CloudEngine)
+        {
+            return Err("The engine controller may only delete CloudEngine subnets".to_string());
         }
 
         // Remove from `subnet_list`.

--- a/rs/registry/canister/src/mutations/do_delete_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_delete_subnet.rs
@@ -29,9 +29,9 @@ impl Registry {
     ///
     /// Authorization by subnet type (the calling principal is already restricted to governance or the
     /// engine controller at the endpoint):
-    /// - System subnets (e.g. the NNS) may never be deleted.
+    /// - Governance may delete any non-System subnet (including CloudEngine subnets).
     /// - The engine controller may only delete CloudEngine subnets.
-    /// - Governance may delete any non-System subnet.
+    /// - As a corollary of the above, no one may delete a System subnet (e.g. the NNS).
     pub fn do_delete_subnet(
         &mut self,
         caller: PrincipalId,
@@ -44,14 +44,14 @@ impl Registry {
         let subnet_record = self.get_subnet(subnet_id_, self.latest_version())?;
 
         // System subnets (e.g. the NNS) may never be deleted.
-        if subnet_record.subnet_type == i32::from(SubnetType::System) {
+        if subnet_record.subnet_type == SubnetType::System as i32 {
             return Err("System subnets may not be deleted".to_string());
         }
 
         // The engine controller may only delete CloudEngine subnets; governance may
         // delete any non-System subnet.
         if caller == ENGINE_CONTROLLER_CANISTER_ID.get()
-            && subnet_record.subnet_type != i32::from(SubnetType::CloudEngine)
+            && subnet_record.subnet_type != SubnetType::CloudEngine as i32
         {
             return Err("The engine controller may only delete CloudEngine subnets".to_string());
         }

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -231,20 +231,10 @@ pub fn prepare_registry_with_cloud_engine_subnet(
     };
     let (nodes_request, node_ids_and_pks) =
         prepare_registry_with_nodes_from_template(node_count, starting_mutation_id, node_template);
-    let mut mutations = nodes_request.mutations;
-
-    let node_ids_and_dkg_pks: BTreeMap<NodeId, PublicKey> = node_ids_and_pks
-        .iter()
-        .map(|(node_id, valid_pks)| (*node_id, valid_pks.dkg_dealing_encryption_key().clone()))
-        .collect();
 
     // CloudEngine subnets are not charged cycles, i.e. they use the `Free` cost
     // schedule.
     let subnet_record = SubnetRecord {
-        membership: node_ids_and_pks
-            .keys()
-            .map(|node_id| node_id.get().to_vec())
-            .collect(),
         subnet_type: i32::from(SubnetType::CloudEngine),
         canister_cycles_cost_schedule: i32::from(CanisterCyclesCostSchedule::Free),
         replica_version_id: ReplicaVersion::default().to_string(),
@@ -252,38 +242,7 @@ pub fn prepare_registry_with_cloud_engine_subnet(
         ..Default::default()
     };
 
-    // The invariant-compliant base contains a single system subnet (`TEST_ID`);
-    // append the new CloudEngine subnet to the subnet list.
-    let cloud_engine_subnet_id = subnet_test_id(TEST_ID + 1);
-    let subnet_list_record = SubnetListRecord {
-        subnets: vec![
-            subnet_test_id(TEST_ID).get().to_vec(),
-            cloud_engine_subnet_id.get().to_vec(),
-        ],
-    };
-
-    mutations.push(upsert(
-        make_subnet_list_record_key().as_bytes(),
-        subnet_list_record.encode_to_vec(),
-    ));
-    mutations.push(upsert(
-        make_subnet_record_key(cloud_engine_subnet_id).as_bytes(),
-        subnet_record.encode_to_vec(),
-    ));
-    mutations.append(
-        &mut create_subnet_threshold_signing_pubkey_and_cup_mutations(
-            cloud_engine_subnet_id,
-            &node_ids_and_dkg_pks,
-        ),
-    );
-
-    (
-        RegistryAtomicMutateRequest {
-            mutations,
-            preconditions: vec![],
-        },
-        cloud_engine_subnet_id,
-    )
+    add_subnet_to_registry(nodes_request, &node_ids_and_pks, subnet_record)
 }
 
 /// Prepares mutations adding an Application subnet on top of the
@@ -296,29 +255,47 @@ pub fn prepare_registry_with_application_subnet(
 ) -> (RegistryAtomicMutateRequest, SubnetId) {
     let (nodes_request, node_ids_and_pks) =
         prepare_registry_with_nodes_and_valid_pks(node_count, starting_mutation_id);
-    let mut mutations = nodes_request.mutations;
-
-    let node_ids_and_dkg_pks: BTreeMap<NodeId, PublicKey> = node_ids_and_pks
-        .iter()
-        .map(|(node_id, valid_pks)| (*node_id, valid_pks.dkg_dealing_encryption_key().clone()))
-        .collect();
 
     let subnet_record = SubnetRecord {
-        membership: node_ids_and_pks
-            .keys()
-            .map(|node_id| node_id.get().to_vec())
-            .collect(),
         subnet_type: i32::from(SubnetType::Application),
         replica_version_id: ReplicaVersion::default().to_string(),
         unit_delay_millis: 600,
         ..Default::default()
     };
 
-    let application_subnet_id = subnet_test_id(TEST_ID + 1);
+    add_subnet_to_registry(nodes_request, &node_ids_and_pks, subnet_record)
+}
+
+/// Adds a new subnet (described by `subnet_record`, made up of the nodes in
+/// `node_ids_and_pks`) on top of the node-registration mutations in
+/// `nodes_request`. The subnet's `membership` is populated from
+/// `node_ids_and_pks`, so callers only need to set the fields that distinguish
+/// their subnet type. The new subnet is appended to the subnet list alongside
+/// the single system subnet (`TEST_ID`) of the invariant-compliant base, and the
+/// required threshold-signing public key and CUP mutations are added. Returns the
+/// completed request together with the new subnet's ID.
+fn add_subnet_to_registry(
+    nodes_request: RegistryAtomicMutateRequest,
+    node_ids_and_pks: &BTreeMap<NodeId, ValidNodePublicKeys>,
+    mut subnet_record: SubnetRecord,
+) -> (RegistryAtomicMutateRequest, SubnetId) {
+    let mut mutations = nodes_request.mutations;
+
+    subnet_record.membership = node_ids_and_pks
+        .keys()
+        .map(|node_id| node_id.get().to_vec())
+        .collect();
+
+    let node_ids_and_dkg_pks: BTreeMap<NodeId, PublicKey> = node_ids_and_pks
+        .iter()
+        .map(|(node_id, valid_pks)| (*node_id, valid_pks.dkg_dealing_encryption_key().clone()))
+        .collect();
+
+    let subnet_id = subnet_test_id(TEST_ID + 1);
     let subnet_list_record = SubnetListRecord {
         subnets: vec![
             subnet_test_id(TEST_ID).get().to_vec(),
-            application_subnet_id.get().to_vec(),
+            subnet_id.get().to_vec(),
         ],
     };
 
@@ -327,12 +304,12 @@ pub fn prepare_registry_with_application_subnet(
         subnet_list_record.encode_to_vec(),
     ));
     mutations.push(upsert(
-        make_subnet_record_key(application_subnet_id).as_bytes(),
+        make_subnet_record_key(subnet_id).as_bytes(),
         subnet_record.encode_to_vec(),
     ));
     mutations.append(
         &mut create_subnet_threshold_signing_pubkey_and_cup_mutations(
-            application_subnet_id,
+            subnet_id,
             &node_ids_and_dkg_pks,
         ),
     );
@@ -342,7 +319,7 @@ pub fn prepare_registry_with_application_subnet(
             mutations,
             preconditions: vec![],
         },
-        application_subnet_id,
+        subnet_id,
     )
 }
 

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -286,6 +286,66 @@ pub fn prepare_registry_with_cloud_engine_subnet(
     )
 }
 
+/// Prepares mutations adding an Application subnet on top of the
+/// invariant-compliant base (which already contains a single system subnet),
+/// mirroring [`prepare_registry_with_cloud_engine_subnet`]. Returns the subnet's
+/// ID so tests can target it with `delete_subnet`.
+pub fn prepare_registry_with_application_subnet(
+    node_count: u64,
+    starting_mutation_id: u8,
+) -> (RegistryAtomicMutateRequest, SubnetId) {
+    let (nodes_request, node_ids_and_pks) =
+        prepare_registry_with_nodes_and_valid_pks(node_count, starting_mutation_id);
+    let mut mutations = nodes_request.mutations;
+
+    let node_ids_and_dkg_pks: BTreeMap<NodeId, PublicKey> = node_ids_and_pks
+        .iter()
+        .map(|(node_id, valid_pks)| (*node_id, valid_pks.dkg_dealing_encryption_key().clone()))
+        .collect();
+
+    let subnet_record = SubnetRecord {
+        membership: node_ids_and_pks
+            .keys()
+            .map(|node_id| node_id.get().to_vec())
+            .collect(),
+        subnet_type: i32::from(SubnetType::Application),
+        replica_version_id: ReplicaVersion::default().to_string(),
+        unit_delay_millis: 600,
+        ..Default::default()
+    };
+
+    let application_subnet_id = subnet_test_id(TEST_ID + 1);
+    let subnet_list_record = SubnetListRecord {
+        subnets: vec![
+            subnet_test_id(TEST_ID).get().to_vec(),
+            application_subnet_id.get().to_vec(),
+        ],
+    };
+
+    mutations.push(upsert(
+        make_subnet_list_record_key().as_bytes(),
+        subnet_list_record.encode_to_vec(),
+    ));
+    mutations.push(upsert(
+        make_subnet_record_key(application_subnet_id).as_bytes(),
+        subnet_record.encode_to_vec(),
+    ));
+    mutations.append(
+        &mut create_subnet_threshold_signing_pubkey_and_cup_mutations(
+            application_subnet_id,
+            &node_ids_and_dkg_pks,
+        ),
+    );
+
+    (
+        RegistryAtomicMutateRequest {
+            mutations,
+            preconditions: vec![],
+        },
+        application_subnet_id,
+    )
+}
+
 fn get_added_subnets(
     former_subnet_list_record: &SubnetListRecord,
     current_subnet_list_record: &SubnetListRecord,

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -81,9 +81,7 @@ async fn delete_subnet(
             Encode!(&payload).unwrap(),
         )
         .await
-        .unwrap_or_else(|err| {
-            panic!("delete_subnet call by {caller} was unexpectedly rejected: {err:?}")
-        });
+        .unwrap();
     Decode!(&response, Result<(), String>).unwrap()
 }
 

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -23,7 +23,8 @@ mod common;
 
 use common::test_helpers::{
     get_subnet_list_record, install_registry_canister_with_payload_builder,
-    prepare_registry_with_cloud_engine_subnet, prepare_registry_with_nodes,
+    prepare_registry_with_application_subnet, prepare_registry_with_cloud_engine_subnet,
+    prepare_registry_with_nodes,
 };
 
 /// Installs an invariant-compliant registry (which already contains a single,
@@ -173,15 +174,16 @@ async fn test_engine_controller_can_delete_a_cloud_engine_subnet() {
 }
 
 #[tokio::test]
-async fn test_authorized_callers_cannot_delete_a_non_cloud_engine_subnet() {
+async fn test_authorized_callers_cannot_delete_a_system_subnet() {
     let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
 
     let payload = DeleteSubnetPayload { subnet_id };
 
-    // The existing subnet is a system subnet, not a CloudEngine. Even authorized
-    // callers must not be able to delete it: the call passes the authorization
-    // check but is then rejected by the business logic. Deletion fails, so the
-    // subnet is not consumed and both callers can be checked against it.
+    // The existing subnet is a system subnet (the NNS). System subnets may never
+    // be deleted, so even authorized callers must fail: the call passes the
+    // authorization check but is then rejected by the business logic. Deletion
+    // fails, so the subnet is not consumed and both callers can be checked
+    // against it.
     for caller in [
         GOVERNANCE_CANISTER_ID.get(),
         ENGINE_CONTROLLER_CANISTER_ID.get(),
@@ -201,8 +203,8 @@ async fn test_authorized_callers_cannot_delete_a_non_cloud_engine_subnet() {
         let result = Decode!(&response, Result<(), String>).unwrap();
         assert_eq!(
             result,
-            Err("Only CloudEngines may be deleted".to_string()),
-            "caller {caller} should not be able to delete a non-cloud-engine subnet"
+            Err("System subnets may not be deleted".to_string()),
+            "caller {caller} should not be able to delete a system subnet"
         );
     }
 
@@ -213,7 +215,7 @@ async fn test_authorized_callers_cannot_delete_a_non_cloud_engine_subnet() {
             .subnets;
     assert!(
         subnets.contains(&subnet_id.as_slice().to_vec()),
-        "the non-cloud-engine subnet should not have been deleted"
+        "the system subnet should not have been deleted"
     );
 }
 
@@ -262,5 +264,98 @@ async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
     assert!(
         !subnets.contains(&cloud_engine_subnet_id.get().to_vec()),
         "the cloud engine subnet should have been removed from the subnet list"
+    );
+}
+
+#[tokio::test]
+async fn test_governance_can_delete_an_application_subnet() {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+
+    let (application_mutate, application_subnet_id) =
+        prepare_registry_with_application_subnet(4, INITIAL_MUTATION_ID);
+
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    builder.push_init_mutate_request(application_mutate);
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+
+    // Governance may delete any non-System subnet, including Application subnets.
+    let payload = DeleteSubnetPayload {
+        subnet_id: application_subnet_id.get().0,
+    };
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            GOVERNANCE_CANISTER_ID.get().0,
+            "delete_subnet",
+            Encode!(&payload).unwrap(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("delete_subnet call by governance was unexpectedly rejected: {err:?}")
+        });
+
+    let result = Decode!(&response, Result<(), String>).unwrap();
+    assert_eq!(
+        result,
+        Ok(()),
+        "governance should be able to delete an application subnet"
+    );
+
+    // The subnet should no longer be in the subnet list.
+    let subnets =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+    assert!(
+        !subnets.contains(&application_subnet_id.get().to_vec()),
+        "the application subnet should have been removed from the subnet list"
+    );
+}
+
+#[tokio::test]
+async fn test_engine_controller_cannot_delete_an_application_subnet() {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+
+    let (application_mutate, application_subnet_id) =
+        prepare_registry_with_application_subnet(4, INITIAL_MUTATION_ID);
+
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    builder.push_init_mutate_request(application_mutate);
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+
+    // The engine controller may only delete CloudEngine subnets: the call passes
+    // the authorization check but is then rejected by the business logic.
+    let payload = DeleteSubnetPayload {
+        subnet_id: application_subnet_id.get().0,
+    };
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            ENGINE_CONTROLLER_CANISTER_ID.get().0,
+            "delete_subnet",
+            Encode!(&payload).unwrap(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("delete_subnet call by the engine controller was unexpectedly rejected: {err:?}")
+        });
+
+    let result = Decode!(&response, Result<(), String>).unwrap();
+    assert_eq!(
+        result,
+        Err("The engine controller may only delete CloudEngine subnets".to_string()),
+        "the engine controller should not be able to delete an application subnet"
+    );
+
+    // The subnet should still be present.
+    let subnets =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+    assert!(
+        subnets.contains(&application_subnet_id.get().to_vec()),
+        "the application subnet should not have been deleted"
     );
 }

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -13,6 +13,7 @@ use ic_nns_test_utils::registry::{
 };
 use ic_protobuf::registry::subnet::v1::SubnetListRecord as SubnetListRecordPb;
 use ic_registry_keys::make_subnet_list_record_key;
+use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
 use pocket_ic::PocketIcBuilder;
 use pocket_ic::nonblocking::PocketIc;
 use registry_canister::{
@@ -47,6 +48,50 @@ async fn setup_with_existing_subnet() -> (PocketIc, Principal) {
     let subnet_id = Principal::try_from(subnet_id.as_slice()).unwrap();
 
     (pocket_ic, subnet_id)
+}
+
+/// Installs an invariant-compliant registry augmented with the subnet described
+/// by `subnet_mutate` (e.g. the output of a `prepare_registry_with_*_subnet`
+/// helper) and returns the running `PocketIc`.
+async fn setup_with_subnet(subnet_mutate: RegistryAtomicMutateRequest) -> PocketIc {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    builder.push_init_mutate_request(subnet_mutate);
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+
+    pocket_ic
+}
+
+/// Calls `delete_subnet` on the registry canister as `caller` and returns the
+/// decoded result. Panics only if the call itself is rejected, which is never
+/// expected for the authorized callers used in these tests.
+async fn delete_subnet(
+    pocket_ic: &PocketIc,
+    caller: PrincipalId,
+    subnet_id: Principal,
+) -> Result<(), String> {
+    let payload = DeleteSubnetPayload { subnet_id };
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            caller.0,
+            "delete_subnet",
+            Encode!(&payload).unwrap(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("delete_subnet call by {caller} was unexpectedly rejected: {err:?}")
+        });
+    Decode!(&response, Result<(), String>).unwrap()
+}
+
+/// Returns the current list of subnet IDs (as raw bytes) recorded in the registry.
+async fn subnet_ids(pocket_ic: &PocketIc) -> Vec<Vec<u8>> {
+    decode_registry_value::<SubnetListRecordPb>(pocket_ic, make_subnet_list_record_key())
+        .await
+        .subnets
 }
 
 #[tokio::test]
@@ -177,8 +222,6 @@ async fn test_engine_controller_can_delete_a_cloud_engine_subnet() {
 async fn test_authorized_callers_cannot_delete_a_system_subnet() {
     let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
 
-    let payload = DeleteSubnetPayload { subnet_id };
-
     // The existing subnet is a system subnet (the NNS). System subnets may never
     // be deleted, so even authorized callers must fail: the call passes the
     // authorization check but is then rejected by the business logic. Deletion
@@ -188,19 +231,7 @@ async fn test_authorized_callers_cannot_delete_a_system_subnet() {
         GOVERNANCE_CANISTER_ID.get(),
         ENGINE_CONTROLLER_CANISTER_ID.get(),
     ] {
-        let response = pocket_ic
-            .update_call(
-                REGISTRY_CANISTER_ID.get().0,
-                caller.0,
-                "delete_subnet",
-                Encode!(&payload).unwrap(),
-            )
-            .await
-            .unwrap_or_else(|err| {
-                panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
-            });
-
-        let result = Decode!(&response, Result<(), String>).unwrap();
+        let result = delete_subnet(&pocket_ic, caller, subnet_id).await;
         assert_eq!(
             result,
             Err("System subnets may not be deleted".to_string()),
@@ -209,12 +240,10 @@ async fn test_authorized_callers_cannot_delete_a_system_subnet() {
     }
 
     // The subnet should still be present.
-    let subnets =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
     assert!(
-        subnets.contains(&subnet_id.as_slice().to_vec()),
+        subnet_ids(&pocket_ic)
+            .await
+            .contains(&subnet_id.as_slice().to_vec()),
         "the system subnet should not have been deleted"
     );
 }
@@ -223,33 +252,12 @@ async fn test_authorized_callers_cannot_delete_a_system_subnet() {
 /// that may be deleted) and verifies that `caller` is authorized to delete it
 /// and that the subnet is actually removed from the registry.
 async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
-    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
-
     let (cloud_engine_mutate, cloud_engine_subnet_id) =
         prepare_registry_with_cloud_engine_subnet(4, INITIAL_MUTATION_ID);
-
-    let mut builder = RegistryCanisterInitPayloadBuilder::new();
-    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
-    builder.push_init_mutate_request(cloud_engine_mutate);
-    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+    let pocket_ic = setup_with_subnet(cloud_engine_mutate).await;
 
     // Delete the CloudEngine subnet via the caller under test.
-    let payload = DeleteSubnetPayload {
-        subnet_id: cloud_engine_subnet_id.get().0,
-    };
-    let response = pocket_ic
-        .update_call(
-            REGISTRY_CANISTER_ID.get().0,
-            caller.0,
-            "delete_subnet",
-            Encode!(&payload).unwrap(),
-        )
-        .await
-        .unwrap_or_else(|err| {
-            panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
-        });
-
-    let result = Decode!(&response, Result<(), String>).unwrap();
+    let result = delete_subnet(&pocket_ic, caller, cloud_engine_subnet_id.get().0).await;
     assert_eq!(
         result,
         Ok(()),
@@ -257,45 +265,27 @@ async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
     );
 
     // The subnet should no longer be in the subnet list.
-    let subnets =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
     assert!(
-        !subnets.contains(&cloud_engine_subnet_id.get().to_vec()),
+        !subnet_ids(&pocket_ic)
+            .await
+            .contains(&cloud_engine_subnet_id.get().to_vec()),
         "the cloud engine subnet should have been removed from the subnet list"
     );
 }
 
 #[tokio::test]
 async fn test_governance_can_delete_an_application_subnet() {
-    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
-
     let (application_mutate, application_subnet_id) =
         prepare_registry_with_application_subnet(4, INITIAL_MUTATION_ID);
-
-    let mut builder = RegistryCanisterInitPayloadBuilder::new();
-    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
-    builder.push_init_mutate_request(application_mutate);
-    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+    let pocket_ic = setup_with_subnet(application_mutate).await;
 
     // Governance may delete any non-System subnet, including Application subnets.
-    let payload = DeleteSubnetPayload {
-        subnet_id: application_subnet_id.get().0,
-    };
-    let response = pocket_ic
-        .update_call(
-            REGISTRY_CANISTER_ID.get().0,
-            GOVERNANCE_CANISTER_ID.get().0,
-            "delete_subnet",
-            Encode!(&payload).unwrap(),
-        )
-        .await
-        .unwrap_or_else(|err| {
-            panic!("delete_subnet call by governance was unexpectedly rejected: {err:?}")
-        });
-
-    let result = Decode!(&response, Result<(), String>).unwrap();
+    let result = delete_subnet(
+        &pocket_ic,
+        GOVERNANCE_CANISTER_ID.get(),
+        application_subnet_id.get().0,
+    )
+    .await;
     assert_eq!(
         result,
         Ok(()),
@@ -303,46 +293,28 @@ async fn test_governance_can_delete_an_application_subnet() {
     );
 
     // The subnet should no longer be in the subnet list.
-    let subnets =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
     assert!(
-        !subnets.contains(&application_subnet_id.get().to_vec()),
+        !subnet_ids(&pocket_ic)
+            .await
+            .contains(&application_subnet_id.get().to_vec()),
         "the application subnet should have been removed from the subnet list"
     );
 }
 
 #[tokio::test]
 async fn test_engine_controller_cannot_delete_an_application_subnet() {
-    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
-
     let (application_mutate, application_subnet_id) =
         prepare_registry_with_application_subnet(4, INITIAL_MUTATION_ID);
-
-    let mut builder = RegistryCanisterInitPayloadBuilder::new();
-    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
-    builder.push_init_mutate_request(application_mutate);
-    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+    let pocket_ic = setup_with_subnet(application_mutate).await;
 
     // The engine controller may only delete CloudEngine subnets: the call passes
     // the authorization check but is then rejected by the business logic.
-    let payload = DeleteSubnetPayload {
-        subnet_id: application_subnet_id.get().0,
-    };
-    let response = pocket_ic
-        .update_call(
-            REGISTRY_CANISTER_ID.get().0,
-            ENGINE_CONTROLLER_CANISTER_ID.get().0,
-            "delete_subnet",
-            Encode!(&payload).unwrap(),
-        )
-        .await
-        .unwrap_or_else(|err| {
-            panic!("delete_subnet call by the engine controller was unexpectedly rejected: {err:?}")
-        });
-
-    let result = Decode!(&response, Result<(), String>).unwrap();
+    let result = delete_subnet(
+        &pocket_ic,
+        ENGINE_CONTROLLER_CANISTER_ID.get(),
+        application_subnet_id.get().0,
+    )
+    .await;
     assert_eq!(
         result,
         Err("The engine controller may only delete CloudEngine subnets".to_string()),
@@ -350,12 +322,10 @@ async fn test_engine_controller_cannot_delete_an_application_subnet() {
     );
 
     // The subnet should still be present.
-    let subnets =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
     assert!(
-        subnets.contains(&application_subnet_id.get().to_vec()),
+        subnet_ids(&pocket_ic)
+            .await
+            .contains(&application_subnet_id.get().to_vec()),
         "the application subnet should not have been deleted"
     );
 }

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,12 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `delete_subnet` may now delete any non-System subnet, lifting the previous
+  restriction to `CloudEngine` subnets. Authorization by subnet type:
+  System subnets (e.g. the NNS) may never be deleted; the engine controller
+  canister may only delete `CloudEngine` subnets; governance may delete any
+  non-System subnet.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
Lift the CloudEngine-only restriction in `do_delete_subnet` now that the deterministic state machine handles deletion of any remote subnet.

Authorization by subnet type (the caller is already restricted to governance or the engine controller at the endpoint):
- System subnets (e.g. the NNS) may never be deleted.
- The engine controller may only delete CloudEngine subnets.
- Governance may delete any non-System subnet.

Adds/updates registry tests covering governance deleting an Application subnet, the engine controller being refused, and System subnets remaining undeletable.