### PR TITLE
feat: introduce `BackwardsCompatible`

### DIFF
--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 /// Compared to [`Option`], its [`Hash`] implementation:
 ///  - ignores `None` (so adding an unset field preserves the surrounding struct hash), and
 ///  - hashes `Some(v)` like `v` (so later replacing it with `T` preserves hashes).
+///
 /// The purpose of this is to have a compatible `Hash` implementation across versions of a struct,
 /// so that replicas running different versions of the code can still agree on the hash of a struct
 /// instance.

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -9,6 +9,17 @@ use std::hash::{Hash, Hasher};
 ///  - ignores `None` (so adding an unset field preserves the surrounding struct hash), and
 ///  - hashes `Some(v)` like `v` (so later replacing it with `T` preserves hashes).
 ///
+/// IMPORTANT: there should be only one field of type `BackwardsCompatible` in a struct. Otherwise,
+/// two different instances of the struct could have the same hash. For example:
+/// ```
+/// #[derive(Hash)]
+/// struct S { a: BackwardsCompatible<u8, false>, b: BackwardsCompatible<u8, false> }
+///
+/// S { a: Some(1), b: None }
+/// S { a: None, b: Some(1) }
+/// ```
+/// would have the same hash.
+///
 /// Lifecycle of adding a new field to a struct in a backwards compatible way:
 /// 1. Add a new field to the struct with type `BackwardsCompatible<T, false>`. At this point the
 ///    field is *NOT* allowed to be instantiated with any value other than `None`. Though, it still

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -60,3 +60,170 @@ impl<T, const SETTABLE: bool> BackwardsCompatibleOption<T, SETTABLE> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    fn hash_of<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn none_variant_is_ignored_in_hash() {
+        let none = BackwardsCompatibleOption::<u64, false>::new_for_test_only(None);
+
+        // Hashing the `None` variant must not write anything to the hasher, so
+        // the result must be identical to that of a fresh, untouched hasher.
+        assert_eq!(hash_of(&none), DefaultHasher::new().finish());
+    }
+
+    #[test]
+    fn some_variant_hashes_like_inner_value() {
+        let value = 42_u64;
+        let some = BackwardsCompatibleOption::<u64, true>::new(value);
+
+        assert_eq!(hash_of(&some), hash_of(&value));
+    }
+
+    #[derive(Hash)]
+    struct WithoutField {
+        a: u64,
+        b: String,
+    }
+    #[derive(Hash)]
+    struct WithUnsettableField {
+        a: u64,
+        b: String,
+        unsettable_field: BackwardsCompatibleOption<u32, false>,
+    }
+    #[derive(Hash)]
+    struct WithSettableField {
+        a: u64,
+        b: String,
+        settable_field: BackwardsCompatibleOption<u32, true>,
+    }
+
+    #[test]
+    fn adding_none_field_preserves_struct_hash() {
+        let without = WithoutField {
+            a: 7,
+            b: "ic".to_string(),
+        };
+        let with = WithUnsettableField {
+            a: 7,
+            b: "ic".to_string(),
+            unsettable_field: BackwardsCompatibleOption::default(),
+        };
+
+        // The whole point of the type: introducing a `None` field leaves the
+        // hash of the surrounding struct unchanged.
+        assert_eq!(hash_of(&without), hash_of(&with));
+    }
+
+    #[test]
+    fn adding_some_field_changes_struct_hash() {
+        let without = WithoutField {
+            a: 7,
+            b: "ic".to_string(),
+        };
+        let with = WithSettableField {
+            a: 7,
+            b: "ic".to_string(),
+            settable_field: BackwardsCompatibleOption::default(),
+        };
+
+        // Introducing a `Some` field changes the hash of the surrounding struct.
+        assert_ne!(hash_of(&without), hash_of(&with));
+    }
+
+    #[test]
+    fn default_is_none_when_not_settable() {
+        let opt = BackwardsCompatibleOption::<u64, false>::default();
+
+        assert_eq!(opt.as_ref(), None);
+    }
+
+    #[test]
+    fn default_is_some_default_when_settable() {
+        let opt = BackwardsCompatibleOption::<u64, true>::default();
+
+        assert_eq!(opt.as_ref(), Some(&u64::default()));
+    }
+
+    #[test]
+    fn new_wraps_value_in_some() {
+        let opt = BackwardsCompatibleOption::<u64, true>::new(123);
+
+        assert_eq!(opt.as_ref(), Some(&123));
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Value(u64);
+
+    struct ValidProto(u64);
+    impl TryFrom<ValidProto> for Value {
+        type Error = ProxyDecodeError;
+        fn try_from(proto: ValidProto) -> Result<Self, Self::Error> {
+            Ok(Value(proto.0))
+        }
+    }
+
+    struct InvalidProto;
+    impl TryFrom<InvalidProto> for Value {
+        type Error = ProxyDecodeError;
+        fn try_from(_: InvalidProto) -> Result<Self, Self::Error> {
+            Err(ProxyDecodeError::MissingField("Value"))
+        }
+    }
+
+    #[test]
+    fn try_from_proto_maps_none_to_none() {
+        let opt_settable =
+            BackwardsCompatibleOption::<Value, true>::try_from_proto(None::<ValidProto>)
+                .expect("conversion of `None` should never fail");
+        let opt_not_settable =
+            BackwardsCompatibleOption::<Value, false>::try_from_proto(None::<ValidProto>)
+                .expect("conversion of `None` should never fail");
+
+        // `None` maps to `None` regardless of whether the field is settable or not.
+        assert_eq!(opt_settable.as_ref(), None);
+        assert_eq!(opt_not_settable.as_ref(), None);
+    }
+
+    #[test]
+    fn try_from_proto_maps_some_to_converted_value() {
+        let opt_settable =
+            BackwardsCompatibleOption::<Value, true>::try_from_proto(Some(ValidProto(9)))
+                .expect("conversion should succeed");
+        let opt_not_settable =
+            BackwardsCompatibleOption::<Value, false>::try_from_proto(Some(ValidProto(9)))
+                .expect("conversion should succeed");
+
+        // `Some(proto)` maps to `Some(converted_value)` regardless of whether the field is
+        // settable or not.
+        assert_eq!(opt_settable.as_ref(), Some(&Value(9)));
+        assert_eq!(opt_not_settable.as_ref(), Some(&Value(9)));
+    }
+
+    #[test]
+    fn try_from_proto_propagates_conversion_error() {
+        let result_settable =
+            BackwardsCompatibleOption::<Value, true>::try_from_proto(Some(InvalidProto));
+        let result_not_settable =
+            BackwardsCompatibleOption::<Value, false>::try_from_proto(Some(InvalidProto));
+
+        // Conversion errors are propagated regardless of whether the field is settable or not.
+        assert!(matches!(
+            result_settable,
+            Err(ProxyDecodeError::MissingField("Value"))
+        ));
+        assert!(matches!(
+            result_not_settable,
+            Err(ProxyDecodeError::MissingField("Value"))
+        ));
+    }
+}

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -68,6 +68,9 @@ impl<T> BackwardsCompatible<T, true> {
 }
 
 impl<T, const SETTABLE: bool> BackwardsCompatible<T, SETTABLE> {
+    /// Creates a new `BackwardsCompatible` value with the given inner value. This is only intended
+    /// for use in unit tests, where we would want to be able to fill a field that would not be
+    /// settable yet in production.
     #[doc(hidden)]
     pub const fn new_for_test_only(value: Option<T>) -> Self {
         Self(value)

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -8,6 +8,9 @@ use std::hash::{Hash, Hasher};
 /// Compared to [`Option`], its [`Hash`] implementation:
 ///  - ignores `None` (so adding an unset field preserves the surrounding struct hash), and
 ///  - hashes `Some(v)` like `v` (so later replacing it with `T` preserves hashes).
+/// The purpose of this is to have a compatible `Hash` implementation across versions of a struct,
+/// so that replicas running different versions of the code can still agree on the hash of a struct
+/// instance.
 ///
 /// IMPORTANT: there should be only one field of type `BackwardsCompatible` in a struct. Otherwise,
 /// two different instances of the struct could have the same hash. For example:
@@ -28,29 +31,8 @@ use std::hash::{Hash, Hasher};
 /// 2. When the change is deployed to all replicas, we can switch the type to
 ///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct BackwardsCompatible<T, const SETTABLE: bool>(Option<T>);
-
-impl<T: Serialize, const SETTABLE: bool> Serialize for BackwardsCompatible<T, SETTABLE> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de, T: Deserialize<'de>, const SETTABLE: bool> Deserialize<'de>
-    for BackwardsCompatible<T, SETTABLE>
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = Option::<T>::deserialize(deserializer)?;
-        Ok(Self(value))
-    }
-}
 
 impl<T: Default> Default for BackwardsCompatible<T, false> {
     fn default() -> Self {

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -9,26 +9,26 @@ use std::hash::{Hash, Hasher};
 /// of the struct with the field present but set to `None`.
 ///
 /// Lifecycle of adding a new field to a struct in a backwards compatible way:
-/// 1. Add a new field to the struct with type `BackwardsCompatibleOption<T, false>`. At this point
-///    the field is *NOT* allowed to have any value other than `None`.
+/// 1. Add a new field to the struct with type `BackwardsCompatible<T, false>`. At this point the
+///    field is *NOT* allowed to have any value other than `None`.
 /// 2. When the change is deployed to all replicas, we can switch the type to
-///    `BackwardsCompatibleOption<T, true>` and the field can begin to be populated.
+///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.
-pub struct BackwardsCompatibleOption<T, const SETTABLE: bool>(Option<T>);
+pub struct BackwardsCompatible<T, const SETTABLE: bool>(Option<T>);
 
-impl<T: Default> Default for BackwardsCompatibleOption<T, false> {
+impl<T: Default> Default for BackwardsCompatible<T, false> {
     fn default() -> Self {
         Self(None)
     }
 }
 
-impl<T: Default> Default for BackwardsCompatibleOption<T, true> {
+impl<T: Default> Default for BackwardsCompatible<T, true> {
     fn default() -> Self {
         Self(Some(T::default()))
     }
 }
 
-impl<T: Hash, const SETTABLE: bool> Hash for BackwardsCompatibleOption<T, SETTABLE> {
+impl<T: Hash, const SETTABLE: bool> Hash for BackwardsCompatible<T, SETTABLE> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         if let Some(value) = &self.0 {
             value.hash(state);
@@ -36,13 +36,13 @@ impl<T: Hash, const SETTABLE: bool> Hash for BackwardsCompatibleOption<T, SETTAB
     }
 }
 
-impl<T> BackwardsCompatibleOption<T, true> {
+impl<T> BackwardsCompatible<T, true> {
     pub const fn new(value: T) -> Self {
         Self(Some(value))
     }
 }
 
-impl<T, const SETTABLE: bool> BackwardsCompatibleOption<T, SETTABLE> {
+impl<T, const SETTABLE: bool> BackwardsCompatible<T, SETTABLE> {
     #[doc(hidden)]
     pub const fn new_for_test_only(value: Option<T>) -> Self {
         Self(value)
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn none_variant_is_ignored_in_hash() {
-        let none = BackwardsCompatibleOption::<u64, false>::new_for_test_only(None);
+        let none = BackwardsCompatible::<u64, false>::new_for_test_only(None);
 
         // Hashing the `None` variant must not write anything to the hasher, so
         // the result must be identical to that of a fresh, untouched hasher.
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn some_variant_hashes_like_inner_value() {
         let value = 42_u64;
-        let some = BackwardsCompatibleOption::<u64, true>::new(value);
+        let some = BackwardsCompatible::<u64, true>::new(value);
 
         assert_eq!(hash_of(&some), hash_of(&value));
     }
@@ -99,13 +99,13 @@ mod tests {
     struct WithUnsettableField {
         a: u64,
         b: String,
-        unsettable_field: BackwardsCompatibleOption<u32, false>,
+        unsettable_field: BackwardsCompatible<u32, false>,
     }
     #[derive(Hash)]
     struct WithSettableField {
         a: u64,
         b: String,
-        settable_field: BackwardsCompatibleOption<u32, true>,
+        settable_field: BackwardsCompatible<u32, true>,
     }
 
     #[test]
@@ -117,7 +117,7 @@ mod tests {
         let with = WithUnsettableField {
             a: 7,
             b: "ic".to_string(),
-            unsettable_field: BackwardsCompatibleOption::default(),
+            unsettable_field: BackwardsCompatible::default(),
         };
 
         // The whole point of the type: introducing a `None` field leaves the
@@ -134,7 +134,7 @@ mod tests {
         let with = WithSettableField {
             a: 7,
             b: "ic".to_string(),
-            settable_field: BackwardsCompatibleOption::default(),
+            settable_field: BackwardsCompatible::default(),
         };
 
         // Introducing a `Some` field changes the hash of the surrounding struct.
@@ -143,21 +143,21 @@ mod tests {
 
     #[test]
     fn default_is_none_when_not_settable() {
-        let opt = BackwardsCompatibleOption::<u64, false>::default();
+        let opt = BackwardsCompatible::<u64, false>::default();
 
         assert_eq!(opt.as_ref(), None);
     }
 
     #[test]
     fn default_is_some_default_when_settable() {
-        let opt = BackwardsCompatibleOption::<u64, true>::default();
+        let opt = BackwardsCompatible::<u64, true>::default();
 
         assert_eq!(opt.as_ref(), Some(&u64::default()));
     }
 
     #[test]
     fn new_wraps_value_in_some() {
-        let opt = BackwardsCompatibleOption::<u64, true>::new(123);
+        let opt = BackwardsCompatible::<u64, true>::new(123);
 
         assert_eq!(opt.as_ref(), Some(&123));
     }
@@ -183,11 +183,10 @@ mod tests {
 
     #[test]
     fn try_from_proto_maps_none_to_none() {
-        let opt_settable =
-            BackwardsCompatibleOption::<Value, true>::try_from_proto(None::<ValidProto>)
-                .expect("conversion of `None` should never fail");
+        let opt_settable = BackwardsCompatible::<Value, true>::try_from_proto(None::<ValidProto>)
+            .expect("conversion of `None` should never fail");
         let opt_not_settable =
-            BackwardsCompatibleOption::<Value, false>::try_from_proto(None::<ValidProto>)
+            BackwardsCompatible::<Value, false>::try_from_proto(None::<ValidProto>)
                 .expect("conversion of `None` should never fail");
 
         // `None` maps to `None` regardless of whether the field is settable or not.
@@ -197,11 +196,10 @@ mod tests {
 
     #[test]
     fn try_from_proto_maps_some_to_converted_value() {
-        let opt_settable =
-            BackwardsCompatibleOption::<Value, true>::try_from_proto(Some(ValidProto(9)))
-                .expect("conversion should succeed");
+        let opt_settable = BackwardsCompatible::<Value, true>::try_from_proto(Some(ValidProto(9)))
+            .expect("conversion should succeed");
         let opt_not_settable =
-            BackwardsCompatibleOption::<Value, false>::try_from_proto(Some(ValidProto(9)))
+            BackwardsCompatible::<Value, false>::try_from_proto(Some(ValidProto(9)))
                 .expect("conversion should succeed");
 
         // `Some(proto)` maps to `Some(converted_value)` regardless of whether the field is
@@ -213,9 +211,9 @@ mod tests {
     #[test]
     fn try_from_proto_propagates_conversion_error() {
         let result_settable =
-            BackwardsCompatibleOption::<Value, true>::try_from_proto(Some(InvalidProto));
+            BackwardsCompatible::<Value, true>::try_from_proto(Some(InvalidProto));
         let result_not_settable =
-            BackwardsCompatibleOption::<Value, false>::try_from_proto(Some(InvalidProto));
+            BackwardsCompatible::<Value, false>::try_from_proto(Some(InvalidProto));
 
         // Conversion errors are propagated regardless of whether the field is settable or not.
         assert!(matches!(

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -4,13 +4,17 @@ use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 /// A helper struct for introducing new fields to structs that must stay backwards compatible.
+/// Its inner value can be read with [`as_ref`](BackwardsCompatible::as_ref).
+///
 /// Compared to [`Option`], its [`Hash`] implementation:
 ///  - ignores `None` (so adding an unset field preserves the surrounding struct hash), and
 ///  - hashes `Some(v)` like `v` (so later replacing it with `T` preserves hashes).
 ///
 /// Lifecycle of adding a new field to a struct in a backwards compatible way:
 /// 1. Add a new field to the struct with type `BackwardsCompatible<T, false>`. At this point the
-///    field is *NOT* allowed to have any value other than `None`.
+///    field is *NOT* allowed to be instantiated with any value other than `None`. Though, it still
+///    "understands" it: if it receives a protobuf containing a set value, it will still convert it
+///    and store it in the `BackwardsCompatible` value.
 /// 2. When the change is deployed to all replicas, we can switch the type to
 ///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -43,6 +43,7 @@ impl<T> BackwardsCompatibleOption<T, true> {
 }
 
 impl<T, const SETTABLE: bool> BackwardsCompatibleOption<T, SETTABLE> {
+    #[doc(hidden)]
     pub const fn new_for_test_only(value: Option<T>) -> Self {
         Self(value)
     }

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -2,7 +2,6 @@ use ic_protobuf::proxy::ProxyDecodeError;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 /// A helper struct for introducing new fields to structs that must stay backwards compatible.
 /// Its inner value can be read with [`as_ref`](BackwardsCompatible::as_ref).
 ///
@@ -18,6 +17,7 @@ use std::hash::{Hash, Hasher};
 /// 2. When the change is deployed to all replicas, we can switch the type to
 ///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct BackwardsCompatible<T, const SETTABLE: bool>(Option<T>);
 
 impl<T: Default> Default for BackwardsCompatible<T, false> {

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -1,0 +1,62 @@
+use ic_protobuf::proxy::ProxyDecodeError;
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+/// A helper struct used for introducing new fields to structs which need to be backwards compatible.
+/// The main difference w.r.t. an [`Option`] is that its [`Hash`] implementation ignores the `None`
+/// variant, which means that the hash of the struct without the field would be the same as the hash
+/// of the struct with the field present but set to `None`.
+///
+/// Lifecycle of adding a new field to a struct in a backwards compatible way:
+/// 1. Add a new field to the struct with type `BackwardsCompatibleOption<T, false>`. At this point
+///    the field is *NOT* allowed to have any value other than `None`.
+/// 2. When the change is deployed to all replicas, we can switch the type to
+///    `BackwardsCompatibleOption<T, true>` and the field can begin to be populated.
+/// 3. When the change is deployed to all replicas, we can replace the type with `T`.
+pub struct BackwardsCompatibleOption<T, const SETTABLE: bool>(Option<T>);
+
+impl<T: Default> Default for BackwardsCompatibleOption<T, false> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<T: Default> Default for BackwardsCompatibleOption<T, true> {
+    fn default() -> Self {
+        Self(Some(T::default()))
+    }
+}
+
+impl<T: Hash, const SETTABLE: bool> Hash for BackwardsCompatibleOption<T, SETTABLE> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if let Some(value) = &self.0 {
+            value.hash(state);
+        }
+    }
+}
+
+impl<T> BackwardsCompatibleOption<T, true> {
+    pub const fn new(value: T) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<T, const SETTABLE: bool> BackwardsCompatibleOption<T, SETTABLE> {
+    pub const fn new_for_test_only(value: Option<T>) -> Self {
+        Self(value)
+    }
+
+    pub const fn as_ref(&self) -> Option<&T> {
+        self.0.as_ref()
+    }
+
+    pub fn try_from_proto<Proto: TryInto<T, Error = ProxyDecodeError>>(
+        proto: Option<Proto>,
+    ) -> Result<Self, ProxyDecodeError> {
+        match proto {
+            Some(value) => Ok(Self(Some(value.try_into()?))),
+            None => Ok(Self(None)),
+        }
+    }
+}

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -61,6 +61,12 @@ impl<T: Hash, const SETTABLE: bool> Hash for BackwardsCompatible<T, SETTABLE> {
     }
 }
 
+impl<T> BackwardsCompatible<T, false> {
+    pub const fn empty() -> Self {
+        Self(None)
+    }
+}
+
 impl<T> BackwardsCompatible<T, true> {
     pub const fn new(value: T) -> Self {
         Self(Some(value))
@@ -194,7 +200,7 @@ mod tests {
         assert_eq!(opt.as_ref(), Some(&123));
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Hash)]
     struct Value(u64);
 
     struct ValidProto(u64);
@@ -256,5 +262,220 @@ mod tests {
             result_not_settable,
             Err(ProxyDecodeError::MissingField("Value"))
         ));
+    }
+
+    /// Showcases the full backwards-compatible rollout *and* rollback of a new struct field, as
+    /// documented on [`BackwardsCompatible`]. Each `V0`..`V3` struct models a replica version;
+    /// during a rollout/rollback adjacent versions run side by side, so for the same logical state
+    /// they must agree on the struct hash and must be able to exchange the field over the wire
+    /// without losing it.
+    mod rollout {
+        use super::*;
+
+        // Base fields shared by every version; only the new field evolves across versions.
+        const A: u64 = 7;
+        const B: &str = "ic";
+
+        // Protobuf-like wire format exchanged between replicas. Like a freshly added proto field,
+        // `new_field` is optional.
+        struct Wire {
+            a: u64,
+            b: String,
+            new_field: Option<ValidProto>,
+        }
+
+        // Before the field existed.
+        #[derive(Hash)]
+        struct V0 {
+            a: u64,
+            b: String,
+        }
+
+        // Step 1: field added as `<_, false>` — understood on the wire, but never populated.
+        #[derive(Hash)]
+        struct V1 {
+            a: u64,
+            b: String,
+            new_field: BackwardsCompatible<Value, false>,
+        }
+
+        // Step 2: field switched to `<_, true>` — now allowed to be populated.
+        #[derive(Hash)]
+        struct V2 {
+            a: u64,
+            b: String,
+            new_field: BackwardsCompatible<Value, true>,
+        }
+
+        // Step 3: field replaced with the bare type `T` — now mandatory.
+        #[derive(Hash)]
+        struct V3 {
+            a: u64,
+            b: String,
+            new_field: Value,
+        }
+
+        impl V0 {
+            fn to_wire(&self) -> Wire {
+                // V0 knows nothing about the field...
+                Wire {
+                    a: self.a,
+                    b: self.b.clone(),
+                    new_field: None,
+                }
+            }
+            fn from_wire(wire: Wire) -> Self {
+                // ...and ignores it on the way in.
+                Self {
+                    a: wire.a,
+                    b: wire.b,
+                }
+            }
+        }
+
+        impl V1 {
+            fn to_wire(&self) -> Wire {
+                Wire {
+                    a: self.a,
+                    b: self.b.clone(),
+                    new_field: self.new_field.as_ref().map(|v| ValidProto(v.0)),
+                }
+            }
+            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
+                Ok(Self {
+                    a: wire.a,
+                    b: wire.b,
+                    new_field: BackwardsCompatible::try_from_proto(wire.new_field)?,
+                })
+            }
+        }
+
+        impl V2 {
+            fn to_wire(&self) -> Wire {
+                Wire {
+                    a: self.a,
+                    b: self.b.clone(),
+                    new_field: self.new_field.as_ref().map(|v| ValidProto(v.0)),
+                }
+            }
+            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
+                Ok(Self {
+                    a: wire.a,
+                    b: wire.b,
+                    new_field: BackwardsCompatible::try_from_proto(wire.new_field)?,
+                })
+            }
+        }
+
+        impl V3 {
+            fn to_wire(&self) -> Wire {
+                Wire {
+                    a: self.a,
+                    b: self.b.clone(),
+                    new_field: Some(ValidProto(self.new_field.0)),
+                }
+            }
+            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
+                let new_field = wire
+                    .new_field
+                    .map(Value::try_from)
+                    .transpose()?
+                    .ok_or(ProxyDecodeError::MissingField("V3::new_field"))?;
+                Ok(Self {
+                    a: wire.a,
+                    b: wire.b,
+                    new_field,
+                })
+            }
+        }
+
+        #[test]
+        fn full_rollout_and_rollback_preserve_cross_version_hashes() {
+            let v0 = V0 {
+                a: A,
+                b: B.to_string(),
+            };
+            let v1_unset = V1 {
+                a: A,
+                b: B.to_string(),
+                new_field: BackwardsCompatible::empty(),
+            };
+
+            // === Rollout step 1 — introduce the field as `<_, false>` (V0 <-> V1) ===
+            // Adding an unset backwards-compatible field must not change the struct hash, so V0 and
+            // V1 replicas agree while both are in the fleet.
+            assert_eq!(hash_of(&v0), hash_of(&v1_unset));
+            // The (absent) field round-trips: a V0 wire decodes into an unset V1 with an equal hash.
+            let v1_from_v0 = V1::from_wire(v0.to_wire()).unwrap();
+            assert_eq!(v1_from_v0.new_field.as_ref(), None);
+            assert_eq!(hash_of(&v1_from_v0), hash_of(&v0));
+
+            // === Rollout step 2 — make the field settable `<_, true>` (V1 <-> V2) ===
+            // A pure type change; in production the field is still unset, so the switch is
+            // hash-neutral. We build the V2 state by decoding a V1 wire, exactly like a replica
+            // migrating its own state across the upgrade.
+            let v2_unset = V2::from_wire(v1_unset.to_wire()).unwrap();
+            assert_eq!(v2_unset.new_field.as_ref(), None);
+            assert_eq!(hash_of(&v1_unset), hash_of(&v2_unset));
+
+            // === All replicas at V2 — start populating the field ===
+            let v2_set = V2 {
+                a: A,
+                b: B.to_string(),
+                new_field: BackwardsCompatible::new(Value(42)),
+            };
+            // Populating the field now genuinely changes the hash (it is no longer `None`).
+            assert_ne!(hash_of(&v2_unset), hash_of(&v2_set));
+
+            // === Rollout step 3 — replace with the bare type `T` (V2 <-> V3) ===
+            // `Some(v)` hashes like `v`, so a populated V2 and a mandatory-field V3 agree.
+            let v3 = V3 {
+                a: A,
+                b: B.to_string(),
+                new_field: Value(42),
+            };
+            assert_eq!(hash_of(&v2_set), hash_of(&v3));
+            // The value round-trips from V2 to V3.
+            let v3_from_v2 = V3::from_wire(v2_set.to_wire()).unwrap();
+            assert_eq!(v3_from_v2.new_field, Value(42));
+            assert_eq!(hash_of(&v3_from_v2), hash_of(&v2_set));
+
+            // Trying to rollout to V3 with an unset field fails, as expected.
+            let v3_from_v2_unset = V3::from_wire(v2_unset.to_wire());
+            assert!(matches!(
+                v3_from_v2_unset,
+                Err(ProxyDecodeError::MissingField("V3::new_field"))
+            ));
+
+            // ============================= Rollback =============================
+
+            // --- Rollback step 3 -> 2 (V3 -> V2) ---
+            // A replica downgraded from V3 ingests the now-optional value and still agrees on hash.
+            let v2_from_v3 = V2::from_wire(v3.to_wire()).unwrap();
+            assert_eq!(v2_from_v3.new_field.as_ref(), Some(&Value(42)));
+            assert_eq!(hash_of(&v2_from_v3), hash_of(&v3));
+
+            // --- Rollback step 2 -> 1 (V2 -> V1), field already populated (the crux) ---
+            // A `<_, false>` field cannot *produce* a value, but it still *understands* one decoded
+            // from a newer replica, and hashes it identically. This is what makes rolling back a
+            // populated fleet safe.
+            let v1_from_v2_set = V1::from_wire(v2_set.to_wire()).unwrap();
+            assert_eq!(v1_from_v2_set.new_field.as_ref(), Some(&Value(42)));
+            assert_eq!(hash_of(&v1_from_v2_set), hash_of(&v2_set));
+            // Sanity check also for the V2 unset case
+            let v1_from_v2_unset = V1::from_wire(v2_unset.to_wire()).unwrap();
+            assert_eq!(v1_from_v2_unset.new_field.as_ref(), None);
+            assert_eq!(hash_of(&v1_from_v2_unset), hash_of(&v2_unset));
+
+            // --- Rollback step 1 -> 0 (V1 -> V0), only safe while the field is unset ---
+            let v0_from_v1 = V0::from_wire(v1_unset.to_wire());
+            assert_eq!(hash_of(&v0_from_v1), hash_of(&v0));
+
+            // --- Safety floor: once populated, rolling back to V0 would diverge ---
+            // A no-field V0 replica cannot match a populated field. This is exactly why the field
+            // is rolled out as "understood" (step 1) everywhere before any value is produced, and
+            // why the safe rollback floor rises to V1 once the field is populated.
+            assert_ne!(hash_of(&v0), hash_of(&v1_from_v2_set));
+        }
     }
 }

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -17,8 +17,29 @@ use std::hash::{Hash, Hasher};
 /// 2. When the change is deployed to all replicas, we can switch the type to
 ///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.
-#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct BackwardsCompatible<T, const SETTABLE: bool>(Option<T>);
+
+impl<T: Serialize, const SETTABLE: bool> Serialize for BackwardsCompatible<T, SETTABLE> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>, const SETTABLE: bool> Deserialize<'de>
+    for BackwardsCompatible<T, SETTABLE>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Option::<T>::deserialize(deserializer)?;
+        Ok(Self(value))
+    }
+}
 
 impl<T: Default> Default for BackwardsCompatible<T, false> {
     fn default() -> Self {

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
-/// A helper struct used for introducing new fields to structs which need to be backwards compatible.
-/// The main difference w.r.t. an [`Option`] is that its [`Hash`] implementation ignores the `None`
-/// variant, which means that the hash of the struct without the field would be the same as the hash
-/// of the struct with the field present but set to `None`.
+/// A helper struct for introducing new fields to structs that must stay backwards compatible.
+/// Compared to [`Option`], its [`Hash`] implementation:
+///  - ignores `None` (so adding an unset field preserves the surrounding struct hash), and
+///  - hashes `Some(v)` like `v` (so later replacing it with `T` preserves hashes).
 ///
 /// Lifecycle of adding a new field to a struct in a backwards compatible way:
 /// 1. Add a new field to the struct with type `BackwardsCompatible<T, false>`. At this point the
@@ -48,10 +48,17 @@ impl<T, const SETTABLE: bool> BackwardsCompatible<T, SETTABLE> {
         Self(value)
     }
 
+    /// Allows to access the inner value, if set. Note that this could still be `Some(T)` even if
+    /// `SETTABLE` is `false` in case the replica version was rolled back from a version that
+    /// populated the field.
     pub const fn as_ref(&self) -> Option<&T> {
         self.0.as_ref()
     }
 
+    /// Converts an optional protobuf value into a `BackwardsCompatible` value. Even if `SETTABLE`
+    /// is `false`, if the protobuf value is `Some`, the inner value will be converted and stored in
+    /// the `BackwardsCompatible` value. This is to allow for the case where a replica version that
+    /// populated the field is rolled back to a version that does not populate the field.
     pub fn try_from_proto<Proto: TryInto<T, Error = ProxyDecodeError>>(
         proto: Option<Proto>,
     ) -> Result<Self, ProxyDecodeError> {

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -95,6 +95,8 @@ impl<T, const SETTABLE: bool> BackwardsCompatible<T, SETTABLE> {
 
 #[cfg(test)]
 mod tests {
+    use ic_exhaustive_derive::ExhaustiveSet;
+
     use super::*;
     use std::hash::{DefaultHasher, Hash, Hasher};
 
@@ -193,7 +195,7 @@ mod tests {
         assert_eq!(opt.as_ref(), Some(&123));
     }
 
-    #[derive(Debug, PartialEq, Hash)]
+    #[derive(Clone, Debug, Default, PartialEq, Hash, ExhaustiveSet)]
     struct Value(u64);
 
     struct ValidProto(u64);
@@ -257,218 +259,82 @@ mod tests {
         ));
     }
 
-    /// Showcases the full backwards-compatible rollout *and* rollback of a new struct field, as
-    /// documented on [`BackwardsCompatible`]. Each `V0`..`V3` struct models a replica version;
-    /// during a rollout/rollback adjacent versions run side by side, so for the same logical state
-    /// they must agree on the struct hash and must be able to exchange the field over the wire
-    /// without losing it.
-    mod rollout {
+    /// Verifies, over every value produced by [`ExhaustiveSet`], that a `BackwardsCompatible` field
+    /// hashes identically across the representations it takes on throughout its lifecycle. This is
+    /// what lets replicas running different versions of the code agree on the hash of a struct.
+    mod hash_compatibility {
         use super::*;
+        use crate::exhaustive::ExhaustiveSet;
+        use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 
-        // Base fields shared by every version; only the new field evolves across versions.
-        const A: u64 = 7;
-        const B: &str = "ic";
-
-        // Protobuf-like wire format exchanged between replicas. Like a freshly added proto field,
-        // `new_field` is optional.
-        struct Wire {
-            a: u64,
-            b: String,
-            new_field: Option<ValidProto>,
-        }
-
-        // Before the field existed.
-        #[derive(Hash)]
-        struct V0 {
-            a: u64,
-            b: String,
-        }
-
-        // Step 1: field added as `<_, false>` — understood on the wire, but never populated.
-        #[derive(Hash)]
-        struct V1 {
-            a: u64,
-            b: String,
-            new_field: BackwardsCompatible<Value, false>,
-        }
-
-        // Step 2: field switched to `<_, true>` — now allowed to be populated.
-        #[derive(Hash)]
-        struct V2 {
-            a: u64,
-            b: String,
-            new_field: BackwardsCompatible<Value, true>,
-        }
-
-        // Step 3: field replaced with the bare type `T` — now mandatory.
-        #[derive(Hash)]
-        struct V3 {
-            a: u64,
-            b: String,
-            new_field: Value,
-        }
-
-        impl V0 {
-            fn to_wire(&self) -> Wire {
-                // V0 knows nothing about the field...
-                Wire {
-                    a: self.a,
-                    b: self.b.clone(),
-                    new_field: None,
-                }
-            }
-            fn from_wire(wire: Wire) -> Self {
-                // ...and ignores it on the way in.
-                Self {
-                    a: wire.a,
-                    b: wire.b,
-                }
-            }
-        }
-
-        impl V1 {
-            fn to_wire(&self) -> Wire {
-                Wire {
-                    a: self.a,
-                    b: self.b.clone(),
-                    new_field: self.new_field.as_ref().map(|v| ValidProto(v.0)),
-                }
-            }
-            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
-                Ok(Self {
-                    a: wire.a,
-                    b: wire.b,
-                    new_field: BackwardsCompatible::try_from_proto(wire.new_field)?,
-                })
-            }
-        }
-
-        impl V2 {
-            fn to_wire(&self) -> Wire {
-                Wire {
-                    a: self.a,
-                    b: self.b.clone(),
-                    new_field: self.new_field.as_ref().map(|v| ValidProto(v.0)),
-                }
-            }
-            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
-                Ok(Self {
-                    a: wire.a,
-                    b: wire.b,
-                    new_field: BackwardsCompatible::try_from_proto(wire.new_field)?,
-                })
-            }
-        }
-
-        impl V3 {
-            fn to_wire(&self) -> Wire {
-                Wire {
-                    a: self.a,
-                    b: self.b.clone(),
-                    new_field: Some(ValidProto(self.new_field.0)),
-                }
-            }
-            fn from_wire(wire: Wire) -> Result<Self, ProxyDecodeError> {
-                let new_field = wire
-                    .new_field
-                    .map(Value::try_from)
-                    .transpose()?
-                    .ok_or(ProxyDecodeError::MissingField("V3::new_field"))?;
-                Ok(Self {
-                    a: wire.a,
-                    b: wire.b,
-                    new_field,
-                })
-            }
-        }
-
+        /// Every value the *unsettable* field can be generated with (its `ExhaustiveSet` is exactly
+        /// `[None]`) hashes identically to:
+        ///  - *having nothing* — an absent field contributes nothing to the hash
+        ///  - the *settable* field (`<_, true>`) holding the same value
+        ///  - the *settable* field deserialized from the serialized unsettable field
+        ///
+        /// This is what lets step 1 of the lifecycle be deployed without changing any hash.
         #[test]
-        fn full_rollout_and_rollback_preserve_cross_version_hashes() {
-            let v0 = V0 {
-                a: A,
-                b: B.to_string(),
-            };
-            let v1_unset = V1 {
-                a: A,
-                b: B.to_string(),
-                new_field: BackwardsCompatible::empty(),
-            };
+        fn unsettable_values_hash_like_nothing_and_settable() {
+            let mut rng = reproducible_rng();
+            for unsettable in BackwardsCompatible::<Value, false>::exhaustive_set(&mut rng) {
+                // Same hash as having nothing: hashing the field leaves the hasher untouched.
+                assert_eq!(hash_of(&unsettable), DefaultHasher::new().finish());
 
-            // === Rollout step 1 — introduce the field as `<_, false>` (V0 <-> V1) ===
-            // Adding an unset backwards-compatible field must not change the struct hash, so V0 and
-            // V1 replicas agree while both are in the fleet.
-            assert_eq!(hash_of(&v0), hash_of(&v1_unset));
-            // The (absent) field round-trips: a V0 wire decodes into an unset V1 with an equal hash.
-            let v1_from_v0 = V1::from_wire(v0.to_wire()).unwrap();
-            assert_eq!(v1_from_v0.new_field.as_ref(), None);
-            assert_eq!(hash_of(&v1_from_v0), hash_of(&v0));
+                let same_value_but_settable = BackwardsCompatible::<Value, true>::new_for_test_only(
+                    unsettable.as_ref().cloned(),
+                );
+                // Same hash as the settable representation of the same value.
+                assert_eq!(hash_of(&unsettable), hash_of(&same_value_but_settable));
 
-            // === Rollout step 2 — make the field settable `<_, true>` (V1 <-> V2) ===
-            // A pure type change; in production the field is still unset, so the switch is
-            // hash-neutral. We build the V2 state by decoding a V1 wire, exactly like a replica
-            // migrating its own state across the upgrade.
-            let v2_unset = V2::from_wire(v1_unset.to_wire()).unwrap();
-            assert_eq!(v2_unset.new_field.as_ref(), None);
-            assert_eq!(hash_of(&v1_unset), hash_of(&v2_unset));
+                let deserialized_settable = BackwardsCompatible::<Value, true>::try_from_proto(
+                    unsettable.as_ref().cloned().map(|v| ValidProto(v.0)),
+                )
+                .unwrap();
+                // Same hash as the settable representation of the same value, even when
+                // deserialized from a protobuf.
+                assert_eq!(hash_of(&unsettable), hash_of(&deserialized_settable));
+            }
+        }
 
-            // === All replicas at V2 — start populating the field ===
-            let v2_set = V2 {
-                a: A,
-                b: B.to_string(),
-                new_field: BackwardsCompatible::new(Value(42)),
-            };
-            // Populating the field now genuinely changes the hash (it is no longer `None`).
-            assert_ne!(hash_of(&v2_unset), hash_of(&v2_set));
+        /// Every value the *settable* field can be generated with (its `ExhaustiveSet` is every
+        /// `Some(v)`) hashes identically to:
+        ///  - the *unsettable* field (`<_, false>`) holding the same value (so a rollback still
+        ///    agrees)
+        ///  - the *settable* field deserialized from the serialized settable field (so a
+        ///    rollback still agrees)
+        ///  - the bare `T` it is eventually replaced with
+        ///  - the bare `T` deserialized from the serialized settable field
+        ///
+        /// This is what lets steps 2 and 3 of the lifecycle be deployed without changing any hash.
+        #[test]
+        fn settable_values_hash_like_unsettable_and_bare() {
+            let mut rng = reproducible_rng();
+            for settable in BackwardsCompatible::<Value, true>::exhaustive_set(&mut rng) {
+                let same_value_but_unsettable =
+                    BackwardsCompatible::<Value, false>::new_for_test_only(
+                        settable.as_ref().cloned(),
+                    );
+                // Same hash as the unsettable representation of the same value.
+                assert_eq!(hash_of(&settable), hash_of(&same_value_but_unsettable));
+                let deserialized_unsettable = BackwardsCompatible::<Value, false>::try_from_proto(
+                    settable.as_ref().cloned().map(|v| ValidProto(v.0)),
+                )
+                .unwrap();
+                // Same hash as the unsettable representation of the same value, even when
+                // deserialized from a protobuf.
+                assert_eq!(hash_of(&settable), hash_of(&deserialized_unsettable));
 
-            // === Rollout step 3 — replace with the bare type `T` (V2 <-> V3) ===
-            // `Some(v)` hashes like `v`, so a populated V2 and a mandatory-field V3 agree.
-            let v3 = V3 {
-                a: A,
-                b: B.to_string(),
-                new_field: Value(42),
-            };
-            assert_eq!(hash_of(&v2_set), hash_of(&v3));
-            // The value round-trips from V2 to V3.
-            let v3_from_v2 = V3::from_wire(v2_set.to_wire()).unwrap();
-            assert_eq!(v3_from_v2.new_field, Value(42));
-            assert_eq!(hash_of(&v3_from_v2), hash_of(&v2_set));
-
-            // Trying to rollout to V3 with an unset field fails, as expected.
-            let v3_from_v2_unset = V3::from_wire(v2_unset.to_wire());
-            assert!(matches!(
-                v3_from_v2_unset,
-                Err(ProxyDecodeError::MissingField("V3::new_field"))
-            ));
-
-            // ============================= Rollback =============================
-
-            // --- Rollback step 3 -> 2 (V3 -> V2) ---
-            // A replica downgraded from V3 ingests the now-optional value and still agrees on hash.
-            let v2_from_v3 = V2::from_wire(v3.to_wire()).unwrap();
-            assert_eq!(v2_from_v3.new_field.as_ref(), Some(&Value(42)));
-            assert_eq!(hash_of(&v2_from_v3), hash_of(&v3));
-
-            // --- Rollback step 2 -> 1 (V2 -> V1), field already populated (the crux) ---
-            // A `<_, false>` field cannot *produce* a value, but it still *understands* one decoded
-            // from a newer replica, and hashes it identically. This is what makes rolling back a
-            // populated fleet safe.
-            let v1_from_v2_set = V1::from_wire(v2_set.to_wire()).unwrap();
-            assert_eq!(v1_from_v2_set.new_field.as_ref(), Some(&Value(42)));
-            assert_eq!(hash_of(&v1_from_v2_set), hash_of(&v2_set));
-            // Sanity check also for the V2 unset case
-            let v1_from_v2_unset = V1::from_wire(v2_unset.to_wire()).unwrap();
-            assert_eq!(v1_from_v2_unset.new_field.as_ref(), None);
-            assert_eq!(hash_of(&v1_from_v2_unset), hash_of(&v2_unset));
-
-            // --- Rollback step 1 -> 0 (V1 -> V0), only safe while the field is unset ---
-            let v0_from_v1 = V0::from_wire(v1_unset.to_wire());
-            assert_eq!(hash_of(&v0_from_v1), hash_of(&v0));
-
-            // --- Safety floor: once populated, rolling back to V0 would diverge ---
-            // A no-field V0 replica cannot match a populated field. This is exactly why the field
-            // is rolled out as "understood" (step 1) everywhere before any value is produced, and
-            // why the safe rollback floor rises to V1 once the field is populated.
-            assert_ne!(hash_of(&v0), hash_of(&v1_from_v2_set));
+                let bare = settable
+                    .as_ref()
+                    .cloned()
+                    .expect("the settable `ExhaustiveSet` only contains populated values");
+                // Same hash as the bare `T`.
+                assert_eq!(hash_of(&settable), hash_of(&bare));
+                let deserialized_bare = Value::try_from(ValidProto(bare.0)).unwrap();
+                // Same hash as the bare `T`, even when deserialized from a protobuf.
+                assert_eq!(hash_of(&settable), hash_of(&deserialized_bare));
+            }
         }
     }
 }

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -14,13 +14,13 @@ use std::hash::{Hash, Hasher};
 ///
 /// IMPORTANT: there should be only one field of type `BackwardsCompatible` in a struct. Otherwise,
 /// two different instances of the struct could have the same hash. For example:
-/// ```
+///
 /// #[derive(Hash)]
 /// struct S { a: BackwardsCompatible<u8, false>, b: BackwardsCompatible<u8, false> }
 ///
 /// S { a: Some(1), b: None }
 /// S { a: None, b: Some(1) }
-/// ```
+///
 /// would have the same hash.
 ///
 /// Lifecycle of adding a new field to a struct in a backwards compatible way:

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -238,16 +238,13 @@ impl ExhaustiveSet for String {
 
 impl<T: Clone + Default> ExhaustiveSet for BackwardsCompatible<T, false> {
     fn exhaustive_set<R: RngCore + CryptoRng>(_rng: &mut R) -> Vec<Self> {
-        vec![Default::default()]
+        vec![Self::empty()]
     }
 }
 
 impl<T: Clone + ExhaustiveSet> ExhaustiveSet for BackwardsCompatible<T, true> {
     fn exhaustive_set<R: RngCore + CryptoRng>(rng: &mut R) -> Vec<Self> {
-        Option::<T>::exhaustive_set(rng)
-            .into_iter()
-            .map(Self::new_for_test_only)
-            .collect()
+        T::exhaustive_set(rng).into_iter().map(Self::new).collect()
     }
 }
 

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -1,7 +1,7 @@
 //! Implementations and serialization tests of the ExhaustiveSet trait
 
 use crate::artifact::IngressMessageId;
-use crate::backwards_compatibility::BackwardsCompatibleOption;
+use crate::backwards_compatibility::BackwardsCompatible;
 use crate::batch::ChainKeyAgreement;
 use crate::canister_http::CanisterHttpResponseSignature;
 use crate::consensus::dkg::RemoteDkgAttempts;
@@ -236,13 +236,13 @@ impl ExhaustiveSet for String {
     }
 }
 
-impl<T: Clone + Default> ExhaustiveSet for BackwardsCompatibleOption<T, false> {
+impl<T: Clone + Default> ExhaustiveSet for BackwardsCompatible<T, false> {
     fn exhaustive_set<R: RngCore + CryptoRng>(_rng: &mut R) -> Vec<Self> {
         vec![Default::default()]
     }
 }
 
-impl<T: Clone + ExhaustiveSet> ExhaustiveSet for BackwardsCompatibleOption<T, true> {
+impl<T: Clone + ExhaustiveSet> ExhaustiveSet for BackwardsCompatible<T, true> {
     fn exhaustive_set<R: RngCore + CryptoRng>(rng: &mut R) -> Vec<Self> {
         Option::<T>::exhaustive_set(rng)
             .into_iter()

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -1,6 +1,7 @@
 //! Implementations and serialization tests of the ExhaustiveSet trait
 
 use crate::artifact::IngressMessageId;
+use crate::backwards_compatibility::BackwardsCompatibleOption;
 use crate::batch::ChainKeyAgreement;
 use crate::canister_http::CanisterHttpResponseSignature;
 use crate::consensus::dkg::RemoteDkgAttempts;
@@ -232,6 +233,21 @@ impl ExhaustiveSet for bool {
 impl ExhaustiveSet for String {
     fn exhaustive_set<R: RngCore + CryptoRng>(_: &mut R) -> Vec<Self> {
         vec!["0123abcd!@#$.,;()[]<>".to_string(), "".to_string()]
+    }
+}
+
+impl<T: Clone + Default> ExhaustiveSet for BackwardsCompatibleOption<T, false> {
+    fn exhaustive_set<R: RngCore + CryptoRng>(_rng: &mut R) -> Vec<Self> {
+        vec![Default::default()]
+    }
+}
+
+impl<T: Clone + ExhaustiveSet> ExhaustiveSet for BackwardsCompatibleOption<T, true> {
+    fn exhaustive_set<R: RngCore + CryptoRng>(rng: &mut R) -> Vec<Self> {
+        Option::<T>::exhaustive_set(rng)
+            .into_iter()
+            .map(Self::new_for_test_only)
+            .collect()
     }
 }
 

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -63,6 +63,7 @@
 // executions).
 
 pub mod artifact;
+pub mod backwards_compatibility;
 pub mod batch;
 pub mod canister_http;
 pub mod canister_log;


### PR DESCRIPTION
This PR introduces a new `BackwardsCompatible` type, intended to be used when introducing new fields to structs that cross upgrade boundaries and which need to be backwards compatible, like in the replicated state or in CUPs. The current rollout usually looks like:
- Introducing the field as optional, setting it to `None` everywhere.
- After the previous step is rolled out to all subnets, start filling the value with `Some` everywhere.
- After the previous step is rolled out to all subnets, turn the field non-optional.

This is well understood by now but could still be error-prone. The new `BackwardsCompatible` acts as a regular `Option`, though is impossible to instantiate and is ignored during hashing if still in the first step. Though it still "understands" the field and can be loaded from a future version that populated it.