### PR TITLE
chore: propagate credentials to remote downloader

### DIFF
--- a/.github/actions/netrc/action.yaml
+++ b/.github/actions/netrc/action.yaml
@@ -10,8 +10,11 @@ runs:
         # Set up .netrc so that tools can authenticate with GitHub to have higher rate limits for fetching dependencies.
         touch  ~/.netrc
         chmod 600 ~/.netrc
-        echo "machine github.com login x-access-token password ${{ github.token }}" > ~/.netrc
-        echo "machine api.github.com login x-access-token password ${{ github.token }}" >> ~/.netrc
+        cat > ~/.netrc <<EOF
+        machine github.com login x-access-token password ${{ github.token }}
+        machine api.github.com login x-access-token password ${{ github.token }}
+        machine ghcr.io login x-access-token password ${{ github.token }}
+        EOF
         echo "Current GitHub API rate limits:"
 
         # Show how close we are to the limits (ignore errors from curl or invalid JSON)

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -7,6 +7,7 @@ common --lockfile_mode=off
 
 # If the download via the Remote Asset API on the bazel-remote cache failed, try it again locally.
 common --experimental_remote_downloader_local_fallback
+common --experimental_remote_downloader_propagate_credentials
 
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -31,7 +31,7 @@ common --remote_download_all
 # up-to-date" and --check_up_to_date aborted the upload.
 common --noexperimental_inmemory_dotd_files
 
-build --experimental_remote_downloader=bazel-remote.idx.dfinity.network --experimental_remote_downloader_local_fallback
+build --experimental_remote_downloader=bazel-remote.idx.dfinity.network
 build:local --experimental_remote_downloader=
 build --remote_local_fallback
 build    --remote_upload_local_results=false


### PR DESCRIPTION
Make sure GitHub credentials are forwarded to the remote downloader such that it doesn't hit rate limits / auth issues (in case of ghcr.io). This is mostly useful when we start running more of CI on Namespace where we use their Remote Asset API.