### PR TITLE
chore: deduplicate tower dependencies

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "536d712e718236b3a04344298bbf77c9e8e7b30260976936342398646d6185ef",
+  "checksum": "32ec6217ab5e519df3802c595c6da8a91fd03dc03d30250951aeba00641ccfab",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -23142,7 +23142,7 @@
               "target": "tower_test"
             },
             {
-              "id": "tower_governor 0.7.0",
+              "id": "tower_governor 0.8.0",
               "target": "tower_governor"
             },
             {
@@ -23563,7 +23563,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -30663,120 +30663,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "governor 0.8.1": {
-      "name": "governor",
-      "version": "0.8.1",
-      "package_url": "https://github.com/boinkor-net/governor.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/governor/0.8.1/download",
-          "sha256": "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "governor",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "governor",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "dashmap",
-            "default",
-            "jitter",
-            "quanta",
-            "rand",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "dashmap 6.1.0",
-              "target": "dashmap"
-            },
-            {
-              "id": "futures-sink 0.3.31",
-              "target": "futures_sink"
-            },
-            {
-              "id": "futures-timer 3.0.3",
-              "target": "futures_timer"
-            },
-            {
-              "id": "futures-util 0.3.31",
-              "target": "futures_util"
-            },
-            {
-              "id": "getrandom 0.3.4",
-              "target": "getrandom"
-            },
-            {
-              "id": "no-std-compat 0.4.1",
-              "target": "no_std_compat"
-            },
-            {
-              "id": "nonzero_ext 0.3.0",
-              "target": "nonzero_ext"
-            },
-            {
-              "id": "parking_lot 0.12.5",
-              "target": "parking_lot"
-            },
-            {
-              "id": "portable-atomic 1.11.0",
-              "target": "portable_atomic"
-            },
-            {
-              "id": "quanta 0.12.3",
-              "target": "quanta"
-            },
-            {
-              "id": "rand 0.9.4",
-              "target": "rand"
-            },
-            {
-              "id": "smallvec 1.15.1",
-              "target": "smallvec"
-            },
-            {
-              "id": "spinning_top 0.3.0",
-              "target": "spinning_top"
-            },
-            {
-              "id": "web-time 1.1.0",
-              "target": "web_time"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.1"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": null
-    },
     "governor 0.10.2": {
       "name": "governor",
       "version": "0.10.2",
@@ -34748,7 +34634,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "socket2 0.6.1",
+              "id": "socket2 0.5.9",
               "target": "socket2"
             },
             {
@@ -51817,51 +51703,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "no-std-compat 0.4.1": {
-      "name": "no-std-compat",
-      "version": "0.4.1",
-      "package_url": "https://gitlab.com/jD91mZM2/no-std-compat",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/no-std-compat/0.4.1/download",
-          "sha256": "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "no_std_compat",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "no_std_compat",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.1"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "nohash 0.2.0": {
       "name": "nohash",
       "version": "0.2.0",
@@ -63871,7 +63712,7 @@
             ],
             "cfg(not(all(target_family = \"wasm\", target_os = \"unknown\")))": [
               {
-                "id": "socket2 0.6.1",
+                "id": "socket2 0.5.9",
                 "target": "socket2"
               }
             ]
@@ -70471,7 +70312,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ],
@@ -71427,7 +71268,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -71542,7 +71383,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
@@ -81683,7 +81524,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.61.2",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ],
@@ -86354,89 +86195,6 @@
       },
       "license": "MIT",
       "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "tower_governor 0.7.0": {
-      "name": "tower_governor",
-      "version": "0.7.0",
-      "package_url": "https://github.com/benwis/tower-governor",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tower_governor/0.7.0/download",
-          "sha256": "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tower_governor",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "tower_governor",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "axum",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "axum 0.8.9",
-              "target": "axum"
-            },
-            {
-              "id": "forwarded-header-value 0.1.1",
-              "target": "forwarded_header_value"
-            },
-            {
-              "id": "governor 0.8.1",
-              "target": "governor"
-            },
-            {
-              "id": "http 1.3.1",
-              "target": "http"
-            },
-            {
-              "id": "pin-project 1.1.2",
-              "target": "pin_project"
-            },
-            {
-              "id": "thiserror 2.0.18",
-              "target": "thiserror"
-            },
-            {
-              "id": "tower 0.5.2",
-              "target": "tower"
-            },
-            {
-              "id": "tracing 0.1.44",
-              "target": "tracing"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -101880,7 +101638,7 @@
     "tower-http 0.6.11",
     "tower-request-id 0.3.0",
     "tower-test 0.4.0",
-    "tower_governor 0.7.0",
+    "tower_governor 0.8.0",
     "tracing 0.1.44",
     "tracing-appender 0.2.3",
     "tracing-flame 0.2.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -4016,7 +4016,7 @@ dependencies = [
  "tower-http 0.6.11",
  "tower-request-id",
  "tower-test",
- "tower_governor 0.7.0",
+ "tower_governor",
  "tracing",
  "tracing-appender",
  "tracing-flame",
@@ -4093,7 +4093,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5225,29 +5225,6 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
-dependencies = [
- "cfg-if",
- "dashmap 6.1.0",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.4",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot 0.12.5",
- "portable-atomic",
- "quanta",
- "rand 0.9.4",
- "smallvec",
- "spinning_top",
- "web-time",
-]
-
-[[package]]
-name = "governor"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e23d5986fd4364c2fb7498523540618b4b8d92eec6c36a02e565f66748e2f79"
@@ -5961,7 +5938,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.9",
  "system-configuration 0.7.0",
  "tokio",
  "tower-layer",
@@ -6067,7 +6044,7 @@ dependencies = [
  "fqdn",
  "futures",
  "futures-util",
- "governor 0.10.2",
+ "governor",
  "hex",
  "hickory-proto",
  "hickory-resolver",
@@ -6118,7 +6095,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
- "tower_governor 0.8.0",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -8866,12 +8843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nohash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10816,7 +10787,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.27",
- "socket2 0.6.1",
+ "socket2 0.5.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11848,7 +11819,7 @@ dependencies = [
  "errno 0.3.10",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11991,7 +11962,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12012,7 +11983,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13686,7 +13657,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14472,29 +14443,13 @@ dependencies = [
 
 [[package]]
 name = "tower_governor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
-dependencies = [
- "axum 0.8.9",
- "forwarded-header-value",
- "governor 0.8.1",
- "http 1.3.1",
- "pin-project",
- "thiserror 2.0.18",
- "tower 0.5.2",
- "tracing",
-]
-
-[[package]]
-name = "tower_governor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
  "axum 0.8.9",
  "forwarded-header-value",
- "governor 0.10.2",
+ "governor",
  "http 1.3.1",
  "pin-project",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,29 +5287,6 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.4",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.3",
- "smallvec",
- "spinning_top",
- "web-time",
-]
-
-[[package]]
-name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
@@ -6651,7 +6628,7 @@ dependencies = [
  "fqdn",
  "futures",
  "futures-util",
- "governor 0.10.4",
+ "governor",
  "hex",
  "hickory-proto",
  "hickory-resolver",
@@ -6702,7 +6679,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-service",
- "tower_governor 0.8.0",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -6826,7 +6803,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http 0.6.8",
- "tower_governor 0.7.0",
+ "tower_governor",
  "tracing",
  "tracing-serde 0.1.3",
  "tracing-subscriber",
@@ -18766,12 +18743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "node-system-tests"
 version = "0.9.0"
 dependencies = [
@@ -24899,29 +24870,13 @@ dependencies = [
 
 [[package]]
 name = "tower_governor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
-dependencies = [
- "axum",
- "forwarded-header-value",
- "governor 0.8.1",
- "http 1.4.0",
- "pin-project",
- "thiserror 2.0.18",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "tower_governor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
  "axum",
  "forwarded-header-value",
- "governor 0.10.4",
+ "governor",
  "http 1.4.0",
  "pin-project",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -899,6 +899,7 @@ tower-http = { version = "0.6.4", features = [
     "compression-full",
     "tracing",
 ] }
+tower_governor = "0.8.0"
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-flame = "0.2.0"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1838,7 +1838,7 @@ crate.spec(
 )
 crate.spec(
     package = "tower_governor",
-    version = "^0.7.0",
+    version = "^0.8.0",
 )
 crate.spec(
     package = "tower-request-id",

--- a/rs/boundary_node/ic_boundary/Cargo.toml
+++ b/rs/boundary_node/ic_boundary/Cargo.toml
@@ -80,7 +80,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
-tower_governor = "0.7.0"
+tower_governor = { workspace = true }
 tracing = { workspace = true }
 tracing-serde = "0.1.3"
 tracing-subscriber = { workspace = true }

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
@@ -76,9 +76,7 @@ impl RateLimit {
             .finish()
             .unwrap();
 
-        router.layer(ServiceBuilder::new().layer(GovernorLayer {
-            config: Arc::new(governor_conf),
-        }))
+        router.layer(ServiceBuilder::new().layer(GovernorLayer::new(Arc::new(governor_conf))))
     }
 
     /// Allow requests_per_second requests per subnet
@@ -94,9 +92,7 @@ impl RateLimit {
             .finish()
             .unwrap();
 
-        router.layer(ServiceBuilder::new().layer(GovernorLayer {
-            config: Arc::new(governor_conf),
-        }))
+        router.layer(ServiceBuilder::new().layer(GovernorLayer::new(Arc::new(governor_conf))))
     }
 }
 


### PR DESCRIPTION
Our local `ic-boundary` was tracking old versions of the tower crates. By bumping those we are now aligned with versions pulled in transitively, which simplifies the dep graph.