### PR TITLE
chore(engine-controller): remove the subnet admin normalization

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -296,39 +296,13 @@ fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), S
     }
 }
 
-/// Ensures that the configured `AUTHORIZED_CALLER` (the engine controller's
-/// "super admin") is always present in the resulting admin list, even if the
-/// caller forgot to include it.
-fn normalize_subnet_admins(admins: Vec<PrincipalId>) -> Vec<PrincipalId> {
-    let super_admin = PrincipalId(AUTHORIZED_CALLER.with(|c| *c.borrow()));
-    let mut admins = admins;
-    if !admins.contains(&super_admin) {
-        admins.push(super_admin);
-    }
-    admins
-}
-
 /// Proxies to the registry's `update_subnet` endpoint. Only `subnet_admins`
 /// and `is_halted` may be updated through this path; every other field must be
 /// left at its default value (`None` / `false`) or the call is rejected.
-///
-/// The `subnet_admins` list is always normalized to include the engine
-/// controller's authorized caller (the super admin), so callers cannot
-/// accidentally lock the controller out of the subnet.
 #[update]
 async fn update_subnet(payload: UpdateSubnetPayload) -> Result<(), String> {
     ensure_authorized()?;
     ensure_only_allowed_fields_set(&payload)?;
-
-    // Normalize `subnet_admins` so the super admin is always present.
-    // The caller may omit the field entirely (no change requested), but if
-    // they do supply one, we treat it as the source of truth and add the
-    // super admin if missing.
-    #[allow(unused_mut)]
-    let mut payload = payload;
-    if let Some(admins) = payload.subnet_admins {
-        payload.subnet_admins = Some(normalize_subnet_admins(admins));
-    }
 
     Call::unbounded_wait(REGISTRY_CANISTER_ID.into(), "update_subnet")
         .with_arg(payload)

--- a/rs/engine_controller/canister/tests.rs
+++ b/rs/engine_controller/canister/tests.rs
@@ -138,4 +138,3 @@ fn ensure_only_allowed_fields_set_rejects_non_default_gossip_flag() {
         "error must mention the non-default bool: {err}"
     );
 }
-

--- a/rs/engine_controller/canister/tests.rs
+++ b/rs/engine_controller/canister/tests.rs
@@ -139,36 +139,3 @@ fn ensure_only_allowed_fields_set_rejects_non_default_gossip_flag() {
     );
 }
 
-#[test]
-fn normalize_subnet_admins_adds_super_admin_when_missing() {
-    let other = PrincipalId::new_user_test_id(7);
-    let normalized = normalize_subnet_admins(vec![other]);
-
-    let super_admin = PrincipalId(default_authorized_caller());
-    assert!(
-        normalized.contains(&super_admin),
-        "super admin must be present after normalization"
-    );
-    assert!(
-        normalized.contains(&other),
-        "other admins must be preserved"
-    );
-}
-
-#[test]
-fn normalize_subnet_admins_keeps_list_intact_when_super_admin_present() {
-    let super_admin = PrincipalId(default_authorized_caller());
-    let other = PrincipalId::new_user_test_id(8);
-    let input = vec![other, super_admin];
-    let normalized = normalize_subnet_admins(input.clone());
-    assert_eq!(
-        normalized, input,
-        "list must not be reordered or duplicated when super admin is already present"
-    );
-}
-
-#[test]
-fn normalize_subnet_admins_handles_empty_input() {
-    let normalized = normalize_subnet_admins(vec![]);
-    assert_eq!(normalized, vec![PrincipalId(default_authorized_caller())]);
-}

--- a/rs/engine_controller/unreleased_changelog.md
+++ b/rs/engine_controller/unreleased_changelog.md
@@ -15,6 +15,10 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `update_subnet` no longer forces the engine controller's authorized caller
+  (super admin) into the `subnet_admins` list. The supplied list is now
+  forwarded to the registry as-is.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
For ease of use and to protect against unwanted changes, this canister forced the authorized caller to be a subnet admin. We are now removing that requirement.