### PR TITLE
feat: Add subnet size and cycle cost schedule to HTTP request context

### DIFF
--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -500,6 +500,7 @@ mod tests {
     use ic_test_utilities_state::ReplicatedStateBuilder;
     use ic_test_utilities_types::{ids::node_test_id, messages::RequestBuilder};
     use ic_types::{
+        NumberOfNodes,
         canister_http::{
             CanisterHttpMethod, CanisterHttpRequestContext, PricingVersion, RefundStatus,
             Replication,
@@ -737,6 +738,7 @@ mod tests {
             pricing_version: PricingVersion::Legacy,
             refund_status: RefundStatus::default(),
             registry_version,
+            subnet_size: NumberOfNodes::from(13),
         }
     }
 

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -739,6 +739,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version,
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         }
     }
 

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -707,6 +707,7 @@ mod tests {
                 pricing_version: PricingVersion::Legacy,
                 refund_status: RefundStatus::default(),
                 registry_version: RegistryVersion::from(1),
+                subnet_size: NumberOfNodes::from(13),
             },
             socks_proxy_addrs: vec![],
             cost_schedule: CanisterCyclesCostSchedule::Normal,

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -708,6 +708,7 @@ mod tests {
                 refund_status: RefundStatus::default(),
                 registry_version: RegistryVersion::from(1),
                 subnet_size: NumberOfNodes::from(13),
+                cost_schedule: None,
             },
             socks_proxy_addrs: vec![],
             cost_schedule: CanisterCyclesCostSchedule::Normal,

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -490,6 +490,7 @@ fn request_context(replication: Replication) -> CanisterHttpRequestContext {
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
+        cost_schedule: None,
     }
 }
 

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -23,7 +23,7 @@ use ic_test_utilities_types::{
     messages::RequestBuilder,
 };
 use ic_types::{
-    CountBytes, Height, NodeId, RegistryVersion, ReplicaVersion,
+    CountBytes, Height, NodeId, NumberOfNodes, RegistryVersion, ReplicaVersion,
     batch::{
         CanisterHttpPayload, FlexibleCanisterHttpResponseWithProof, FlexibleCanisterHttpResponses,
         ValidationContext,
@@ -489,6 +489,7 @@ fn request_context(replication: Replication) -> CanisterHttpRequestContext {
         pricing_version: PricingVersion::Legacy,
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
+        subnet_size: NumberOfNodes::from(13),
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -873,6 +873,7 @@ fn non_replicated_request_response_coming_in_gossip_payload_created() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Insert the context in the replicated state
@@ -946,6 +947,7 @@ fn non_replicated_request_with_extra_share_includes_only_delegated_share() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Insert the context in the replicated state
@@ -1020,6 +1022,7 @@ fn non_replicated_share_is_ignored_if_content_is_missing() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         inject_request_contexts(&mut payload_builder, [(callback_id, request_context)]);
@@ -1072,6 +1075,7 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1277,6 +1281,7 @@ fn validate_payload_fails_for_non_replicated_response_with_wrong_signer() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Inject this context into the state reader.
@@ -1347,6 +1352,7 @@ fn validate_payload_fails_for_response_with_no_signatures() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1424,6 +1430,7 @@ fn validate_payload_fails_when_non_replicated_proof_is_for_fully_replicated_requ
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // Inject this context into the state reader.
@@ -1502,6 +1509,7 @@ fn validate_payload_fails_for_duplicate_non_replicated_response() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         // 2. Inject this context into the state reader
@@ -4707,6 +4715,7 @@ pub(crate) fn request_context(replication: Replication) -> CanisterHttpRequestCo
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
+        cost_schedule: None,
     }
 }
 
@@ -4733,6 +4742,7 @@ fn flexible_request_context(
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
+        cost_schedule: None,
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -39,7 +39,7 @@ use ic_test_utilities_types::{
     messages::RequestBuilder,
 };
 use ic_types::{
-    CountBytes, Height, NodeId, NumBytes, RegistryVersion, ReplicaVersion,
+    CountBytes, Height, NodeId, NumBytes, NumberOfNodes, RegistryVersion, ReplicaVersion,
     batch::{
         CanisterHttpPayload, FlexibleCanisterHttpError, FlexibleCanisterHttpResponseWithProof,
         FlexibleCanisterHttpResponses, MAX_CANISTER_HTTP_PAYLOAD_SIZE, ValidationContext,
@@ -872,6 +872,7 @@ fn non_replicated_request_response_coming_in_gossip_payload_created() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Insert the context in the replicated state
@@ -944,6 +945,7 @@ fn non_replicated_request_with_extra_share_includes_only_delegated_share() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Insert the context in the replicated state
@@ -1017,6 +1019,7 @@ fn non_replicated_share_is_ignored_if_content_is_missing() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         inject_request_contexts(&mut payload_builder, [(callback_id, request_context)]);
@@ -1068,6 +1071,7 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1272,6 +1276,7 @@ fn validate_payload_fails_for_non_replicated_response_with_wrong_signer() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Inject this context into the state reader.
@@ -1341,6 +1346,7 @@ fn validate_payload_fails_for_response_with_no_signatures() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1417,6 +1423,7 @@ fn validate_payload_fails_when_non_replicated_proof_is_for_fully_replicated_requ
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // Inject this context into the state reader.
@@ -1494,6 +1501,7 @@ fn validate_payload_fails_for_duplicate_non_replicated_response() {
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         // 2. Inject this context into the state reader
@@ -4698,6 +4706,7 @@ pub(crate) fn request_context(replication: Replication) -> CanisterHttpRequestCo
         pricing_version: ic_types::canister_http::PricingVersion::Legacy,
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
+        subnet_size: NumberOfNodes::from(13),
     }
 }
 
@@ -4723,6 +4732,7 @@ fn flexible_request_context(
         pricing_version: ic_types::canister_http::PricingVersion::PayAsYouGo,
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
+        subnet_size: NumberOfNodes::from(13),
     }
 }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -777,6 +777,7 @@ pub mod test {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         }
     }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -776,6 +776,7 @@ pub mod test {
             pricing_version,
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         }
     }
 

--- a/rs/https_outcalls/pricing/src/payg.rs
+++ b/rs/https_outcalls/pricing/src/payg.rs
@@ -190,6 +190,7 @@ mod tests {
             },
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         }
     }
 

--- a/rs/https_outcalls/pricing/src/payg.rs
+++ b/rs/https_outcalls/pricing/src/payg.rs
@@ -189,6 +189,7 @@ mod tests {
                 refunding_nodes: BTreeSet::new(),
             },
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         }
     }
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -163,6 +163,7 @@ message CanisterHttpRequestContext {
   optional PricingVersion pricing_version = 12;
   optional RefundStatus refund_status = 13;
   uint64 registry_version = 14;
+  uint32 subnet_size = 15;
   reserved 5;
 }
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -164,6 +164,7 @@ message CanisterHttpRequestContext {
   optional RefundStatus refund_status = 13;
   uint64 registry_version = 14;
   uint32 subnet_size = 15;
+  registry.subnet.v1.CanisterCyclesCostSchedule cost_schedule = 16;
   reserved 5;
 }
 

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -233,6 +233,11 @@ pub struct CanisterHttpRequestContext {
     pub registry_version: u64,
     #[prost(uint32, tag = "15")]
     pub subnet_size: u32,
+    #[prost(
+        enumeration = "super::super::super::registry::subnet::v1::CanisterCyclesCostSchedule",
+        tag = "16"
+    )]
+    pub cost_schedule: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RefundStatus {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -231,6 +231,8 @@ pub struct CanisterHttpRequestContext {
     pub refund_status: ::core::option::Option<RefundStatus>,
     #[prost(uint64, tag = "14")]
     pub registry_version: u64,
+    #[prost(uint32, tag = "15")]
+    pub subnet_size: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RefundStatus {

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -875,6 +875,7 @@ fn subnet_call_contexts_deserialization() {
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
+        cost_schedule: None,
     };
     subnet_call_context_manager.push_context(SubnetCallContext::CanisterHttpRequest(
         canister_http_request,

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -40,7 +40,7 @@ use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealers, IDkgReceivers,
 use ic_types::ingress::WasmResult;
 use ic_types::messages::{CallbackId, CanisterCall, Payload, Refund, Request, RequestMetadata};
 use ic_types::time::{CoarseTime, current_time};
-use ic_types::{ExecutionRound, Height, RegistryVersion};
+use ic_types::{ExecutionRound, Height, NumberOfNodes, RegistryVersion};
 use ic_types_cycles::{Cycles, NominalCyclesTesting};
 use lazy_static::lazy_static;
 use maplit::btreemap;
@@ -874,6 +874,7 @@ fn subnet_call_contexts_deserialization() {
         pricing_version: PricingVersion::Legacy,
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
+        subnet_size: NumberOfNodes::from(13),
     };
     subnet_call_context_manager.push_context(SubnetCallContext::CanisterHttpRequest(
         canister_http_request,

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -60,6 +60,7 @@ use ic_management_canister_types_private::{
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
+    registry::subnet::v1::CanisterCyclesCostSchedule as CanisterCyclesCostScheduleProto,
     state::system_metadata::v1 as pb_metadata,
 };
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
@@ -144,6 +145,8 @@ pub struct CanisterHttpRequestContext {
     pub registry_version: RegistryVersion,
     /// The subnet size at the registry version above.
     pub subnet_size: NumberOfNodes,
+    /// The cycles cost schedule at the registry version above.
+    pub cost_schedule: Option<CanisterCyclesCostSchedule>,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
@@ -307,6 +310,12 @@ impl From<&CanisterHttpRequestContext> for pb_metadata::CanisterHttpRequestConte
             refund_status: Some(refund_status),
             registry_version: context.registry_version.get(),
             subnet_size: context.subnet_size.get(),
+            cost_schedule: context
+                .cost_schedule
+                .map(|cost_schedule| {
+                    i32::from(CanisterCyclesCostScheduleProto::from(cost_schedule))
+                })
+                .unwrap_or_default(),
         }
     }
 }
@@ -433,6 +442,16 @@ impl TryFrom<pb_metadata::CanisterHttpRequestContext> for CanisterHttpRequestCon
             refund_status,
             registry_version: RegistryVersion::from(context.registry_version),
             subnet_size: NumberOfNodes::from(context.subnet_size),
+            cost_schedule: match CanisterCyclesCostScheduleProto::try_from(context.cost_schedule)
+                .map_err(|err| ProxyDecodeError::ValueOutOfRange {
+                    typ: "CanisterCyclesCostSchedule",
+                    err: format!(
+                        "Failed to convert CanisterCyclesCostSchedule for CanisterHttpRequestContext: {err:?}"
+                    ),
+                })? {
+                CanisterCyclesCostScheduleProto::Unspecified => None,
+                cost_schedule => Some(CanisterCyclesCostSchedule::from(cost_schedule)),
+            },
         })
     }
 }
@@ -616,6 +635,8 @@ impl CanisterHttpRequestContext {
             registry_version,
             // TODO: populate with the actual subnet size this request is processed at.
             subnet_size: NumberOfNodes::from(0),
+            // TODO: populate with the actual cost schedule this request is processed at.
+            cost_schedule: None,
         })
     }
 
@@ -723,6 +744,8 @@ impl CanisterHttpRequestContext {
             registry_version,
             // TODO: populate with the actual subnet size this request is processed at.
             subnet_size: NumberOfNodes::from(0),
+            // TODO: populate with the actual cost schedule this request is processed at.
+            cost_schedule: None,
         })
     }
 }
@@ -1270,6 +1293,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         let expected_size = context.url.len()
@@ -1317,6 +1341,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
         };
 
         let expected_size = context.url.len()
@@ -1398,10 +1423,64 @@ mod tests {
                 },
                 registry_version: RegistryVersion::from(7),
                 subnet_size: NumberOfNodes::from(13),
+                cost_schedule: Some(CanisterCyclesCostSchedule::Free),
             };
 
             let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
             let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
+            assert_eq!(initial, round_trip);
+        }
+    }
+
+    #[test]
+    fn canister_http_request_context_cost_schedule_proto_round_trip() {
+        let base = CanisterHttpRequestContext {
+            request: Request {
+                receiver: CanisterId::ic_00(),
+                sender: CanisterId::ic_00(),
+                sender_reply_callback: CallbackId::from(3),
+                payment: Cycles::new(10),
+                method_name: "transform".to_string(),
+                method_payload: Vec::new(),
+                metadata: Default::default(),
+                deadline: NO_DEADLINE,
+            },
+            url: "https://example.com".to_string(),
+            max_response_bytes: None,
+            headers: vec![],
+            body: None,
+            http_method: CanisterHttpMethod::GET,
+            transform: None,
+            time: UNIX_EPOCH,
+            replication: Replication::FullyReplicated,
+            pricing_version: PricingVersion::Legacy,
+            refund_status: RefundStatus::default(),
+            registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
+            cost_schedule: None,
+        };
+
+        for cost_schedule in [
+            None,
+            Some(CanisterCyclesCostSchedule::Normal),
+            Some(CanisterCyclesCostSchedule::Free),
+        ] {
+            let initial = CanisterHttpRequestContext {
+                cost_schedule,
+                ..base.clone()
+            };
+
+            let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
+            // An unpopulated cost schedule must serialize to the proto default
+            // (`Unspecified` == 0) so that it stays non-existent in the proto
+            // representation for compatibility.
+            if cost_schedule.is_none() {
+                assert_eq!(pb.cost_schedule, 0);
+            }
+
+            let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
+            // In particular, `None` must not decode back as `Some(Normal)`.
+            assert_eq!(round_trip.cost_schedule, cost_schedule);
             assert_eq!(initial, round_trip);
         }
     }

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -142,7 +142,7 @@ pub struct CanisterHttpRequestContext {
     pub refund_status: RefundStatus,
     /// The registry version at which this request is being processed.
     pub registry_version: RegistryVersion,
-    /// The number of nodes on the subnet processing this request.
+    /// The subnet size at the registry version above.
     pub subnet_size: NumberOfNodes,
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -142,6 +142,8 @@ pub struct CanisterHttpRequestContext {
     pub refund_status: RefundStatus,
     /// The registry version at which this request is being processed.
     pub registry_version: RegistryVersion,
+    /// The number of nodes on the subnet processing this request.
+    pub subnet_size: NumberOfNodes,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
@@ -304,6 +306,7 @@ impl From<&CanisterHttpRequestContext> for pb_metadata::CanisterHttpRequestConte
             pricing_version: Some(pricing_message),
             refund_status: Some(refund_status),
             registry_version: context.registry_version.get(),
+            subnet_size: context.subnet_size.get(),
         }
     }
 }
@@ -429,6 +432,7 @@ impl TryFrom<pb_metadata::CanisterHttpRequestContext> for CanisterHttpRequestCon
             pricing_version,
             refund_status,
             registry_version: RegistryVersion::from(context.registry_version),
+            subnet_size: NumberOfNodes::from(context.subnet_size),
         })
     }
 }
@@ -610,6 +614,8 @@ impl CanisterHttpRequestContext {
             // based on the request's payment and the base fee.
             refund_status: RefundStatus::default(),
             registry_version,
+            // TODO: populate with the actual subnet size this request is processed at.
+            subnet_size: NumberOfNodes::from(0),
         })
     }
 
@@ -715,6 +721,8 @@ impl CanisterHttpRequestContext {
             // based on the request's payment and the base fee.
             refund_status: RefundStatus::default(),
             registry_version,
+            // TODO: populate with the actual subnet size this request is processed at.
+            subnet_size: NumberOfNodes::from(0),
         })
     }
 }
@@ -1261,6 +1269,7 @@ mod tests {
             pricing_version: PricingVersion::Legacy,
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         let expected_size = context.url.len()
@@ -1307,6 +1316,7 @@ mod tests {
             pricing_version: PricingVersion::Legacy,
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
         };
 
         let expected_size = context.url.len()
@@ -1387,6 +1397,7 @@ mod tests {
                     refunding_nodes: BTreeSet::from([node_test_id(1), node_test_id(2)]),
                 },
                 registry_version: RegistryVersion::from(7),
+                subnet_size: NumberOfNodes::from(13),
             };
 
             let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();


### PR DESCRIPTION
This is needed to correctly calculate part of the new pricing.

Technically we could retrieve both of the new fields via the registry version (which is already in the context), but there is no registry client available in the execution environment.

For compatibility reasons, the registry version is set to `0`, and the cycle cost schedule is introduced as optional (`None`) for now.