### PR TITLE
refactor: remove legacy canister_log and drop log memory store feature flag

### DIFF
--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1501,8 +1501,7 @@ impl CkBtcSetup {
     }
 
     pub fn print_minter_canister_logs(&self) {
-        let log = self.env.canister_log(self.minter_id);
-        let mut records = log.records().iter().collect::<Vec<_>>();
+        let mut records = self.env.canister_log_records(self.minter_id);
         records.sort_by_key(|a| a.idx);
         for entry in records {
             println!(

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -15,23 +15,8 @@ const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Disa
 
 const FLEXIBLE_HTTP_REQUESTS_FEATURE: FlagStatus = FlagStatus::Disabled;
 
-// TODO(DSM-105): remove after the feature is enabled by default.
-pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = true;
-pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-    FlagStatus::Enabled
-} else {
-    FlagStatus::Disabled
-};
-pub const TEST_DEFAULT_LOG_MEMORY_LIMIT: u64 = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-    4 * KIB
-} else {
-    0
-};
-pub const TEST_DEFAULT_LOG_MEMORY_USAGE: u64 = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-    4 * KIB + 4 * KIB + TEST_DEFAULT_LOG_MEMORY_LIMIT // header, index table, data region
-} else {
-    0
-};
+pub const TEST_DEFAULT_LOG_MEMORY_LIMIT: u64 = 4 * KIB;
+pub const TEST_DEFAULT_LOG_MEMORY_USAGE: u64 = 4 * KIB + 4 * KIB + TEST_DEFAULT_LOG_MEMORY_LIMIT; // header, index table, data region
 
 /// This specifies the threshold in bytes at which the subnet memory usage is
 /// considered to be high. If this value is greater or equal to the subnet
@@ -381,9 +366,6 @@ pub struct Config {
     /// Enables the replicated inter-canister calls to `fetch_canister_logs`.
     pub replicated_inter_canister_log_fetch: FlagStatus,
 
-    /// Enables the log memory store feature.
-    pub log_memory_store_feature: FlagStatus,
-
     /// Enables the flexible HTTP outcalls API (`flexible_http_request`).
     pub flexible_http_requests: FlagStatus,
 }
@@ -471,7 +453,6 @@ impl Default for Config {
             max_environment_variable_name_length: MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH,
             max_environment_variable_value_length: MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH,
             replicated_inter_canister_log_fetch: REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE,
-            log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,
             flexible_http_requests: FLEXIBLE_HTTP_REQUESTS_FEATURE,
         }
     }

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -393,16 +393,10 @@ impl SystemStateModifications {
     ) -> HypervisorResult<RequestMetadataStats> {
         // Append delta logs.
         if !self.canister_log.is_empty() {
-            // TODO(DSM-11): Move this into append_delta_log() once there is only one of it.
             metrics.observe_delta_log_size(self.canister_log.bytes_used());
         }
-        if system_state.log_memory_store.is_migrated() {
-            system_state
-                .log_memory_store
-                .append_delta_log(&mut self.canister_log.clone());
-        }
         system_state
-            .canister_log
+            .log_memory_store
             .append_delta_log(&mut self.canister_log);
 
         // Verify total cycle change is not positive and update cycles balance.
@@ -819,14 +813,10 @@ impl SandboxSafeSystemState {
             })
             .min()
             .unwrap_or(DEFAULT_QUEUE_CAPACITY);
-        let (next_canister_log_record_idx, canister_log_memory_limit) =
-            if system_state.log_memory_store.is_migrated() {
-                let lms = &system_state.log_memory_store;
-                (lms.next_idx(), lms.byte_capacity())
-            } else {
-                let cl = &system_state.canister_log;
-                (cl.next_idx(), cl.byte_capacity())
-            };
+        let (next_canister_log_record_idx, canister_log_memory_limit) = {
+            let lms = &system_state.log_memory_store;
+            (lms.next_idx(), lms.byte_capacity())
+        };
 
         Self::new_internal(
             system_state.canister_id(),

--- a/rs/embedders/src/wasmtime_embedder/tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 use ic_base_types::NumSeconds;
 use ic_config::{
     embedders::Config as EmbeddersConfig,
-    execution_environment::{Config as HypervisorConfig, LOG_MEMORY_STORE_FEATURE},
+    execution_environment::Config as HypervisorConfig,
     subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
@@ -66,7 +66,6 @@ fn test_wasmtime_system_api() {
         UNIX_EPOCH,
         NumSeconds::from(0),
         Arc::new(TestPageAllocatorFileDescriptorImpl),
-        LOG_MEMORY_STORE_FEATURE,
     );
     let api_type = ApiType::start(UNIX_EPOCH);
     let sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -698,9 +698,7 @@ impl CkEthSetup {
     }
 
     pub fn minter_canister_logs(&self) -> Vec<CanisterLog> {
-        let log = self.env.canister_log(self.minter_id);
-
-        let mut records = log.records().iter().collect::<Vec<_>>();
+        let mut records = self.env.canister_log_records(self.minter_id);
         records.sort_by_key(|a| a.idx);
         records
             .into_iter()

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_config::execution_environment::{Config as ExecutionConfig, LOG_MEMORY_STORE_FEATURE};
+use ic_config::execution_environment::Config as ExecutionConfig;
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SubnetConfig;
 use ic_management_canister_types_private::{
@@ -73,7 +73,6 @@ fn setup_fetch_bench(
         SubnetConfig::new(subnet_type),
         ExecutionConfig {
             replicated_inter_canister_log_fetch: FlagStatus::Enabled,
-            log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,
             ..Default::default()
         },
     );

--- a/rs/execution_environment/src/canister_logs.rs
+++ b/rs/execution_environment/src/canister_logs.rs
@@ -1,22 +1,18 @@
 use crate::canister_manager::types::{CanisterManagerError, CanisterManagerResponse};
 use crate::canister_settings::VisibilitySettings;
 use candid::Encode;
-use ic_config::flag_status::FlagStatus;
 use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 use ic_management_canister_types_private::{
-    CanisterLogRecord, FetchCanisterLogsFilter, FetchCanisterLogsRange, FetchCanisterLogsRequest,
-    FetchCanisterLogsResponse, LogVisibilityV2,
+    FetchCanisterLogsRequest, FetchCanisterLogsResponse, LogVisibilityV2,
 };
 use ic_replicated_state::CanisterState;
 use ic_types::messages::CanisterCall;
 use ic_types::{NumBytes, PrincipalId};
-use std::collections::VecDeque;
 
 pub(crate) fn fetch_canister_logs(
     sender: PrincipalId,
     canister: &CanisterState,
     args: FetchCanisterLogsRequest,
-    log_memory_store_feature: FlagStatus,
     msg: &mut CanisterCall,
     cycles_account_manager: &CyclesAccountManager,
     subnet_cycles_config: CyclesAccountManagerSubnetConfig,
@@ -30,7 +26,7 @@ pub(crate) fn fetch_canister_logs(
         });
     }
     let canister_id = canister.canister_id();
-    let reply = fetch_canister_logs_response(sender, canister, args, log_memory_store_feature)?;
+    let reply = fetch_canister_logs_response(sender, canister, args)?;
     msg.deduct_cycles(
         cycles_account_manager
             .fetch_canister_logs_fee(NumBytes::new(reply.len() as u64), subnet_cycles_config),
@@ -50,16 +46,9 @@ pub(crate) fn fetch_canister_logs_response(
     sender: PrincipalId,
     canister: &CanisterState,
     args: FetchCanisterLogsRequest,
-    log_memory_store_feature: FlagStatus,
 ) -> Result<Vec<u8>, CanisterManagerError> {
     check_log_visibility_permission(&sender, canister.log_visibility(), canister.controllers())?;
-    let s = &canister.system_state;
-    let canister_log_records = match log_memory_store_feature {
-        FlagStatus::Enabled if s.log_memory_store.is_migrated() => {
-            s.log_memory_store.records(args.filter)
-        }
-        _ => filter_records(&args, s.canister_log.records()),
-    };
+    let canister_log_records = canister.system_state.log_memory_store.records(args.filter);
     Ok(Encode!(&FetchCanisterLogsResponse {
         canister_log_records
     })
@@ -76,28 +65,4 @@ pub(crate) fn check_log_visibility_permission(
         return Err(CanisterManagerError::FetchCanisterLogsAccessDenied { caller: *caller });
     }
     Ok(())
-}
-
-fn filter_records(
-    args: &FetchCanisterLogsRequest,
-    records: &VecDeque<CanisterLogRecord>,
-) -> Vec<CanisterLogRecord> {
-    let Some(filter) = &args.filter else {
-        return records.iter().cloned().collect();
-    };
-
-    let (range, key): (&FetchCanisterLogsRange, fn(&CanisterLogRecord) -> u64) = match filter {
-        FetchCanisterLogsFilter::ByIdx(r) => (r, |rec| rec.idx),
-        FetchCanisterLogsFilter::ByTimestampNanos(r) => (r, |rec| rec.timestamp_nanos),
-    };
-
-    if range.is_empty() {
-        return Vec::new();
-    }
-
-    records
-        .iter()
-        .filter(|r| range.contains(key(r)))
-        .cloned()
-        .collect()
 }

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -548,9 +548,7 @@ impl CanisterManager {
         }
 
         // Log memory limit: validate, charge cycles for resize, and apply.
-        if canister.system_state.log_memory_store.is_migrated()
-            && let Some(requested_limit) = settings.log_memory_limit()
-        {
+        if let Some(requested_limit) = settings.log_memory_limit() {
             let max_limit = NumBytes::new(MAX_AGGREGATE_LOG_MEMORY_LIMIT as u64);
             if requested_limit > max_limit {
                 return Err(CanisterManagerError::CanisterLogMemoryLimitIsTooHigh {
@@ -1484,7 +1482,6 @@ impl CanisterManager {
             state.metadata.batch_time,
             self.config.default_freeze_threshold,
             Arc::clone(&self.fd_factory),
-            self.config.log_memory_store_feature,
         );
 
         system_state.consume_cycles(creation_fee);

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -20,7 +20,6 @@ use ic_config::embedders::DEFAULT_CREATE_EXECUTION_STATE_BASE_COST;
 use ic_config::{
     execution_environment::{
         CANISTER_GUARANTEED_CALLBACK_QUOTA, Config, DEFAULT_WASM_MEMORY_LIMIT,
-        LOG_MEMORY_STORE_FEATURE, LOG_MEMORY_STORE_FEATURE_ENABLED,
         MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH, MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH,
         MAX_ENVIRONMENT_VARIABLES, MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
         SUBNET_CALLBACK_SOFT_LIMIT, SUBNET_MEMORY_RESERVATION, TEST_DEFAULT_LOG_MEMORY_USAGE,
@@ -325,7 +324,6 @@ fn canister_manager_config(
         MAX_ENVIRONMENT_VARIABLES,
         MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH,
         MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH,
-        LOG_MEMORY_STORE_FEATURE,
     )
 }
 
@@ -537,11 +535,8 @@ fn install_canister_fails_if_memory_capacity_exceeded() {
 
     // Try installing canister2, should fail due to insufficient memory capacity on the subnet.
     let err = test.install_canister(canister2, wasm).unwrap_err();
-    let msg = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        "Canister requested 10.00 MiB of memory but only 9.99 MiB are available in the subnet."
-    } else {
-        "Canister requested 10.00 MiB of memory but only 10.00 MiB are available in the subnet."
-    };
+    let msg =
+        "Canister requested 10.00 MiB of memory but only 9.99 MiB are available in the subnet.";
     err.assert_contains(ErrorCode::SubnetOversubscribed, msg);
     assert_eq!(
         test.canister_state(canister2).system_state.balance(),
@@ -2295,11 +2290,8 @@ fn upgrading_canister_fails_if_memory_capacity_exceeded() {
 
     // Try upgrading the canister, should fail because there is not enough memory capacity
     // on the subnet.
-    let msg = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        "Canister requested 10.00 MiB of memory but only 9.99 MiB are available in the subnet."
-    } else {
-        "Canister requested 10.00 MiB of memory but only 10.00 MiB are available in the subnet."
-    };
+    let msg =
+        "Canister requested 10.00 MiB of memory but only 9.99 MiB are available in the subnet.";
     test.upgrade_canister(canister2, wasm)
         .unwrap_err()
         .assert_contains(ErrorCode::SubnetOversubscribed, msg);
@@ -5400,9 +5392,7 @@ fn setup_canister_log_heap_delta_test(
     // of the two records.
     const MSG: &[u8] = &[b'x'; 2100];
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_log_memory_store_feature_enabled()
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
     let canister_id = test
         .create_canister_with_settings(
             CYCLES,
@@ -5589,7 +5579,6 @@ fn update_settings_fails_when_heap_delta_rate_limited() {
 
     let mut test = ExecutionTestBuilder::new()
         .with_heap_delta_rate_limit(LIMIT)
-        .with_log_memory_store_feature_enabled()
         .build();
     let canister_id = test
         .create_canister_with_settings(
@@ -5637,9 +5626,7 @@ fn update_settings_fails_when_heap_delta_rate_limited() {
 fn create_canister_heap_delta_log_memory_limit_default() {
     const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_log_memory_store_feature_enabled()
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
     test.create_canister(CYCLES);
 
     assert_eq!(test.state().metadata.heap_delta_estimate, NumBytes::from(0));
@@ -5652,9 +5639,7 @@ fn create_canister_heap_delta_log_memory_limit_explicit() {
     const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
     const MIB: u64 = 1024 * 1024;
 
-    let mut test = ExecutionTestBuilder::new()
-        .with_log_memory_store_feature_enabled()
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
     test.create_canister_with_settings(
         CYCLES,
         CanisterSettingsArgsBuilder::new()

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -80,7 +80,6 @@ pub(crate) struct CanisterMgrConfig {
     pub(crate) max_environment_variables: usize,
     pub(crate) max_environment_variable_name_length: usize,
     pub(crate) max_environment_variable_value_length: usize,
-    pub(crate) log_memory_store_feature: FlagStatus,
 }
 
 impl CanisterMgrConfig {
@@ -105,7 +104,6 @@ impl CanisterMgrConfig {
         max_environment_variables: usize,
         max_environment_variable_name_length: usize,
         max_environment_variable_value_length: usize,
-        log_memory_store_feature: FlagStatus,
     ) -> Self {
         Self {
             default_provisional_cycles_balance,
@@ -127,7 +125,6 @@ impl CanisterMgrConfig {
             max_environment_variables,
             max_environment_variable_name_length,
             max_environment_variable_value_length,
-            log_memory_store_feature,
         }
     }
 }

--- a/rs/execution_environment/src/execution/install.rs
+++ b/rs/execution_environment/src/execution/install.rs
@@ -90,7 +90,7 @@ pub(crate) fn execute_install(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -109,7 +109,7 @@ pub(crate) fn execute_install(
                 original,
                 round,
                 err,
-                helper.take_canister_log(),
+                helper.clone_log_memory_store(),
             );
         }
     };
@@ -135,7 +135,7 @@ pub(crate) fn execute_install(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
     helper.clear_certified_data();
@@ -249,7 +249,7 @@ fn install_stage_2a_process_start_result(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -361,7 +361,7 @@ fn install_stage_3_process_init_result(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
     helper.finish(clean_canister, original, round, round_limits)

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -24,7 +24,7 @@ use ic_replicated_state::metadata_state::subnet_call_context_manager::InstallCod
 use ic_replicated_state::{CanisterState, ExecutionState, num_bytes_try_from};
 use ic_sys::PAGE_SIZE;
 use ic_types::{
-    CanisterLog, CanisterTimer, MemoryAllocation, NumInstructions, Time, messages::CanisterCall,
+    CanisterTimer, MemoryAllocation, NumInstructions, Time, messages::CanisterCall,
 };
 use ic_types_cycles::{CompoundCycles, Cycles, CyclesUseCase, Instructions};
 use ic_wasm_types::WasmHash;
@@ -249,14 +249,7 @@ impl InstallCodeHelper {
         paused: PausedInstallCodeHelper,
         original: &OriginalContext,
         round: &RoundContext,
-    ) -> Result<
-        Self,
-        (
-            CanisterManagerError,
-            NumInstructions,
-            (CanisterLog, LogMemoryStore),
-        ),
-    > {
+    ) -> Result<Self, (CanisterManagerError, NumInstructions, LogMemoryStore)> {
         let mut helper = Self::new(clean_canister, original);
         let paused_instructions_left = paused.instructions_left;
         for state_change in paused.steps.into_iter() {
@@ -618,12 +611,8 @@ impl InstallCodeHelper {
     }
 
     /// Takes the canister log.
-    pub(crate) fn take_canister_log(&mut self) -> (CanisterLog, LogMemoryStore) {
-        // TODO(DSM-105): Remove duplication when the migration is fully done.
-        (
-            self.canister.system_state.canister_log.take(),
-            self.canister.system_state.log_memory_store.clone(),
-        )
+    pub(crate) fn take_canister_log(&mut self) -> LogMemoryStore {
+        self.canister.system_state.log_memory_store.clone()
     }
 
     /// Checks the result of Wasm execution and applies the state changes.
@@ -859,11 +848,11 @@ pub(crate) fn finish_err(
     original: OriginalContext,
     round: RoundContext,
     err: CanisterManagerError,
-    new_canister_log: (CanisterLog, LogMemoryStore),
+    new_log_memory_store: LogMemoryStore,
 ) -> DtsInstallCodeResult {
     let mut new_canister = clean_canister;
 
-    new_canister.set_log(new_canister_log);
+    new_canister.set_log(new_log_memory_store);
     new_canister
         .system_state
         .apply_ingress_induction_cycles_debit(

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -23,9 +23,7 @@ use ic_replicated_state::canister_state::system_state::{
 use ic_replicated_state::metadata_state::subnet_call_context_manager::InstallCodeCallId;
 use ic_replicated_state::{CanisterState, ExecutionState, num_bytes_try_from};
 use ic_sys::PAGE_SIZE;
-use ic_types::{
-    CanisterTimer, MemoryAllocation, NumInstructions, Time, messages::CanisterCall,
-};
+use ic_types::{CanisterTimer, MemoryAllocation, NumInstructions, Time, messages::CanisterCall};
 use ic_types_cycles::{CompoundCycles, Cycles, CyclesUseCase, Instructions};
 use ic_wasm_types::WasmHash;
 

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -253,7 +253,13 @@ impl InstallCodeHelper {
         for state_change in paused.steps.into_iter() {
             helper
                 .replay_step(state_change, original, round)
-                .map_err(|err| (err, paused_instructions_left, helper.take_canister_log()))?;
+                .map_err(|err| {
+                    (
+                        err,
+                        paused_instructions_left,
+                        helper.clone_log_memory_store(),
+                    )
+                })?;
         }
         debug_assert_eq!(paused_instructions_left, helper.instructions_left());
         Ok(helper)
@@ -340,7 +346,7 @@ impl InstallCodeHelper {
                     original,
                     round,
                     CanisterManagerError::Hypervisor(self.canister.canister_id(), err),
-                    self.take_canister_log(),
+                    self.clone_log_memory_store(),
                 );
             }
         }
@@ -384,7 +390,7 @@ impl InstallCodeHelper {
                         original,
                         round,
                         err,
-                        self.take_canister_log(),
+                        self.clone_log_memory_store(),
                     );
                 }
             }
@@ -413,7 +419,7 @@ impl InstallCodeHelper {
                     original,
                     round,
                     err,
-                    self.take_canister_log(),
+                    self.clone_log_memory_store(),
                 );
             }
         }
@@ -457,7 +463,7 @@ impl InstallCodeHelper {
                         original,
                         round,
                         err,
-                        self.take_canister_log(),
+                        self.clone_log_memory_store(),
                     );
                 }
             }
@@ -608,8 +614,11 @@ impl InstallCodeHelper {
         }
     }
 
-    /// Takes the canister log.
-    pub(crate) fn take_canister_log(&mut self) -> LogMemoryStore {
+    /// Returns a clone of the canister's log memory store.
+    ///
+    /// Cloning is cheap as the log memory store is backed by a persistent
+    /// `PageMap` whose clone creates an independent snapshot cheaply.
+    pub(crate) fn clone_log_memory_store(&self) -> LogMemoryStore {
         self.canister.system_state.log_memory_store.clone()
     }
 

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -111,7 +111,7 @@ pub(crate) fn execute_upgrade(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -128,7 +128,7 @@ pub(crate) fn execute_upgrade(
                 original,
                 round,
                 (canister_id, HypervisorError::WasmModuleNotFound).into(),
-                helper.take_canister_log(),
+                helper.clone_log_memory_store(),
             );
         }
     };
@@ -237,7 +237,7 @@ fn upgrade_stage_1_process_pre_upgrade_result(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -275,7 +275,7 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
                 original,
                 round,
                 err,
-                helper.take_canister_log(),
+                helper.clone_log_memory_store(),
             );
         }
     };
@@ -307,7 +307,7 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
                 original,
                 round,
                 err,
-                helper.take_canister_log(),
+                helper.clone_log_memory_store(),
             );
         }
     };
@@ -325,7 +325,7 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -438,7 +438,7 @@ fn upgrade_stage_3b_process_start_result(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
 
@@ -553,7 +553,7 @@ fn upgrade_stage_4b_process_post_upgrade_result(
             original,
             round,
             err,
-            helper.take_canister_log(),
+            helper.clone_log_memory_store(),
         );
     }
     helper.finish(clean_canister, original, round, round_limits)

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1869,7 +1869,6 @@ impl ExecutionEnvironment {
                                                 sender,
                                                 canister,
                                                 args,
-                                                self.config.log_memory_store_feature,
                                                 msg,
                                                 &self.cycles_account_manager,
                                                 subnet_cycles_config,

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -180,7 +180,6 @@ impl ExecutionServices {
             logger,
             config.rate_limiting_of_heap_delta,
             config.rate_limiting_of_instructions,
-            config.log_memory_store_feature,
             Arc::clone(&fd_factory),
         ));
 
@@ -380,7 +379,6 @@ fn setup_execution_helper(
         config.max_environment_variables,
         config.max_environment_variable_name_length,
         config.max_environment_variable_value_length,
-        config.log_memory_store_feature,
     );
     let canister_manager = Arc::new(CanisterManager::new(
         Arc::clone(&hypervisor),

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -204,13 +204,8 @@ impl InternalHttpQueryHandler {
                                 )
                             })?;
                     let result = Ok(WasmResult::Reply(
-                        fetch_canister_logs_response(
-                            query.source(),
-                            canister,
-                            args,
-                            self.config.log_memory_store_feature,
-                        )
-                        .map_err(UserError::from)?,
+                        fetch_canister_logs_response(query.source(), canister, args)
+                            .map_err(UserError::from)?,
                     ));
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::FetchCanisterLogs,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -26,9 +26,7 @@ use ic_interfaces::execution_environment::{
     IngressHistoryWriter, Scheduler, SubnetAvailableMemory,
 };
 use ic_logger::{ReplicaLogger, debug, error, fatal, info, new_logger, warn};
-use ic_management_canister_types_private::{
-    CanisterLogRecord, CanisterStatusType, Method as Ic00Method,
-};
+use ic_management_canister_types_private::{CanisterStatusType, Method as Ic00Method};
 use ic_metrics::MetricsRegistry;
 use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_subnet_type::SubnetType;
@@ -43,14 +41,13 @@ use ic_types::batch::ChainKeyData;
 use ic_types::ingress::{IngressState, IngressStatus};
 use ic_types::messages::{Ingress, MessageId, NO_DEADLINE, Response, SubnetMessage};
 use ic_types::{
-    CanisterId, CanisterLog, ComputeAllocation, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, ExecutionRound,
-    MemoryAllocation, NumBytes, NumInstructions, NumMessages, NumSlices, Randomness,
-    ReplicaVersion, Time,
+    CanisterId, ComputeAllocation, ExecutionRound, MemoryAllocation, NumBytes, NumInstructions,
+    NumMessages, NumSlices, Randomness, ReplicaVersion, Time,
 };
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use more_asserts::{debug_assert_ge, debug_assert_le, debug_assert_lt};
 use std::cell::RefCell;
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
@@ -156,7 +153,6 @@ pub(crate) struct SchedulerImpl {
     thread_pool: RefCell<scoped_threadpool::Pool>,
     rate_limiting_of_heap_delta: FlagStatus,
     rate_limiting_of_instructions: FlagStatus,
-    log_memory_store_feature: FlagStatus,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
 }
 
@@ -172,7 +168,6 @@ impl SchedulerImpl {
         log: ReplicaLogger,
         rate_limiting_of_heap_delta: FlagStatus,
         rate_limiting_of_instructions: FlagStatus,
-        log_memory_store_feature: FlagStatus,
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
     ) -> Self {
         let scheduler_cores = config.scheduler_cores as u32;
@@ -187,7 +182,6 @@ impl SchedulerImpl {
             log,
             rate_limiting_of_heap_delta,
             rate_limiting_of_instructions,
-            log_memory_store_feature,
             fd_factory,
         }
     }
@@ -1126,47 +1120,6 @@ impl Scheduler for SchedulerImpl {
         // When making changes to this method, please make sure each piece of code is covered by duration metrics.
         // The goal is to ensure that we can track the performance of `execute_round` and its individual components.
         let root_measurement_scope = MeasurementScope::root(&self.metrics.round);
-
-        if !state.metadata.logs_migrated {
-            let _timer = self
-                .metrics
-                .round_log_memory_store_migration_duration
-                .start_timer();
-            let log_memory_store_feature = self.log_memory_store_feature;
-            state.canisters_for_each_mut(|canister_id, canister| {
-                if log_memory_store_feature == FlagStatus::Enabled
-                    && !canister.system_state.log_memory_store.is_migrated()
-                {
-                    let system_state = &mut Arc::make_mut(canister).system_state;
-                    system_state.log_memory_store.resize(
-                        DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT,
-                        Arc::clone(&self.fd_factory),
-                    );
-                    let canister_log = &system_state.canister_log;
-                    let next_idx = canister_log.next_idx();
-                    let records = filter_canister_log_records(
-                        canister_log.records(),
-                        next_idx,
-                        *canister_id,
-                        &self.log,
-                    );
-                    let mut filtered_log = CanisterLog::new_aggregate(next_idx, records);
-                    system_state
-                        .log_memory_store
-                        .append_delta_log(&mut filtered_log);
-                    system_state.log_memory_store.set_migrated();
-                } else if log_memory_store_feature == FlagStatus::Disabled
-                    && canister.system_state.log_memory_store.is_migrated()
-                {
-                    let system_state = &mut Arc::make_mut(canister).system_state;
-                    system_state
-                        .log_memory_store
-                        .resize(0, Arc::clone(&self.fd_factory));
-                    system_state.log_memory_store.clear_migrated();
-                }
-            });
-            state.metadata.logs_migrated = true;
-        }
 
         let round_log;
         let mut csprng;
@@ -2141,60 +2094,6 @@ fn subnet_heap_delta_capacity(
         .unwrap_or(config.subnet_heap_delta_capacity)
 }
 
-/// Filters `records` to the contiguous suffix ending at `next_idx - 1`,
-/// logging and discarding any records with invalid or gap-preceding indices.
-fn filter_canister_log_records(
-    records: &VecDeque<CanisterLogRecord>,
-    next_idx: u64,
-    canister_id: CanisterId,
-    log: &ReplicaLogger,
-) -> Vec<CanisterLogRecord> {
-    let warn_drop = |record: &CanisterLogRecord, reason: &str| {
-        warn!(
-            log,
-            "Canister {}: dropping log record with idx {} ({} next_idx {})",
-            canister_id,
-            record.idx,
-            reason,
-            next_idx,
-        );
-    };
-    for record in records.iter().filter(|r| r.idx >= next_idx) {
-        warn_drop(record, ">=");
-    }
-    let mut filtered: Vec<_> = records.iter().cloned().collect();
-    filtered.retain(|r| r.idx < next_idx);
-    // Keep only the contiguous suffix ending at next_idx - 1,
-    // discarding any earlier records that precede a gap.
-    if next_idx > 0 {
-        if filtered.last().map(|r| r.idx) != Some(next_idx - 1) {
-            for record in &filtered {
-                warn_drop(record, "gap before");
-            }
-            filtered.clear();
-        } else {
-            let mut expected = next_idx - 1;
-            let mut contiguous_start = filtered.len() - 1;
-            for i in (0..filtered.len() - 1).rev() {
-                if expected == 0 {
-                    break;
-                }
-                if filtered[i].idx == expected - 1 {
-                    expected -= 1;
-                    contiguous_start = i;
-                } else {
-                    break;
-                }
-            }
-            for record in filtered.iter().take(contiguous_start) {
-                warn_drop(record, "gap before");
-            }
-            filtered.drain(..contiguous_start);
-        }
-    }
-    filtered
-}
-
 /// Aborts the paused execution, if any, of the given canister.
 ///
 /// If a paused execution was aborted, resets the canister's executed rounds to
@@ -2227,106 +2126,5 @@ pub fn abort_all_paused_executions(
     let (canister_states, subnet_schedule) = state.canisters_and_schedule_mut();
     for canister in canister_states.hot_values_mut() {
         abort_canister(canister, subnet_schedule, exec_env, cost_schedule, log);
-    }
-}
-
-#[cfg(test)]
-mod canister_log_filter_tests {
-    use super::filter_canister_log_records;
-    use ic_logger::no_op_logger;
-    use ic_management_canister_types_private::CanisterLogRecord;
-    use ic_types_test_utils::ids::canister_test_id;
-    use std::collections::VecDeque;
-
-    fn make_records(idxs: &[u64]) -> VecDeque<CanisterLogRecord> {
-        idxs.iter()
-            .map(|&idx| CanisterLogRecord {
-                idx,
-                timestamp_nanos: idx * 1_000,
-                content: format!("record {idx}").into_bytes(),
-            })
-            .collect()
-    }
-
-    fn filtered_idxs(records: &VecDeque<CanisterLogRecord>, next_idx: u64) -> Vec<u64> {
-        filter_canister_log_records(records, next_idx, canister_test_id(0), &no_op_logger())
-            .into_iter()
-            .map(|r| r.idx)
-            .collect()
-    }
-
-    #[test]
-    fn test_filter_single_record_from_zero() {
-        let records = make_records(&[0]);
-        assert_eq!(filtered_idxs(&records, 1), vec![0]);
-    }
-
-    #[test]
-    fn test_filter_single_record_nonzero() {
-        let records = make_records(&[42]);
-        assert_eq!(filtered_idxs(&records, 43), vec![42]);
-    }
-
-    #[test]
-    fn test_filter_duplicate_zero() {
-        // Two records at idx=0: walk breaks immediately (expected==0), first is dropped.
-        let records = make_records(&[0, 0]);
-        assert_eq!(filtered_idxs(&records, 1), vec![0]);
-    }
-
-    #[test]
-    fn test_filter_duplicate_nonzero() {
-        // Two records at idx=42: 42 != expected-1=41, breaks, first is dropped.
-        let records = make_records(&[42, 42]);
-        assert_eq!(filtered_idxs(&records, 43), vec![42]);
-    }
-
-    #[test]
-    fn test_filter_leading_duplicate_then_consecutive() {
-        // Walk reaches the second 0 (0==expected-1=0), then expected==0 breaks; first 0 dropped.
-        let records = make_records(&[0, 0, 1, 2]);
-        assert_eq!(filtered_idxs(&records, 3), vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn test_filter_duplicate_in_middle() {
-        // Walk: 3←2←1 (second 1), then first 1 != expected-1=0; first two records dropped.
-        let records = make_records(&[0, 1, 1, 2, 3]);
-        assert_eq!(filtered_idxs(&records, 4), vec![1, 2, 3]);
-    }
-
-    #[test]
-    fn test_filter_consecutive_from_zero() {
-        let records = make_records(&[0, 1, 2]);
-        assert_eq!(filtered_idxs(&records, 3), vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn test_filter_consecutive_nonzero() {
-        let records = make_records(&[10, 11, 12]);
-        assert_eq!(filtered_idxs(&records, 13), vec![10, 11, 12]);
-    }
-
-    #[test]
-    fn test_filter_leading_duplicates_before_gap() {
-        // Walk: 12←11←10, then idx=0 != expected-1=9; first two records dropped.
-        let records = make_records(&[0, 0, 10, 11, 12]);
-        assert_eq!(filtered_idxs(&records, 13), vec![10, 11, 12]);
-    }
-
-    #[test]
-    fn test_filter_gap_suffix() {
-        // records [10, 11, 20, 21, 22], next_idx=23
-        // → [10, 11] precede a gap at [12..19]; only contiguous suffix [20, 21, 22] survives
-        let records = make_records(&[10, 11, 20, 21, 22]);
-        assert_eq!(filtered_idxs(&records, 23), vec![20, 21, 22]);
-    }
-
-    #[test]
-    fn test_filter_gap_end() {
-        // records [10, 11, 20, 21, 22], next_idx=24
-        // → last record (idx=22) != next_idx-1 (23), so all records are discarded
-        let records = make_records(&[10, 11, 20, 21, 22]);
-        assert_eq!(filtered_idxs(&records, 24), Vec::<u64>::new());
     }
 }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -31,7 +31,6 @@ pub struct SchedulerMetrics {
     pub(super) inner_round_loop_consumed_max_instructions: IntCounter,
     pub(super) num_canisters_uninstalled_out_of_cycles: IntCounter,
     pub(super) round: ScopedMetrics,
-    pub(super) round_log_memory_store_migration_duration: Histogram,
     pub(super) round_preparation_duration: Histogram,
     pub(super) round_preparation_ingress: Histogram,
     pub(super) round_consensus_queue: ScopedMetrics,
@@ -180,7 +179,6 @@ impl SchedulerMetrics {
                     metrics_registry,
                 ),
             },
-            round_log_memory_store_migration_duration: round_phase_duration_histogram("log_memory_store_migration", metrics_registry),
             round_preparation_duration: round_phase_duration_histogram("preparation", metrics_registry),
             // Expiration of messages in the ingress queue.
             round_preparation_ingress: round_preparation_phase_duration_histogram("expire ingress", metrics_registry),

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -1100,7 +1100,6 @@ impl SchedulerTestBuilder {
             self.log,
             rate_limiting_of_heap_delta,
             rate_limiting_of_instructions,
-            config.log_memory_store_feature,
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
         );
 

--- a/rs/execution_environment/tests/backtraces.rs
+++ b/rs/execution_environment/tests/backtraces.rs
@@ -81,8 +81,8 @@ fn assert_error(
         .execute_ingress_as(CONTROLLER, canister_id, method, Encode!(&()).unwrap())
         .unwrap_err();
     result.assert_matches(code, &format!("{message}.*{backtrace}.*"));
-    let logs = env.canister_log(canister_id);
-    let last_error = std::str::from_utf8(&logs.records().back().as_ref().unwrap().content).unwrap();
+    let logs = env.canister_log_records(canister_id);
+    let last_error = std::str::from_utf8(&logs.last().as_ref().unwrap().content).unwrap();
     let backtrace_regex = RegexBuilder::new(&format!(".*{backtrace}.*"))
         .dot_matches_new_line(true)
         .build()
@@ -129,8 +129,8 @@ fn no_backtrace_without_name_section() {
         "Result message: {} cointains unexpected 'Backtrace'",
         result.description(),
     );
-    let logs = env.canister_log(canister_id);
-    for log in logs.records() {
+    let logs = env.canister_log_records(canister_id);
+    for log in &logs {
         let log = std::str::from_utf8(&log.content).unwrap();
         assert!(
             !log.contains("Backtrace"),
@@ -236,9 +236,8 @@ mod visibility {
             );
         }
         // The backtrace should still be in the logs.
-        let logs = env.canister_log(canister_id);
-        let last_error =
-            std::str::from_utf8(&logs.records().back().as_ref().unwrap().content).unwrap();
+        let logs = env.canister_log_records(canister_id);
+        let last_error = std::str::from_utf8(&logs.last().as_ref().unwrap().content).unwrap();
         assert!(
             backtrace_regex.is_match(last_error),
             "Last log:\n----------\n{last_error}\n----------\ndoesn't contain backtrace: {backtrace}"

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -1000,7 +1000,7 @@ fn test_canister_log_in_state_stays_within_limit() {
         let _ = env.execute_ingress(canister_id, "test", vec![]);
     }
     // Expect that the total size of the log in canister state is not zero and less than the limit.
-    let log_size = env.canister_log(canister_id).bytes_used();
+    let log_size = env.canister_log_bytes_used(canister_id);
     assert_lt!(0, log_size);
     assert_le!(log_size, TEST_DEFAULT_LOG_MEMORY_LIMIT);
 }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -15,9 +15,7 @@ use ic_state_machine_tests::{
     ErrorCode, StateMachine, StateMachineBuilder, StateMachineConfig, SubmitIngressError, UserError,
 };
 use ic_test_utilities::universal_canister::{UNIVERSAL_CANISTER_WASM, call_args, wasm};
-use ic_test_utilities_execution_environment::{
-    get_reject, get_reply, wat_canister, wat_fn,
-};
+use ic_test_utilities_execution_environment::{get_reject, get_reply, wat_canister, wat_fn};
 use ic_test_utilities_metrics::{fetch_histogram_stats, fetch_histogram_vec_stats, labels};
 use ic_types::{CanisterId, NumInstructions, ingress::WasmResult};
 use ic_types_cycles::Cycles;

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -1,12 +1,8 @@
 use ic_base_types::PrincipalId;
-use ic_config::execution_environment::{
-    Config as ExecutionConfig, LOG_MEMORY_STORE_FEATURE, LOG_MEMORY_STORE_FEATURE_ENABLED,
-    TEST_DEFAULT_LOG_MEMORY_USAGE,
-};
+use ic_config::execution_environment::{Config as ExecutionConfig, TEST_DEFAULT_LOG_MEMORY_USAGE};
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SubnetConfig;
 use ic_execution_environment::units::{KIB, MIB};
-use ic_interfaces_state_manager::{CertificationScope, StateManager};
 use ic_management_canister_types_private::{
     self as ic00, BoundedAllowedViewers, CanisterIdRecord, CanisterInstallMode, CanisterLogRecord,
     CanisterSettingsArgs, CanisterSettingsArgsBuilder, DataSize, EmptyBlob,
@@ -20,10 +16,10 @@ use ic_state_machine_tests::{
 };
 use ic_test_utilities::universal_canister::{UNIVERSAL_CANISTER_WASM, call_args, wasm};
 use ic_test_utilities_execution_environment::{
-    ExecutionTestBuilder, get_reject, get_reply, wat_canister, wat_fn,
+    get_reject, get_reply, wat_canister, wat_fn,
 };
 use ic_test_utilities_metrics::{fetch_histogram_stats, fetch_histogram_vec_stats, labels};
-use ic_types::{CanisterId, CanisterLog, NumInstructions, ingress::WasmResult};
+use ic_types::{CanisterId, NumInstructions, ingress::WasmResult};
 use ic_types_cycles::Cycles;
 use more_asserts::{assert_gt, assert_le, assert_lt};
 use proptest::{prelude::ProptestConfig, prop_assume};
@@ -102,7 +98,6 @@ fn setup_env_with(replicated_inter_canister_log_fetch: FlagStatus) -> StateMachi
         subnet_config,
         ExecutionConfig {
             replicated_inter_canister_log_fetch,
-            log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,
             ..Default::default()
         },
     );
@@ -1752,45 +1747,11 @@ const METRIC_BYTES_OVERHEAD_FACTOR: f64 = 1.05;
 const METRIC_PAYLOAD_SIZE: usize = 1_000;
 
 #[test]
-fn test_metric_canister_log_memory_usage_bytes_from_canister_log() {
-    // When the log memory store feature is disabled, the metric tracks
-    // `CanisterLog.bytes_used()`, which grows with each debug_print.
-    if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
-    const METRIC: &str = "canister_log_memory_usage_bytes_v3";
-    let env = setup_env();
-    let canister_id = create_and_install_canister(
-        &env,
-        CanisterSettingsArgsBuilder::new().build(),
-        wat_canister()
-            .update("test", wat_fn().debug_print(&[37; METRIC_PAYLOAD_SIZE]))
-            .build_wasm(),
-    );
-
-    // Nothing logged yet — sum is zero.
-    let stats = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
-    assert_eq!(stats.sum, 0.0);
-
-    // One debug_print — sum reflects the payload plus small record metadata.
-    let _ = env.execute_ingress(canister_id, "test", vec![]);
-    let stats = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
-    assert_le!(METRIC_PAYLOAD_SIZE as f64, stats.sum);
-    assert_le!(
-        stats.sum,
-        METRIC_BYTES_OVERHEAD_FACTOR * METRIC_PAYLOAD_SIZE as f64
-    );
-}
-
-#[test]
 fn test_metric_canister_log_memory_usage_bytes_from_log_memory_store() {
-    // When the log memory store feature is enabled, the metric tracks
-    // `LogMemoryStore.memory_usage()` — the allocated capacity of the store.
-    // It is set at canister creation from the default limit and stays stable
-    // under debug_print; only a `log_memory_limit` resize changes it.
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
+    // The metric tracks `LogMemoryStore.memory_usage()` — the allocated
+    // capacity of the store. It is set at canister creation from the default
+    // limit and stays stable under debug_print; only a `log_memory_limit`
+    // resize changes it.
     const METRIC: &str = "canister_log_memory_usage_bytes_v3";
     let env = setup_env();
     let canister_id = create_and_install_canister(
@@ -1851,9 +1812,7 @@ fn test_metric_canister_log_delta_memory_usage_bytes() {
 fn test_metric_canister_log_retention_seconds() {
     // Observed by the scheduler at round finalization for canisters that
     // appended log records this round. Retention is the wall-clock span
-    // between the oldest and newest records held in the buffer. Both log
-    // stores (old `CanisterLog` and new `LogMemoryStore`) compute it the
-    // same way — the assertions hold regardless of the feature flag.
+    // between the oldest and newest records held in the `LogMemoryStore`.
     const METRIC: &str = "canister_log_retention_seconds";
     const TIME_ADVANCE: Duration = Duration::from_secs(60);
     let env = setup_env();
@@ -1885,9 +1844,6 @@ fn test_metric_canister_log_resize_duration_seconds() {
     // Observed at the resize call site in `CanisterManager::update_settings`
     // whenever `log_memory_limit` actually changes. The `would_resize` gate
     // ensures no-op resizes (same limit) do not emit samples.
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     const METRIC: &str = "canister_log_resize_duration_seconds";
     let controller = PrincipalId::new_anonymous();
     let (env, canister_id) = setup_with_controller(controller, UNIVERSAL_CANISTER_WASM.to_vec());
@@ -2087,9 +2043,6 @@ fn test_canister_log_on_cleanup() {
 
 #[test]
 fn test_default_log_memory_limit_and_size() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let (env, canister_id) = setup_with_controller(controller, UNIVERSAL_CANISTER_WASM.to_vec());
 
@@ -2106,9 +2059,6 @@ fn test_default_log_memory_limit_and_size() {
 
 #[test]
 fn test_changing_log_memory_limit_and_size() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let (env, canister_id) = setup_with_controller(controller, UNIVERSAL_CANISTER_WASM.to_vec());
 
@@ -2133,9 +2083,6 @@ fn test_changing_log_memory_limit_and_size() {
 
 #[test]
 fn test_setting_log_memory_limit_to_zero() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let (env, canister_id) = setup_with_controller(controller, UNIVERSAL_CANISTER_WASM.to_vec());
 
@@ -2156,9 +2103,6 @@ fn test_setting_log_memory_limit_to_zero() {
 
 #[test]
 fn test_canister_reinstall_clears_logs_but_preserves_log_memory_limit() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let expected_memory_usage = 8 * KIB + TEST_DEFAULT_LOG_MEMORY_LIMIT as u64;
     let controller = PrincipalId::new_anonymous();
     let wasm = wat_canister()
@@ -2187,9 +2131,6 @@ fn test_canister_reinstall_clears_logs_but_preserves_log_memory_limit() {
 
 #[test]
 fn test_canister_uninstall_code_clears_logs() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let wasm = wat_canister()
         .update("test", wat_fn().debug_print(b"hello"))
@@ -2231,9 +2172,6 @@ fn test_canister_uninstall_code_clears_logs() {
 
 #[test]
 fn test_canister_uninstall_and_install_clears_log() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let wasm = wat_canister()
         .update("test", wat_fn().debug_print(b"hello"))
@@ -2265,9 +2203,6 @@ fn test_canister_uninstall_and_install_clears_log() {
 
 #[test]
 fn test_large_delta_log_in_single_execution() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     // Test that a single message execution can generate a large delta log
     // (e.g., ~1.5 MiB) that exceeds the default 4 KiB capacity but is still
     // within the configured canister log memory limit.
@@ -2300,9 +2235,6 @@ fn test_large_delta_log_in_single_execution() {
 
 #[test]
 fn test_canister_resize_up_preserves_logs() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let log_memory_limit = 2 * MIB;
 
     let env = setup_env();
@@ -2353,9 +2285,6 @@ fn test_canister_resize_up_preserves_logs() {
 
 #[test]
 fn test_canister_resize_down_preserves_logs() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let log_memory_limit = 2 * MIB;
 
     let env = setup_env();
@@ -2406,9 +2335,6 @@ fn test_canister_resize_down_preserves_logs() {
 
 #[test]
 fn test_canister_log_resize_deducts_cycles() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let log_memory_limit = 2 * MIB;
 
     let env = setup_env();
@@ -2460,9 +2386,6 @@ fn test_canister_log_resize_deducts_cycles() {
 
 #[test]
 fn test_canister_log_resize_rejected_insufficient_cycles() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let log_memory_limit = 256 * KIB;
 
     let env = setup_env();
@@ -2513,9 +2436,6 @@ fn test_canister_log_resize_rejected_insufficient_cycles() {
 
 #[test]
 fn test_canister_log_resize_empty_buffer_minimal_charge() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let log_memory_limit = 2 * MIB;
     let env = setup_env();
     let controller = PrincipalId::new_anonymous();
@@ -2554,60 +2474,6 @@ fn test_canister_log_resize_empty_buffer_minimal_charge() {
         resize_cost,
         baseline_cost * 2,
         "Empty buffer resize cost ({}) should be close to baseline ({})",
-        resize_cost,
-        baseline_cost
-    );
-}
-
-#[test]
-fn test_canister_log_resize_no_extra_charge_feature_disabled() {
-    if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
-    let env = setup_env();
-    let controller = PrincipalId::new_anonymous();
-    let canister_id = create_and_install_canister(
-        &env,
-        CanisterSettingsArgsBuilder::new()
-            .with_controllers(vec![controller])
-            .build(),
-        wat_canister()
-            .update("test", wat_fn().debug_print(b"hello"))
-            .build_wasm(),
-    );
-
-    // Write some logs (goes to old canister_log, not log_memory_store).
-    let _ = env.execute_ingress(canister_id, "test", vec![]);
-    let _ = env.execute_ingress(canister_id, "test", vec![]);
-    let _ = env.execute_ingress(canister_id, "test", vec![]);
-
-    // Baseline: update_settings without log_memory_limit.
-    let balance_before_baseline = env.cycle_balance(canister_id);
-    let _ = env.update_settings(
-        &canister_id,
-        CanisterSettingsArgsBuilder::new()
-            .with_log_visibility(LogVisibilityV2::Public)
-            .build(),
-    );
-    let baseline_cost = balance_before_baseline - env.cycle_balance(canister_id);
-
-    // Update_settings with log_memory_limit — should cost the same as baseline
-    // because log_memory_store.bytes_used() is 0 when the feature is disabled.
-    let balance_before_resize = env.cycle_balance(canister_id);
-    let result = env.update_settings(
-        &canister_id,
-        CanisterSettingsArgsBuilder::new()
-            .with_log_memory_limit(4096)
-            .build(),
-    );
-    assert!(result.is_ok());
-    let resize_cost = balance_before_resize - env.cycle_balance(canister_id);
-
-    // Costs should be roughly equal — no extra charge for resize.
-    assert_le!(
-        resize_cost,
-        baseline_cost * 2,
-        "With feature disabled, resize cost ({}) should be close to baseline ({})",
         resize_cost,
         baseline_cost
     );
@@ -2695,395 +2561,10 @@ fn test_fetch_canister_logs_update_call_deducts_cycles() {
 }
 
 #[test]
-fn test_log_memory_store_feature_flag_via_execution_test_builder() {
-    // With the flag disabled, canister creation does not allocate a ring buffer.
-    let mut test = ExecutionTestBuilder::new()
-        .with_log_memory_store_feature_disabled()
-        .build();
-    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
-    assert_eq!(
-        test.canister_status(canister_id)
-            .unwrap()
-            .log_memory_store_size()
-            .get(),
-        0,
-    );
-
-    // With the flag enabled, canister creation allocates the ring buffer.
-    let mut test = ExecutionTestBuilder::new()
-        .with_log_memory_store_feature_enabled()
-        .build();
-    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
-    assert_gt!(
-        test.canister_status(canister_id)
-            .unwrap()
-            .log_memory_store_size()
-            .get(),
-        0,
-    );
-}
-
-#[test]
-fn test_log_memory_store_upgrade_downgrade() {
-    let controller = PrincipalId::new_anonymous();
-    let subnet_type = SubnetType::Application;
-
-    let check_records = |env: &StateMachine,
-                         canister_id: CanisterId,
-                         expected_len: usize,
-                         expected_last_idx: u64,
-                         expected_last_content: &Vec<u8>| {
-        let records = fetch_log_records(env, controller, canister_id);
-        assert_eq!(records.len(), expected_len);
-        assert_eq!(
-            records.last().map(|r| (r.idx, &r.content)),
-            Some((expected_last_idx, expected_last_content))
-        );
-    };
-    let check_canister_log =
-        |env: &StateMachine, canister_id: CanisterId, expected_next_idx: u64| {
-            let state = env.get_latest_state();
-            let ss = &state.canister_state(&canister_id).unwrap().system_state;
-            assert_eq!(ss.canister_log.next_idx(), expected_next_idx);
-        };
-    let check_lms = |env: &StateMachine,
-                     canister_id: CanisterId,
-                     expected_migrated: bool,
-                     expected_allocated: bool,
-                     expected_empty: bool,
-                     expected_next_idx: u64| {
-        let state = env.get_latest_state();
-        let lms = &state
-            .canister_state(&canister_id)
-            .unwrap()
-            .system_state
-            .log_memory_store;
-        assert_eq!(lms.is_migrated(), expected_migrated);
-        assert_eq!(lms.is_allocated(), expected_allocated);
-        assert_eq!(lms.is_empty(), expected_empty);
-        assert_eq!(lms.next_idx(), expected_next_idx);
-    };
-
-    // Step 1: StateMachine with log_memory_store feature disabled. Install canisters
-    // and produce log entries that land in canister_log (legacy storage).
-    let env = StateMachineBuilder::new()
-        .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type),
-            ExecutionConfig {
-                log_memory_store_feature: FlagStatus::Disabled,
-                ..Default::default()
-            },
-        )))
-        .with_subnet_type(subnet_type)
-        .with_checkpoints_enabled(true)
-        .build();
-
-    let canister_settings = || {
-        CanisterSettingsArgsBuilder::new()
-            .with_log_visibility(LogVisibilityV2::Public)
-            .with_controllers(vec![controller])
-            .build()
-    };
-
-    // canister_many: receives 200+ messages, exercises wrap-around in canister_log.
-    let canister_many =
-        create_and_install_canister(&env, canister_settings(), UNIVERSAL_CANISTER_WASM.to_vec());
-    // canister_cleared: receives 42 log messages then gets uninstalled, so logs are
-    // cleared but next_idx is preserved at 42.
-    let canister_cleared =
-        create_and_install_canister(&env, canister_settings(), UNIVERSAL_CANISTER_WASM.to_vec());
-    // canister_few: one log before migration, one after, one after downgrade (3 total).
-    let canister_few =
-        create_and_install_canister(&env, canister_settings(), UNIVERSAL_CANISTER_WASM.to_vec());
-
-    // Execute enough messages to cause wrap-around in the legacy canister_log storage.
-    let num_pre_migration = 200_usize;
-    for i in 0..num_pre_migration {
-        let msg = format!("hello migration {i}");
-        let _ = env.execute_ingress(
-            canister_many,
-            "update",
-            wasm().debug_print(msg.as_bytes()).reply().build(),
-        );
-    }
-    let last_pre_migration_msg = format!("hello migration {}", num_pre_migration - 1).into_bytes();
-
-    let records = fetch_log_records(&env, controller, canister_many);
-    let pre_migration_len = records.len();
-    // Wrap-around dropped old records: fewer survive than were produced.
-    assert!(pre_migration_len < num_pre_migration);
-    // next_idx advances for every produced record, including dropped ones.
-    check_canister_log(&env, canister_many, num_pre_migration as u64);
-    check_lms(&env, canister_many, false, false, true, 0);
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64 - 1,
-        &last_pre_migration_msg,
-    );
-
-    let num_cleared_logs = 42_usize;
-    for i in 0..num_cleared_logs {
-        let msg = format!("to be cleared {i}");
-        let _ = env.execute_ingress(
-            canister_cleared,
-            "update",
-            wasm().debug_print(msg.as_bytes()).reply().build(),
-        );
-    }
-    let _ = env.uninstall_code(canister_cleared).unwrap();
-    // After uninstall: records are cleared but next_idx is preserved.
-    assert!(fetch_log_records(&env, controller, canister_cleared).is_empty());
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(&env, canister_cleared, false, false, true, 0);
-
-    let log_0 = b"log 0".to_vec();
-    let _ = env.execute_ingress(
-        canister_few,
-        "update",
-        wasm().debug_print(&log_0).reply().build(),
-    );
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(&env, canister_cleared, false, false, true, 0);
-
-    check_canister_log(&env, canister_few, 1);
-    check_lms(&env, canister_few, false, false, true, 0);
-    check_records(&env, canister_few, 1, 0, &log_0);
-
-    // Step 2: Restart with log_memory_store feature enabled. Before any round
-    // executes, migration has not run yet: is_migrated=false, is_allocated=false,
-    // but fetch_canister_logs still works via the canister_log fallback.
-    let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type),
-        ExecutionConfig {
-            log_memory_store_feature: FlagStatus::Enabled,
-            ..Default::default()
-        },
-    ));
-
-    // canister_log next_idx survives the restart via the checkpoint.
-    check_canister_log(&env, canister_many, num_pre_migration as u64);
-    // log_memory_store is not yet migrated; next_idx is 0 until migration runs.
-    check_lms(&env, canister_many, false, false, true, 0);
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64 - 1,
-        &last_pre_migration_msg,
-    );
-
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(&env, canister_cleared, false, false, true, 0);
-
-    check_canister_log(&env, canister_few, 1);
-    check_lms(&env, canister_few, false, false, true, 0);
-    check_records(&env, canister_few, 1, 0, &log_0);
-
-    // Step 3: Execute a round to trigger migration. Afterwards is_migrated=true,
-    // is_allocated=true, log_memory_store contains the migrated records, and
-    // fetch_canister_logs reads from log_memory_store.
-    env.tick();
-
-    // After migration next_idx matches the canister_log next_idx.
-    check_canister_log(&env, canister_many, num_pre_migration as u64);
-    check_lms(
-        &env,
-        canister_many,
-        true,
-        true,
-        false,
-        num_pre_migration as u64,
-    );
-    // Migration must preserve exactly the records that survived wrap-around.
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64 - 1,
-        &last_pre_migration_msg,
-    );
-
-    // Cleared canister: migrated and allocated but has no records; next_idx carried over from uninstall.
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(
-        &env,
-        canister_cleared,
-        true,
-        true,
-        true,
-        num_cleared_logs as u64,
-    );
-
-    check_canister_log(&env, canister_few, 1);
-    check_lms(&env, canister_few, true, true, false, 1);
-    check_records(&env, canister_few, 1, 0, &log_0);
-
-    // Step 4: After migration, produce new log entries and verify they can be queried
-    // from log_memory_store together with the migrated records.
-    let post_migration_msg = format!("hello migration {num_pre_migration}").into_bytes();
-    let _ = env.execute_ingress(
-        canister_many,
-        "update",
-        wasm().debug_print(&post_migration_msg).reply().build(),
-    );
-
-    let log_1 = b"log 1".to_vec();
-    let _ = env.execute_ingress(
-        canister_few,
-        "update",
-        wasm().debug_print(&log_1).reply().build(),
-    );
-
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len + 1,
-        num_pre_migration as u64,
-        &post_migration_msg,
-    );
-    check_lms(
-        &env,
-        canister_many,
-        true,
-        true,
-        false,
-        num_pre_migration as u64 + 1,
-    );
-    check_canister_log(&env, canister_many, num_pre_migration as u64 + 1);
-
-    check_lms(
-        &env,
-        canister_cleared,
-        true,
-        true,
-        true,
-        num_cleared_logs as u64,
-    );
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-
-    check_lms(&env, canister_few, true, true, false, 2);
-    check_canister_log(&env, canister_few, 2);
-    check_records(&env, canister_few, 2, 1, &log_1);
-
-    // Step 5: Downgrade — restart with log_memory_store feature disabled.
-    // The checkpoint still has migrated=true since it was saved after step 3.
-    let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type),
-        ExecutionConfig {
-            log_memory_store_feature: FlagStatus::Disabled,
-            ..Default::default()
-        },
-    ));
-
-    // Before any round, lms is still marked migrated as loaded from the checkpoint.
-    check_canister_log(&env, canister_many, num_pre_migration as u64 + 1);
-    check_lms(
-        &env,
-        canister_many,
-        true,
-        true,
-        false,
-        num_pre_migration as u64 + 1,
-    );
-    // With the feature disabled, fetch_canister_logs reads from canister_log, not lms.
-    // canister_log uses CanisterLogRecord
-    // while lms stores records more compactly (less overhead per record).
-    // Both have the same 4 KiB byte capacity, but canister_log fits fewer records before
-    // wrapping. By step 4, canister_log was already at its wrap point (pre_migration_len records),
-    // while lms had room for one more — so they now differ by one record.
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64,
-        &post_migration_msg,
-    );
-
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(
-        &env,
-        canister_cleared,
-        true,
-        true,
-        true,
-        num_cleared_logs as u64,
-    );
-
-    check_canister_log(&env, canister_few, 2);
-    check_lms(&env, canister_few, true, true, false, 2);
-    check_records(&env, canister_few, 2, 1, &log_1);
-
-    // Execute a round to trigger the downgrade.
-    env.tick();
-
-    // After downgrade, lms is deallocated, the migration flag is cleared,
-    // and persistent_next_idx is reset to zero in lms.
-    check_canister_log(&env, canister_many, num_pre_migration as u64 + 1);
-    check_lms(&env, canister_many, false, false, true, 0);
-    // fetch_canister_logs falls back to canister_log after downgrade.
-    // canister_log was at capacity before step 4, so it wrapped around and still
-    // holds pre_migration_len records with the post-migration message at the tail.
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64,
-        &post_migration_msg,
-    );
-
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(&env, canister_cleared, false, false, true, 0);
-
-    check_canister_log(&env, canister_few, 2);
-    check_lms(&env, canister_few, false, false, true, 0);
-    check_records(&env, canister_few, 2, 1, &log_1);
-
-    // Execute messages after downgrade: new logs go only to canister_log since
-    // lms is not migrated. canister_log wraps around again, keeping pre_migration_len records.
-    let post_downgrade_msg = format!("hello migration {}", num_pre_migration + 1).into_bytes();
-    let _ = env.execute_ingress(
-        canister_many,
-        "update",
-        wasm().debug_print(&post_downgrade_msg).reply().build(),
-    );
-
-    let log_2 = b"log 2".to_vec();
-    let _ = env.execute_ingress(
-        canister_few,
-        "update",
-        wasm().debug_print(&log_2).reply().build(),
-    );
-
-    check_canister_log(&env, canister_many, num_pre_migration as u64 + 2);
-    check_lms(&env, canister_many, false, false, true, 0);
-    check_records(
-        &env,
-        canister_many,
-        pre_migration_len,
-        num_pre_migration as u64 + 1,
-        &post_downgrade_msg,
-    );
-
-    check_canister_log(&env, canister_cleared, num_cleared_logs as u64);
-    check_lms(&env, canister_cleared, false, false, true, 0);
-
-    check_canister_log(&env, canister_few, 3);
-    check_lms(&env, canister_few, false, false, true, 0);
-    check_records(&env, canister_few, 3, 2, &log_2);
-}
-
-#[test]
 fn test_canister_log_with_zero_log_memory_limit() {
     let subnet_type = SubnetType::Application;
-    let config = StateMachineConfig::new(
-        SubnetConfig::new(subnet_type),
-        ExecutionConfig {
-            log_memory_store_feature: FlagStatus::Enabled,
-            ..Default::default()
-        },
-    );
+    let config =
+        StateMachineConfig::new(SubnetConfig::new(subnet_type), ExecutionConfig::default());
     let env = StateMachineBuilder::new()
         .with_config(Some(config.clone()))
         .with_subnet_type(subnet_type)
@@ -3111,20 +2592,18 @@ fn test_canister_log_with_zero_log_memory_limit() {
             .build(),
     );
 
-    // Produce a second log with no ring buffer. Both canister_log and
-    // persistent_next_idx advance to next_idx == 2.
+    // Produce a second log with no ring buffer. persistent_next_idx advances
+    // to next_idx == 2.
     let _ = env.execute_ingress(
         canister_id,
         "update",
         wasm().debug_print(b"log").reply().build(),
     );
 
-    // Both canister_log.next_idx() and lms.next_idx() must be 2 before
-    // and after a checkpoint/reload cycle.
+    // lms.next_idx() must be 2 before and after a checkpoint/reload cycle.
     let check_next_idx = |env: &StateMachine| {
         let state = env.get_latest_state();
         let ss = &state.canister_state(&canister_id).unwrap().system_state;
-        assert_eq!(ss.canister_log.next_idx(), 2);
         assert_eq!(ss.log_memory_store.next_idx(), 2);
     };
     check_next_idx(&env);
@@ -3136,9 +2615,6 @@ fn test_canister_log_with_zero_log_memory_limit() {
 #[test]
 fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
     // Test that the log memory store is deallocated when a canister runs out of cycles.
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let controller = PrincipalId::new_anonymous();
     let env = setup_env();
     // Use 300T cycles — enough to satisfy the freeze-threshold reserve for
@@ -3198,100 +2674,5 @@ fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
             .system_state
             .log_memory_store
             .is_allocated()
-    );
-}
-
-#[test]
-fn test_log_memory_store_migration_filters_gap_records() {
-    // Regression test: canister_log records may have gaps in their idx sequence.
-    // Only the contiguous suffix ending at next_idx - 1 must be migrated.
-    //
-    // Records [10, 11, 20, 21, 22] have a gap at [12..19]; with next_idx=23
-    // only the contiguous suffix [20, 21, 22] survives.
-    let controller = PrincipalId::new_anonymous();
-    let subnet_type = SubnetType::Application;
-
-    let env = StateMachineBuilder::new()
-        .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type),
-            ExecutionConfig {
-                log_memory_store_feature: FlagStatus::Disabled,
-                ..Default::default()
-            },
-        )))
-        .with_subnet_type(subnet_type)
-        .with_checkpoints_enabled(true)
-        .build();
-
-    let canister_id = create_and_install_canister(
-        &env,
-        CanisterSettingsArgsBuilder::new()
-            .with_log_visibility(LogVisibilityV2::Public)
-            .with_controllers(vec![controller])
-            .build(),
-        UNIVERSAL_CANISTER_WASM.to_vec(),
-    );
-
-    {
-        let (_height, mut state) = env.state_manager.take_tip();
-        let arc = state.take_canister_state(&canister_id).unwrap();
-        let mut c = (*arc).clone();
-        // next_idx=23: last record (idx=22) == next_idx-1; gap at [12..19] causes
-        // [10, 11] to be dropped, leaving contiguous suffix [20, 21, 22].
-        c.system_state.canister_log = CanisterLog::new_aggregate(
-            23,
-            vec![
-                CanisterLogRecord {
-                    idx: 10,
-                    timestamp_nanos: 1_000,
-                    content: b"a".to_vec(),
-                },
-                CanisterLogRecord {
-                    idx: 11,
-                    timestamp_nanos: 1_001,
-                    content: b"b".to_vec(),
-                },
-                CanisterLogRecord {
-                    idx: 20,
-                    timestamp_nanos: 2_000,
-                    content: b"c".to_vec(),
-                },
-                CanisterLogRecord {
-                    idx: 21,
-                    timestamp_nanos: 2_001,
-                    content: b"d".to_vec(),
-                },
-                CanisterLogRecord {
-                    idx: 22,
-                    timestamp_nanos: 2_002,
-                    content: b"e".to_vec(),
-                },
-            ],
-        );
-        state.put_canister_state(c);
-        env.state_manager
-            .commit_and_certify(state, CertificationScope::Full, None);
-    }
-
-    let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type),
-        ExecutionConfig {
-            log_memory_store_feature: FlagStatus::Enabled,
-            ..Default::default()
-        },
-    ));
-
-    env.tick();
-
-    let state = env.get_latest_state();
-    let ss = &state.canister_state(&canister_id).unwrap().system_state;
-    assert!(ss.log_memory_store.is_migrated());
-    assert!(ss.log_memory_store.is_allocated());
-    assert!(!ss.log_memory_store.is_empty());
-    assert_eq!(ss.log_memory_store.next_idx(), 23);
-    let records = ss.log_memory_store.records(None);
-    assert_eq!(
-        records.iter().map(|r| r.idx).collect::<Vec<_>>(),
-        vec![20, 21, 22]
     );
 }

--- a/rs/execution_environment/tests/memory_matrix.rs
+++ b/rs/execution_environment/tests/memory_matrix.rs
@@ -35,7 +35,6 @@ The scenarios cover the following:
 */
 
 use ic_base_types::{CanisterId, NumBytes, PrincipalId, SnapshotId};
-use ic_config::execution_environment::LOG_MEMORY_STORE_FEATURE_ENABLED;
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_error_types::{ErrorCode, UserError};
 use ic_execution_environment::units::{GIB, KIB};
@@ -1628,9 +1627,6 @@ fn test_memory_suite_decrease_memory_allocation() {
 
 #[test]
 fn test_memory_suite_increase_log_memory_limit() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let op = |test: &mut ExecutionTest, canister_id: CanisterId, ()| {
         let update_settings_args =
             update_memory_allocation_args(canister_id, None, Some(1024 * KIB));
@@ -1648,9 +1644,6 @@ fn test_memory_suite_increase_log_memory_limit() {
 
 #[test]
 fn test_memory_suite_increase_log_memory_limit_and_memory_allocation() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let op = |test: &mut ExecutionTest, canister_id: CanisterId, ()| {
         let current_memory_allocation = test
             .canister_state(canister_id)
@@ -1675,9 +1668,6 @@ fn test_memory_suite_increase_log_memory_limit_and_memory_allocation() {
 
 #[test]
 fn test_memory_suite_decrease_log_memory_limit() {
-    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
-        return;
-    }
     let op = |test: &mut ExecutionTest, canister_id: CanisterId, ()| {
         let update_settings_args =
             update_memory_allocation_args(canister_id, None, Some(256 * KIB));

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1963,9 +1963,9 @@ fn test_notify_caller_logging() {
     );
 
     // Verify that the ledger logged the caller of the notify method.
-    let log = env.canister_log(canister_id);
+    let log = env.canister_log_records(canister_id);
     let expected_log_entry = format!("notify method called by [{user1}]");
-    for record in log.records().iter() {
+    for record in log.iter() {
         let entry =
             String::from_utf8(record.content.clone()).expect("log entry should be a string");
         if entry.contains(&expected_log_entry) {

--- a/rs/migration_canister/tests/tests.rs
+++ b/rs/migration_canister/tests/tests.rs
@@ -1,7 +1,6 @@
 use candid::{CandidType, Decode, Encode, Principal, Reserved};
 use canister_test::Project;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_config::execution_environment::LOG_MEMORY_STORE_FEATURE_ENABLED;
 use ic_management_canister_types::{CanisterLogRecord, CanisterSettings};
 use ic_management_canister_types_private::{
     CanisterChangeDetails, CanisterInfoRequest, CanisterInfoResponse, Payload as _,
@@ -182,11 +181,7 @@ async fn setup(
         let cycles = if enough_cycles {
             None
         } else {
-            Some(if LOG_MEMORY_STORE_FEATURE_ENABLED {
-                40_000_000_000
-            } else {
-                30_000_000_000
-            })
+            Some(40_000_000_000)
         };
         let migrated_canister = pic
             .create_canister_with_params(

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -432,7 +432,12 @@ message TaskQueue {
 
 // Next ID: 69
 message CanisterStateBits {
-  reserved 1, 2, 3, 5, 6, 9, 10, 14, 16, 17, 24, 30, 35, 42, 47, 48, 49, 52, 53;
+  reserved 1, 2, 3, 5, 6, 9, 10, 14, 16, 17, 24, 30, 35, 42, 43, 44, 47, 48, 49, 52, 53, 66;
+  // Removed: canister logs are now stored exclusively in the LogMemoryStore.
+  // Previously: `canister_log_records`, `next_canister_log_record_idx` and
+  // `log_memory_store_migrated`, used by the legacy `CanisterLog` store and the
+  // one-time migration to the LogMemoryStore.
+  reserved "canister_log_records", "next_canister_log_record_idx", "log_memory_store_migrated";
 
   uint64 compute_allocation = 4;
   ExecutionStateBits execution_state_bits = 7;
@@ -498,12 +503,6 @@ message CanisterStateBits {
   LogVisibilityV2 log_visibility_v2 = 51;
   // The capacity of the canister log in bytes.
   uint64 log_memory_limit = 56;
-  // Removed: canister logs are now stored exclusively in the LogMemoryStore.
-  // Previously: `canister_log_records`, `next_canister_log_record_idx` and
-  // `log_memory_store_migrated`, used by the legacy `CanisterLog` store and the
-  // one-time migration to the LogMemoryStore.
-  reserved 43, 44, 66;
-  reserved "canister_log_records", "next_canister_log_record_idx", "log_memory_store_migrated";
   // The persistent high-water mark for log record indexing in LogMemoryStore.
   uint64 log_memory_store_persistent_next_idx = 67;
   // The Wasm memory limit. This is a field in developer-visible canister

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -503,8 +503,7 @@ message CanisterStateBits {
   // `log_memory_store_migrated`, used by the legacy `CanisterLog` store and the
   // one-time migration to the LogMemoryStore.
   reserved 43, 44, 66;
-  reserved "canister_log_records", "next_canister_log_record_idx",
-      "log_memory_store_migrated";
+  reserved "canister_log_records", "next_canister_log_record_idx", "log_memory_store_migrated";
   // The persistent high-water mark for log record indexing in LogMemoryStore.
   uint64 log_memory_store_persistent_next_idx = 67;
   // The Wasm memory limit. This is a field in developer-visible canister

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -498,13 +498,13 @@ message CanisterStateBits {
   LogVisibilityV2 log_visibility_v2 = 51;
   // The capacity of the canister log in bytes.
   uint64 log_memory_limit = 56;
-  // Log records of the canister.
-  repeated CanisterLogRecord canister_log_records = 43;
-  // The index of the next log record to be created.
-  uint64 next_canister_log_record_idx = 44;
-  // Whether the one-time migration from CanisterLog to LogMemoryStore has
-  // already been performed for this canister.
-  bool log_memory_store_migrated = 66;
+  // Removed: canister logs are now stored exclusively in the LogMemoryStore.
+  // Previously: `canister_log_records`, `next_canister_log_record_idx` and
+  // `log_memory_store_migrated`, used by the legacy `CanisterLog` store and the
+  // one-time migration to the LogMemoryStore.
+  reserved 43, 44, 66;
+  reserved "canister_log_records", "next_canister_log_record_idx",
+      "log_memory_store_migrated";
   // The persistent high-water mark for log record indexing in LogMemoryStore.
   uint64 log_memory_store_persistent_next_idx = 67;
   // The Wasm memory limit. This is a field in developer-visible canister

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -743,16 +743,6 @@ pub struct CanisterStateBits {
     /// The capacity of the canister log in bytes.
     #[prost(uint64, tag = "56")]
     pub log_memory_limit: u64,
-    /// Log records of the canister.
-    #[prost(message, repeated, tag = "43")]
-    pub canister_log_records: ::prost::alloc::vec::Vec<CanisterLogRecord>,
-    /// The index of the next log record to be created.
-    #[prost(uint64, tag = "44")]
-    pub next_canister_log_record_idx: u64,
-    /// Whether the one-time migration from CanisterLog to LogMemoryStore has
-    /// already been performed for this canister.
-    #[prost(bool, tag = "66")]
-    pub log_memory_store_migrated: bool,
     /// The persistent high-water mark for log record indexing in LogMemoryStore.
     #[prost(uint64, tag = "67")]
     pub log_memory_store_persistent_next_idx: u64,

--- a/rs/replicated_state/benches/log_memory_store.rs
+++ b/rs/replicated_state/benches/log_memory_store.rs
@@ -1,5 +1,4 @@
 use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
-use ic_config::flag_status::FlagStatus;
 use ic_management_canister_types_private::{FetchCanisterLogsFilter, FetchCanisterLogsRange};
 use ic_replicated_state::canister_state::system_state::log_memory_store::LogMemoryStore;
 use ic_types::CanisterLog;
@@ -8,7 +7,6 @@ use more_asserts::assert_gt;
 const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
 
-const TEST_LOG_MEMORY_STORE_FEATURE: FlagStatus = FlagStatus::Enabled;
 const TEST_DELTA_LOG_CAPACITY: usize = 2 * MIB as usize;
 const MAX_LOG_MESSAGE_LEN: u64 = 32 * KIB;
 const AVG_LOG_MESSAGE_LEN: u64 = 100;
@@ -16,7 +14,7 @@ const AVG_LOG_MESSAGE_LEN: u64 = 100;
 /// Creates a `LogMemoryStore` resized to `capacity` and filled
 /// with log records of `message_len` bytes each.
 fn create_populated_store(capacity: u64, message_len: u64) -> LogMemoryStore {
-    let mut store = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut store = LogMemoryStore::new();
     store.resize_for_testing(capacity as usize);
     let len = message_len.min(MAX_LOG_MESSAGE_LEN) as usize;
     let log_message = vec![b'a'; len];

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -25,7 +25,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_types::messages::{CallbackId, CanisterMessage, Ingress, RequestOrResponse, Response};
 use ic_types::methods::{SystemMethod, WasmMethod};
 use ic_types::{
-    CanisterId, CanisterLog, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
+    CanisterId, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
     PrincipalId, Time,
 };
 use ic_validate_eq::ValidateEq;
@@ -626,19 +626,16 @@ impl CanisterState {
 
     /// Clears the canister log.
     pub fn clear_log(&mut self) {
-        self.system_state.canister_log.clear();
         self.system_state.log_memory_store.clear();
     }
 
     /// Removes the canister log.
     pub fn remove_log(&mut self) {
-        self.system_state.canister_log.clear();
         self.system_state.log_memory_store.deallocate();
     }
 
     /// Sets the new canister log.
-    pub fn set_log(&mut self, (canister_log, log_memory_store): (CanisterLog, LogMemoryStore)) {
-        self.system_state.canister_log = canister_log;
+    pub fn set_log(&mut self, log_memory_store: LogMemoryStore) {
         self.system_state.log_memory_store = log_memory_store;
     }
 

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -25,8 +25,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_types::messages::{CallbackId, CanisterMessage, Ingress, RequestOrResponse, Response};
 use ic_types::methods::{SystemMethod, WasmMethod};
 use ic_types::{
-    CanisterId, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
-    PrincipalId, Time,
+    CanisterId, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions, PrincipalId, Time,
 };
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -22,8 +22,6 @@ use crate::{
 };
 pub use call_context_manager::{CallContext, CallContextAction, CallContextManager, CallOrigin};
 use ic_base_types::{EnvironmentVariables, NumSeconds};
-use ic_config::execution_environment::LOG_MEMORY_STORE_FEATURE;
-use ic_config::flag_status::FlagStatus;
 use ic_error_types::RejectCode;
 use ic_interfaces::execution_environment::{HypervisorError, MessageMemoryUsage};
 use ic_logger::{ReplicaLogger, error};
@@ -43,8 +41,8 @@ use ic_types::messages::{
 use ic_types::methods::{Callback, WasmClosure};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::{
-    CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, CountBytes, MemoryAllocation,
-    NumBytes, NumInstructions, PrincipalId, Time,
+    CanisterId, CanisterTimer, ComputeAllocation, CountBytes, MemoryAllocation, NumBytes,
+    NumInstructions, PrincipalId, Time,
 };
 use ic_types_cycles::{
     CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, CyclesUseCaseKind,
@@ -587,10 +585,6 @@ pub struct SystemState {
     /// Snapshot visibility of the canister.
     pub snapshot_visibility: SnapshotVisibility,
 
-    /// Log records of the canister.
-    #[validate_eq(CompareWithValidateEq)]
-    pub canister_log: CanisterLog,
-
     /// The memory used for storing log entries.
     #[validate_eq(CompareWithValidateEq)]
     pub log_memory_store: LogMemoryStore,
@@ -727,7 +721,6 @@ impl SystemState {
         time_of_last_allocation_charge: Time,
         freeze_threshold: NumSeconds,
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
-        log_memory_store_feature: FlagStatus,
     ) -> Self {
         Self::new_internal(
             canister_id,
@@ -737,7 +730,6 @@ impl SystemState {
             freeze_threshold,
             CanisterStatus::new_running(),
             WasmChunkStore::new(fd_factory),
-            log_memory_store_feature,
         )
     }
 
@@ -749,7 +741,6 @@ impl SystemState {
         freeze_threshold: NumSeconds,
         status: CanisterStatus,
         wasm_chunk_store: WasmChunkStore,
-        log_memory_store_feature: FlagStatus,
     ) -> Self {
         Self {
             canister_id,
@@ -777,11 +768,7 @@ impl SystemState {
             wasm_chunk_store,
             log_visibility: Default::default(),
             snapshot_visibility: Default::default(),
-            // TODO(EXC-2118): CanisterLog does not store log records efficiently,
-            // therefore it should not scale to memory limit from above.
-            // Remove this field after migration is done.
-            canister_log: CanisterLog::default_aggregate(),
-            log_memory_store: LogMemoryStore::new(log_memory_store_feature),
+            log_memory_store: LogMemoryStore::new(),
             wasm_memory_limit: None,
             next_snapshot_id: 0,
         }
@@ -814,10 +801,8 @@ impl SystemState {
         wasm_chunk_store_metadata: WasmChunkStoreMetadata,
         log_visibility: LogVisibilityV2,
         snapshot_visibility: SnapshotVisibility,
-        canister_log: CanisterLog,
         log_memory_store_data: Option<PageMap>,
         log_memory_store_persistent_next_idx: u64,
-        log_memory_store_migrated: bool,
         wasm_memory_limit: Option<NumBytes>,
         next_snapshot_id: u64,
         environment_variables: BTreeMap<String, String>,
@@ -851,11 +836,9 @@ impl SystemState {
             ),
             log_visibility,
             snapshot_visibility,
-            canister_log,
             log_memory_store: LogMemoryStore::from_checkpoint(
                 log_memory_store_data,
                 log_memory_store_persistent_next_idx,
-                log_memory_store_migrated,
             ),
             wasm_memory_limit,
             next_snapshot_id,
@@ -930,7 +913,6 @@ impl SystemState {
             freeze_threshold,
             status,
             WasmChunkStore::new_for_testing(),
-            LOG_MEMORY_STORE_FEATURE,
         )
     }
 
@@ -2688,11 +2670,7 @@ pub mod testing {
             wasm_chunk_store: WasmChunkStore::new_for_testing(),
             log_visibility: Default::default(),
             snapshot_visibility: Default::default(),
-            // TODO(EXC-2118): CanisterLog does not store log records efficiently,
-            // therefore it should not scale to memory limit from above.
-            // Remove this field after migration is done.
-            canister_log: CanisterLog::default_aggregate(),
-            log_memory_store: LogMemoryStore::new(LOG_MEMORY_STORE_FEATURE),
+            log_memory_store: LogMemoryStore::new(),
             wasm_memory_limit: Default::default(),
             next_snapshot_id: Default::default(),
             environment_variables: Default::default(),

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -355,6 +355,12 @@ impl LogMemoryStore {
     }
 
     /// Returns the canister log records, optionally filtered.
+    ///
+    /// The result is trimmed to fit within the maximum message response size
+    /// (`RESULT_MAX_SIZE`), so this must NOT be used (e.g. with a `None` filter)
+    /// to obtain the complete set of stored records: doing so silently drops
+    /// records once they exceed the response-size limit. Callers that need all
+    /// records must use [`Self::all_records_for_testing`] instead.
     pub fn records(&self, filter: Option<FetchCanisterLogsFilter>) -> Vec<CanisterLogRecord> {
         self.load_ring_buffer()
             .map(|rb| rb.records(filter))

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -361,6 +361,16 @@ impl LogMemoryStore {
             .unwrap_or_default()
     }
 
+    /// Returns all canister log records currently stored in the ring buffer.
+    ///
+    /// Unlike `records`, this does not trim the result to the maximum message
+    /// response size, so it is only intended for testing.
+    pub fn all_records_for_testing(&self) -> Vec<CanisterLogRecord> {
+        self.load_ring_buffer()
+            .map(|rb| rb.iter().collect())
+            .unwrap_or_default()
+    }
+
     /// Appends a delta log to the ring buffer if it exists.
     pub fn append_delta_log(&mut self, delta_log: &mut CanisterLog) {
         if delta_log.is_empty() {

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -14,7 +14,6 @@ use crate::canister_state::system_state::log_memory_store::{
     },
 };
 use crate::page_map::{PageAllocatorFileDescriptor, PageMap};
-use ic_config::flag_status::FlagStatus;
 use ic_management_canister_types_private::{CanisterLogRecord, FetchCanisterLogsFilter};
 use ic_types::{CanisterLog, NumBytes};
 use ic_validate_eq::ValidateEq;
@@ -61,16 +60,6 @@ pub struct LogMemoryStore {
     /// modified: appended, cleared or deallocated.
     persistent_next_idx: u64,
 
-    /// Tracks whether the one-time migration from `CanisterLog` to
-    /// `LogMemoryStore` has already been performed for this canister.
-    ///
-    /// On the first round execution after the upgrade that enables the feature
-    /// the store is initialised with `DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT` and
-    /// existing `CanisterLog` records are copied in.  Once that has happened
-    /// this flag is set to `true` and persisted so that the migration is never
-    /// repeated, even if the user later resets `log_memory_limit` to 0.
-    migrated: bool,
-
     /// Caches the ring buffer header to avoid expensive reads from the `PageMap`.
     #[validate_eq(Ignore)]
     header_cache: OnceLock<Option<Header>>,
@@ -93,30 +82,17 @@ impl LogMemoryStore {
     /// The store technically exists but has 0 capacity and is considered "uninitialized".
     /// Any attempts to append logs will be silently ignored until the store is
     /// explicitly resized to a non-zero capacity.
-    pub fn new(feature_flag: FlagStatus) -> Self {
+    pub fn new() -> Self {
         const DEFAULT_NEXT_IDX: u64 = 0;
-        // A freshly created canister has no legacy CanisterLog records to migrate,
-        // so migration is considered done from the start.
-        let migrated = feature_flag == FlagStatus::Enabled;
-        Self::new_inner(None, DEFAULT_NEXT_IDX, migrated)
+        Self::new_inner(None, DEFAULT_NEXT_IDX)
     }
 
     /// Creates a new store from a checkpoint.
-    pub fn from_checkpoint(
-        maybe_page_map: Option<PageMap>,
-        persistent_next_idx: u64,
-        migrated: bool,
-    ) -> Self {
-        Self::new_inner(maybe_page_map, persistent_next_idx, migrated)
+    pub fn from_checkpoint(maybe_page_map: Option<PageMap>, persistent_next_idx: u64) -> Self {
+        Self::new_inner(maybe_page_map, persistent_next_idx)
     }
 
-    fn new_inner(
-        maybe_page_map: Option<PageMap>,
-        persistent_next_idx: u64,
-        migrated: bool,
-    ) -> Self {
-        let maybe_page_map = if migrated { maybe_page_map } else { None };
-        let persistent_next_idx = if migrated { persistent_next_idx } else { 0 };
+    fn new_inner(maybe_page_map: Option<PageMap>, persistent_next_idx: u64) -> Self {
         // Rebuild the first-timestamp cache from the ring buffer so the
         // invariant holds immediately after `from_checkpoint`, without
         // waiting for the next mutation to populate it.
@@ -127,31 +103,11 @@ impl LogMemoryStore {
         let store = Self {
             maybe_page_map,
             persistent_next_idx,
-            migrated,
             header_cache: OnceLock::new(),
             first_timestamp_cache,
         };
         debug_assert!(store.stats_ok());
         store
-    }
-
-    /// Returns `true` if the one-time migration from `CanisterLog` has already
-    /// been performed for this canister.
-    pub fn is_migrated(&self) -> bool {
-        self.migrated
-    }
-
-    /// Marks the one-time migration as complete.
-    pub fn set_migrated(&mut self) {
-        self.migrated = true;
-    }
-
-    /// Clears the migration flag and resets the persistent index to zero so
-    /// that the feature can be cleanly re-enabled later. The migration will
-    /// run again on the next round execution after the feature is re-enabled.
-    pub fn clear_migrated(&mut self) {
-        self.migrated = false;
-        self.persistent_next_idx = 0;
     }
 
     /// Provides access to the underlying `PageMap`.
@@ -463,7 +419,6 @@ impl Clone for LogMemoryStore {
             // an independent snapshot.
             maybe_page_map: self.maybe_page_map.clone(),
             persistent_next_idx: self.persistent_next_idx,
-            migrated: self.migrated,
             // OnceLock is not Clone, so we must manually clone the state.
             header_cache: match self.header_cache.get() {
                 Some(val) => OnceLock::from(*val),
@@ -480,11 +435,16 @@ impl PartialEq for LogMemoryStore {
         // should not be compared.
         self.maybe_page_map == other.maybe_page_map
             && self.persistent_next_idx == other.persistent_next_idx
-            && self.migrated == other.migrated
     }
 }
 
 impl Eq for LogMemoryStore {}
+
+impl Default for LogMemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
@@ -42,7 +42,7 @@ impl MockCanister {
     /// Creates a new canister with default settings.
     fn create_canister() -> Self {
         let mut canister = Self {
-            log_memory_store: LogMemoryStore::new(FlagStatus::Enabled),
+            log_memory_store: LogMemoryStore::new(),
             fake_timestamp: 0,
         };
         canister.update_settings(CanisterSettings {

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -55,11 +55,9 @@ fn total_size(records: &[CanisterLogRecord]) -> usize {
     records.iter().map(|r| r.data_size()).sum()
 }
 
-const TEST_LOG_MEMORY_STORE_FEATURE: FlagStatus = FlagStatus::Enabled;
-
 #[test]
 fn initialization_defaults() {
-    let s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let s = LogMemoryStore::new();
     assert!(s.is_empty());
     assert_eq!(s.memory_usage(), 0);
     assert_eq!(s.byte_capacity(), 0);
@@ -73,7 +71,7 @@ fn test_retention_across_lifecycle() {
     use std::time::Duration;
 
     // Empty store: no header, no retention.
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     assert_eq!(s.first_timestamp(), None);
     assert_eq!(s.max_timestamp(), None);
     assert_eq!(s.retention(), None);
@@ -120,7 +118,7 @@ fn test_retention_across_lifecycle() {
 
 #[test]
 fn test_appending_to_uninitialized_store_updates_next_idx() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     let mut delta = CanisterLog::default_delta();
     delta.add_record(1, b"data".to_vec());
 
@@ -137,7 +135,7 @@ fn test_appending_to_uninitialized_store_updates_next_idx() {
 
 #[test]
 fn test_minimal_allowed_capacity() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
 
     s.resize_for_testing(1); // Set a small limit.
 
@@ -152,7 +150,7 @@ fn test_memory_usage_after_appending_logs() {
     delta.add_record(200, b"bb".to_vec());
     delta.add_record(300, b"ccc".to_vec());
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     s.append_delta_log(&mut delta);
 
@@ -178,7 +176,7 @@ fn test_memory_usage_after_appending_empty_log_records() {
     delta.add_record(200, vec![]);
     delta.add_record(300, vec![]);
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     s.append_delta_log(&mut delta);
 
@@ -204,7 +202,7 @@ fn append_preserves_order_and_metadata() {
     delta.add_record(200, b"bb".to_vec());
     delta.add_record(300, b"ccc".to_vec());
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     s.append_delta_log(&mut delta);
 
@@ -229,7 +227,7 @@ fn filtering_by_idx_and_timestamp() {
     delta.add_record(20, b"b".to_vec());
     delta.add_record(30, b"c".to_vec());
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     s.append_delta_log(&mut delta);
 
@@ -253,7 +251,7 @@ fn eviction_when_capacity_reached() {
     // Force repeated large appends so aggregate log approaches capacity — beginning records should be dropped.
     let aggregate_capacity = 50_000; // keep small for the test.
     let start_idx = 0;
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(aggregate_capacity);
 
     // Append 100k records in batches of 10k deltas of ~1KB record each.
@@ -287,7 +285,7 @@ fn max_response_size_respected_without_filtering() {
         "large enough capacity"
     );
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(aggregate_capacity);
     // Append 5 MB records in batches of 1 MB deltas of ~1KB record each.
     append_deltas(&mut s, start_idx, 5_000_000, 1_000_000, 1_000);
@@ -310,7 +308,7 @@ fn max_response_size_respected_with_filtering_by_idx() {
         "large enough capacity"
     );
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(aggregate_capacity);
     // Append 5 MB records in batches of 1 MB deltas of ~1KB record each.
     append_deltas(&mut s, start_idx, 5_000_000, 1_000_000, 1_000);
@@ -350,7 +348,7 @@ fn max_response_size_respected_with_filtering_by_timestamp() {
         "large enough capacity"
     );
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(aggregate_capacity);
     // Append 5 MB records in batches of 1 MB deltas of ~1KB record each.
     append_deltas(&mut s, start_idx, 5_000_000, 1_000_000, 1_000);
@@ -381,7 +379,7 @@ fn max_response_size_respected_with_filtering_by_timestamp() {
 
 #[test]
 fn test_increasing_capacity_preserves_records() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     let big_size = 100 * KIB;
     let delta_size = 10 * KIB;
     let message_len = 0;
@@ -403,7 +401,7 @@ fn test_increasing_capacity_preserves_records() {
 
 #[test]
 fn test_decreasing_capacity_drops_oldest_records_but_preserves_recent() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     let big_size = 100 * KIB;
     let delta_size = 10 * KIB;
     let message_len = 0;
@@ -431,7 +429,7 @@ fn test_decreasing_capacity_drops_oldest_records_but_preserves_recent() {
 
 #[test]
 fn test_small_capacity_indexing() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     // Set a very small capacity, smaller than 146 bytes (INDEX_ENTRY_COUNT_MAX).
     // 146 entries. If capacity is 100. 100 / 146 = 0.
     s.resize_for_testing(100);
@@ -459,7 +457,7 @@ fn test_small_capacity_indexing() {
 
 #[test]
 fn test_multiple_records_in_same_segment() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     // Capacity 100KB. Segment size ~685 bytes.
     s.resize_for_testing(100_000);
 
@@ -488,7 +486,7 @@ fn test_multiple_records_in_same_segment() {
 
 #[test]
 fn test_very_small_capacity_single_byte() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     // Set capacity to 1 byte - this will be clamped to DATA_CAPACITY_MIN (4096 bytes).
     s.resize_for_testing(1);
 
@@ -512,7 +510,7 @@ fn test_very_small_capacity_single_byte() {
 
 #[test]
 fn test_small_capacity_with_eviction() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     let capacity = 4096;
     s.resize_for_testing(capacity);
 
@@ -551,7 +549,7 @@ fn test_small_capacity_with_eviction() {
 
 #[test]
 fn test_filtering_with_multiple_records_in_same_segment() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     // Capacity 100KB. Segment size ~685 bytes.
     s.resize_for_testing(100_000);
 
@@ -586,7 +584,7 @@ fn test_filtering_with_multiple_records_in_same_segment() {
 
 #[test]
 fn test_cache_lifecycle() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
 
     // 1. Initial state: Uninitialized (None in OnceLock)
     assert!(s.header_cache.get().is_none());
@@ -623,7 +621,7 @@ fn test_cache_lifecycle() {
 
 #[test]
 fn test_clear() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     let mut delta = CanisterLog::default_delta();
     delta.add_record(1, b"a".to_vec());
@@ -644,7 +642,7 @@ fn test_clear() {
 
 #[test]
 fn test_deallocate() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     assert!(s.maybe_page_map().is_some());
     assert_eq!(s.byte_capacity(), TEST_LOG_MEMORY_LIMIT);
@@ -660,7 +658,7 @@ fn test_deallocate() {
 
 #[test]
 fn test_deallocate_when_resize_to_zero() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
     assert!(s.maybe_page_map().is_some());
     assert_eq!(s.byte_capacity(), TEST_LOG_MEMORY_LIMIT);
@@ -673,7 +671,7 @@ fn test_deallocate_when_resize_to_zero() {
 
 #[test]
 fn test_single_record_returned_by_records_no_filter() {
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
 
     let mut delta = CanisterLog::new_delta_with_next_index(0, TEST_LOG_MEMORY_LIMIT);
@@ -692,7 +690,7 @@ fn test_resize_up_preserves_records_and_next_idx() {
     let initial_capacity = EXPECTED_DATA_CAPACITY_MIN;
     let larger_capacity = 3 * initial_capacity;
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(initial_capacity);
 
     // Append 3 records.
@@ -732,7 +730,7 @@ fn test_resize_down_preserves_records_and_next_idx() {
     let smaller_capacity = EXPECTED_DATA_CAPACITY_MIN;
     let initial_capacity = 3 * smaller_capacity;
 
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(initial_capacity);
 
     // Append a few small records (fit in both capacities).
@@ -755,22 +753,12 @@ fn test_resize_down_preserves_records_and_next_idx() {
 }
 
 #[test]
-fn test_from_checkpoint_migrated() {
+fn test_from_checkpoint() {
     let some_page_map = Some(PageMap::new_for_testing());
 
-    let s = LogMemoryStore::from_checkpoint(some_page_map, TEST_NEXT_IDX, true);
+    let s = LogMemoryStore::from_checkpoint(some_page_map, TEST_NEXT_IDX);
     assert!(s.maybe_page_map().is_some());
     assert_eq!(s.next_idx(), TEST_NEXT_IDX);
-}
-
-#[test]
-fn test_from_checkpoint_not_migrated() {
-    let some_page_map = Some(PageMap::new_for_testing());
-
-    let s = LogMemoryStore::from_checkpoint(some_page_map, TEST_NEXT_IDX, false);
-    assert!(s.maybe_page_map().is_none());
-    // When not yet migrated, next_idx should be initialized to 0 regardless of the provided value.
-    assert_eq!(s.next_idx(), 0);
 }
 
 #[test]
@@ -780,7 +768,7 @@ fn test_next_idx_preserved_after_deallocate() {
     delta.add_record(1001, b"a".to_vec());
     delta.add_record(1002, b"b".to_vec());
 
-    let mut store = LogMemoryStore::new(FlagStatus::Enabled);
+    let mut store = LogMemoryStore::new();
     store.resize_for_testing(log_size);
     store.append_delta_log(&mut delta);
     assert_eq!(store.next_idx(), TEST_NEXT_IDX + 2);
@@ -799,7 +787,7 @@ fn test_next_idx_preserved_when_appending_empty_delta_log() {
     let log_size = 4096;
     let next_idx = TEST_NEXT_IDX;
 
-    let mut store = LogMemoryStore::new(FlagStatus::Enabled);
+    let mut store = LogMemoryStore::new();
     store.resize_for_testing(log_size);
     assert_eq!(store.next_idx(), 0);
 
@@ -813,8 +801,8 @@ fn test_next_idx_preserved_when_appending_empty_delta_log() {
     assert_eq!(store.next_idx(), next_idx);
 }
 
-fn assert_memory_usage_for_limit(feature_flag: FlagStatus, limit: usize) {
-    let mut s = LogMemoryStore::new(feature_flag);
+fn assert_memory_usage_for_limit(limit: usize) {
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(limit);
     assert_eq!(
         s.memory_usage_for_limit(NumBytes::new(limit as u64)).get() as usize,
@@ -823,28 +811,23 @@ fn assert_memory_usage_for_limit(feature_flag: FlagStatus, limit: usize) {
 }
 
 #[test]
-fn memory_usage_for_limit_feature_disabled() {
-    assert_memory_usage_for_limit(FlagStatus::Disabled, 1);
-}
-
-#[test]
 fn memory_usage_for_limit_zero_limit() {
-    assert_memory_usage_for_limit(TEST_LOG_MEMORY_STORE_FEATURE, 0);
+    assert_memory_usage_for_limit(0);
 }
 
 #[test]
 fn memory_usage_for_limit_below_minimum() {
-    assert_memory_usage_for_limit(TEST_LOG_MEMORY_STORE_FEATURE, 1); // below DATA_CAPACITY_MIN
+    assert_memory_usage_for_limit(1); // below DATA_CAPACITY_MIN
 }
 
 #[test]
 fn memory_usage_for_limit_at_minimum() {
-    assert_memory_usage_for_limit(TEST_LOG_MEMORY_STORE_FEATURE, EXPECTED_DATA_CAPACITY_MIN);
+    assert_memory_usage_for_limit(EXPECTED_DATA_CAPACITY_MIN);
 }
 
 #[test]
 fn memory_usage_for_limit_above_minimum() {
-    assert_memory_usage_for_limit(TEST_LOG_MEMORY_STORE_FEATURE, TEST_LOG_MEMORY_LIMIT);
+    assert_memory_usage_for_limit(TEST_LOG_MEMORY_LIMIT);
 }
 
 #[test]
@@ -855,7 +838,7 @@ fn test_gap_in_delta_clears_store() {
     // Setup: store has records idx 0 and 1 (next_idx == 2).
     // Delta: starts at idx 5 (gap: 2, 3, 4 were evicted from the delta).
     // Expected: store is cleared before appending, so only idx 5 remains.
-    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    let mut s = LogMemoryStore::new();
     s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
 
     // Populate the store with records 0 and 1.

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -177,18 +177,6 @@ pub struct SystemMetadata {
     /// This field is transient and is emptied before writing the next checkpoint.
     pub unflushed_checkpoint_ops: UnflushedCheckpointOps,
 
-    /// Whether the logs have been migrated from `CanisterLog` to `LogMemoryStore`
-    /// or from `LogMemoryStore` to `CanisterLog`, as per the
-    /// `log_memory_store_feature` flag.
-    ///
-    /// This is a (temporary) transient field tracking whether all canisters are
-    /// definitely using the log store required by the `log_memory_store_feature`
-    /// flag. It is intended to be used as a one-time trigger (when `false`) to
-    /// launch the (idempotent, if already performed) logs migration exactly once
-    /// per replica process (since the flag is hardcoded into the binary).
-    #[validate_eq(Ignore)]
-    pub logs_migrated: bool,
-
     /// The subnet list from network topology that was last used by
     /// `generate_reject_responses_for_deleted_subnets()`. The function
     /// exits early if the subnet list has not changed since the last call.
@@ -581,7 +569,6 @@ impl SystemMetadata {
             bitcoin_get_successors_follow_up_responses: BTreeMap::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
             unflushed_checkpoint_ops: Default::default(),
-            logs_migrated: false,
             subnet_ids_at_last_reject_generation: None,
         }
     }
@@ -887,7 +874,6 @@ impl SystemMetadata {
             bitcoin_get_successors_follow_up_responses: _,
             blockmaker_metrics_time_series: _,
             unflushed_checkpoint_ops: _,
-            logs_migrated: _,
             subnet_ids_at_last_reject_generation: _,
         } = self;
 
@@ -990,7 +976,6 @@ impl SystemMetadata {
             mut bitcoin_get_successors_follow_up_responses,
             blockmaker_metrics_time_series,
             unflushed_checkpoint_ops,
-            logs_migrated,
             subnet_ids_at_last_reject_generation: _,
         } = self;
 
@@ -1098,7 +1083,6 @@ impl SystemMetadata {
             // Just updated by `ReplicatedState::online_split()`, adding delete operations
             // for the snapshots of no longer hosted canisters.
             unflushed_checkpoint_ops,
-            logs_migrated,
             // Transient field; reset so that `generate_reject_responses_for_deleted_subnets()`
             // runs unconditionally on the first post-split round.
             subnet_ids_at_last_reject_generation: None,
@@ -2217,7 +2201,6 @@ pub mod testing {
             bitcoin_get_successors_follow_up_responses: Default::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
             unflushed_checkpoint_ops: Default::default(),
-            logs_migrated: false,
             subnet_ids_at_last_reject_generation: None,
         };
     }

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -649,7 +649,6 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
                 None => BlockmakerMetricsTimeSeries::default(),
             },
             unflushed_checkpoint_ops: Default::default(),
-            logs_migrated: false,
             subnet_ids_at_last_reject_generation: None,
         })
     }

--- a/rs/replicated_state/src/metrics.rs
+++ b/rs/replicated_state/src/metrics.rs
@@ -647,21 +647,10 @@ impl ReplicatedStateMetrics {
         self.canister_compute_allocation
             .observe(canister.compute_allocation().as_percent() as f64 / 100.0);
 
-        let log_memory_usage = if canister.system_state.log_memory_store.is_migrated() {
-            canister.system_state.log_memory_store.memory_usage()
-        } else {
-            canister.system_state.canister_log.bytes_used()
-        };
         self.canister_log_memory_usage_v3
-            .observe(log_memory_usage as f64);
+            .observe(canister.system_state.log_memory_store.memory_usage() as f64);
 
-        // Observe retention from whichever log store is active.
-        let retention = if canister.system_state.log_memory_store.is_migrated() {
-            canister.system_state.log_memory_store.retention()
-        } else {
-            canister.system_state.canister_log.retention()
-        };
-        if let Some(retention) = retention {
+        if let Some(retention) = canister.system_state.log_memory_store.retention() {
             self.canister_log_retention.observe(retention.as_secs_f64());
         }
 

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -19,8 +19,8 @@ use ic_replicated_state::{
 };
 use ic_sys::{fs::sync_path, mmap::ScopedMmap};
 use ic_types::{
-    CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, ExecutionRound, Height,
-    MemoryAllocation, NumInstructions, PrincipalId, SnapshotId, Time, batch::TotalQueryStats,
+    CanisterId, CanisterTimer, ComputeAllocation, ExecutionRound, Height, MemoryAllocation,
+    NumInstructions, PrincipalId, SnapshotId, Time, batch::TotalQueryStats,
 };
 use ic_types_cycles::{Cycles, CyclesUseCase, NominalCycles};
 use ic_utils::thread::maybe_parallel_map;
@@ -204,9 +204,6 @@ pub struct CanisterStateBits {
     pub log_visibility: LogVisibilityV2,
     pub snapshot_visibility: SnapshotVisibility,
     pub log_memory_limit: NumBytes,
-    pub canister_log: CanisterLog,
-    pub next_canister_log_record_idx: u64,
-    pub log_memory_store_migrated: bool,
     pub log_memory_store_persistent_next_idx: u64,
     pub wasm_memory_limit: Option<NumBytes>,
     pub next_snapshot_id: u64,

--- a/rs/state_layout/src/state_layout/proto.rs
+++ b/rs/state_layout/src/state_layout/proto.rs
@@ -70,14 +70,6 @@ impl From<CanisterStateBits> for pb_canister_state_bits::CanisterStateBits {
             )
             .into(),
             log_memory_limit: item.log_memory_limit.get(),
-            canister_log_records: item
-                .canister_log
-                .records()
-                .iter()
-                .map(|record| record.into())
-                .collect(),
-            next_canister_log_record_idx: item.next_canister_log_record_idx,
-            log_memory_store_migrated: item.log_memory_store_migrated,
             log_memory_store_persistent_next_idx: item.log_memory_store_persistent_next_idx,
             wasm_memory_limit: item.wasm_memory_limit.map(|v| v.get()),
             next_snapshot_id: item.next_snapshot_id,
@@ -226,16 +218,6 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
             )
             .unwrap_or_default(),
             log_memory_limit: NumBytes::from(value.log_memory_limit),
-            canister_log: CanisterLog::new_aggregate(
-                value.next_canister_log_record_idx,
-                value
-                    .canister_log_records
-                    .into_iter()
-                    .map(|record| record.into())
-                    .collect(),
-            ),
-            next_canister_log_record_idx: value.next_canister_log_record_idx,
-            log_memory_store_migrated: value.log_memory_store_migrated,
             log_memory_store_persistent_next_idx: value.log_memory_store_persistent_next_idx,
             wasm_memory_limit: value.wasm_memory_limit.map(NumBytes::from),
             next_snapshot_id: value.next_snapshot_id,

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use ic_config::execution_environment::LOG_MEMORY_STORE_FEATURE_ENABLED;
 use ic_management_canister_types_private::{
     CanisterChange, CanisterChangeDetails, CanisterChangeOrigin, CanisterInstallMode, IC_00,
 };
@@ -61,8 +60,6 @@ fn default_canister_state_bits() -> CanisterStateBits {
         log_visibility: Default::default(),
         snapshot_visibility: Default::default(),
         log_memory_limit: NumBytes::from(0),
-        canister_log: CanisterLog::default_aggregate(),
-        next_canister_log_record_idx: 0,
         wasm_memory_limit: None,
         next_snapshot_id: 0,
         environment_variables: BTreeMap::new(),
@@ -72,7 +69,6 @@ fn default_canister_state_bits() -> CanisterStateBits {
         local_subnet_messages_executed: 0,
         http_outcalls_executed: 0,
         heartbeats_and_global_timers_executed: 0,
-        log_memory_store_migrated: LOG_MEMORY_STORE_FEATURE_ENABLED,
         log_memory_store_persistent_next_idx: 0,
     }
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -59,12 +59,12 @@ use ic_limits::{MAX_INGRESS_TTL, PERMITTED_DRIFT, SMALL_APP_SUBNET_MAX_SIZE};
 use ic_logger::replica_logger::test_logger;
 use ic_logger::{ReplicaLogger, error};
 use ic_management_canister_types_private::{
-    self as ic00, CanisterIdRecord, CanisterSnapshotDataKind, CanisterSnapshotDataOffset,
-    InstallCodeArgs, ListCanisterSnapshotArgs, ListCanisterSnapshotResponse, MasterPublicKeyId,
-    Method, Payload, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotDataResponse,
-    ReadCanisterSnapshotMetadataArgs, ReadCanisterSnapshotMetadataResponse,
-    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs,
-    UploadCanisterSnapshotMetadataResponse,
+    self as ic00, CanisterIdRecord, CanisterLogRecord, CanisterSnapshotDataKind,
+    CanisterSnapshotDataOffset, InstallCodeArgs, ListCanisterSnapshotArgs,
+    ListCanisterSnapshotResponse, MasterPublicKeyId, Method, Payload, ReadCanisterSnapshotDataArgs,
+    ReadCanisterSnapshotDataResponse, ReadCanisterSnapshotMetadataArgs,
+    ReadCanisterSnapshotMetadataResponse, UploadCanisterSnapshotDataArgs,
+    UploadCanisterSnapshotMetadataArgs, UploadCanisterSnapshotMetadataResponse,
 };
 use ic_management_canister_types_private::{
     CanisterHttpResponsePayload, CanisterInstallMode, CanisterSettingsArgs,
@@ -141,9 +141,8 @@ use ic_test_utilities_registry::{
 use ic_test_utilities_time::FastForwardTimeSource;
 pub use ic_types::ingress::WasmResult;
 use ic_types::{
-    CanisterId, CanisterLog, CountBytes, CryptoHashOfPartialState, CryptoHashOfState, Height,
-    NodeId, NumBytes, PrincipalId, Randomness, RegistryVersion, ReplicaVersion, SnapshotId,
-    SubnetId, UserId,
+    CanisterId, CountBytes, CryptoHashOfPartialState, CryptoHashOfState, Height, NodeId, NumBytes,
+    PrincipalId, Randomness, RegistryVersion, ReplicaVersion, SnapshotId, SubnetId, UserId,
     artifact::IngressMessageId,
     batch::{
         Batch, BatchContent, BatchMessages, BatchSummary, BlockmakerMetrics, ChainKeyData,
@@ -5024,14 +5023,25 @@ impl StateMachine {
         dst
     }
 
-    /// Returns the canister log of the specified canister.
-    pub fn canister_log(&self, canister_id: CanisterId) -> CanisterLog {
+    /// Returns all canister log records of the specified canister.
+    pub fn canister_log_records(&self, canister_id: CanisterId) -> Vec<CanisterLogRecord> {
         let replicated_state = self.state_manager.get_latest_state().take();
         let canister_state = replicated_state
             .canister_state(&canister_id)
             .unwrap_or_else(|| panic!("Canister {canister_id} does not exist"));
-        let log_memory_store = &canister_state.system_state.log_memory_store;
-        CanisterLog::new_aggregate(log_memory_store.next_idx(), log_memory_store.records(None))
+        canister_state
+            .system_state
+            .log_memory_store
+            .all_records_for_testing()
+    }
+
+    /// Returns the number of bytes used by the canister log of the specified canister.
+    pub fn canister_log_bytes_used(&self, canister_id: CanisterId) -> usize {
+        let replicated_state = self.state_manager.get_latest_state().take();
+        let canister_state = replicated_state
+            .canister_state(&canister_id)
+            .unwrap_or_else(|| panic!("Canister {canister_id} does not exist"));
+        canister_state.system_state.log_memory_store.bytes_used()
     }
 
     /// Sets the content of the stable memory for the specified canister.

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -5030,7 +5030,8 @@ impl StateMachine {
         let canister_state = replicated_state
             .canister_state(&canister_id)
             .unwrap_or_else(|| panic!("Canister {canister_id} does not exist"));
-        canister_state.system_state.canister_log.clone()
+        let log_memory_store = &canister_state.system_state.log_memory_store;
+        CanisterLog::new_aggregate(log_memory_store.next_idx(), log_memory_store.records(None))
     }
 
     /// Sets the content of the stable memory for the specified canister.

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -861,26 +861,13 @@ pub fn load_canister_state(
         canister_state_bits.wasm_chunk_store_metadata,
         canister_state_bits.log_visibility,
         canister_state_bits.snapshot_visibility,
-        canister_state_bits.canister_log,
         log_memory_store_data,
         canister_state_bits.log_memory_store_persistent_next_idx,
-        canister_state_bits.log_memory_store_migrated,
         canister_state_bits.wasm_memory_limit,
         canister_state_bits.next_snapshot_id,
         canister_state_bits.environment_variables,
         metrics,
     );
-
-    if system_state.log_memory_store.is_migrated() {
-        let lms_next_idx = system_state.log_memory_store.next_idx();
-        let log_next_idx = system_state.canister_log.next_idx();
-        if lms_next_idx != log_next_idx {
-            metrics.observe_broken_soft_invariant(format!(
-                "canister {canister_id}: log_memory_store.next_idx ({lms_next_idx}) \
-                 != canister_log.next_idx ({log_next_idx})",
-            ));
-        }
-    }
 
     let canister_state = CanisterState {
         system_state,

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1283,9 +1283,6 @@ fn serialize_canister_protos_to_checkpoint_readwrite(
             log_visibility: canister_state.system_state.log_visibility.clone(),
             snapshot_visibility: canister_state.system_state.snapshot_visibility.clone(),
             log_memory_limit: canister_state.log_memory_limit(),
-            canister_log: canister_state.system_state.canister_log.clone(),
-            next_canister_log_record_idx: canister_state.system_state.canister_log.next_idx(),
-            log_memory_store_migrated: canister_state.system_state.log_memory_store.is_migrated(),
             log_memory_store_persistent_next_idx: canister_state
                 .system_state
                 .log_memory_store

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2669,16 +2669,6 @@ impl ExecutionTestBuilder {
         self
     }
 
-    pub fn with_log_memory_store_feature_disabled(mut self) -> Self {
-        self.execution_config.log_memory_store_feature = FlagStatus::Disabled;
-        self
-    }
-
-    pub fn with_log_memory_store_feature_enabled(mut self) -> Self {
-        self.execution_config.log_memory_store_feature = FlagStatus::Enabled;
-        self
-    }
-
     pub fn with_flexible_http_requests_enabled(mut self) -> Self {
         self.execution_config.flexible_http_requests = FlagStatus::Enabled;
         self


### PR DESCRIPTION
The one-time migration from the legacy `CanisterLog` store to the `LogMemoryStore` has completed on all subnets, so the migration scaffolding and the legacy store can be removed.

- Drop the `log_memory_store_feature` flag (and the `LOG_MEMORY_STORE_FEATURE`/`_ENABLED` consts); the log memory store is now always enabled.
- Remove the `SystemState.canister_log` field and the `CanisterState` log wrappers now operate solely on `log_memory_store`.
- Remove the migration scaffolding: the per-canister `migrated` flag (`is_migrated`/`set_migrated`/`clear_migrated`), the subnet-level `logs_migrated` metadata, the scheduler migration code, and the migration-duration metric. Reads, writes and metrics now use `log_memory_store` unconditionally.
- Stop serializing `canister_log_records`, `next_canister_log_record_idx` and `log_memory_store_migrated`; the corresponding proto fields (43, 44, 66) are marked reserved.
 - Replace the `StateMachine::canister_log test` helper (which rebuilt a `CanisterLog` aggregate) with `canister_log_records` and `canister_log_bytes_used`, reading directly from `LogMemoryStore`. Add a test-only `LogMemoryStore::all_records_for_testing` that returns all records without the response-size trimming that `records()` applies, and migrate all callers.

The `CanisterLog` type and the transient `SystemStateModifications` delta log buffer are retained.