### PR TITLE
test: consolidate on a single pinned solc (0.8.35)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -417,35 +417,15 @@ http_file(
     url = "https://github.com/dfinity/dogecoin-canister/releases/download/release/2026-03-12/ic-doge-canister.wasm.gz",
 )
 
-# solc compilers used by //rs/tests/cross_chain:ic_xc_cketh_test to compile the
-# ckETH/ckERC20 helper smart contracts offline. Vendoring these avoids `forge`
+# Single pinned solc used to compile the ckETH/ckERC20 helper and demo smart
+# contracts offline for //rs/tests/cross_chain:ic_xc_cketh_test and
+# //rs/ethereum/cketh/minter:deposit_from_cex_demo_test. Vendoring avoids `forge`
 # downloading solc from https://binaries.soliditylang.org at test runtime, which
-# made the test flaky in data centers with unreliable IPv4 connectivity.
-# The sha256 hashes are taken from https://binaries.soliditylang.org/linux-amd64/list.json.
-#
-# `solc` is used to compile most contracts. `EthDepositHelper.sol` pins an older
-# Solidity version to stay faithful to its immutable mainnet deployment, so it
-# gets its own `solc_eth_deposit_helper`.
-http_file(
-    name = "solc",
-    downloaded_file_path = "solc",
-    executable = True,
-    sha256 = "0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782",
-    url = "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.20+commit.a1b79de6",
-)
-
-http_file(
-    name = "solc_eth_deposit_helper",
-    downloaded_file_path = "solc_eth_deposit_helper",
-    executable = True,
-    sha256 = "95e6ed4949a63ad89afb443ecba1fb8302dd2860ee5e9baace3e674a0f48aa77",
-    url = "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.18+commit.87f61d96",
-)
-
-# Latest stable solc, used by //rs/ethereum/cketh/minter:deposit_from_cex_demo_test
-# to compile the demo contracts (pinned exactly for reproducible bytecode/gas).
-# One binary per host platform; the consuming target selects the right one.
-# The macosx-amd64 download is a universal (x86_64 + arm64) Mach-O, so it runs
+# made the test flaky in data centers with unreliable IPv4 connectivity. Pinning
+# exactly keeps compiled bytecode and gas reproducible. One binary per host
+# platform; the consuming target selects the right one. The sha256 hashes are
+# taken from https://binaries.soliditylang.org/<platform>/list.json. The
+# macosx-amd64 download is a universal (x86_64 + arm64) Mach-O, so it runs
 # natively on both Intel and Apple Silicon Macs.
 http_file(
     name = "solc_0_8_35_linux_amd64",

--- a/rs/ethereum/cketh/minter/ERC20DepositHelper.sol
+++ b/rs/ethereum/cketh/minter/ERC20DepositHelper.sol
@@ -464,7 +464,7 @@ library SafeERC20 {
 */
 
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 
 /**

--- a/rs/ethereum/cketh/minter/EthDepositHelper.sol
+++ b/rs/ethereum/cketh/minter/EthDepositHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 /**
  * @title A helper smart contract for ETH <-> ckETH conversion.

--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -82,8 +82,7 @@ uvm_config_image(
         ":ERC20.sol": "ERC20.sol",
         ":foundry.tar": "foundry.tar",
         "//rs/ethereum/cketh/minter:helper_contracts": "/",
-        "@solc//file": "solc",
-        "@solc_eth_deposit_helper//file": "solc_eth_deposit_helper",
+        "//:solc": "solc",
     },
     tags = ["manual"],  # this target will be built if required as a dependency of another target
 )

--- a/rs/tests/cross_chain/ic_xc_cketh_test.rs
+++ b/rs/tests/cross_chain/ic_xc_cketh_test.rs
@@ -49,17 +49,12 @@ use std::time::Duration;
 const FOUNDRY_VM_NAME: &str = "foundry";
 const DOCKER_NETWORK_NAME: &str = "ethereum";
 const FOUNDRY_PORT: u16 = 8545;
-/// File names of the `solc` compilers vendored via Bazel (see `MODULE.bazel`)
-/// and shipped in the foundry UVM config image. They are used by
-/// `deploy_smart_contract` so that `forge` compiles the helper smart contracts
-/// offline instead of downloading `solc` at runtime. Each compiler must satisfy
-/// the `pragma solidity` of the contracts it compiles.
-///
-/// Most contracts are compiled with `SOLC`. `EthDepositHelper.sol` pins an older
-/// Solidity version to stay faithful to its immutable mainnet deployment, so it
-/// is compiled with its own `SOLC_ETH_DEPOSIT_HELPER`.
+/// File name of the `solc` compiler vendored via Bazel (see `MODULE.bazel`) and
+/// shipped in the foundry UVM config image. It is used by `deploy_smart_contract`
+/// so that `forge` compiles the helper smart contracts offline instead of
+/// downloading `solc` at runtime. The pinned version satisfies the
+/// `pragma solidity` of every contract it compiles.
 const SOLC: &str = "solc";
-const SOLC_ETH_DEPOSIT_HELPER: &str = "solc_eth_deposit_helper";
 const ENCODED_PRINCIPAL: &str =
     "0x1d9facb184cbe453de4841b6b9d9cc95bfc065344e485789b550544529020000";
 
@@ -113,9 +108,8 @@ fn setup_anvil(env: &TestEnv) {
 docker load -i /config/foundry.tar
 docker network create {DOCKER_NETWORK_NAME}
 docker run --net {DOCKER_NETWORK_NAME} --detach --rm --name anvil -p {FOUNDRY_PORT}:{FOUNDRY_PORT} foundry:latest "anvil --host 0.0.0.0"
-cp /config/{SOLC_ETH_DEPOSIT_HELPER} /tmp/{SOLC_ETH_DEPOSIT_HELPER}
 cp /config/{SOLC} /tmp/{SOLC}
-chmod +x /tmp/{SOLC_ETH_DEPOSIT_HELPER} /tmp/{SOLC}
+chmod +x /tmp/{SOLC}
 "#
             ))
             .unwrap();
@@ -402,7 +396,7 @@ fn deploy_eth_deposit_helper_contract(
         docker_host,
         &EthereumAccount::HelperContractDeployer,
         "EthDepositHelper.sol",
-        SOLC_ETH_DEPOSIT_HELPER,
+        SOLC,
         "CkEthDeposit",
         &minter_address.to_string(),
         logger,


### PR DESCRIPTION
Follow-up to #10670, addressing a review suggestion to consolidate the vendored `solc` versions.

The repo carried three vendored `solc` pins (0.8.18, 0.8.20 and 0.8.35). This consolidates on the single latest-stable 0.8.35 already used by the deposit-from-CEX demo, so the cross-chain system test and the demo share one compiler.

The two deprecated ckETH/ckERC20 helper contracts that exact-pinned the older versions have their `pragma solidity` relaxed to a caret range so they compile under 0.8.35; contracts already using a caret range are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)