### PR TITLE
chore: use simpler assert in delete_subnet_test

### DIFF
--- a/rs/tests/nns/delete_subnet_test.rs
+++ b/rs/tests/nns/delete_subnet_test.rs
@@ -168,11 +168,7 @@ pub fn test(env: TestEnv) {
         // The deleted subnets should no longer be in the subnet list; only the
         // System (NNS) subnet should remain.
         let final_subnets = get_subnet_list_from_registry(&registry_client).await;
-        assert!(!final_subnets.contains(&engine_subnet.subnet_id));
-        assert!(!final_subnets.contains(&app_subnet.subnet_id));
-        assert!(!final_subnets.contains(&vapp_subnet.subnet_id));
-        assert!(final_subnets.contains(&nns_subnet.subnet_id));
-        assert_eq!(final_subnets.len(), 1);
+        assert_eq!(final_subnets, vec![nns_subnet_id]);
 
         // The subnet records and routing table entries of the deleted subnets should be gone.
         for deleted_subnet_id in [

--- a/rs/tests/nns/delete_subnet_test.rs
+++ b/rs/tests/nns/delete_subnet_test.rs
@@ -168,7 +168,7 @@ pub fn test(env: TestEnv) {
         // The deleted subnets should no longer be in the subnet list; only the
         // System (NNS) subnet should remain.
         let final_subnets = get_subnet_list_from_registry(&registry_client).await;
-        assert_eq!(final_subnets, vec![nns_subnet_id]);
+        assert_eq!(final_subnets, vec![nns_subnet.subnet_id]);
 
         // The subnet records and routing table entries of the deleted subnets should be gone.
         for deleted_subnet_id in [


### PR DESCRIPTION
As [suggested](https://github.com/dfinity/ic/pull/10713/changes#r3557795611) by @daniel-wong-dfinity-org this simplifies the `final_subnet` asserts which should also result in better error messages in case the assert fails.