### PR TITLE
refactor: Switch HTTP outcalls receipts to hold spent cycles instead of refunds

### DIFF
--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -283,7 +283,7 @@ impl<'a> PayloadAssembler<'a> {
     }
 
     /// Builds a node's contribution to an aggregated proof: a default (zero
-    /// refund) payment receipt together with that node's signature over the
+    /// spent) payment receipt together with that node's signature over the
     /// corresponding receipt share.
     fn signature(
         &self,
@@ -303,7 +303,7 @@ impl<'a> PayloadAssembler<'a> {
     }
 
     /// Builds a single signed [`CanisterHttpResponseShare`] (receipt share with
-    /// a default, zero-refund payment receipt) for the given node.
+    /// a default, zero-spent payment receipt) for the given node.
     fn share(
         &self,
         signer: &Signer,

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -484,9 +484,9 @@ impl CanisterHttpPayloadBuilderImpl {
                 });
             }
 
-            // Enforce the per-replica refund allowance on every receipt in the proof.
+            // Enforce the per-replica allowance on every receipt in the proof.
             for sig in response.proof.signatures.values() {
-                utils::check_refund_allowance(
+                utils::check_spent_allowance(
                     &sig.payment_receipt,
                     request_context.refund_status.per_replica_allowance,
                 )
@@ -571,9 +571,9 @@ impl CanisterHttpPayloadBuilderImpl {
                     context.registry_version,
                 ));
 
-                // Enforce per-replica refund allowance for divergence shares.
+                // Enforce per-replica allowance for divergence shares.
                 for share in grouped_shares.values().flatten() {
-                    utils::check_refund_allowance(
+                    utils::check_spent_allowance(
                         &share.content.payment_receipt,
                         context.refund_status.per_replica_allowance,
                     )

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -1098,15 +1098,15 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_non_replicated() {
+fn validate_payload_fails_for_spent_exceeding_allowance_non_replicated() {
     let delegated_node_id = node_test_id(1);
     let callback_id = CallbackId::from(99);
 
     let (response, metadata) = test_response_and_metadata(callback_id.get());
     let mut proof = response_and_metadata_to_proof(&response, &metadata);
-    add_signer_with_excess_refund_to_proof(&mut proof, delegated_node_id);
+    add_signer_with_excess_spent_to_proof(&mut proof, delegated_node_id);
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         4,
         vec![(
             callback_id,
@@ -1121,17 +1121,17 @@ fn validate_payload_fails_for_refund_exceeding_allowance_non_replicated() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_fully_replicated() {
+fn validate_payload_fails_for_spent_exceeding_allowance_fully_replicated() {
     let num_nodes = 4;
     let callback_id = CallbackId::from(99);
 
     let (response, metadata) = test_response_and_metadata(callback_id.get());
     let mut proof = response_and_metadata_to_proof(&response, &metadata);
     for node in 0..num_nodes as u64 {
-        add_signer_with_excess_refund_to_proof(&mut proof, node_test_id(node));
+        add_signer_with_excess_spent_to_proof(&mut proof, node_test_id(node));
     }
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         num_nodes,
         vec![(callback_id, request_context(Replication::FullyReplicated))],
         default_validation_context(),
@@ -1143,18 +1143,18 @@ fn validate_payload_fails_for_refund_exceeding_allowance_fully_replicated() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_divergence() {
+fn validate_payload_fails_for_spent_exceeding_allowance_divergence() {
     let callback_id = CallbackId::from(99);
 
     let (_response, metadata) = test_response_and_metadata(callback_id.get());
     let payload = CanisterHttpPayload {
         divergence_responses: vec![CanisterHttpResponseDivergence {
-            shares: vec![share_with_excess_refund(0, &metadata)],
+            shares: vec![share_with_excess_spent(0, &metadata)],
         }],
         ..Default::default()
     };
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         4,
         vec![(callback_id, request_context(Replication::FullyReplicated))],
         default_validation_context(),
@@ -1163,7 +1163,7 @@ fn validate_payload_fails_for_refund_exceeding_allowance_divergence() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_flexible_response() {
+fn validate_payload_fails_for_spent_exceeding_allowance_flexible_response() {
     let num_nodes = 4;
     let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
     let callback_id = CallbackId::from(99);
@@ -1177,13 +1177,13 @@ fn validate_payload_fails_for_refund_exceeding_allowance_flexible_response() {
             callback_id,
             responses: vec![FlexibleCanisterHttpResponseWithProof {
                 response,
-                proof: share_with_excess_refund(0, &metadata),
+                proof: share_with_excess_spent(0, &metadata),
             }],
         }],
         ..Default::default()
     };
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         num_nodes,
         vec![(callback_id, flexible_request_context(committee, 1, 4))],
         default_validation_context(),
@@ -1192,7 +1192,7 @@ fn validate_payload_fails_for_refund_exceeding_allowance_flexible_response() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_too_many_rejects() {
+fn validate_payload_fails_for_spent_exceeding_allowance_too_many_rejects() {
     let num_nodes = 4;
     let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
     let callback_id = CallbackId::from(99);
@@ -1209,13 +1209,13 @@ fn validate_payload_fails_for_refund_exceeding_allowance_too_many_rejects() {
             callback_id,
             reject_responses: vec![FlexibleCanisterHttpResponseWithProof {
                 response,
-                proof: share_with_excess_refund(0, &metadata),
+                proof: share_with_excess_spent(0, &metadata),
             }],
         }],
         ..Default::default()
     };
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         num_nodes,
         vec![(callback_id, flexible_request_context(committee, 1, 4))],
         default_validation_context(),
@@ -1224,7 +1224,7 @@ fn validate_payload_fails_for_refund_exceeding_allowance_too_many_rejects() {
 }
 
 #[test]
-fn validate_payload_fails_for_refund_exceeding_allowance_responses_too_large() {
+fn validate_payload_fails_for_spent_exceeding_allowance_responses_too_large() {
     let num_nodes = 4;
     let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
     let callback_id = CallbackId::from(99);
@@ -1233,16 +1233,16 @@ fn validate_payload_fails_for_refund_exceeding_allowance_responses_too_large() {
     let payload = CanisterHttpPayload {
         flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
             callback_id,
-            all_seen_shares: vec![share_with_excess_refund(0, &metadata)],
+            all_seen_shares: vec![share_with_excess_spent(0, &metadata)],
             // Match the committee size and context `min_responses` so validation
-            // reaches the per-share refund check.
+            // reaches the per-share spent check.
             total_requests: num_nodes as u32,
             min_responses: 2,
         }],
         ..Default::default()
     };
 
-    assert_payload_rejected_for_excess_refund(
+    assert_payload_rejected_for_excess_spent(
         num_nodes,
         vec![(callback_id, flexible_request_context(committee, 2, 4))],
         default_validation_context(),
@@ -1686,17 +1686,17 @@ pub(crate) fn add_signer_to_proof(proof: &mut CanisterHttpResponseWithConsensus,
     );
 }
 
-/// A payment receipt whose refund exceeds the default (zero) per-replica
+/// A payment receipt whose spent cycles exceed the default (zero) per-replica
 /// allowance.
 fn receipt_exceeding_allowance() -> CanisterHttpPaymentReceipt {
     CanisterHttpPaymentReceipt {
-        refund: Cycles::new(1),
+        spent: Cycles::new(1),
     }
 }
 
 /// Builds a share for `metadata` signed by `signer_node` whose payment receipt
-/// claims a refund exceeding the default per-replica allowance.
-fn share_with_excess_refund(
+/// claims spent cycles exceeding the default per-replica allowance.
+fn share_with_excess_spent(
     signer_node: u64,
     metadata: &CanisterHttpResponseMetadata,
 ) -> CanisterHttpResponseShare {
@@ -1710,8 +1710,8 @@ fn share_with_excess_refund(
 }
 
 /// Inserts a fake signature for `signer` together with a payment receipt whose
-/// refund exceeds the default per-replica allowance into an aggregated proof.
-fn add_signer_with_excess_refund_to_proof(
+/// spent cycles exceed the default per-replica allowance into an aggregated proof.
+fn add_signer_with_excess_spent_to_proof(
     proof: &mut CanisterHttpResponseWithConsensus,
     signer: NodeId,
 ) {
@@ -1726,8 +1726,8 @@ fn add_signer_with_excess_refund_to_proof(
 
 /// Configures a payload builder with `num_nodes` nodes and the given request
 /// `contexts`, validates `payload`, and asserts that it is rejected because a
-/// payment receipt's refund exceeds the per-replica allowance.
-fn assert_payload_rejected_for_excess_refund(
+/// payment receipt's spent cycles exceed the per-replica allowance.
+fn assert_payload_rejected_for_excess_spent(
     num_nodes: usize,
     contexts: Vec<(CallbackId, CanisterHttpRequestContext)>,
     validation_context: ValidationContext,
@@ -1745,12 +1745,12 @@ fn assert_payload_rejected_for_excess_refund(
             validation_result,
             Err(ValidationError::InvalidArtifact(
                 InvalidPayloadReason::InvalidCanisterHttpPayload(
-                    InvalidCanisterHttpPayloadReason::RefundExceedsAllowance {
-                        refund,
+                    InvalidCanisterHttpPayloadReason::SpentExceedsAllowance {
+                        spent,
                         per_replica_allowance,
                     },
                 ),
-            )) if refund == receipt_exceeding_allowance().refund
+            )) if spent == receipt_exceeding_allowance().spent
                 && per_replica_allowance == Cycles::new(0)
         );
     });

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -77,14 +77,9 @@ pub(crate) fn check_response_consistency(
 
 /// Enforces the per-replica allowance from the request context: the amount the
 /// replica claims to have `spent` in the payment receipt must never exceed the
-/// `per_replica_allowance` derived from the request's context. This bounds a
-/// Byzantine node's claim, which could otherwise be as large as `u128::MAX` and
-/// corrupt the downstream cycles accounting.
+/// `per_replica_allowance` derived from the request's context.
 ///
-/// NOTE: on a free cost schedule the allowance is zero, so this forces the
-/// reported spend to zero. Recording a nonzero per-replica spend on free
-/// subnets (e.g. for user-space cost accounting) would require bounding against
-/// a cost-based maximum instead of the allowance.
+/// TODO: Allow free subnets to spend more than their allowance.
 pub(crate) fn check_spent_allowance(
     receipt: &CanisterHttpPaymentReceipt,
     per_replica_allowance: Cycles,

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -75,16 +75,23 @@ pub(crate) fn check_response_consistency(
     Ok(())
 }
 
-/// Enforces the per-replica refund allowance from the request context: the
-/// `refund` claimed in the payment receipt must never exceed the
-/// `per_replica_allowance` derived from the request's context.
-pub(crate) fn check_refund_allowance(
+/// Enforces the per-replica allowance from the request context: the amount the
+/// replica claims to have `spent` in the payment receipt must never exceed the
+/// `per_replica_allowance` derived from the request's context. This bounds a
+/// Byzantine node's claim, which could otherwise be as large as `u128::MAX` and
+/// corrupt the downstream cycles accounting.
+///
+/// NOTE: on a free cost schedule the allowance is zero, so this forces the
+/// reported spend to zero. Recording a nonzero per-replica spend on free
+/// subnets (e.g. for user-space cost accounting) would require bounding against
+/// a cost-based maximum instead of the allowance.
+pub(crate) fn check_spent_allowance(
     receipt: &CanisterHttpPaymentReceipt,
     per_replica_allowance: Cycles,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
-    if receipt.refund > per_replica_allowance {
-        return Err(InvalidCanisterHttpPayloadReason::RefundExceedsAllowance {
-            refund: receipt.refund,
+    if receipt.spent > per_replica_allowance {
+        return Err(InvalidCanisterHttpPayloadReason::SpentExceedsAllowance {
+            spent: receipt.spent,
             per_replica_allowance,
         });
     }
@@ -198,7 +205,7 @@ pub(crate) fn validate_flexible_response_with_proof(
 /// Validates a single [`CanisterHttpResponseShare`]'s metadata.
 ///
 /// Checks callback-id consistency, duplicate signers, committee membership,
-/// and the per-replica refund allowance.
+/// and the per-replica allowance.
 ///
 /// **NOTE**: The signature is not verified. Callers are expected to
 /// batch-verify the signatures of all shares in the surrounding group via
@@ -210,7 +217,7 @@ pub(crate) fn validate_response_share(
     seen_signers: &mut HashSet<NodeId>,
     per_replica_allowance: Cycles,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
-    check_refund_allowance(&share.content.payment_receipt, per_replica_allowance)?;
+    check_spent_allowance(&share.content.payment_receipt, per_replica_allowance)?;
 
     if share.content.id() != callback_id {
         return Err(

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -518,12 +518,12 @@ impl CanisterHttpPoolManagerImpl {
                     return Some(CanisterHttpChangeAction::RemoveUnvalidated(share.clone()));
                 };
 
-                // Invalidate shares whose refund exceeds what a single
-                // replica is allowed to claim.
-                if share.content.refund() > context.refund_status.per_replica_allowance {
+                // Invalidate shares whose claimed spent cycles exceed what a
+                // single replica is allowed to consume.
+                if share.content.spent() > context.refund_status.per_replica_allowance {
                     return Some(CanisterHttpChangeAction::HandleInvalid(
                         share.clone(),
-                        "Refund is greater than replica allowance".to_string(),
+                        "Spent cycles are greater than replica allowance".to_string(),
                     ));
                 }
 
@@ -3110,7 +3110,7 @@ pub mod test {
     }
 
     #[test]
-    fn test_refund_greater_than_replica_allowance_is_invalid() {
+    fn test_spent_greater_than_replica_allowance_is_invalid() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|log| {
                 let Dependencies {
@@ -3151,7 +3151,7 @@ pub mod test {
                 let mut canister_http_pool =
                     CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
 
-                // Build a per-replica receipt share whose refund claim is
+                // Build a per-replica receipt share whose spent claim is
                 // larger than the per-replica allowance.
                 let receipt_share = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
@@ -3162,7 +3162,7 @@ pub mod test {
                         replica_version: ReplicaVersion::default(),
                     },
                     payment_receipt: CanisterHttpPaymentReceipt {
-                        refund: Cycles::new(200),
+                        spent: Cycles::new(200),
                     },
                 };
                 let signature = crypto
@@ -3204,7 +3204,7 @@ pub mod test {
                 assert_matches!(
                     &changes[0],
                     CanisterHttpChangeAction::HandleInvalid(_, reason)
-                        if reason == "Refund is greater than replica allowance"
+                        if reason == "Spent cycles are greater than replica allowance"
                 );
             })
         });

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -49,8 +49,11 @@ impl BudgetTracker for LegacyTracker {
     }
 
     fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt {
-        // Legacy pricing does not perform cycles accounting, so no cycles
-        // are ever refunded.
+        // Legacy pricing performs no per-replica cycles accounting, so the
+        // replica reports having spent nothing (the default). Legacy refunds are
+        // handled separately (the full legacy fee is charged upfront), so the
+        // per-replica refund derived from this receipt must not be applied to
+        // legacy-priced requests.
         CanisterHttpPaymentReceipt::default()
     }
 }

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -49,11 +49,8 @@ impl BudgetTracker for LegacyTracker {
     }
 
     fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt {
-        // Legacy pricing performs no per-replica cycles accounting, so the
-        // replica reports having spent nothing (the default). Legacy refunds are
-        // handled separately (the full legacy fee is charged upfront), so the
-        // per-replica refund derived from this receipt must not be applied to
-        // legacy-priced requests.
+        // Legacy pricing does not perform cycles accounting, so no cycles
+        // are ever spent.
         CanisterHttpPaymentReceipt::default()
     }
 }

--- a/rs/https_outcalls/pricing/src/payg.rs
+++ b/rs/https_outcalls/pricing/src/payg.rs
@@ -140,8 +140,16 @@ impl BudgetTracker for PayAsYouGoTracker {
     }
 
     fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt {
+        // Cap the reported spend at the allowance: an over-budget outcall (which
+        // accumulates `spent` past the allowance before failing) reports having
+        // consumed exactly its allowance, deriving a zero refund downstream, and
+        // the gossiped value can never exceed what the per-replica validation
+        // permits. On a free cost schedule the allowance is zero and nothing was
+        // charged, so this reports zero. (Recording a nonzero per-replica spend
+        // on free subnets would require a different, cost-based bound; see the
+        // note on `check_spent_allowance`.)
         CanisterHttpPaymentReceipt {
-            refund: Cycles::new(self.allowance.saturating_sub(self.spent)),
+            spent: Cycles::new(self.spent.min(self.allowance)),
         }
     }
 }
@@ -232,14 +240,12 @@ mod tests {
     #[test]
     fn does_not_charge_base_cost() {
         // The base cost is handled at context creation, so a freshly created
-        // tracker has spent nothing and a zero-usage request refunds everything.
+        // tracker has spent nothing and a zero-usage request records no spend
+        // (the full allowance is refunded downstream).
         let ctx = context(Replication::FullyReplicated, 1_000_000);
         let tracker = make_tracker(&ctx, 13);
         assert_eq!(tracker.spent, 0);
-        assert_eq!(
-            tracker.create_payment_receipt().refund,
-            Cycles::new(1_000_000)
-        );
+        assert_eq!(tracker.create_payment_receipt().spent, Cycles::zero());
     }
 
     #[test]
@@ -273,8 +279,8 @@ mod tests {
 
         assert_eq!(tracker.spent, network + transform);
         assert_eq!(
-            tracker.create_payment_receipt().refund,
-            Cycles::new(allowance - network - transform)
+            tracker.create_payment_receipt().spent,
+            Cycles::new(network + transform)
         );
     }
 
@@ -293,7 +299,8 @@ mod tests {
 
     #[test]
     fn returns_pricing_error_when_budget_is_exceeded() {
-        let ctx = context(Replication::FullyReplicated, 100);
+        let allowance = 100;
+        let ctx = context(Replication::FullyReplicated, allowance);
         let mut tracker = make_tracker(&ctx, 13);
         assert_eq!(
             tracker.subtract_network_usage(NetworkUsage {
@@ -302,15 +309,22 @@ mod tests {
             }),
             Err(PricingError::InsufficientCycles)
         );
-        assert_eq!(tracker.create_payment_receipt().refund, Cycles::zero());
+        // The reported spend is capped at the allowance, so an over-budget
+        // outcall reports consuming exactly its allowance (the refund derived
+        // downstream is zero) rather than the larger raw amount.
+        assert_eq!(
+            tracker.create_payment_receipt().spent,
+            Cycles::new(allowance)
+        );
     }
 
     #[test]
     fn charges_nothing_on_free_cost_schedule() {
         // On a free subnet the tracker charges nothing, even for usage that
-        // would otherwise exceed the allowance, so the full allowance is
-        // refunded. A flexible request is used so the gossip term (which would
-        // not be charged for fully-replicated requests) is also exercised.
+        // would otherwise exceed the allowance, so it records no spend (the full
+        // allowance is refunded downstream). A flexible request is used so the
+        // gossip term (which would not be charged for fully-replicated requests)
+        // is also exercised.
         let allowance = 1_000_000_u128;
         let ctx = context(flexible(13), allowance);
         let mut tracker = PayAsYouGoTracker::new(
@@ -336,9 +350,6 @@ mod tests {
         );
 
         assert_eq!(tracker.spent, 0);
-        assert_eq!(
-            tracker.create_payment_receipt().refund,
-            Cycles::new(allowance)
-        );
+        assert_eq!(tracker.create_payment_receipt().spent, Cycles::zero());
     }
 }

--- a/rs/https_outcalls/pricing/src/payg.rs
+++ b/rs/https_outcalls/pricing/src/payg.rs
@@ -140,14 +140,7 @@ impl BudgetTracker for PayAsYouGoTracker {
     }
 
     fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt {
-        // Cap the reported spend at the allowance: an over-budget outcall (which
-        // accumulates `spent` past the allowance before failing) reports having
-        // consumed exactly its allowance, deriving a zero refund downstream, and
-        // the gossiped value can never exceed what the per-replica validation
-        // permits. On a free cost schedule the allowance is zero and nothing was
-        // charged, so this reports zero. (Recording a nonzero per-replica spend
-        // on free subnets would require a different, cost-based bound; see the
-        // note on `check_spent_allowance`.)
+        // TODO: Allow free subnets to spend more than their allowance.
         CanisterHttpPaymentReceipt {
             spent: Cycles::new(self.spent.min(self.allowance)),
         }

--- a/rs/interfaces/src/canister_http.rs
+++ b/rs/interfaces/src/canister_http.rs
@@ -51,10 +51,10 @@ pub enum InvalidCanisterHttpPayloadReason {
     NotTimedOut(CallbackId),
     /// There was an error with a signature calculation
     SignatureError(Box<CryptoError>),
-    /// A payment receipt claims a refund larger than the per-replica allowance
-    /// derived from the request's payment.
-    RefundExceedsAllowance {
-        refund: Cycles,
+    /// A payment receipt claims the replica spent more than the per-replica
+    /// allowance derived from the request's payment.
+    SpentExceedsAllowance {
+        spent: Cycles,
         per_replica_allowance: Cycles,
     },
     /// Some of the signatures in the canister http proof were not members of

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -7,7 +7,7 @@ import "types/v1/errors.proto";
 import "types/v1/types.proto";
 
 message CanisterHttpPaymentReceipt {
-  state.queues.v1.Cycles refund = 1;
+  state.queues.v1.Cycles spent = 1;
 }
 
 message HttpHeader {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -520,7 +520,7 @@ pub struct ThresholdSignatureShare {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterHttpPaymentReceipt {
     #[prost(message, optional, tag = "1")]
-    pub refund: ::core::option::Option<super::super::state::queues::v1::Cycles>,
+    pub spent: ::core::option::Option<super::super::state::queues::v1::Cycles>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpHeader {

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -189,7 +189,7 @@ impl CanisterHttpPayload {
 impl From<CanisterHttpPaymentReceipt> for pb::CanisterHttpPaymentReceipt {
     fn from(receipt: CanisterHttpPaymentReceipt) -> Self {
         pb::CanisterHttpPaymentReceipt {
-            refund: Some(receipt.refund.into()),
+            spent: Some(receipt.spent.into()),
         }
     }
 }
@@ -198,7 +198,7 @@ impl TryFrom<pb::CanisterHttpPaymentReceipt> for CanisterHttpPaymentReceipt {
     type Error = ProxyDecodeError;
     fn try_from(receipt: pb::CanisterHttpPaymentReceipt) -> Result<Self, Self::Error> {
         Ok(CanisterHttpPaymentReceipt {
-            refund: try_from_option_field(receipt.refund, "CanisterHttpPaymentReceipt::refund")?,
+            spent: try_from_option_field(receipt.spent, "CanisterHttpPaymentReceipt::spent")?,
         })
     }
 }
@@ -643,7 +643,7 @@ mod tests {
                     replica_version: ReplicaVersion::default(),
                 },
                 payment_receipt: CanisterHttpPaymentReceipt {
-                    refund: Cycles::new(42),
+                    spent: Cycles::new(42),
                 },
             },
             signature: BasicSignature {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1048,9 +1048,8 @@ impl CountBytes for CanisterHttpResponseDivergence {
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct CanisterHttpPaymentReceipt {
     /// The amount of cycles, out of the per-replica allowance, that the replica
-    /// consumed. The cycles to refund to the caller are derived downstream as
-    /// `per_replica_allowance - spent`. Never exceeds the per-replica allowance:
-    /// the producer caps it and consensus rejects any receipt above it.
+    /// has spent. The cycles to refund to the caller are derived downstream as
+    /// `per_replica_allowance - spent`.
     pub spent: Cycles,
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1047,15 +1047,17 @@ impl CountBytes for CanisterHttpResponseDivergence {
 #[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct CanisterHttpPaymentReceipt {
-    /// The amount of cycles, out of the per-replica allowance, that the
-    /// replica did not use and wishes to refund to the caller.
-    pub refund: Cycles,
+    /// The amount of cycles, out of the per-replica allowance, that the replica
+    /// consumed. The cycles to refund to the caller are derived downstream as
+    /// `per_replica_allowance - spent`. Never exceeds the per-replica allowance:
+    /// the producer caps it and consensus rejects any receipt above it.
+    pub spent: Cycles,
 }
 
 impl CountBytes for CanisterHttpPaymentReceipt {
     fn count_bytes(&self) -> usize {
-        let Self { refund } = self;
-        size_of_val(refund)
+        let Self { spent } = self;
+        size_of_val(spent)
     }
 }
 
@@ -1128,8 +1130,8 @@ impl CanisterHttpResponseReceipt {
         &self.metadata.replica_version
     }
 
-    pub fn refund(&self) -> Cycles {
-        self.payment_receipt.refund
+    pub fn spent(&self) -> Cycles {
+        self.payment_receipt.spent
     }
 }
 

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -1096,7 +1096,7 @@ mod crypto_hash_stability {
         let receipt_share = CanisterHttpResponseReceipt {
             metadata,
             payment_receipt: CanisterHttpPaymentReceipt {
-                refund: Cycles::new(42),
+                spent: Cycles::new(42),
             },
         };
         let data = Signed {


### PR DESCRIPTION
As part of the new pay-as-you-go pricing for HTTP outcalls, each replica participating in the outcall reports its own cycles usage. This usage is reported as part of the response shares gossiped between peers of a subnet.

Before this PR, each node gossiped a _refund_ share, describing the amount of cycles (out of the per-replica allowance), that the node would like to refund to the caller.

The problem with this approach is that on free subnets, the per-replica allowance is zero, in order to avoid minting cycles by mistake. This means that nodes on free subnets cannot properly report their (nominal) cycles usage, which is relevant for properly updating canister metrics.

Therefore, with this PR, nodes will instead report the amount of _spent_ cycles (out of the per-replica allowance). In a follow up we can then allow nodes on free subnets to spend more cycles than their allowance of zero.