### PR TITLE
refactor(ic-admin): Re-use fns to build clients and keys in ic-admin

### DIFF
--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -88,16 +88,17 @@ use ic_protobuf::registry::{
 };
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_client_helpers::{
-    chain_keys::ChainKeysRegistry, crypto::CryptoRegistry, deserialize_registry_value,
-    ecdsa_keys::EcdsaKeysRegistry, hostos_version::HostosRegistry,
+    api_boundary_node::ApiBoundaryNodeRegistry, chain_keys::ChainKeysRegistry,
+    crypto::CryptoRegistry, deserialize_registry_value, ecdsa_keys::EcdsaKeysRegistry,
+    hostos_version::HostosRegistry, node_operator::NodeOperatorRegistry,
     replica_version::ReplicaVersionRegistry, subnet::SubnetRegistry,
 };
 use ic_registry_keys::{
-    API_BOUNDARY_NODE_RECORD_KEY_PREFIX, FirewallRulesScope, NODE_OPERATOR_RECORD_KEY_PREFIX,
-    NODE_RECORD_KEY_PREFIX, NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY,
-    get_node_operator_id_from_record_key, get_node_record_node_id, is_node_operator_record_key,
-    is_node_record_key, make_api_boundary_node_record_key, make_canister_migrations_record_key,
-    make_crypto_node_key, make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
+    FirewallRulesScope, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
+    NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY, get_node_operator_id_from_record_key,
+    get_node_record_node_id, is_node_operator_record_key, is_node_record_key,
+    make_api_boundary_node_record_key, make_canister_migrations_record_key, make_crypto_node_key,
+    make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
     make_data_center_record_key, make_firewall_config_record_key, make_firewall_rules_record_key,
     make_node_operator_record_key, make_node_record_key, make_provisional_whitelist_record_key,
     make_replica_version_key, make_subnet_list_record_key, make_subnet_record_key,
@@ -4661,19 +4662,19 @@ async fn main() {
             ),
         }
 
-        if let Some(secret_key_path) = opts.secret_key_pem {
+        if let Some(secret_key_path) = &opts.secret_key_pem {
             let contents = read_to_string(secret_key_path).expect("Could not read key file");
             let sig_keys = SigKeys::from_pem(&contents).expect("Failed to parse pem file");
             Sender::SigKeys(sig_keys)
         } else if opts.use_hsm {
             make_hsm_sender(
-                &opts.hsm_slot.expect(
+                opts.hsm_slot.as_ref().expect(
                     "HSM slot must also be provided for --use-hsm; use --hsm-slot or see --help.",
                 ),
-                &opts.hsm_key_id.expect(
+                opts.hsm_key_id.as_ref().expect(
                     "HSM key ID must also be provided for --use-hsm; use --key-id or see --help.",
                 ),
-                &opts.hsm_pin.expect(
+                opts.hsm_pin.as_ref().expect(
                     "HSM pin must also be provided for --use-hsm; use --pin or see --help.",
                 ),
             )
@@ -4775,7 +4776,7 @@ async fn main() {
             }
             eprintln!("INFO: Fetching API Boundary nodes...");
             // list all API Boundary Nodes
-            let api_bn_node_ids = get_api_boundary_node_ids(reachable_nns_urls.clone())
+            let api_bn_node_ids = get_api_boundary_node_ids(opts, reachable_nns_urls.clone())
                 .iter()
                 .map(|n| NodeId::from(PrincipalId::from_str(n).unwrap()))
                 .collect();
@@ -5329,12 +5330,10 @@ async fn main() {
                 .await;
         }
         SubCommand::GetNodeOperatorList => {
-            let registry_client = RegistryClientImpl::new(
-                Arc::new(NnsDataProvider::new(
-                    tokio::runtime::Handle::current(),
-                    reachable_nns_urls.clone(),
-                )),
-                None,
+            let registry_client = make_registry_client(
+                reachable_nns_urls,
+                opts.verify_nns_responses,
+                opts.nns_public_key_pem_file,
             );
 
             // maximum number of retries, let the user ctrl+c if necessary
@@ -5342,20 +5341,14 @@ async fn main() {
                 .try_polling_latest_version(usize::MAX)
                 .unwrap();
 
-            let keys = registry_client
-                .get_key_family(
-                    NODE_OPERATOR_RECORD_KEY_PREFIX,
-                    registry_client.get_latest_version(),
-                )
-                .unwrap();
+            let node_operators = registry_client
+                .get_node_operators(registry_client.get_latest_version())
+                .unwrap()
+                .unwrap_or_default();
 
-            let records = keys
-                .iter()
-                .map(|k| k.strip_prefix(NODE_OPERATOR_RECORD_KEY_PREFIX).unwrap())
-                .collect::<Vec<_>>();
             println!(
                 "{}",
-                serde_json::to_string_pretty(&records)
+                serde_json::to_string_pretty(&node_operators)
                     .expect("Failed to serialize the records to JSON")
             );
         }
@@ -5853,12 +5846,10 @@ async fn main() {
             .await;
         }
         SubCommand::GetElectedHostosVersions => {
-            let registry_client = RegistryClientImpl::new(
-                Arc::new(NnsDataProvider::new(
-                    tokio::runtime::Handle::current(),
-                    reachable_nns_urls.clone(),
-                )),
-                None,
+            let registry_client = make_registry_client(
+                reachable_nns_urls,
+                opts.verify_nns_responses,
+                opts.nns_public_key_pem_file,
             );
 
             // maximum number of retries, let the user ctrl+c if necessary
@@ -5939,7 +5930,7 @@ async fn main() {
             .await;
         }
         SubCommand::GetApiBoundaryNodes => {
-            let records = get_api_boundary_node_ids(reachable_nns_urls.clone());
+            let records = get_api_boundary_node_ids(opts, reachable_nns_urls.clone());
             println!(
                 "{}",
                 serde_json::to_string_pretty(&records)
@@ -6750,32 +6741,22 @@ async fn get_subnet_pk(registry: &RegistryCanister, subnet_id: SubnetId) -> Publ
     }
 }
 
-fn get_api_boundary_node_ids(nns_url: Vec<Url>) -> Vec<String> {
-    let registry_client = RegistryClientImpl::new(
-        Arc::new(NnsDataProvider::new(
-            tokio::runtime::Handle::current(),
-            nns_url,
-        )),
-        None,
+fn get_api_boundary_node_ids(opts: Opts, nns_url: Vec<Url>) -> Vec<String> {
+    let registry_client = make_registry_client(
+        nns_url,
+        opts.verify_nns_responses,
+        opts.nns_public_key_pem_file,
     );
     // maximum number of retries, let the user ctrl+c if necessary
     registry_client
         .try_polling_latest_version(usize::MAX)
         .unwrap();
-    let keys = registry_client
-        .get_key_family(
-            API_BOUNDARY_NODE_RECORD_KEY_PREFIX,
-            registry_client.get_latest_version(),
-        )
+
+    let bns = registry_client
+        .get_api_boundary_node_ids(registry_client.get_latest_version())
         .unwrap();
 
-    keys.iter()
-        .map(|k| {
-            k.strip_prefix(API_BOUNDARY_NODE_RECORD_KEY_PREFIX)
-                .unwrap()
-                .to_string()
-        })
-        .collect::<Vec<_>>()
+    bns.iter().map(|v| v.to_string()).collect::<Vec<_>>()
 }
 
 fn print_routing_table(routing_table: &Vec<(CanisterIdRange, SubnetId)>, version: RegistryVersion) {

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -4662,19 +4662,19 @@ async fn main() {
             ),
         }
 
-        if let Some(secret_key_path) = &opts.secret_key_pem {
+        if let Some(secret_key_path) = opts.secret_key_pem {
             let contents = read_to_string(secret_key_path).expect("Could not read key file");
             let sig_keys = SigKeys::from_pem(&contents).expect("Failed to parse pem file");
             Sender::SigKeys(sig_keys)
         } else if opts.use_hsm {
             make_hsm_sender(
-                opts.hsm_slot.as_ref().expect(
+                &opts.hsm_slot.expect(
                     "HSM slot must also be provided for --use-hsm; use --hsm-slot or see --help.",
                 ),
-                opts.hsm_key_id.as_ref().expect(
+                &opts.hsm_key_id.expect(
                     "HSM key ID must also be provided for --use-hsm; use --key-id or see --help.",
                 ),
-                opts.hsm_pin.as_ref().expect(
+                &opts.hsm_pin.expect(
                     "HSM pin must also be provided for --use-hsm; use --pin or see --help.",
                 ),
             )
@@ -4776,7 +4776,12 @@ async fn main() {
             }
             eprintln!("INFO: Fetching API Boundary nodes...");
             // list all API Boundary Nodes
-            let api_bn_node_ids = get_api_boundary_node_ids(opts, reachable_nns_urls.clone())
+            let registry_client = make_registry_client(
+                reachable_nns_urls.clone(),
+                opts.verify_nns_responses,
+                opts.nns_public_key_pem_file,
+            );
+            let api_bn_node_ids = get_api_boundary_node_ids(registry_client)
                 .iter()
                 .map(|n| NodeId::from(PrincipalId::from_str(n).unwrap()))
                 .collect();
@@ -5930,7 +5935,12 @@ async fn main() {
             .await;
         }
         SubCommand::GetApiBoundaryNodes => {
-            let records = get_api_boundary_node_ids(opts, reachable_nns_urls.clone());
+            let registry_client = make_registry_client(
+                reachable_nns_urls.clone(),
+                opts.verify_nns_responses,
+                opts.nns_public_key_pem_file,
+            );
+            let records = get_api_boundary_node_ids(registry_client);
             println!(
                 "{}",
                 serde_json::to_string_pretty(&records)
@@ -6741,12 +6751,7 @@ async fn get_subnet_pk(registry: &RegistryCanister, subnet_id: SubnetId) -> Publ
     }
 }
 
-fn get_api_boundary_node_ids(opts: Opts, nns_url: Vec<Url>) -> Vec<String> {
-    let registry_client = make_registry_client(
-        nns_url,
-        opts.verify_nns_responses,
-        opts.nns_public_key_pem_file,
-    );
+fn get_api_boundary_node_ids(registry_client: RegistryClientImpl) -> Vec<String> {
     // maximum number of retries, let the user ctrl+c if necessary
     registry_client
         .try_polling_latest_version(usize::MAX)

--- a/rs/registry/helpers/src/node_operator.rs
+++ b/rs/registry/helpers/src/node_operator.rs
@@ -2,10 +2,15 @@ use crate::deserialize_registry_value;
 use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
 pub use ic_protobuf::registry::node::v1::{ConnectionEndpoint, NodeRecord};
 pub use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
-use ic_registry_keys::make_node_operator_record_key;
+use ic_registry_keys::{NODE_OPERATOR_RECORD_KEY_PREFIX, make_node_operator_record_key};
 pub use ic_types::{NodeId, PrincipalId, RegistryVersion, SubnetId};
 
 pub trait NodeOperatorRegistry {
+    fn get_node_operators(
+        &self,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<Vec<NodeOperatorRecord>>;
+
     fn get_node_operator_record(
         &self,
         node_operator_id: PrincipalId,
@@ -14,6 +19,23 @@ pub trait NodeOperatorRegistry {
 }
 
 impl<T: RegistryClient + ?Sized> NodeOperatorRegistry for T {
+    fn get_node_operators(
+        &self,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<Vec<NodeOperatorRecord>> {
+        let keys = self.get_key_family(NODE_OPERATOR_RECORD_KEY_PREFIX, version)?;
+
+        let mut records = Vec::new();
+        for key in keys {
+            let bytes = self.get_value(&key, version);
+            let node_operator_proto =
+                deserialize_registry_value::<NodeOperatorRecord>(bytes)?.unwrap_or_default();
+            records.push(node_operator_proto)
+        }
+
+        Ok(Some(records))
+    }
+
     fn get_node_operator_record(
         &self,
         node_operator_id: PrincipalId,


### PR DESCRIPTION
Where possible, use helpers to avoid building `RegistryClientImpl`s and registry keys, directly.