### PR TITLE
fix: `CanisterHttpPoolImpl::get()` serves full response for flexible & non-replicated requests

### DIFF
--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -25,7 +25,7 @@ use prometheus::IntCounter;
 const POOL_CANISTER_HTTP: &str = "canister_http";
 const POOL_CANISTER_HTTP_CONTENT: &str = "canister_http_content";
 
-type ValidatedCanisterHttpPoolSection = PoolSection<CanisterHttpResponseShare, ResponseGossip>;
+type ValidatedCanisterHttpPoolSection = PoolSection<CanisterHttpResponseShare, ServedResponse>;
 
 type UnvalidatedCanisterHttpPoolSection =
     PoolSection<CanisterHttpResponseShare, CanisterHttpResponseArtifact>;
@@ -37,7 +37,7 @@ type ContentCanisterHttpPoolSection =
 /// when the artifact is served to peers that *pull* it via
 /// [`ValidatedPoolReader::get`].
 #[derive(Clone, Copy)]
-enum ResponseGossip {
+enum ServedResponse {
     /// The request is not fully replicated (`NonReplicated` / `Flexible`): the
     /// `CanisterHttpResponse` is produced by only a subset of nodes, so it must
     /// be included with the artifact.
@@ -47,7 +47,7 @@ enum ResponseGossip {
     Exclude,
 }
 
-impl HasLabel for ResponseGossip {
+impl HasLabel for ServedResponse {
     fn label(&self) -> &str {
         ""
     }
@@ -154,8 +154,8 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    // Response content should be gossiped
-                    self.validated.insert(share, ResponseGossip::Include);
+                    // Response content should be served
+                    self.validated.insert(share, ServedResponse::Include);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
                 }
@@ -168,8 +168,8 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    // Response content should not be gossiped
-                    self.validated.insert(share, ResponseGossip::Exclude);
+                    // Response content should not be served
+                    self.validated.insert(share, ServedResponse::Exclude);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
                 }
@@ -177,15 +177,16 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                     if let Some(artifact) = self.unvalidated.remove(&share) {
                         // If there is a response associated with this share, we want to move it to the `content`
                         // section of the pool, corresponding to valid responses. A validated share carries a
-                        // response exactly for responses that should be gossiped.
-                        let response_gossip = if let Some(content) = artifact.response {
+                        // response exactly for non-fully-replicated requests, whose response must be served
+                        // to peers that pull the artifact.
+                        let served_response = if let Some(content) = artifact.response {
                             self.content
                                 .insert(ic_types::crypto::crypto_hash(&content), content);
-                            ResponseGossip::Include
+                            ServedResponse::Include
                         } else {
-                            ResponseGossip::Exclude
+                            ServedResponse::Exclude
                         };
-                        self.validated.insert(share, response_gossip);
+                        self.validated.insert(share, served_response);
                     }
                 }
                 CanisterHttpChangeAction::RemoveValidated(id) => {
@@ -221,7 +222,7 @@ impl ValidatedPoolReader<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl 
         // Important: this may be called by a peer that *pulls* a validated artifact,
         // if the corresponding advert was stashed by the peer's bouncer.
         let response = match self.validated.get(id)? {
-            ResponseGossip::Include => {
+            ServedResponse::Include => {
                 let Some(content) = self.content.get(id.content.content_hash()).cloned() else {
                     warn!(
                         every_n_seconds => 30,
@@ -234,7 +235,7 @@ impl ValidatedPoolReader<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl 
                 };
                 Some(content)
             }
-            ResponseGossip::Exclude => None,
+            ServedResponse::Exclude => None,
         };
         Some(CanisterHttpResponseArtifact {
             share: id.clone(),

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -154,7 +154,7 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    // Response should be gossiped
+                    // Response content should be gossiped
                     self.validated.insert(share, ResponseGossip::Include);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
@@ -168,24 +168,23 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    // Response should not be gossiped
+                    // Response content should not be gossiped
                     self.validated.insert(share, ResponseGossip::Exclude);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
                 }
                 CanisterHttpChangeAction::MoveToValidated(share) => {
                     if let Some(artifact) = self.unvalidated.remove(&share) {
-                        // A validated share carries a response exactly for
-                        // responses that should be gossiped.
-                        let response_gossip = if artifact.response.is_some() {
+                        // If there is a response associated with this share, we want to move it to the `content`
+                        // section of the pool, corresponding to valid responses. A validated share carries a
+                        // response exactly for responses that should be gossiped.
+                        let response_gossip = if let Some(content) = artifact.response {
+                            self.content
+                                .insert(ic_types::crypto::crypto_hash(&content), content);
                             ResponseGossip::Include
                         } else {
                             ResponseGossip::Exclude
                         };
-                        if let Some(content) = artifact.response {
-                            self.content
-                                .insert(ic_types::crypto::crypto_hash(&content), content);
-                        }
                         self.validated.insert(share, response_gossip);
                     }
                 }
@@ -219,13 +218,15 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
 
 impl ValidatedPoolReader<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
     fn get(&self, id: &CanisterHttpResponseId) -> Option<CanisterHttpResponseArtifact> {
+        // Important: this may be called by a peer that *pulls* a validated artifact,
+        // if the corresponding advert was stashed by the peer's bouncer.
         let response = match self.validated.get(id)? {
             ResponseGossip::Include => {
                 let Some(content) = self.content.get(id.content.content_hash()).cloned() else {
                     warn!(
                         every_n_seconds => 30,
                         self.log,
-                        "Validated non-fully-replicated share {:?} is missing its response \
+                        "Validated share {:?} is missing its expected response \
                          content in the pool; not serving the artifact.",
                         id.content.id()
                     );

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -25,13 +25,33 @@ use prometheus::IntCounter;
 const POOL_CANISTER_HTTP: &str = "canister_http";
 const POOL_CANISTER_HTTP_CONTENT: &str = "canister_http_content";
 
-type ValidatedCanisterHttpPoolSection = PoolSection<CanisterHttpResponseShare, ()>;
+type ValidatedCanisterHttpPoolSection = PoolSection<CanisterHttpResponseShare, ResponseGossip>;
 
 type UnvalidatedCanisterHttpPoolSection =
     PoolSection<CanisterHttpResponseShare, CanisterHttpResponseArtifact>;
 
 type ContentCanisterHttpPoolSection =
     PoolSection<CryptoHashOf<CanisterHttpResponse>, CanisterHttpResponse>;
+
+/// Records, for a validated share, whether the full response must be included
+/// when the artifact is served to peers that *pull* it via
+/// [`ValidatedPoolReader::get`].
+#[derive(Clone, Copy)]
+enum ResponseGossip {
+    /// The request is not fully replicated (`NonReplicated` / `Flexible`): the
+    /// `CanisterHttpResponse` is produced by only a subset of nodes, so it must
+    /// be included with the artifact.
+    Include,
+    /// The request is fully replicated: every node recomputes the response
+    /// locally, so it must be excluded from the artifact.
+    Exclude,
+}
+
+impl HasLabel for ResponseGossip {
+    fn label(&self) -> &str {
+        ""
+    }
+}
 
 pub struct CanisterHttpPoolImpl {
     validated: ValidatedCanisterHttpPoolSection,
@@ -101,7 +121,7 @@ impl CanisterHttpPool for CanisterHttpPoolImpl {
         &self,
         share: &CanisterHttpResponseShare,
     ) -> Option<CanisterHttpResponseShare> {
-        self.validated.get(share).map(|()| share.clone())
+        self.validated.get(share).map(|_| share.clone())
     }
 }
 
@@ -134,7 +154,8 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    self.validated.insert(share, ());
+                    // Response should be gossiped
+                    self.validated.insert(share, ResponseGossip::Include);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
                 }
@@ -147,19 +168,25 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
                         artifact,
                         is_latency_sensitive: true,
                     }));
-                    self.validated.insert(share, ());
+                    // Response should not be gossiped
+                    self.validated.insert(share, ResponseGossip::Exclude);
                     self.content
                         .insert(ic_types::crypto::crypto_hash(&content), content);
                 }
                 CanisterHttpChangeAction::MoveToValidated(share) => {
                     if let Some(artifact) = self.unvalidated.remove(&share) {
-                        // If there is a response associated with this share, we want to move it to the `content`
-                        // section of the pool, corresponding to valid responses.
+                        // A validated share carries a response exactly for
+                        // responses that should be gossiped.
+                        let response_gossip = if artifact.response.is_some() {
+                            ResponseGossip::Include
+                        } else {
+                            ResponseGossip::Exclude
+                        };
                         if let Some(content) = artifact.response {
                             self.content
                                 .insert(ic_types::crypto::crypto_hash(&content), content);
                         }
-                        self.validated.insert(share, ());
+                        self.validated.insert(share, response_gossip);
                     }
                 }
                 CanisterHttpChangeAction::RemoveValidated(id) => {
@@ -192,18 +219,26 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
 
 impl ValidatedPoolReader<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
     fn get(&self, id: &CanisterHttpResponseId) -> Option<CanisterHttpResponseArtifact> {
-        // Important: this is actually never used, as Http artifacts are always sent directly (no adverts).
-        // If we ever decide to use adverts, we should make the distinction between artifacts with or without a
-        // response. We should either:
-        //  - only use adverts when gossiping a full response; this way, this should always return the response
-        //  - store a flag in the share which says whether the full response needs to be gossiped or not.
-        // This is to avoid sending the response in full in the fully replicated case.
-        self.validated
-            .get(id)
-            .map(|()| CanisterHttpResponseArtifact {
-                share: id.clone(),
-                response: None,
-            })
+        let response = match self.validated.get(id)? {
+            ResponseGossip::Include => {
+                let Some(content) = self.content.get(id.content.content_hash()).cloned() else {
+                    warn!(
+                        every_n_seconds => 30,
+                        self.log,
+                        "Validated non-fully-replicated share {:?} is missing its response \
+                         content in the pool; not serving the artifact.",
+                        id.content.id()
+                    );
+                    return None;
+                };
+                Some(content)
+            }
+            ResponseGossip::Exclude => None,
+        };
+        Some(CanisterHttpResponseArtifact {
+            share: id.clone(),
+            response,
+        })
     }
 
     fn get_all_for_initial_broadcast(
@@ -284,6 +319,23 @@ mod tests {
         }
     }
 
+    /// Like [`fake_share`], but with a `content_hash` that matches `response`.
+    fn fake_share_matching(id: u64, response: &CanisterHttpResponse) -> CanisterHttpResponseShare {
+        Signed {
+            content: CanisterHttpResponseReceipt {
+                metadata: CanisterHttpResponseMetadata {
+                    id: CallbackId::from(id),
+                    content_hash: ic_types::crypto::crypto_hash(response),
+                    content_size: 42,
+                    is_reject: false,
+                    replica_version: ReplicaVersion::default(),
+                },
+                payment_receipt: CanisterHttpPaymentReceipt::default(),
+            },
+            signature: BasicSignature::fake(node_test_id(id)),
+        }
+    }
+
     #[test]
     fn test_canister_http_pool_insert_and_remove() {
         let mut pool = CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
@@ -342,9 +394,9 @@ mod tests {
     #[test]
     fn test_canister_http_pool_add_to_validated_and_gossip_response() {
         let mut pool = CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
-        let share = fake_share(123);
-        let id = share.clone();
         let response = fake_response(123);
+        let share = fake_share_matching(123, &response);
+        let id = share.clone();
         let content_hash = ic_types::crypto::crypto_hash(&response);
 
         let result = pool.apply(vec![
@@ -365,11 +417,88 @@ mod tests {
         assert!(result.poll_immediately);
         assert_eq!(result.transmits.len(), 1);
         assert_eq!(share, pool.lookup_validated(&id).unwrap());
-        assert_eq!(share, pool.get(&id).unwrap().share);
+        // A pulled non-fully-replicated artifact carries the full response.
+        assert_eq!(pool.get(&id).unwrap(), expected_artifact);
         assert_eq!(
             response,
             pool.get_response_content_by_hash(&content_hash).unwrap()
         );
+    }
+
+    /// A peer that *pulls* a validated artifact (via
+    /// [`ValidatedPoolReader::get`]) must receive the full response for
+    /// non-fully-replicated requests, and must not receive one for fully
+    /// replicated requests.
+    #[test]
+    fn test_get_serves_response_only_for_non_fully_replicated_shares() {
+        let mut pool = CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+        // Non-fully-replicated, locally produced: response is served on pull.
+        let response = fake_response(1);
+        let share = fake_share_matching(1, &response);
+        let id = share.clone();
+        pool.apply(vec![
+            CanisterHttpChangeAction::AddToValidatedAndGossipResponse(
+                share.clone(),
+                response.clone(),
+            ),
+        ]);
+        assert_eq!(pool.get(&id).unwrap().response, Some(response));
+
+        // Fully replicated, locally produced: response is not served on pull.
+        let response = fake_response(2);
+        let share = fake_share_matching(2, &response);
+        let id = share.clone();
+        pool.apply(vec![CanisterHttpChangeAction::AddToValidated(
+            share.clone(),
+            response.clone(),
+        )]);
+        assert!(pool.get(&id).unwrap().response.is_none());
+
+        // Non-fully-replicated, received from a peer (MoveToValidated with a
+        // response present): response is served on pull.
+        let response = fake_response(3);
+        let share = fake_share_matching(3, &response);
+        let id = share.clone();
+        pool.insert(UnvalidatedArtifact {
+            message: CanisterHttpResponseArtifact {
+                share: share.clone(),
+                response: Some(response.clone()),
+            },
+            peer_id: node_test_id(0),
+            timestamp: UNIX_EPOCH,
+        });
+        pool.apply(vec![CanisterHttpChangeAction::MoveToValidated(
+            share.clone(),
+        )]);
+        assert_eq!(pool.get(&id).unwrap().response, Some(response));
+
+        // Fully replicated, received from a peer (MoveToValidated without a
+        // response): response is not served on pull.
+        let share = fake_share(4);
+        let id = share.clone();
+        pool.insert(to_unvalidated(share.clone()));
+        pool.apply(vec![CanisterHttpChangeAction::MoveToValidated(
+            share.clone(),
+        )]);
+        assert!(pool.get(&id).unwrap().response.is_none());
+
+        // Non-fully-replicated share whose response content is missing: `get`
+        // must serve nothing, rather than a response-less artifact that the
+        // pulling peer would only invalidate.
+        let response = fake_response(5);
+        let share = fake_share_matching(5, &response);
+        let id = share.clone();
+        let content_hash = ic_types::crypto::crypto_hash(&response);
+        pool.apply(vec![
+            CanisterHttpChangeAction::AddToValidatedAndGossipResponse(
+                share.clone(),
+                response.clone(),
+            ),
+        ]);
+        assert!(pool.get(&id).unwrap().response.is_some());
+        pool.apply(vec![CanisterHttpChangeAction::RemoveContent(content_hash)]);
+        assert!(pool.get(&id).is_none());
     }
 
     #[test]

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -49,7 +49,7 @@ enum ServedResponse {
 
 impl HasLabel for ServedResponse {
     fn label(&self) -> &str {
-        ""
+        "served_response"
     }
 }
 

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -220,7 +220,7 @@ impl MutablePool<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
 impl ValidatedPoolReader<CanisterHttpResponseArtifact> for CanisterHttpPoolImpl {
     fn get(&self, id: &CanisterHttpResponseId) -> Option<CanisterHttpResponseArtifact> {
         // Important: this may be called by a peer that *pulls* a validated artifact,
-        // if the corresponding advert was stashed by the peer's bouncer.
+        // if the corresponding advert was previously stashed by the peer's bouncer.
         let response = match self.validated.get(id)? {
             ServedResponse::Include => {
                 let Some(content) = self.content.get(id.content.content_hash()).cloned() else {


### PR DESCRIPTION
## Background
For fully replicated HTTP outcalls requests, the gossiped shares include only the response hash, because each replica determines the HTTP response content by making the outcall themselves.

For flexible & non-replicated requests, not all replicas make the HTTP outcall. Yet, all replicas should still know the results of all outcalls, such that all replicas can potentially include them in a block. Therefore, the gossiped responses also include the full HTTP response content. Otherwise, a replica making a non-replicated request (where only one replica makes the outcall), would need to wait 1-13 blocks (13 node subnet) until it is the blockmaker to include the response in a block.

Additionally, HTTP outcalls shares are not relayed, or advertised. They are pushed to all peers immediately (`is_latency_sensitive: true`).

## Problem
Because HTTP outcalls shares are pushed without adverts, the code before this PR assumed that `CanisterHttpPoolImpl::get()` would never actually be called (`get()` is usually how a node returns an artifact that is requested / "pulled" by other nodes, i.e. when resolving an advert). Because of this assumption, `get()` never returned the full response content, and instead set it to `None` for simplicity: https://github.com/dfinity/ic/blob/5ee93a413156c9fdc2787194731d6bec9488de15/rs/artifact_pool/src/canister_http_pool.rs#L194-L207

However, this assumption is incorrect due to the following reason: When a node receives an HTTP outcalls share, it calls its "bouncer" to see if the artifact is `Wanted`, `Unwanted` or `MaybeWantsLater`: https://github.com/dfinity/ic/blob/478eb8343cb4be99db7e715b1fc96c8bc0c14f41/rs/https_outcalls/consensus/src/gossip.rs#L58-L67

If the bouncer returns `MaybeWantsLater`, then P2P will _only_ stash the advert, and take out the (larger) artifact content in order to conserve memory, even if the advert was pushed together with its content:
https://github.com/dfinity/ic/blob/478eb8343cb4be99db7e715b1fc96c8bc0c14f41/rs/p2p/artifact_downloader/src/fetch_artifact/download.rs#L180-L184

If at a later point, the bouncer value switches to `Wants`, then the advert needs to be resolved from scratch, meaning the artifact content is downloaded from a peer which calls `CanisterHttpPoolImpl::get()`.

In case of non-replicated or flexible outcalls, due to the assumption above, the contacted peer will then serve the artifact without the HTTP response content. The HTTP share without response content is unexpected for non-replicated and flexible requests, meaning the receiving peer will invalidate it.

## Proposed Changes
This PR fixes the problem by recording in the pool (at insertion time), if the response content should be served via `get()` or not. This will allow nodes to correctly fetch shares for flexible or non-replicated requests (including the response content) from other nodes.
