### PR TITLE
fix(governance): Correct DeleteSubnet proposal description

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -4285,6 +4285,7 @@ pub enum NnsFunction {
     /// Delete a subnet. The subnet record, catch-up package, threshold signing key
     /// and routing table entries are removed from the registry, the subnet is
     /// removed from the subnet list, and the subnet's nodes become unassigned.
+    /// System subnets (e.g. the NNS or II subnet) cannot be deleted.
     DeleteSubnet = 57,
     /// Set or unset the default subnet to which `SetupInitialDKG` management
     /// canister calls are routed when no subnet is specified explicitly. If unset,

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -4283,9 +4283,8 @@ pub enum NnsFunction {
     /// The proposal requests to split a subnet.
     SplitSubnet = 56,
     /// Delete a subnet. The subnet record, catch-up package, threshold signing key
-    /// and routing table entries are removed from the registry, and the subnet's
-    /// nodes become unassigned.
-    /// Currently limited to CloudEngine subnets.
+    /// and routing table entries are removed from the registry, the subnet is
+    /// removed from the subnet list, and the subnet's nodes become unassigned.
     DeleteSubnet = 57,
     /// Set or unset the default subnet to which `SetupInitialDKG` management
     /// canister calls are routed when no subnet is specified explicitly. If unset,

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -501,9 +501,8 @@ enum NnsFunction {
   NNS_FUNCTION_SPLIT_SUBNET = 56;
 
   // Delete a subnet. The subnet record, catch-up package, threshold signing key
-  // and routing table entries are removed from the registry, and the subnet's
-  // nodes become unassigned.
-  // Currently limited to CloudEngine subnets.
+  // and routing table entries are removed from the registry, the subnet is
+  // removed from the subnet list, and the subnet's nodes become unassigned.
   NNS_FUNCTION_DELETE_SUBNET = 57;
 
   // Set or unset the default subnet to which `SetupInitialDKG` management

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -503,6 +503,7 @@ enum NnsFunction {
   // Delete a subnet. The subnet record, catch-up package, threshold signing key
   // and routing table entries are removed from the registry, the subnet is
   // removed from the subnet list, and the subnet's nodes become unassigned.
+  // System subnets (e.g. the NNS or II subnet) cannot be deleted.
   NNS_FUNCTION_DELETE_SUBNET = 57;
 
   // Set or unset the default subnet to which `SetupInitialDKG` management

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -5279,6 +5279,7 @@ pub enum NnsFunction {
     /// Delete a subnet. The subnet record, catch-up package, threshold signing key
     /// and routing table entries are removed from the registry, the subnet is
     /// removed from the subnet list, and the subnet's nodes become unassigned.
+    /// System subnets (e.g. the NNS or II subnet) cannot be deleted.
     DeleteSubnet = 57,
     /// Set or unset the default subnet to which `SetupInitialDKG` management
     /// canister calls are routed when no subnet is specified explicitly. If unset,

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -5277,9 +5277,8 @@ pub enum NnsFunction {
     /// The proposal requests to split a subnet.
     SplitSubnet = 56,
     /// Delete a subnet. The subnet record, catch-up package, threshold signing key
-    /// and routing table entries are removed from the registry, and the subnet's
-    /// nodes become unassigned.
-    /// Currently limited to CloudEngine subnets.
+    /// and routing table entries are removed from the registry, the subnet is
+    /// removed from the subnet list, and the subnet's nodes become unassigned.
     DeleteSubnet = 57,
     /// Set or unset the default subnet to which `SetupInitialDKG` management
     /// canister calls are routed when no subnet is specified explicitly. If unset,

--- a/rs/nns/governance/src/proposals/execute_nns_function.rs
+++ b/rs/nns/governance/src/proposals/execute_nns_function.rs
@@ -935,8 +935,8 @@ impl ValidNnsFunction {
             }
             ValidNnsFunction::DeleteSubnet => {
                 "Delete a subnet. The subnet record, catch-up package, threshold signing key \
-                and routing table entries are removed from the registry, and the subnet's \
-                nodes become unassigned. Currently limited to CloudEngine subnets."
+                and routing table entries are removed from the registry, the subnet is \
+                removed from the subnet list, and the subnet's nodes become unassigned."
             }
             ValidNnsFunction::SetDefaultInitialDkgSubnet => {
                 "Set or unset the default subnet to which `SetupInitialDKG` management canister \

--- a/rs/nns/governance/src/proposals/execute_nns_function.rs
+++ b/rs/nns/governance/src/proposals/execute_nns_function.rs
@@ -936,7 +936,8 @@ impl ValidNnsFunction {
             ValidNnsFunction::DeleteSubnet => {
                 "Delete a subnet. The subnet record, catch-up package, threshold signing key \
                 and routing table entries are removed from the registry, the subnet is \
-                removed from the subnet list, and the subnet's nodes become unassigned."
+                removed from the subnet list, and the subnet's nodes become unassigned. \
+                System subnets (e.g. the NNS or II subnet) cannot be deleted."
             }
             ValidNnsFunction::SetDefaultInitialDkgSubnet => {
                 "Set or unset the default subnet to which `SetupInitialDKG` management canister \

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -18,7 +18,8 @@ on the process that this file is part of, see
 ## Fixed
 
 * Corrected the `DeleteSubnet` proposal description: dropped the outdated
-  "Currently limited to CloudEngine subnets" clause and added that the subnet
-  is also removed from the subnet list.
+  "Currently limited to CloudEngine subnets" clause, added that the subnet
+  is also removed from the subnet list, and noted that system subnets cannot
+  be deleted.
 
 ## Security

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -17,4 +17,8 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Corrected the `DeleteSubnet` proposal description: dropped the outdated
+  "Currently limited to CloudEngine subnets" clause and added that the subnet
+  is also removed from the subnet list.
+
 ## Security


### PR DESCRIPTION
Update the note "Currently limited to CloudEngine subnets" clause (no longer accurate after https://github.com/dfinity/ic/commit/65ad179d4ae53ff4244d57829f5cfe368e680f0f) to saying that system subnets cannot be deleted and add the removal of the subnet from the subnet list, which the registry canister performs but the description omitted.