### PR TITLE
fix: only run //rs/tests/message_routing/xnet:subnet_delete_test on Farm

### DIFF
--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -140,6 +140,8 @@ system_test(
 
 system_test(
     name = "subnet_delete_test",
+    backend = "farm",  # Too big for the "local" backend.
+    cpus = MIN_LOCAL_CPUS + (1 + 5 * 4) * DEFAULT_VCPUS_PER_VM,  # 1 API BN + 5 subnets * 4 nodes * 6 vCPUs each
     tags = [
         "long_test",
     ],


### PR DESCRIPTION
`//rs/tests/message_routing/xnet:subnet_delete_test_local` [fails](https://dash.dm1-idx1.dfinity.network/invocation/e78f0983-049f-4460-8c15-0735eb21ec37?target=%2F%2Frs%2Ftests%2Fmessage_routing%2Fxnet%3Asubnet_delete_test_local&targetStatus=6) so we configure the test to run on Farm only.