### PR TITLE
fix: deflake //rs/bitcoin/adapter:adapter_integration_test

### DIFF
--- a/rs/bitcoin/adapter/src/transaction_store.rs
+++ b/rs/bitcoin/adapter/src/transaction_store.rs
@@ -133,7 +133,7 @@ impl TransactionStore {
 
     /// This method is used to broadcast known transaction IDs to connected peers.
     /// A transaction ID is broadcasted to a peer if it has never been advertised to that
-    /// peer, or if the last advertisement was more than [TX_READVERTISE_PERIOD_SECS] ago.
+    /// peer, or if the last advertisement was at least [TX_READVERTISE_PERIOD_SECS] ago.
     pub fn advertise_txids<Header, Block>(&mut self, channel: &mut impl Channel<Header, Block>) {
         self.remove_old_txns();
         let now = SystemTime::now();
@@ -397,7 +397,8 @@ mod test {
     /// 1. Add transaction to manager.
     /// 2. Advertise that transaction.
     /// 3. Check that this transaction does not get advertised again during manager tick.
-    /// 4. Backdate the advertisement to more than [TX_READVERTISE_PERIOD_SECS] ago.
+    /// 4. Backdate the advertisement to exactly [TX_READVERTISE_PERIOD_SECS] ago,
+    ///    the (inclusive) re-advertisement boundary.
     /// 5. Check that the transaction is advertised to the peer again.
     #[test]
     fn test_adapter_readvertise_after_period() {

--- a/rs/bitcoin/adapter/src/transaction_store.rs
+++ b/rs/bitcoin/adapter/src/transaction_store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::{time::Duration, time::SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use bitcoin::consensus::deserialize;
 use bitcoin::{
@@ -50,7 +50,9 @@ struct TransactionInfo {
     /// lost, e.g. when the connection is dropped and re-established. Therefore the
     /// transaction is re-advertised every [TX_READVERTISE_PERIOD_SECS] for as long as
     /// it stays in the cache.
-    advertised: HashMap<SocketAddr, SystemTime>,
+    /// [Instant] is used instead of [SystemTime] because the re-advertisement schedule
+    /// must be immune to wall-clock jumps (NTP corrections, VM clock adjustments).
+    advertised: HashMap<SocketAddr, Instant>,
     /// How long the transaction should be held on to.
     /// This is needed in order to be able to reply to GetData requests.
     ttl: SystemTime,
@@ -136,7 +138,7 @@ impl TransactionStore {
     /// peer, or if the last advertisement was at least [TX_READVERTISE_PERIOD_SECS] ago.
     pub fn advertise_txids<Header, Block>(&mut self, channel: &mut impl Channel<Header, Block>) {
         self.remove_old_txns();
-        let now = SystemTime::now();
+        let now = Instant::now();
         let readvertise_period = Duration::from_secs(TX_READVERTISE_PERIOD_SECS);
         for address in channel.available_connections() {
             let mut inventory = vec![];
@@ -428,7 +430,7 @@ mod test {
             .expect("transaction should be in the map");
         info.advertised.insert(
             address,
-            SystemTime::now() - Duration::from_secs(TX_READVERTISE_PERIOD_SECS),
+            Instant::now() - Duration::from_secs(TX_READVERTISE_PERIOD_SECS),
         );
 
         // 5.

--- a/rs/bitcoin/adapter/src/transaction_store.rs
+++ b/rs/bitcoin/adapter/src/transaction_store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::{time::Duration, time::SystemTime};
 
@@ -18,6 +18,14 @@ use crate::{Channel, Command};
 /// How long should the transaction manager hold on to a transaction.
 const TX_CACHE_TIMEOUT_PERIOD_SECS: u64 = 10 * 60; // 10 minutes
 
+/// How long to wait before re-advertising a transaction to a peer.
+/// The `inv → getdata → tx` exchange is not acknowledged, so any of its messages can be
+/// lost without a trace, e.g. when the connection to the peer is dropped and
+/// re-established. Re-advertising until the transaction leaves the cache makes the relay
+/// robust against such losses. Peers that already received the transaction simply ignore
+/// the repeated `inv`.
+const TX_READVERTISE_PERIOD_SECS: u64 = 10;
+
 /// Maximum number of transaction to advertise.
 // https://developer.bitcoin.org/reference/p2p_networking.html#inv
 const MAXIMUM_TRANSACTION_PER_INV: usize = 50_000;
@@ -36,12 +44,13 @@ const TX_CACHE_SIZE: usize = 250;
 struct TransactionInfo {
     /// The actual transaction to be sent to the BTC network.
     transaction: Transaction,
-    /// Set of peer to which we advertised this transaction.
-    /// Having a peer in this set doesn't guarantee that the peer actually saw the transaction.
-    /// If the connection is healthy during sending most likely the peer will see the transaction.
-    /// The adapter maintains a pool of connected peers, so it is unlikely that
-    /// the transaction won't be seen by at least a few peers.
-    advertised: HashSet<SocketAddr>,
+    /// When this transaction was last advertised to each peer.
+    /// Having a peer in this map doesn't guarantee that the peer actually saw the
+    /// transaction: the advertisement or the follow-up `getdata`/`tx` exchange may be
+    /// lost, e.g. when the connection is dropped and re-established. Therefore the
+    /// transaction is re-advertised every [TX_READVERTISE_PERIOD_SECS] for as long as
+    /// it stays in the cache.
+    advertised: HashMap<SocketAddr, SystemTime>,
     /// How long the transaction should be held on to.
     /// This is needed in order to be able to reply to GetData requests.
     ttl: SystemTime,
@@ -52,7 +61,7 @@ impl TransactionInfo {
     fn new(transaction: &Transaction) -> Self {
         Self {
             transaction: transaction.clone(),
-            advertised: HashSet::new(),
+            advertised: HashMap::new(),
             ttl: SystemTime::now() + Duration::from_secs(TX_CACHE_TIMEOUT_PERIOD_SECS),
         }
     }
@@ -123,16 +132,22 @@ impl TransactionStore {
     }
 
     /// This method is used to broadcast known transaction IDs to connected peers.
-    /// If the timeout period has passed for a transaction ID, it is broadcasted again.
-    /// If the transaction has not been broadcasted, the transaction ID is broadcasted.
+    /// A transaction ID is broadcasted to a peer if it has never been advertised to that
+    /// peer, or if the last advertisement was more than [TX_READVERTISE_PERIOD_SECS] ago.
     pub fn advertise_txids<Header, Block>(&mut self, channel: &mut impl Channel<Header, Block>) {
         self.remove_old_txns();
+        let now = SystemTime::now();
+        let readvertise_period = Duration::from_secs(TX_READVERTISE_PERIOD_SECS);
         for address in channel.available_connections() {
             let mut inventory = vec![];
             for (txid, info) in self.transactions.iter_mut() {
-                if !info.advertised.contains(&address) {
+                let advertise = match info.advertised.get(&address) {
+                    Some(last_advertised) => *last_advertised + readvertise_period <= now,
+                    None => true,
+                };
+                if advertise {
                     inventory.push(Inventory::Transaction(*txid));
-                    info.advertised.insert(address);
+                    info.advertised.insert(address, now);
                 }
                 // If the inventory contains the maximum allowed number of transactions, we will send it
                 // and start building a new one.
@@ -141,14 +156,12 @@ impl TransactionStore {
                         self.logger,
                         "Broadcasting Txids ({:?}) to peer {:?}", inventory, address
                     );
-                    for address in channel.available_connections() {
-                        channel
-                            .send(Command {
-                                address: Some(address),
-                                message: NetworkMessage::Inv(std::mem::take(&mut inventory)),
-                            })
-                            .ok();
-                    }
+                    channel
+                        .send(Command {
+                            address: Some(address),
+                            message: NetworkMessage::Inv(std::mem::take(&mut inventory)),
+                        })
+                        .ok();
                 }
             }
             if !inventory.is_empty() {
@@ -325,7 +338,7 @@ mod test {
         assert!(manager.transactions.get(&first_tx.compute_txid()).is_none());
     }
 
-    /// This function tests that we don't readvertise transactions that were already advertised.
+    /// This function tests that we don't readvertise transactions that were recently advertised.
     /// Test Steps:
     /// 1. Add transaction to manager.
     /// 2. Advertise that transaction and create requests from peer.
@@ -368,14 +381,63 @@ mod test {
                 .len(),
             1
         );
-        assert_eq!(
+        assert!(
             manager
                 .transactions
                 .get(&transaction.compute_txid())
                 .unwrap()
                 .advertised
-                .get(&address),
-            Some(&address)
+                .contains_key(&address)
+        );
+    }
+
+    /// This function tests that a transaction is re-advertised to a peer once the
+    /// re-advertisement period has elapsed.
+    /// Test Steps:
+    /// 1. Add transaction to manager.
+    /// 2. Advertise that transaction.
+    /// 3. Check that this transaction does not get advertised again during manager tick.
+    /// 4. Backdate the advertisement to more than [TX_READVERTISE_PERIOD_SECS] ago.
+    /// 5. Check that the transaction is advertised to the peer again.
+    #[test]
+    fn test_adapter_readvertise_after_period() {
+        let address = SocketAddr::from_str("127.0.0.1:8333").expect("invalid address");
+        let mut channel = TestChannel::new(vec![address]);
+        let mut manager = make_transaction_manager();
+
+        // 1.
+        let transaction = get_transaction();
+        let raw_tx = serialize(&transaction);
+        let txid = transaction.compute_txid();
+        manager.enqueue_transaction(&raw_tx);
+
+        // 2.
+        manager.advertise_txids(&mut channel);
+        assert_eq!(channel.command_count(), 1);
+        channel.pop_front().unwrap();
+
+        // 3.
+        manager.advertise_txids(&mut channel);
+        assert_eq!(channel.command_count(), 0);
+
+        // 4.
+        let info = manager
+            .transactions
+            .get_mut(&txid)
+            .expect("transaction should be in the map");
+        info.advertised.insert(
+            address,
+            SystemTime::now() - Duration::from_secs(TX_READVERTISE_PERIOD_SECS),
+        );
+
+        // 5.
+        manager.advertise_txids(&mut channel);
+        assert_eq!(
+            channel.pop_front().expect("there should be one command"),
+            Command {
+                address: Some(address),
+                message: NetworkMessage::Inv(vec![Inventory::Transaction(txid)])
+            }
         );
     }
 

--- a/rs/bitcoin/adapter/src/transaction_store.rs
+++ b/rs/bitcoin/adapter/src/transaction_store.rs
@@ -400,7 +400,9 @@ mod test {
     /// 2. Advertise that transaction.
     /// 3. Check that this transaction does not get advertised again during manager tick.
     /// 4. Backdate the advertisement to exactly [TX_READVERTISE_PERIOD_SECS] ago,
-    ///    the (inclusive) re-advertisement boundary.
+    ///    the (inclusive) re-advertisement boundary. The test is skipped if the
+    ///    monotonic clock cannot represent that instant (i.e. the system booted
+    ///    less than [TX_READVERTISE_PERIOD_SECS] ago).
     /// 5. Check that the transaction is advertised to the peer again.
     #[test]
     fn test_adapter_readvertise_after_period() {
@@ -424,14 +426,16 @@ mod test {
         assert_eq!(channel.command_count(), 0);
 
         // 4.
+        let Some(backdated) =
+            Instant::now().checked_sub(Duration::from_secs(TX_READVERTISE_PERIOD_SECS))
+        else {
+            return;
+        };
         let info = manager
             .transactions
             .get_mut(&txid)
             .expect("transaction should be in the map");
-        info.advertised.insert(
-            address,
-            Instant::now() - Duration::from_secs(TX_READVERTISE_PERIOD_SECS),
-        );
+        info.advertised.insert(address, backdated);
 
         // 5.
         manager.advertise_txids(&mut channel);


### PR DESCRIPTION
# Why

`//rs/bitcoin/adapter:adapter_integration_test` is one of the most flaky tests. All 4 flaky runs in the last week failed identically, in the single sub-test `doge_test_send_tx`:

```
thread 'doge_test_send_tx' panicked at rs/bitcoin/adapter/tests/integration.rs:806:9:
assertion `left == right` failed
  left: 0 SAT
 right: 100000000 SAT
```

i.e. the 1 DOGE sent from Alice to Bob never showed up within the test's 30-second polling window. Since Alice and Bob are labelled addresses in the *same* dogecoind wallet, the transaction is "trusted" and counts towards Bob's balance as soon as it enters dogecoind's mempool — so the failure means **the transaction never reached dogecoind's mempool at all**.

## Root cause: the adapter's transaction relay is a one-shot with no retry

The relay path is:

```
test --gRPC SendTransaction--> adapter --P2P inv--> dogecoind
                               adapter <--getdata-- dogecoind
                               adapter --tx-------> dogecoind --> mempool
```

`TransactionStore::advertise_txids` advertises a cached transaction to each peer **exactly once**: the peer's socket address is recorded in `TransactionInfo.advertised` and never advertised to again until the transaction's 10-minute TTL expires. That `advertised` mark:

- is set even when the underlying send fails (`send_to` swallows connection write errors), and
- survives a connection discard + reconnect, because it is keyed by the peer's stable configured socket address and lives independently of the `ConnectionManager`.

The peer (dogecoind) only requests the transaction (`getdata`) in reaction to the `inv`. So if any single step of the unacknowledged `inv → getdata → tx` handshake is lost — e.g. the `inv` is written to a connection that is being torn down (5s incomplete-handshake timeout, ping timeout, invalid-message discard), or the `getdata` arrives after the connection is gone — nobody ever retries and the transaction is silently lost for the rest of the test.

The test binary runs 18 tests concurrently, each spawning bitcoind/dogecoind daemons, so CI runs see heavy CPU contention that provokes exactly this kind of connection churn and event-loop starvation. The DOGE variant flakes first because `dogecoind` v1.14.9 is based on the much older Bitcoin Core 0.14 P2P stack, which is slower under load; the BTC variant runs identical test/adapter code and has not been observed failing.

Prior deflake attempts (#9629, #8929, #8559, #7892, #7338, #7105) addressed other root causes (idleness, handshake waits, timeouts) but left the one-shot relay in place, which is why this test keeps recurring.

# What

Make the transaction relay robust instead of a silent one-shot: `TransactionInfo.advertised` now records **when** the transaction was last advertised to each peer (`HashMap<SocketAddr, Instant>` instead of `HashSet<SocketAddr>`), and `advertise_txids` re-advertises the transaction after `TX_READVERTISE_PERIOD_SECS` (10s) for as long as it stays in the cache. The timestamps use `Instant` (a monotonic clock) rather than `SystemTime`, so wall-clock jumps (NTP corrections, VM clock adjustments) cannot perturb the re-advertisement schedule.

This retries the relay regardless of *which* message of the `inv → getdata → tx` exchange was lost — including across connection discard + reconnect. It is also safe on mainnet: peers that already received the transaction simply ignore the repeated `inv` announcement (a few dozen bytes per peer every 10s per still-cached transaction, worst case).

While touching `advertise_txids`, also fixed a latent bug in the `MAXIMUM_TRANSACTION_PER_INV` overflow branch, where a shadowed loop variable broadcast the partially-built inventory of one peer to *all* peers (currently unreachable: the cache holds at most 250 transactions, far below the 50,000 threshold).

Unit tests: added `test_adapter_readvertise_after_period`, and adjusted the existing `test_adapter_dont_readvertise*` tests, which still verify that transactions are not re-advertised *within* the re-advertisement period.

# Verification

- `bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/bitcoin/adapter:adapter_integration_test` — 3 parallel runs (reproducing the CI contention) all pass.
- `bazel test //rs/bitcoin/adapter:adapter_test //rs/bitcoin/adapter:adapter_integration_test` — pass.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
