### PR TITLE
fix: Fix udev race in reload_icos.sh causing bare metal test failures

### DIFF
--- a/ic-os/testing/reload_icos.sh
+++ b/ic-os/testing/reload_icos.sh
@@ -226,6 +226,10 @@ setup_config() {
     mkdir -p "$SETUPOS_CONFIG_MOUNT"
     mount "$SETUPOS_CONFIG_IMG_PATH" "$SETUPOS_CONFIG_MOUNT"
 
+    # Wait for udev to create the /dev/disk/by-label/OVERRIDE symlink for the
+    # loop-mounted config image, which preload-config.sh depends on.
+    udevadm wait --timeout=10 /dev/disk/by-label/OVERRIDE
+
     # Preload and create config
     /opt/ic/bin/preload-config.sh
     /opt/ic/bin/config_tool create-setupos-config


### PR DESCRIPTION
The bare metal tests intermittently fail with:

```
Error: Failed to parse INI file
Caused by:
    No such file or directory (os error 2)
```

In `reload_icos.sh`'s `setup_config()`, the SetupOS config image is loop-mounted at `/tmp/setupos`, then `preload-config.sh` is called immediately. `preload-config.sh` checks for `/dev/disk/by-label/OVERRIDE` that udevd creates **asynchronously** after the loop device appears.

This causes a race condition:
- `mount` returns as soon as the filesystem is mounted
- udevd processes the new loop device event in the background 
- `preload-config.sh` checks for the symlink before udev has finished

This fix adds `udevadm wait --timeout=10 /dev/disk/by-label/OVERRIDE` before calling `preload-config.sh`.