### PR TITLE
chore: cache mainnet ICOS image downloads via sha256

### DIFF
--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -46,10 +46,7 @@ def _mainnet_icos_images_impl(repository_ctx):
 
     # Pass the sha256 of each image so the download can be served from the local
     # repository cache / Remote Asset API CAS instead of re-fetched from the CDN.
-    setupos_disk_img_hash_key = "setupos_disk_img_hash_dev" if repository_ctx.attr.dev else "setupos_disk_img_hash"
-    setupos_disk_img_hash = info.get(setupos_disk_img_hash_key, None)
-    if setupos_disk_img_hash == None:
-        fail("no {} in mainnet-icos-revisions.json for: {}".format(setupos_disk_img_hash_key, "/".join(parts)))
+    setupos_disk_img_hash = info["setupos_disk_img_hash_dev"] if repository_ctx.attr.dev else info["setupos_disk_img_hash"]
 
     # download the disk image
     repository_ctx.download(url_fn(git_commit_id, "setup-os", False), "disk-img.tar.zst", sha256 = setupos_disk_img_hash)

--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -44,13 +44,22 @@ def _mainnet_icos_images_impl(repository_ctx):
 
     url_fn = icos_dev_image_download_url if repository_ctx.attr.dev else icos_image_download_url
 
-    repository_ctx.download(url_fn(git_commit_id, "setup-os", False), "disk-img.tar.zst")  # download the disk image
+    # Pass the sha256 of each image so the download can be served from the local
+    # repository cache / Remote Asset API CAS instead of re-fetched from the CDN.
+    setupos_disk_img_hash_key = "setupos_disk_img_hash_dev" if repository_ctx.attr.dev else "setupos_disk_img_hash"
+    setupos_disk_img_hash = info.get(setupos_disk_img_hash_key, None)
+    if setupos_disk_img_hash == None:
+        fail("no {} in mainnet-icos-revisions.json for: {}".format(setupos_disk_img_hash_key, "/".join(parts)))
+
+    # download the disk image
+    repository_ctx.download(url_fn(git_commit_id, "setup-os", False), "disk-img.tar.zst", sha256 = setupos_disk_img_hash)
 
     # For GuestOS repositories also download the GuestOS update image so the
     # local system-test file server can serve it to the IC nodes.
     is_guestos = parts[0] == "guestos"
     if is_guestos:
-        repository_ctx.download(url_fn(git_commit_id, "guest-os", True), "guest-update-img.tar.zst")
+        update_img_hash = info["update_img_hash_dev"] if repository_ctx.attr.dev else info["update_img_hash"]
+        repository_ctx.download(url_fn(git_commit_id, "guest-os", True), "guest-update-img.tar.zst", sha256 = update_img_hash)
 
     if repository_ctx.attr.dev:
         json_measurements = json.encode(info["launch_measurements_dev"])

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -31,6 +31,11 @@ class VersionInfo:
     dev_hash: str
     launch_measurements: dict
     dev_measurements: dict
+    # SHA256 of the setup-os disk-img.tar.zst (prod and dev channels). Unlike
+    # `hash` (the NNS-elected update image), the setup-os image is not elected
+    # via the NNS, so this is read from the CDN SHA256SUMS file.
+    setupos_hash: str
+    setupos_dev_hash: str
 
 
 def sync_main_branch_and_checkout_branch(
@@ -162,7 +167,13 @@ def get_replica_version_info(replica_version: str) -> VersionInfo:
         f"https://download.dfinity.systems/ic/{version}/guest-os/update-img-dev/launch-measurements.json"
     )
 
-    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements)
+    setup_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
+    setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
+    setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
+
+    return VersionInfo(
+        version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash
+    )
 
 
 def get_latest_replica_version_info() -> VersionInfo:
@@ -192,7 +203,13 @@ def get_latest_replica_version_info() -> VersionInfo:
         f"https://download.dfinity.systems/ic/{version}/guest-os/update-img-dev/launch-measurements.json"
     )
 
-    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements)
+    setup_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
+    setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
+    setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
+
+    return VersionInfo(
+        version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash
+    )
 
 
 def get_latest_hostos_version_info(logger: logging.Logger) -> VersionInfo:
@@ -226,7 +243,15 @@ def get_latest_hostos_version_info(logger: logging.Logger) -> VersionInfo:
         )
         raise
 
-    return VersionInfo(version, hash, dev_hash, replica_info.launch_measurements, replica_info.dev_measurements)
+    return VersionInfo(
+        version,
+        hash,
+        dev_hash,
+        replica_info.launch_measurements,
+        replica_info.dev_measurements,
+        replica_info.setupos_hash,
+        replica_info.setupos_dev_hash,
+    )
 
 
 def update_saved_subnet_revision(repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, subnet: str):
@@ -239,8 +264,8 @@ def update_saved_subnet_revision(repo_root: pathlib.Path, logger: logging.Logger
     with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    existing_version = data.get("guestos", {}).get("subnets", {}).get(subnet, {}).get("version", "")
-    if existing_version == replica_info.version:
+    existing = data.get("guestos", {}).get("subnets", {}).get(subnet, {})
+    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
         logger.info("Subnet revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -248,6 +273,8 @@ def update_saved_subnet_revision(repo_root: pathlib.Path, logger: logging.Logger
         "version": replica_info.version,
         "update_img_hash": replica_info.hash,
         "update_img_hash_dev": replica_info.dev_hash,
+        "setupos_disk_img_hash": replica_info.setupos_hash,
+        "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
         "launch_measurements": replica_info.launch_measurements,
         "launch_measurements_dev": replica_info.dev_measurements,
     }
@@ -270,8 +297,8 @@ def update_saved_replica_revision(repo_root: pathlib.Path, logger: logging.Logge
     with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    existing_version = data.get("guestos", {}).get("latest_release", {}).get("version", "")
-    if existing_version == replica_info.version:
+    existing = data.get("guestos", {}).get("latest_release", {})
+    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
         logger.info("Latest revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -279,6 +306,8 @@ def update_saved_replica_revision(repo_root: pathlib.Path, logger: logging.Logge
         "version": replica_info.version,
         "update_img_hash": replica_info.hash,
         "update_img_hash_dev": replica_info.dev_hash,
+        "setupos_disk_img_hash": replica_info.setupos_hash,
+        "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
         "launch_measurements": replica_info.launch_measurements,
         "launch_measurements_dev": replica_info.dev_measurements,
     }
@@ -299,8 +328,8 @@ def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger
     with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    existing_version = data.get("hostos", {}).get("latest_release", {}).get("version", "")
-    if existing_version == replica_info.version:
+    existing = data.get("hostos", {}).get("latest_release", {})
+    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
         logger.info("Hostos revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -309,6 +338,8 @@ def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger
             "version": replica_info.version,
             "update_img_hash": replica_info.hash,
             "update_img_hash_dev": replica_info.dev_hash,
+            "setupos_disk_img_hash": replica_info.setupos_hash,
+            "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
             "launch_measurements": replica_info.launch_measurements,
             "launch_measurements_dev": replica_info.dev_measurements,
         }
@@ -352,6 +383,18 @@ def download_and_read_file(url: str):
         urllib.request.urlretrieve(url, tmp_file.name)
         with open(tmp_file.name, "rb") as f:
             return json.loads(f.read().decode())
+
+
+def download_and_read_sha256sums(url: str, filename: str) -> str:
+    """Download a SHA256SUMS file and return the hex sha256 recorded for `filename`."""
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        urllib.request.urlretrieve(url, tmp_file.name)
+        with open(tmp_file.name, "r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) == 2 and parts[1] == filename:
+                    return parts[0]
+    raise Exception(f"No sha256 for {filename} in {url}")
 
 
 def get_logger(level) -> logging.Logger:

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -167,9 +167,9 @@ def get_replica_version_info(replica_version: str) -> VersionInfo:
         f"https://download.dfinity.systems/ic/{version}/guest-os/update-img-dev/launch-measurements.json"
     )
 
-    setup_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
-    setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
-    setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
+    setupos_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
+    setupos_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
+    setupos_dev_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
     return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
 
@@ -201,9 +201,9 @@ def get_latest_replica_version_info() -> VersionInfo:
         f"https://download.dfinity.systems/ic/{version}/guest-os/update-img-dev/launch-measurements.json"
     )
 
-    setup_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
-    setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
-    setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
+    setupos_base = f"https://download.dfinity.systems/ic/{version}/setup-os"
+    setupos_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
+    setupos_dev_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
     return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
 

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -171,9 +171,7 @@ def get_replica_version_info(replica_version: str) -> VersionInfo:
     setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
     setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
-    return VersionInfo(
-        version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash
-    )
+    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
 
 
 def get_latest_replica_version_info() -> VersionInfo:
@@ -207,9 +205,7 @@ def get_latest_replica_version_info() -> VersionInfo:
     setupos_hash = download_and_read_sha256sums(f"{setup_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
     setupos_dev_hash = download_and_read_sha256sums(f"{setup_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
-    return VersionInfo(
-        version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash
-    )
+    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
 
 
 def get_latest_hostos_version_info(logger: logging.Logger) -> VersionInfo:

--- a/mainnet-icos-revisions.json
+++ b/mainnet-icos-revisions.json
@@ -5,6 +5,8 @@
         "version": "8a655ede1f59ea0cb3079a9aa0601b7905b7ca37",
         "update_img_hash": "f75bd4d869e2510b3271f4bd858b4056f93a528cb7bcf454cdd21956ae282bc5",
         "update_img_hash_dev": "16caec68b07460a4d53a6ef57e625b2ce12b4d0e74f3a31bfda3d005844bd835",
+        "setupos_disk_img_hash": "9f8bbe68b592592344cfbe70485892f4061229072b7b9dd9a8f6f4e2c5e06864",
+        "setupos_disk_img_hash_dev": "eb2cace25fd3bc8321f5ac88f29030db3377f0efd7bf4325c35b7139d9867a2d",
         "launch_measurements": {
           "guest_launch_measurements": [
             {
@@ -138,6 +140,8 @@
         "version": "992628c4f26cc7320396b6b8be37133a666a4386",
         "update_img_hash": "82d7e19ee6b708984db97bc1dbf03fd6188be01607ce1d13ef84fe6fc62d274a",
         "update_img_hash_dev": "6f50d00ae6c74d4cf042259528ab7568d9f81215f005d38ca2fbd5bd659c1aa8",
+        "setupos_disk_img_hash": "50bcb55955d60b45d4d09c734fb4e8c49567413b11e1565e66b8fe63a0769c4d",
+        "setupos_disk_img_hash_dev": "56b31731089f233f0672a5bbe9b9093c9d3c9c9a5d61b9e7b4c1a665b361f394",
         "launch_measurements": {
           "guest_launch_measurements": [
             {
@@ -272,6 +276,8 @@
       "version": "992628c4f26cc7320396b6b8be37133a666a4386",
       "update_img_hash": "82d7e19ee6b708984db97bc1dbf03fd6188be01607ce1d13ef84fe6fc62d274a",
       "update_img_hash_dev": "6f50d00ae6c74d4cf042259528ab7568d9f81215f005d38ca2fbd5bd659c1aa8",
+      "setupos_disk_img_hash": "50bcb55955d60b45d4d09c734fb4e8c49567413b11e1565e66b8fe63a0769c4d",
+      "setupos_disk_img_hash_dev": "56b31731089f233f0672a5bbe9b9093c9d3c9c9a5d61b9e7b4c1a665b361f394",
       "launch_measurements": {
         "guest_launch_measurements": [
           {
@@ -407,6 +413,8 @@
       "version": "992628c4f26cc7320396b6b8be37133a666a4386",
       "update_img_hash": "ed987c8b7e0138ba0e12e99e2a5cf94c91e4b6a8ffa9e34073739873f288edbd",
       "update_img_hash_dev": "a922ed470040edd5faa22102e02be5f606f243f549dc16aebb0ecae2a6c13ef4",
+      "setupos_disk_img_hash": "50bcb55955d60b45d4d09c734fb4e8c49567413b11e1565e66b8fe63a0769c4d",
+      "setupos_disk_img_hash_dev": "56b31731089f233f0672a5bbe9b9093c9d3c9c9a5d61b9e7b4c1a665b361f394",
       "launch_measurements": {
         "guest_launch_measurements": [
           {


### PR DESCRIPTION
## Why

During the `Bazel Build with RBE` step of `rbe-namespace-test.yml`, the execution profile shows many long "Fetching repository" traces — e.g. `@@+mainnet_icos_images+mainnet_app_images` takes **over 5 minutes** because the `mainnet_icos_images` repo rule re-downloads large ICOS image artifacts from `download.dfinity.systems` on every run.

Root cause: `bazel/mainnet-icos-images.bzl` called `repository_ctx.download(...)` **without a `sha256`**. The Namespace RBE job enables Bazel's Remote Asset API (`nsc bazel execution setup --enable_remote_asset_api`), which can serve a blob straight from CAS — and Bazel's local `--repository_cache` can be used — **only when the expected content digest is supplied**. So supplying a correct `sha256` per download turns these multi-minute fetches into cache hits.

This is the low-risk alternative to the experimental `--experimental_remote_repo_contents_cache` (which would require dropping `repository_ctx.watch()` and returning `repo_metadata(reproducible = True)`).

## What

- **`bazel/mainnet-icos-images.bzl`**: pass `sha256` to both `download()` calls (dev/prod aware).
  - guest-os update image → existing `update_img_hash` / `update_img_hash_dev`.
  - setup-os disk image → new `setupos_disk_img_hash` / `setupos_disk_img_hash_dev`.
- **`ci/src/mainnet_revisions/mainnet_revisions.py`**: record the setup-os disk-image hash in the JSON, sourced from the CDN `setup-os/disk-img[-dev]/SHA256SUMS` files (setup-os is not NNS-elected, so no proposal hash exists). The "already up to date" guards now also backfill entries that predate the new field.
- **`mainnet-icos-revisions.json`**: backfilled `setupos_disk_img_hash[_dev]` for the current pinned versions.

Naming distinguishes the SetupOS disk image (`setupos_disk_img_hash`) from the GuestOS update image (`update_img_hash`).

## Verification

- `bazel build` of the app-image repos (prod + dev) and the hostos repos succeeds → Bazel sha256-verifies every download; a wrong hash aborts the fetch with a checksum mismatch. Re-fetching a warm artifact drops from minutes to a cache hit.
- Python compiles; a mocked unit check confirms the fetchers populate the new fields from the correct SHA256SUMS URLs; `buildifier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
