### PR TITLE
perf(state_manager): [DSM-145] Take overlay/Wasm validation off the checkpoint critical path

### DIFF
--- a/rs/replicated_state/src/page_map/storage.rs
+++ b/rs/replicated_state/src/page_map/storage.rs
@@ -485,7 +485,7 @@ impl OverlayFile {
                 &storage_layout.overlay(height, Shard::new(shard)),
                 metrics,
                 LABEL_OP_FLUSH,
-            )?
+            )?;
         }
         Ok(())
     }
@@ -1255,15 +1255,36 @@ impl MergeCandidate {
         match &self.dst {
             MergeDestination::MultiShardOverlay { shard_paths, .. } => {
                 assert!(shard_paths.len() >= num_output_shards);
-                for (page_indices, page_data, path) in
-                    izip!(page_indices.into_iter(), page_data.into_iter(), shard_paths)
+                for (shard, (page_indices, page_data, path)) in
+                    izip!(page_indices.into_iter(), page_data.into_iter(), shard_paths).enumerate()
                 {
                     let (page_data, page_indices) = if self.is_full_merge() {
                         expand_with_zeroes(&page_data, &page_indices, ExpandBeforeStart::No)
                     } else {
                         (page_data, page_indices)
                     };
-                    write_overlay(&page_data, &page_indices, path, metrics, LABEL_OP_MERGE)?
+                    let overlay =
+                        write_overlay(&page_data, &page_indices, path, metrics, LABEL_OP_MERGE)?;
+
+                    // Validate that the pages in the merged overlay shard fall within the
+                    // `[shard * N, (shard + 1) * N)` range. This is the per-file equivalent of the
+                    // cross-shard non-overlap check in `StorageImpl::load`. Empty shards write no
+                    // file, hence `Some`.
+                    if let Some(overlay) = overlay {
+                        let shard = shard as u64;
+                        let start = overlay.index_iter().next().unwrap().start_page.get();
+                        let end = overlay.end_logical_pages() as u64;
+                        let range = shard * shard_num_pages..(shard + 1) * shard_num_pages;
+                        if start < range.start || end > range.end {
+                            return Err(PersistenceError::InvalidOverlay {
+                                path: path.display().to_string(),
+                                message: format!(
+                                    "Merged overlay covers pages [{}, {}), outside its shard range [{}, {})",
+                                    start, end, range.start, range.end
+                                ),
+                            });
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -1273,7 +1294,7 @@ impl MergeCandidate {
                 } else {
                     (page_data[0].clone(), page_indices[0].clone())
                 };
-                write_overlay(&page_data, &page_indices, path, metrics, LABEL_OP_MERGE)
+                write_overlay(&page_data, &page_indices, path, metrics, LABEL_OP_MERGE).map(|_| ())
             }
             MergeDestination::BaseFile(path) => write_base(
                 &page_data[0],
@@ -1689,10 +1710,16 @@ fn write_base(
         context: format!("Failed to write base file {}", path.display()),
         internal_error: err.to_string(),
     })?;
+
+    // Validate the base we just wrote (see `write_overlay` for the rationale).
+    // `Checkpoint::open` reparses the base exactly like `StorageImpl::load` does.
+    Checkpoint::open(path)?;
+
     metrics
         .write_bytes
         .with_label_values(&[op_label, LABEL_TYPE_PAGE_DATA])
         .inc_by((pages.len() * PAGE_SIZE) as u64);
+
     Ok(())
 }
 
@@ -1710,16 +1737,18 @@ fn write_pages(file: &mut File, data: &Vec<&[u8]>) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Write an overlay file to `path`.
+/// Writes an overlay file to `path`.
+///
+/// On success, returns the `OverlayFile` that was just written, for validation.
 fn write_overlay(
     pages: &Vec<&[u8]>,
     indices: &[PageIndex],
     path: &Path,
     metrics: &StorageMetrics,
     op_label: &str, // `LABEL_OP_FLUSH` or `LABEL_OP_MERGE`
-) -> Result<(), PersistenceError> {
+) -> Result<Option<OverlayFile>, PersistenceError> {
     if pages.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     let ranges_serialized = group_pages_into_ranges(indices)
         .into_iter()
@@ -1781,6 +1810,11 @@ fn write_overlay(
         })?;
     }
 
+    // Reload the overlay we just wrote to validate it (reparses the index/footer
+    // like `StorageImpl::load` does), so we don't have to do it at checkpoint time.
+    // Return the loaded overlay for callers that require further checks.
+    let overlay = OverlayFile::load(path)?;
+
     let data_size = pages.len() * PAGE_SIZE;
     let index_size = ranges_serialized.len() + 8;
 
@@ -1792,7 +1826,8 @@ fn write_overlay(
         .write_bytes
         .with_label_values(&[op_label, LABEL_TYPE_PAGE_DATA])
         .inc_by(data_size as u64);
-    Ok(())
+
+    Ok(Some(overlay))
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -107,22 +107,6 @@ pub(crate) fn validate_and_finalize_checkpoint_and_remove_unverified_marker(
     metrics: &CheckpointMetrics,
     mut thread_pool: Option<&mut scoped_threadpool::Pool>,
 ) -> Result<(), CheckpointError> {
-    maybe_parallel_map(
-        &mut thread_pool,
-        checkpoint_layout.all_existing_pagemaps()?.into_iter(),
-        |pm| validate(pm),
-    )
-    .into_iter()
-    .try_for_each(identity)?;
-
-    maybe_parallel_map(
-        &mut thread_pool,
-        checkpoint_layout.all_existing_wasm_files()?.into_iter(),
-        |wasm_file| try_mmap_wasm_file(wasm_file),
-    )
-    .into_iter()
-    .try_for_each(identity)?;
-
     if let Some(reference_state) = reference_state {
         validate_eq_checkpoint(
             checkpoint_layout,
@@ -132,6 +116,26 @@ pub(crate) fn validate_and_finalize_checkpoint_and_remove_unverified_marker(
             fd_factory,
             metrics,
         );
+    } else {
+        // Overlays are validated at write time (see `write_overlay` / `write_base` in
+        // `page_map::storage`) and Wasm files are written by us, so we only need to
+        // re-validate them on the state-sync path (`reference_state == None`), where
+        // the files came from peers rather than being produced locally.
+        maybe_parallel_map(
+            &mut thread_pool,
+            checkpoint_layout.all_existing_pagemaps()?.into_iter(),
+            |pm| validate(pm),
+        )
+        .into_iter()
+        .try_for_each(identity)?;
+
+        maybe_parallel_map(
+            &mut thread_pool,
+            checkpoint_layout.all_existing_wasm_files()?.into_iter(),
+            |wasm_file| try_mmap_wasm_file(wasm_file),
+        )
+        .into_iter()
+        .try_for_each(identity)?;
     }
     checkpoint_layout
         .finalize_and_remove_unverified_marker(thread_pool)


### PR DESCRIPTION
Locally-created checkpoints re-loaded every overlay and Wasm file in `validate_and_finalize_checkpoint_and_remove_unverified_marker` before removing the unverified marker. At high canister counts this dominates the CUP-critical path (~30s+ at 200k canisters).

Overlays are now validated at write time instead: `write_overlay` reloads and reparses each overlay it writes (and the multi-shard merge additionally checks each shard's page range against `[shard*N, (shard+1)*N)`, the per-file equivalent of the cross-shard non-overlap check in `StorageImpl::load`), and `write_base` reparses the base via `Checkpoint::open`. Wasm files are written locally and trusted.

So the per-checkpoint `validate_pagemaps` / `validate_mmap_wasm_files` pass is now only needed on the state-sync path (`reference_state == None`), where the files were received from peers rather than produced locally.