### PR TITLE
perf(state_manager): [DSM-145] Flush large writes from background `syncfs` thread

### DIFF
--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -704,6 +704,11 @@ impl StateLayout {
         &self.root
     }
 
+    /// `syncfs` the filesystem holding the state.
+    pub fn syncfs(&self) -> std::io::Result<()> {
+        syncfs(&self.root)
+    }
+
     /// Returns the path to the temporary directory.
     /// This directory is cleaned during restart of a node.
     pub fn tmp(&self) -> PathBuf {
@@ -2853,6 +2858,26 @@ fn mark_readonly_if_file(path: &Path) -> std::io::Result<bool> {
         }
     }
     Ok(false)
+}
+
+/// Synchronizes the filesystem containing the given path.
+///
+/// On Linux, this uses `syncfs` to synchronize the entire filesystem. On other
+/// platforms it falls back to `File::sync_all()`.
+fn syncfs<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    let f = std::fs::File::open(&path)?;
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::AsRawFd;
+        if unsafe { libc::syncfs(f.as_raw_fd()) } == -1 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        f.sync_all()?;
+    }
+    Ok(())
 }
 
 fn dir_list_recursive(

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -178,6 +178,30 @@ pub(crate) fn spawn_tip_thread(
 ) -> (JoinOnDrop<()>, Sender<TipRequest>) {
     #[allow(clippy::disallowed_methods)]
     let (tip_sender, tip_receiver) = unbounded();
+
+    // Background best-effort `syncfs` helper. The tip thread pings it (non-blocking)
+    // after completing large numbers of writes (all protos; or `reset_tip`), so the
+    // kernel starts flushing that dirty data early instead of leaving it all for
+    // the blocking `syncfs` in `finalize_and_remove_unverified_marker`. This is
+    // purely an optimization, so its errors are non-fatal.
+    let (syncfs_sender, syncfs_receiver) = bounded::<()>(1);
+    {
+        let state_layout = state_layout.clone();
+        let metrics = metrics.clone();
+        let log = log.clone();
+        std::thread::Builder::new()
+            .name("TipSyncfs".to_string())
+            .spawn(move || {
+                while syncfs_receiver.recv().is_ok() {
+                    let _timer = request_timer(&metrics, "background_syncfs");
+                    if let Err(err) = state_layout.syncfs() {
+                        warn!(log, "Background syncfs failed: {}", err);
+                    }
+                }
+            })
+            .expect("failed to spawn TipSyncfs thread");
+    }
+
     let mut thread_pool = scoped_threadpool::Pool::new(NUMBER_OF_CHECKPOINT_THREADS);
     let mut tip_state = TipState::default();
     // Height(0) doesn't need manifest
@@ -243,6 +267,8 @@ pub(crate) fn spawn_tip_thread(
                                     fatal!(log, "Failed to serialize to tip @{}: {}", height, err);
                                 });
                             }
+                            // Start flushing the freshly written Wasm binaries.
+                            let _ = syncfs_sender.try_send(());
                             let tip_to_checkpoint_result = {
                                 let _timer =
                                     request_timer(&metrics, "tip_to_checkpoint_and_switch");
@@ -293,6 +319,9 @@ pub(crate) fn spawn_tip_thread(
                                 }
                             };
                             tip_state.latest_checkpoint_state.has_protos = Some(height);
+                            // Start flushing the freshly-written protos in the background so they're mostly
+                            // persisted by the time `finalize` calls its blocking `syncfs`.
+                            let _ = syncfs_sender.try_send(());
                         }
 
                         TipRequest::FlushPageMapDelta {
@@ -373,6 +402,10 @@ pub(crate) fn spawn_tip_thread(
                                     }
                                 },
                             );
+                            // Start flushing any freshly written overlays (and any snapshot hardlinks from
+                            // `flush_unflushed_checkpoint_ops` above) so they don't accumulate for a later
+                            // blocking flush.
+                            let _ = syncfs_sender.try_send(());
                         }
 
                         TipRequest::ResetTipAndMerge {
@@ -399,8 +432,11 @@ pub(crate) fn spawn_tip_thread(
                                     );
                                 });
                             drop(timer);
+                            // Start flushing `reset_tip`'s up to 1M hardlinks now, so it runs concurrently
+                            // with `merge` below rather than piling onto a later blocking flush.
+                            let _ = syncfs_sender.try_send(());
 
-                            let _timer = request_timer(&metrics, "merge");
+                            let timer = request_timer(&metrics, "merge");
                             merge(
                                 &mut tip_handler,
                                 &pagemaptypes,
@@ -410,6 +446,9 @@ pub(crate) fn spawn_tip_thread(
                                 &lsmt_config,
                                 &metrics,
                             );
+                            drop(timer);
+                            // And flush the freshly merged/rewritten overlay files.
+                            let _ = syncfs_sender.try_send(());
                         }
 
                         TipRequest::Wait { sender } => {


### PR DESCRIPTION
The blocking `syncfs` in `finalize_and_remove_unverified_marker` flushes the dirty data produced earlier in the checkpoint (notably the freshly serialized per-canister protos). At high canister counts this is ~15s on the CUP-critical path. Previously it was cheap only because the overlay/Wasm validation (being removed in #10776) happened to give background writeback time to drain that data first.

Spawn a dedicated `TipSyncfs` thread that the tip thread pings (non-blocking, `bounded(1)` + `try_send`, self-coalescing) after every large batch of file writes/hardlinks: after serializing Wasm binaries and protos, after flushing a round's page-map deltas, and after `reset_tip`'s hardlink tree and the merge. The kernel then flushes that data concurrently with the rest of the checkpoint, so the blocking `syncfs` in `finalize` finds little left to do (~15s -> ~0.1s at 200k canisters).

`finalize`'s `syncfs` stays as the durability barrier, so the background `syncfs` calls are purely an optimization and their errors are non-fatal.