### PR TITLE
fix: engine controller canister injecting caller to the subnet admins

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -103,7 +103,7 @@ fn ensure_authorized() -> Result<Principal, String> {
 
 #[update]
 async fn create_engine(args: CreateEngineArgs) -> Result<NewSubnet, String> {
-    let caller = ensure_authorized()?;
+    ensure_authorized()?;
 
     // Validate node list.
     if args.node_ids.len() < REQUIRED_NODE_COUNT {
@@ -119,13 +119,10 @@ async fn create_engine(args: CreateEngineArgs) -> Result<NewSubnet, String> {
         }
     }
 
-    // Make sure the caller is part of the subnet admins.
-    let mut subnet_admins: Vec<PrincipalId> =
+    // Forward the supplied `subnet_admins` list to the registry as-is; the
+    // engine controller does not manipulate it.
+    let subnet_admins: Vec<PrincipalId> =
         args.subnet_admins.into_iter().map(PrincipalId).collect();
-    let caller_pid = PrincipalId(caller);
-    if !subnet_admins.contains(&caller_pid) {
-        subnet_admins.push(caller_pid);
-    }
 
     let node_ids: Vec<NodeId> = args
         .node_ids

--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -121,8 +121,7 @@ async fn create_engine(args: CreateEngineArgs) -> Result<NewSubnet, String> {
 
     // Forward the supplied `subnet_admins` list to the registry as-is; the
     // engine controller does not manipulate it.
-    let subnet_admins: Vec<PrincipalId> =
-        args.subnet_admins.into_iter().map(PrincipalId).collect();
+    let subnet_admins: Vec<PrincipalId> = args.subnet_admins.into_iter().map(PrincipalId).collect();
 
     let node_ids: Vec<NodeId> = args
         .node_ids

--- a/rs/engine_controller/unreleased_changelog.md
+++ b/rs/engine_controller/unreleased_changelog.md
@@ -25,4 +25,8 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* `create_engine` no longer forces the engine controller's authorized caller
+  (super admin) into the `subnet_admins` list. The supplied list is now
+  forwarded to the registry as-is.
+
 ## Security


### PR DESCRIPTION
We shouldn't require setting the caller as the subnet admin as that logic has been rewritten. This adds the missing migration from the previous cleanup in #10704 