### PR TITLE
chore(sender_info_test): request CPUs for the local variant

### DIFF
--- a/rs/tests/execution/BUILD.bazel
+++ b/rs/tests/execution/BUILD.bazel
@@ -178,6 +178,7 @@ system_test_nns(
 
 system_test(
     name = "sender_info_test",
+    cpus = MIN_LOCAL_CPUS + 1 * DEFAULT_VCPUS_PER_VM,  # 1 IC Node VM with 6 vCPUs.
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.


### PR DESCRIPTION
## Summary

Adds `cpus = MIN_LOCAL_CPUS + 1 * DEFAULT_VCPUS_PER_VM` to the `sender_info_test` target in `rs/tests/execution/BUILD.bazel` so its `_local` variant requests the required amount of CPUs from bazel. Needed for the upcoming CI switch to Namespace / Remote Build Execution.

Addresses follow-up review feedback on #9913: https://github.com/dfinity/ic/pull/9913#discussion_r3586717980

## Test plan

- [ ] `bazel test //rs/tests/execution:sender_info_test_local` still runs
- [ ] The requested CPUs (`MIN_LOCAL_CPUS + 6`) match the test's 1 IC Node VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)