### PR TITLE
chore: set bazel cpu reservation via exec_properties instead of via the cpu:n tag

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -70,6 +70,7 @@ rust_test(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
+    exec_properties = {"cpu": "16"},
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -128,6 +129,7 @@ rust_test(
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
+    exec_properties = {"cpu": "16"},
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -183,6 +185,7 @@ rust_test(
             "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server" + name_suffix + ")",
             "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
         },
+        exec_properties = {"cpu": "16"},
         tags = [
             "cpu:16",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -254,6 +257,7 @@ rust_test(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
+    exec_properties = {"cpu": "16"},
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -283,6 +287,7 @@ rust_test(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
+    exec_properties = {"cpu": "16"},
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -72,7 +72,6 @@ rust_test(
     },
     exec_properties = {"cpu": "16"},
     tags = [
-        "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to bind PocketIC server to address 127.0.0.1:0
         "requires-network",
@@ -131,7 +130,6 @@ rust_test(
     },
     exec_properties = {"cpu": "16"},
     tags = [
-        "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to bind PocketIC server to address 127.0.0.1:0
         "requires-network",
@@ -187,7 +185,6 @@ rust_test(
         },
         exec_properties = {"cpu": "16"},
         tags = [
-            "cpu:16",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
             # Failed to bind PocketIC server to address 127.0.0.1:0
             "requires-network",
@@ -259,7 +256,6 @@ rust_test(
     },
     exec_properties = {"cpu": "16"},
     tags = [
-        "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to bind PocketIC server to address 127.0.0.1:0
         "requires-network",
@@ -289,7 +285,6 @@ rust_test(
     },
     exec_properties = {"cpu": "16"},
     tags = [
-        "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to bind PocketIC server to address 127.0.0.1:0
         "requires-network",

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -137,6 +137,7 @@ rust_test(
         "RUST_TEST_THREADS": "4",
         "RUST_TEST_NOCAPTURE": "1",
     },
+    exec_properties = {"cpu": "4"},
     tags = [
         "cpu:4",
     ],

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -138,9 +138,6 @@ rust_test(
         "RUST_TEST_NOCAPTURE": "1",
     },
     exec_properties = {"cpu": "4"},
-    tags = [
-        "cpu:4",
-    ],
     # Because dogecoind binary package is not available on darwin or arm64.
     target_compatible_with = [
         "@platforms//cpu:x86_64",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -215,6 +215,7 @@ rust_ic_test(
         "UNIVERSAL_CANISTER_NO_HEARTBEAT_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister_no_heartbeat.wasm.gz)",
         "RUST_TEST_THREADS": "4",
     },
+    exec_properties = {"cpu": "4"},
     tags = [
         "cpu:4",
         "test_all_platforms_slow",
@@ -253,6 +254,7 @@ rust_ic_test(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
         "RUST_TEST_THREADS": "4",
     },
+    exec_properties = {"cpu": "4"},
     tags = [
         "cpu:4",
         "test_all_platforms_slow",
@@ -288,6 +290,7 @@ rust_ic_test(
         "UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.module)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
+    exec_properties = {"cpu": "4"},
     tags = [
         "cpu:4",
         "test_all_platforms_slow",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -217,7 +217,6 @@ rust_ic_test(
     },
     exec_properties = {"cpu": "4"},
     tags = [
-        "cpu:4",
         "test_all_platforms_slow",
     ],
     deps = [
@@ -256,7 +255,6 @@ rust_ic_test(
     },
     exec_properties = {"cpu": "4"},
     tags = [
-        "cpu:4",
         "test_all_platforms_slow",
     ],
     deps = [
@@ -292,7 +290,6 @@ rust_ic_test(
     },
     exec_properties = {"cpu": "4"},
     tags = [
-        "cpu:4",
         "test_all_platforms_slow",
     ],
     deps = [

--- a/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
+++ b/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
@@ -56,6 +56,7 @@ rust_test(
     env = {
         "RUST_TEST_THREADS": "4",
     },
+    exec_properties = {"cpu": "4"},
     tags = [
         "cpu:4",
         "requires-network",

--- a/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
+++ b/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
@@ -58,7 +58,6 @@ rust_test(
     },
     exec_properties = {"cpu": "4"},
     tags = [
-        "cpu:4",
         "requires-network",
     ],
     deps = [

--- a/rs/ledger_suite/icp/index/BUILD.bazel
+++ b/rs/ledger_suite/icp/index/BUILD.bazel
@@ -142,7 +142,6 @@ rust_ic_test(
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm)",
     },
     exec_properties = {"cpu": "4"},
-    tags = ["cpu:4"],
     deps = [
         # Keep sorted.
         ":ic-icp-index",

--- a/rs/ledger_suite/icp/index/BUILD.bazel
+++ b/rs/ledger_suite/icp/index/BUILD.bazel
@@ -141,6 +141,7 @@ rust_ic_test(
         "IC_ICP_TEST_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/test_utils/icp_test_ledger:icp_test_ledger_canister.wasm.gz)",
         "LEDGER_CANISTER_WASM_PATH": "$(rootpath //rs/ledger_suite/icp/ledger:ledger-canister-wasm)",
     },
+    exec_properties = {"cpu": "4"},
     tags = ["cpu:4"],
     deps = [
         # Keep sorted.

--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -133,7 +133,6 @@ rust_ic_test(
         "LEDGER_CANISTER_PREV_VERSION_WASM_PATH": "$(rootpath :ledger-canister-wasm-prev-version)",
     },
     exec_properties = {"cpu": "4"},
-    tags = ["cpu:4"],
     deps = [
         # Keep sorted.
         ":ledger",

--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -132,6 +132,7 @@ rust_ic_test(
         "LEDGER_CANISTER_NEXT_VERSION_WASM_PATH": "$(rootpath :ledger-canister-wasm-next-version)",
         "LEDGER_CANISTER_PREV_VERSION_WASM_PATH": "$(rootpath :ledger-canister-wasm-prev-version)",
     },
+    exec_properties = {"cpu": "4"},
     tags = ["cpu:4"],
     deps = [
         # Keep sorted.

--- a/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
@@ -124,7 +124,6 @@ rust_test(
         },
         exec_properties = {"cpu": "4"},
         extra_srcs = ["tests/common/mod.rs"],
-        tags = ["cpu:4"],
         deps = [
             # Keep sorted.
             ":index-ng",

--- a/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
@@ -122,6 +122,7 @@ rust_test(
             "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath " + conf["ledger_wasm"] + ")",
             "IC_ICRC3_TEST_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger:icrc3_test_ledger_canister.wasm.gz)",
         },
+        exec_properties = {"cpu": "4"},
         extra_srcs = ["tests/common/mod.rs"],
         tags = ["cpu:4"],
         deps = [

--- a/rs/migration_canister/BUILD.bazel
+++ b/rs/migration_canister/BUILD.bazel
@@ -104,7 +104,6 @@ rust_test(
     proc_macro_deps = [
         "@crate_index//:strum_macros",
     ],
-    tags = ["cpu:16"],
     deps = [
         # Keep sorted
         "//packages/ic-http-types",

--- a/rs/migration_canister/BUILD.bazel
+++ b/rs/migration_canister/BUILD.bazel
@@ -100,6 +100,7 @@ rust_test(
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
         "RUST_TEST_THREADS": "4",  # running too many PocketIC tests in parallel affects overall performance
     },
+    exec_properties = {"cpu": "16"},
     proc_macro_deps = [
         "@crate_index//:strum_macros",
     ],

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -201,6 +201,7 @@ rust_test_suite_with_extra_srcs(
     ),
     data = DEV_DATA,
     env = DEV_ENV,
+    exec_properties = {"cpu": "6"},
     extra_srcs = ["tests/sns_upgrade_test_utils.rs"],
     proc_macro_deps = [
         # Keep sorted.
@@ -226,6 +227,7 @@ rust_test(
         # scenarios to keep the server's memory usage bounded.
         "RUST_TEST_THREADS": "4",
     },
+    exec_properties = {"cpu": "8"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -264,6 +266,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -282,6 +285,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -300,6 +304,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -319,6 +324,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -337,6 +343,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -355,6 +362,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -373,6 +381,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -391,6 +400,7 @@ rust_test(
     ],
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
@@ -416,6 +426,7 @@ rust_test(
         "KONGSWAP_ADAPTOR_CANISTER_WASM_PATH": "$(rootpath @kongswap-adaptor-canister//file)",
         "RUST_TEST_NOCAPTURE": "1",
     },
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -207,9 +207,6 @@ rust_test_suite_with_extra_srcs(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:6",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -232,9 +229,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:8",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -248,12 +242,10 @@ rust_test(
     crate_root = "tests/upgrade_everything_test.rs",
     data = DEV_DATA,
     env = DEV_ENV | {"RUST_TEST_NOCAPTURE": "1"},
+    exec_properties = {"cpu": "6"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
-    ],
-    tags = [
-        "cpu:6",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
@@ -271,9 +263,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:4",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -290,9 +279,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:4",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -308,9 +294,6 @@ rust_test(
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
-    ],
-    tags = [
-        "cpu:4",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
@@ -329,9 +312,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:4",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -347,9 +327,6 @@ rust_test(
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
-    ],
-    tags = [
-        "cpu:4",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
@@ -367,9 +344,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:4",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -386,9 +360,6 @@ rust_test(
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = [
-        "cpu:4",
-    ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
 
@@ -404,9 +375,6 @@ rust_test(
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
-    ],
-    tags = [
-        "cpu:4",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )
@@ -430,9 +398,6 @@ rust_test(
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:rust_decimal_macros",
-    ],
-    tags = [
-        "cpu:4",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES + [
         "//rs/sns/treasury_manager",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -356,7 +356,6 @@ rust_test(
         },
         exec_properties = {"cpu": "8"},
         tags = [
-            "cpu:8",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
             # Failed to bind PocketIC server to address 127.0.0.1:0
             "requires-network",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -354,6 +354,7 @@ rust_test(
             "II_FRONTEND_WASM": "$(rootpath @mainnet_canisters//:internet_identity_frontend.wasm.gz)",
             "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         },
+        exec_properties = {"cpu": "8"},
         tags = [
             "cpu:8",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -388,6 +388,7 @@ rust_test(
         "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
         "LIFELINE_CANISTER_WASM_PATH": "$(rootpath //rs/nns/handlers/lifeline/impl:lifeline_canister)",
     },
+    exec_properties = {"cpu": "4"},
     proc_macro_deps = [
         "@crate_index//:test-strategy",
     ],

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -393,7 +393,6 @@ rust_test(
         "@crate_index//:test-strategy",
     ],
     tags = [
-        "cpu:4",
         "long_test",
     ],
     deps = [

--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -51,7 +51,6 @@ rust_test_suite(
     # TODO(IDX-2225): reconsider when we will use Remote Execution.
     proc_macro_deps = [
     ],
-    tags = ["cpu:4"],
     deps = [
         # Keep sorted.
         ":rosetta-integration-tests-lib",

--- a/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
+++ b/rs/rosetta-api/icp/tests/integration_tests/BUILD.bazel
@@ -46,6 +46,7 @@ rust_test_suite(
         "IC_SENDER_CANISTER_WASM_PATH": "$(rootpath //rs/rosetta-api/icp/test_utils/sender_canister:ic-sender-canister)",
         "ICP_LEDGER_DEPLOYED_VERSION_WASM_PATH": "$(rootpath @mainnet_canisters//:ledger.wasm.gz)",
     },
+    exec_properties = {"cpu": "4"},
     # The test is critical to get resources timely and therefore fails sometimes when run on heavily loaded node.
     # TODO(IDX-2225): reconsider when we will use Remote Execution.
     proc_macro_deps = [

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -398,7 +398,6 @@ rust_test_suite_with_extra_srcs(
     extra_srcs = glob([
         "tests/common/*.rs",
     ]),
-    tags = ["cpu:4"],
     deps = [
         # Keep sorted.
         ":ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -394,6 +394,7 @@ rust_test_suite_with_extra_srcs(
         "ROSETTA_CLI": "$(rootpath //:rosetta-cli)",
         "RUST_TEST_THREADS": "4",
     },
+    exec_properties = {"cpu": "4"},
     extra_srcs = glob([
         "tests/common/*.rs",
     ]),

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -202,6 +202,7 @@ rust_ic_test_suite_with_extra_srcs(
     crate_features = ["test"],
     data = DATA_DEPS,
     env = ENV,
+    exec_properties = {"cpu": "8"},
     extra_srcs = [],
     proc_macro_deps = [
         # Keep sorted.

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -209,7 +209,6 @@ rust_ic_test_suite_with_extra_srcs(
         "@crate_index//:async-trait",
         "@crate_index//:rust_decimal_macros",
     ],
-    tags = ["cpu:8"],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
 )
 
@@ -224,13 +223,13 @@ rust_ic_test(
     crate_features = ["test"],
     data = DATA_DEPS,
     env = ENV,
+    exec_properties = {"cpu": "8"},
     #proc_macro_deps = [
     #    # Keep sorted.
     #    "@crate_index//:async-trait",
     #    "@crate_index//:rust_decimal_macros",
     #],
     tags = [
-        "cpu:8",
         "long_test",  # The P90 duration of this test is over 6 minutes for the week starting on 2025-08-21.
     ],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
@@ -247,13 +246,13 @@ rust_ic_test(
     crate_features = ["test"],
     data = DATA_DEPS,
     env = ENV,
+    exec_properties = {"cpu": "8"},
     proc_macro_deps = [
         # Keep sorted.
         "@crate_index//:async-trait",
         "@crate_index//:rust_decimal_macros",
     ],
     tags = [
-        "cpu:8",
         "long_test",  # The P90 duration of this test is 6 minutes for the month starting on 2026-01-16.
     ],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
@@ -298,6 +297,7 @@ rust_ic_test_suite_with_extra_srcs(
     env = dict(ENV.items() + [
         ("MAINNET_SNS_SWAP_CANISTER_WASM_PATH", "$(rootpath @mainnet_canisters//:swap.wasm.gz)"),
     ]),
+    exec_properties = {"cpu": "8"},
     extra_srcs = [],
     proc_macro_deps = [
         # Keep sorted.
@@ -305,7 +305,6 @@ rust_ic_test_suite_with_extra_srcs(
         "@crate_index//:rust_decimal_macros",
     ],
     tags = [
-        "cpu:8",
         "nns_tests_nightly",  # Run this test in the nns-tests-nightly GitHub Action job.
         "no-sandbox",  # such that the test can access the file $SSH_AUTH_SOCK.
         "requires-network",  # Because mainnet state is downloaded (and used).

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -99,7 +99,7 @@ def system_test(
         `"minIntraDistanceLoadBalanceAllocation"` or `"distributeAcrossDcs"`.
         When None it defaults to `"minIntraDistanceLoadBalanceAllocation"`.
       cpus: Optional number of CPU cores to reserve for the local variant of the test.
-        This will translate into a `exec_properties = {"cpu": str(cpus)}` setting for the `_local` variant.
+        This will translate into an `exec_properties = {"cpu": str(cpus)}` setting for the `_local` variant.
         Heuristic: set it to MIN_LOCAL_CPUS + number of vCPUs required for the whole testnet. DEFAULT_VCPUS_PER_VM can be used for the default number of vCPUs per VM if not overridden.
       **kwargs: additional arguments to pass to the rust_binary rule.
 
@@ -329,7 +329,7 @@ def system_test(
         },
         env_inherit = env_inherit,
         tags = tags + ["local_system_test"] + (["manual"] if backend == "farm" else []),
-        # The cpu:n` tag is not forwarded to the Remote Execution API so we set the exection properties explicitly:
+        # The `cpu:n` tag is not forwarded to the Remote Execution API, so we set the execution properties explicitly:
         exec_properties = {"cpu": str(cpus)} if cpus != None else {},
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -332,7 +332,7 @@ def system_test(
         env_inherit = env_inherit,
         tags = tags + ["local_system_test"] + reserve_cpus + (["manual"] if backend == "farm" else []),
         # The cpu:n` tag is not forwarded to the Remote Execution API so we set the exection properties explicitly:
-        exec_properties = {"cpu": cpus} if cpus != None else {},
+        exec_properties = {"cpu": str(cpus)} if cpus != None else {},
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,
         visibility = visibility,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -99,7 +99,7 @@ def system_test(
         `"minIntraDistanceLoadBalanceAllocation"` or `"distributeAcrossDcs"`.
         When None it defaults to `"minIntraDistanceLoadBalanceAllocation"`.
       cpus: Optional number of CPU cores to reserve for the local variant of the test.
-        This will translate into a `cpu:N` tag for the `_local` variant.
+        This will translate into a `exec_properties = {"cpu": str(cpus)}` setting for the `_local` variant.
         Heuristic: set it to MIN_LOCAL_CPUS + number of vCPUs required for the whole testnet. DEFAULT_VCPUS_PER_VM can be used for the default number of vCPUs per VM if not overridden.
       **kwargs: additional arguments to pass to the rust_binary rule.
 
@@ -317,8 +317,6 @@ def system_test(
     # (--stream-console-logs).
     local_args = ([] if "--no-logs" in extra_args_simple else ["--no-logs"]) + ["--stream-ic-node-logs", "--stream-console-logs"]
 
-    reserve_cpus = [] if cpus == None else ["cpu:{}".format(cpus)]
-
     sh_test(
         name = test_name + "_local",
         srcs = ["//rs/tests:run_systest.sh"],
@@ -330,7 +328,7 @@ def system_test(
             "RUN_SCRIPT_RUNTIME_DEP_ENV_VARS": ";".join(_runtime_deps.keys() + _local_only_deps.keys()),
         },
         env_inherit = env_inherit,
-        tags = tags + ["local_system_test"] + reserve_cpus + (["manual"] if backend == "farm" else []),
+        tags = tags + ["local_system_test"] + (["manual"] if backend == "farm" else []),
         # The cpu:n` tag is not forwarded to the Remote Execution API so we set the exection properties explicitly:
         exec_properties = {"cpu": str(cpus)} if cpus != None else {},
         target_compatible_with = ["@platforms//os:linux"],

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -331,6 +331,8 @@ def system_test(
         },
         env_inherit = env_inherit,
         tags = tags + ["local_system_test"] + reserve_cpus + (["manual"] if backend == "farm" else []),
+        # The cpu:n` tag is not forwarded to the Remote Execution API so we set the exection properties explicitly:
+        exec_properties = {"cpu": cpus} if cpus != None else {},
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,
         visibility = visibility,


### PR DESCRIPTION
Bazel doesn't forward the `cpu:n` tag, for reserving cpu cores, to the Remote Execution API. This means that on Remote Build Execution clusters (like @ Namespace) actions don't get the minimal CPUs they specified. To fix this we replace `cpu:n` tags with `exec_properties = {"cpu": "n"}` settings which are forwarded to the REAPI and work locally as well.

Note that this is supported since bazel-9.2.0. See: https://github.com/bazelbuild/bazel/issues/29419.