### PR TITLE
chore: pin long asset canister

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -399,7 +399,7 @@ http_file(
     name = "long_asset_canister",
     downloaded_file_path = "http_gateway_canister_custom_assets.wasm.gz",
     sha256 = "eedcbf986c67fd4ebe3042094604a9a5703e825e56433e2509a6a4d0384ccf95",
-    url = "https://github.com/dfinity/ic-http-gateway-protocol/raw/refs/heads/main/examples/http-gateway/canister/http_gateway_canister_custom_assets.wasm.gz",
+    url = "https://raw.githubusercontent.com/dfinity/ic-http-gateway-protocol/07bc0f3e6e95a8011de9d1712211cbafdf2e5bfe/examples/http-gateway/canister/http_gateway_canister_custom_assets.wasm.gz",
 )
 
 # Old version of wallet canister


### PR DESCRIPTION
The `long_asset_canister` file was downloaded from the tip of the main branch. If the canister ever was modified, the build would fail. This pins the downloaded Wasm module to a specific commit.