### PR TITLE
chore: bump cddl to 0.10.6

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "04cb3be95a0857e516fce14b2327d9f77d8165b7fb6ac0cd12f56764bf236113",
+  "checksum": "5ba6c2c9b2d935e91985619c02b268ffc24887c3c46810538ff378595b06fbc6",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -453,7 +453,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -524,7 +524,7 @@
               "target": "http"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -944,7 +944,7 @@
               "target": "language_tags"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -960,7 +960,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -972,7 +972,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -1071,11 +1071,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -1131,7 +1131,7 @@
               "target": "futures_core"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -1143,7 +1143,7 @@
               "target": "prometheus"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -2005,7 +2005,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -2346,7 +2346,6 @@
         "crate_features": {
           "common": [
             "auto",
-            "default",
             "wincon"
           ],
           "selects": {}
@@ -2354,7 +2353,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             },
             {
@@ -2374,7 +2373,7 @@
               "target": "is_terminal_polyfill"
             },
             {
-              "id": "utf8parse 0.2.1",
+              "id": "utf8parse 0.2.2",
               "target": "utf8parse"
             }
           ],
@@ -2390,14 +2389,90 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle 1.0.8": {
-      "name": "anstyle",
-      "version": "1.0.8",
+    "anstream 1.0.0": {
+      "name": "anstream",
+      "version": "1.0.0",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle/1.0.8/download",
-          "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+          "url": "https://static.crates.io/crates/anstream/1.0.0/download",
+          "sha256": "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "anstream",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "anstream",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "auto",
+            "default",
+            "wincon"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "anstyle 1.0.14",
+              "target": "anstyle"
+            },
+            {
+              "id": "anstyle-parse 1.0.0",
+              "target": "anstyle_parse"
+            },
+            {
+              "id": "anstyle-query 1.0.0",
+              "target": "anstyle_query"
+            },
+            {
+              "id": "colorchoice 1.0.0",
+              "target": "colorchoice"
+            },
+            {
+              "id": "is_terminal_polyfill 1.70.1",
+              "target": "is_terminal_polyfill"
+            },
+            {
+              "id": "utf8parse 0.2.2",
+              "target": "utf8parse"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "anstyle 1.0.14": {
+      "name": "anstyle",
+      "version": "1.0.14",
+      "package_url": "https://github.com/rust-cli/anstyle.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/anstyle/1.0.14/download",
+          "sha256": "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
         }
       },
       "targets": [
@@ -2427,7 +2502,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.8"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2475,7 +2550,7 @@
         "deps": {
           "common": [
             {
-              "id": "utf8parse 0.2.1",
+              "id": "utf8parse 0.2.2",
               "target": "utf8parse"
             }
           ],
@@ -2483,6 +2558,61 @@
         },
         "edition": "2021",
         "version": "0.2.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "anstyle-parse 1.0.0": {
+      "name": "anstyle-parse",
+      "version": "1.0.0",
+      "package_url": "https://github.com/rust-cli/anstyle.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/anstyle-parse/1.0.0/download",
+          "sha256": "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "anstyle_parse",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "anstyle_parse",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "utf8"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "utf8parse 0.2.2",
+              "target": "utf8parse"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2541,14 +2671,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle-wincon 3.0.1": {
+    "anstyle-wincon 3.0.11": {
       "name": "anstyle-wincon",
-      "version": "3.0.1",
+      "version": "3.0.11",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle-wincon/3.0.1/download",
-          "sha256": "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+          "url": "https://static.crates.io/crates/anstyle-wincon/3.0.11/download",
+          "sha256": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
         }
       },
       "targets": [
@@ -2573,21 +2703,25 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             }
           ],
           "selects": {
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "once_cell_polyfill 1.70.2",
+                "target": "once_cell_polyfill"
+              },
+              {
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "3.0.1"
+        "version": "3.0.11"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -3117,7 +3251,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -3209,7 +3343,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -3221,7 +3355,7 @@
               "target": "serde"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -3595,11 +3729,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -3655,11 +3789,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -3715,11 +3849,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -3771,7 +3905,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -3830,7 +3964,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             },
             {
@@ -4192,7 +4326,7 @@
               "target": "httparse"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -4454,11 +4588,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -4622,11 +4756,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -4723,11 +4857,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -4854,7 +4988,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -5026,7 +5160,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -5406,7 +5540,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -5587,7 +5721,7 @@
               "target": "serde_core"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -6111,11 +6245,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -6172,11 +6306,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -6836,6 +6970,51 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "base45 3.2.0": {
+      "name": "base45",
+      "version": "3.2.0",
+      "package_url": "https://github.com/opendevtools/base45",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/base45/3.2.0/download",
+          "sha256": "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "base45",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "base45",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "3.2.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": null
+    },
     "base58ck 0.1.0": {
       "name": "base58ck",
       "version": "0.1.0",
@@ -7035,14 +7214,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "base64-url 2.0.2": {
+    "base64-url 3.0.4": {
       "name": "base64-url",
-      "version": "2.0.2",
+      "version": "3.0.4",
       "package_url": "https://github.com/magiclen/base64-url",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/base64-url/2.0.2/download",
-          "sha256": "fb9fb9fb058cc3063b5fc88d9a21eefa2735871498a04e1650da76ed511c8569"
+          "url": "https://static.crates.io/crates/base64-url/3.0.4/download",
+          "sha256": "261c4eaab63106ddf34d377f47e5428aa863b61e4a647c872778d9caf8e2c819"
         }
       },
       "targets": [
@@ -7066,22 +7245,21 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "std"
+            "default"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.6",
+              "id": "base64 0.22.1",
               "target": "base64"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.2"
+        "version": "3.0.4"
       },
       "license": "MIT",
       "license_ids": [
@@ -7520,11 +7698,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -7536,7 +7714,7 @@
               "target": "shlex"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -7657,11 +7835,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -7673,7 +7851,7 @@
               "target": "shlex"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -7781,7 +7959,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -7793,11 +7971,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -7809,7 +7987,7 @@
               "target": "shlex"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -7963,7 +8141,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -8878,11 +9056,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -9471,11 +9649,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -10106,7 +10284,7 @@
               "target": "rustc_version"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -10272,11 +10450,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -10687,7 +10865,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -10742,11 +10920,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -11394,11 +11572,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -11633,7 +11811,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -11839,11 +12017,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -12158,7 +12336,7 @@
               "target": "ic0"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -12166,7 +12344,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -12230,11 +12408,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -12351,7 +12529,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -12613,14 +12791,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cddl 0.9.4": {
+    "cddl 0.10.6": {
       "name": "cddl",
-      "version": "0.9.4",
+      "version": "0.10.6",
       "package_url": "https://github.com/anweiss/cddl",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cddl/0.9.4/download",
-          "sha256": "2cc18488a72cef88de14f00d3db73f57a9511d53ae8dd72204a4bf8bc19309d7"
+          "url": "https://static.crates.io/crates/cddl/0.10.6/download",
+          "sha256": "69f7305ff73327bd9ce5e5cdd81223dd91b4969e260ea6cdb8f1da94390be191"
         }
       },
       "targets": [
@@ -12628,6 +12806,18 @@
           "Library": {
             "crate_name": "cddl",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -12644,22 +12834,37 @@
         ],
         "crate_features": {
           "common": [
+            "abnf_to_pest",
             "additional-controls",
             "ast-comments",
             "ast-parent",
             "ast-span",
+            "base45",
             "base64-url",
             "cbor",
             "chrono",
             "ciborium",
+            "ciborium-io",
+            "ciborium-ll",
             "clap",
-            "crossterm",
+            "codespan-reporting",
+            "csv",
+            "csv-validate",
             "default",
+            "fancy-regex",
+            "freezer",
+            "hex",
+            "hexf-parse",
             "json",
+            "log",
+            "pest_meta",
+            "pest_vm",
+            "regex",
             "regex-syntax",
             "serde",
             "serde-wasm-bindgen",
             "serde_json",
+            "simplelog",
             "std",
             "uriparse",
             "wasm-bindgen"
@@ -12677,11 +12882,19 @@
               "target": "base16"
             },
             {
-              "id": "base64-url 2.0.2",
+              "id": "base45 3.2.0",
+              "target": "base45"
+            },
+            {
+              "id": "base64-url 3.0.4",
               "target": "base64_url"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "cddl 0.10.6",
+              "target": "build_script_build"
+            },
+            {
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -12689,47 +12902,67 @@
               "target": "ciborium"
             },
             {
-              "id": "clap 3.2.25",
+              "id": "ciborium-io 0.2.1",
+              "target": "ciborium_io"
+            },
+            {
+              "id": "ciborium-ll 0.2.1",
+              "target": "ciborium_ll"
+            },
+            {
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
-              "id": "codespan-reporting 0.11.1",
+              "id": "codespan-reporting 0.13.1",
               "target": "codespan_reporting"
+            },
+            {
+              "id": "csv 1.4.0",
+              "target": "csv"
             },
             {
               "id": "data-encoding 2.11.0",
               "target": "data_encoding"
             },
             {
+              "id": "fancy-regex 0.18.0",
+              "target": "fancy_regex"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
               "id": "hexf-parse 0.2.1",
               "target": "hexf_parse"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.15.0",
               "target": "itertools"
             },
             {
-              "id": "lexical-core 0.8.5",
-              "target": "lexical_core"
-            },
-            {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
-              "id": "pest_meta 2.7.1",
+              "id": "pest 2.8.7",
+              "target": "pest"
+            },
+            {
+              "id": "pest_meta 2.8.7",
               "target": "pest_meta"
             },
             {
-              "id": "pest_vm 2.7.1",
+              "id": "pest_vm 2.8.7",
               "target": "pest_vm"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.7.4",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
@@ -12737,7 +12970,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -12750,44 +12983,32 @@
             }
           ],
           "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
-              }
-            ],
             "cfg(target_arch = \"wasm32\")": [
               {
                 "id": "console_error_panic_hook 0.1.7",
                 "target": "console_error_panic_hook"
+              },
+              {
+                "id": "js-sys 0.3.103",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen-test 0.3.76",
+                "target": "wasm_bindgen_test"
+              },
+              {
+                "id": "web-sys 0.3.103",
+                "target": "web_sys"
               }
             ],
             "wasm32-unknown-unknown": [
               {
-                "id": "serde-wasm-bindgen 0.5.0",
+                "id": "serde-wasm-bindgen 0.6.5",
                 "target": "serde_wasm_bindgen"
               },
               {
                 "id": "wasm-bindgen 0.2.126",
                 "target": "wasm_bindgen"
-              }
-            ],
-            "x86_64-apple-darwin": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
               }
             ]
           }
@@ -12798,11 +13019,26 @@
             {
               "id": "displaydoc 0.2.4",
               "target": "displaydoc"
+            },
+            {
+              "id": "pest_derive 2.8.7",
+              "target": "pest_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.9.4"
+        "version": "0.10.6"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT",
       "license_ids": [
@@ -13233,14 +13469,14 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "chrono 0.4.42": {
+    "chrono 0.4.45": {
       "name": "chrono",
-      "version": "0.4.42",
+      "version": "0.4.45",
       "package_url": "https://github.com/chronotope/chrono",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/chrono/0.4.42/download",
-          "sha256": "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+          "url": "https://static.crates.io/crates/chrono/0.4.45/download",
+          "sha256": "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
         }
       },
       "targets": [
@@ -13329,7 +13565,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.4.42"
+        "version": "0.4.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13739,114 +13975,14 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "clap 3.2.25": {
+    "clap 4.6.2": {
       "name": "clap",
-      "version": "3.2.25",
+      "version": "4.6.2",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/3.2.25/download",
-          "sha256": "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "clap",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "clap",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "atty",
-            "clap_derive",
-            "color",
-            "default",
-            "derive",
-            "once_cell",
-            "std",
-            "strsim",
-            "suggestions",
-            "termcolor"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "atty 0.2.14",
-              "target": "atty"
-            },
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "clap_lex 0.2.4",
-              "target": "clap_lex"
-            },
-            {
-              "id": "indexmap 1.9.3",
-              "target": "indexmap"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "strsim 0.10.0",
-              "target": "strsim"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "textwrap 0.16.0",
-              "target": "textwrap"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "clap_derive 3.2.25",
-              "target": "clap_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "3.2.25"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "clap 4.5.53": {
-      "name": "clap",
-      "version": "4.5.53",
-      "package_url": "https://github.com/clap-rs/clap",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/clap/4.5.53/download",
-          "sha256": "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+          "url": "https://static.crates.io/crates/clap/4.6.2/download",
+          "sha256": "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
         }
       },
       "targets": [
@@ -13887,23 +14023,23 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.5.53",
+              "id": "clap_builder 4.6.2",
               "target": "clap_builder"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
+        "edition": "2024",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 4.5.49",
+              "id": "clap_derive 4.6.1",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "4.5.53"
+        "version": "4.6.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13912,14 +14048,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_builder 4.5.53": {
+    "clap_builder 4.6.2": {
       "name": "clap_builder",
-      "version": "4.5.53",
+      "version": "4.6.2",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.5.53/download",
-          "sha256": "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+          "url": "https://static.crates.io/crates/clap_builder/4.6.2/download",
+          "sha256": "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
         }
       },
       "targets": [
@@ -13958,15 +14094,15 @@
         "deps": {
           "common": [
             {
-              "id": "anstream 0.6.15",
+              "id": "anstream 1.0.0",
               "target": "anstream"
             },
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             },
             {
-              "id": "clap_lex 0.7.5",
+              "id": "clap_lex 1.1.0",
               "target": "clap_lex"
             },
             {
@@ -13976,8 +14112,8 @@
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "4.5.53"
+        "edition": "2024",
+        "version": "4.6.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13986,84 +14122,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_derive 3.2.25": {
+    "clap_derive 4.6.1": {
       "name": "clap_derive",
-      "version": "3.2.25",
-      "package_url": "https://github.com/clap-rs/clap/tree/master/clap_derive",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/clap_derive/3.2.25/download",
-          "sha256": "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "clap_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "clap_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.4.1",
-              "target": "heck"
-            },
-            {
-              "id": "proc-macro-error 1.0.4",
-              "target": "proc_macro_error"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.42",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "3.2.25"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "clap_derive 4.5.49": {
-      "name": "clap_derive",
-      "version": "4.5.49",
+      "version": "4.6.1",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_derive/4.5.49/download",
-          "sha256": "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+          "url": "https://static.crates.io/crates/clap_derive/4.6.1/download",
+          "sha256": "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
         }
       },
       "targets": [
@@ -14102,18 +14168,18 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "4.5.49"
+        "edition": "2024",
+        "version": "4.6.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14122,62 +14188,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_lex 0.2.4": {
+    "clap_lex 1.1.0": {
       "name": "clap_lex",
-      "version": "0.2.4",
-      "package_url": "https://github.com/clap-rs/clap/tree/master/clap_lex",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/clap_lex/0.2.4/download",
-          "sha256": "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "clap_lex",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "clap_lex",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "os_str_bytes 6.5.1",
-              "target": "os_str_bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.4"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "clap_lex 0.7.5": {
-      "name": "clap_lex",
-      "version": "0.7.5",
+      "version": "1.1.0",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_lex/0.7.5/download",
-          "sha256": "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+          "url": "https://static.crates.io/crates/clap_lex/1.1.0/download",
+          "sha256": "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
         }
       },
       "targets": [
@@ -14199,8 +14217,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2021",
-        "version": "0.7.5"
+        "edition": "2024",
+        "version": "1.1.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14414,6 +14432,65 @@
         "Apache-2.0"
       ],
       "license_file": null
+    },
+    "codespan-reporting 0.13.1": {
+      "name": "codespan-reporting",
+      "version": "0.13.1",
+      "package_url": "https://github.com/brendanzab/codespan",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/codespan-reporting/0.13.1/download",
+          "sha256": "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "codespan_reporting",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "codespan_reporting",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std",
+            "termcolor"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "termcolor 1.4.1",
+              "target": "termcolor"
+            },
+            {
+              "id": "unicode-width 0.2.0",
+              "target": "unicode_width"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.13.1"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
     },
     "colorchoice 1.0.0": {
       "name": "colorchoice",
@@ -14837,7 +14914,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -14897,7 +14974,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -15023,7 +15100,7 @@
               "target": "libc"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -16373,7 +16450,7 @@
               "target": "libm"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -16713,7 +16790,7 @@
               "target": "cranelift_codegen"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -17142,7 +17219,7 @@
               "target": "ciborium"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -17170,7 +17247,7 @@
               "target": "once_cell"
             },
             {
-              "id": "oorandom 11.1.3",
+              "id": "oorandom 11.1.5",
               "target": "oorandom"
             },
             {
@@ -17182,7 +17259,7 @@
               "target": "rayon"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -17190,7 +17267,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -17696,85 +17773,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "crossterm 0.27.0": {
-      "name": "crossterm",
-      "version": "0.27.0",
-      "package_url": "https://github.com/crossterm-rs/crossterm",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/crossterm/0.27.0/download",
-          "sha256": "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crossterm",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "crossterm",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "bracketed-paste",
-            "default",
-            "events",
-            "windows"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.10.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "mio 0.8.10",
-              "target": "mio"
-            },
-            {
-              "id": "parking_lot 0.12.5",
-              "target": "parking_lot"
-            },
-            {
-              "id": "signal-hook 0.3.17",
-              "target": "signal_hook"
-            },
-            {
-              "id": "signal-hook-mio 0.2.5",
-              "target": "signal_hook_mio"
-            }
-          ],
-          "selects": {
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.186",
-                "target": "libc"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.27.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "crossterm 0.28.1": {
       "name": "crossterm",
@@ -18307,11 +18305,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -18377,14 +18375,14 @@
       ],
       "license_file": null
     },
-    "csv 1.2.2": {
+    "csv 1.4.0": {
       "name": "csv",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "package_url": "https://github.com/BurntSushi/rust-csv",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/csv/1.2.2/download",
-          "sha256": "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+          "url": "https://static.crates.io/crates/csv/1.4.0/download",
+          "sha256": "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
         }
       },
       "targets": [
@@ -18409,7 +18407,7 @@
         "deps": {
           "common": [
             {
-              "id": "csv-core 0.1.10",
+              "id": "csv-core 0.1.13",
               "target": "csv_core"
             },
             {
@@ -18421,14 +18419,14 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.228",
-              "target": "serde"
+              "id": "serde_core 1.0.228",
+              "target": "serde_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.2.2"
+        "version": "1.4.0"
       },
       "license": "Unlicense/MIT",
       "license_ids": [
@@ -18437,14 +18435,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "csv-core 0.1.10": {
+    "csv-core 0.1.13": {
       "name": "csv-core",
-      "version": "0.1.10",
+      "version": "0.1.13",
       "package_url": "https://github.com/BurntSushi/rust-csv",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/csv-core/0.1.10/download",
-          "sha256": "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+          "url": "https://static.crates.io/crates/csv-core/0.1.13/download",
+          "sha256": "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
         }
       },
       "targets": [
@@ -18482,7 +18480,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.10"
+        "version": "0.1.13"
       },
       "license": "Unlicense/MIT",
       "license_ids": [
@@ -18783,11 +18781,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19224,7 +19222,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -19298,7 +19296,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -19306,7 +19304,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19372,7 +19370,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -19380,7 +19378,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19442,7 +19440,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -19450,7 +19448,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19501,7 +19499,7 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -19556,11 +19554,11 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19611,11 +19609,11 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19666,11 +19664,11 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -19992,7 +19990,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -20475,11 +20473,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -20591,7 +20589,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -20654,11 +20652,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -20709,11 +20707,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -20830,11 +20828,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -20892,7 +20890,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -20979,7 +20977,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -21110,11 +21108,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -21193,7 +21191,7 @@
               "target": "env_logger"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -21885,7 +21883,7 @@
               "target": "cc"
             },
             {
-              "id": "cddl 0.9.4",
+              "id": "cddl 0.10.6",
               "target": "cddl"
             },
             {
@@ -21902,7 +21900,7 @@
               "alias": "chrono_canisters"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -21914,7 +21912,7 @@
               "target": "cidr"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -21950,7 +21948,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "csv 1.2.2",
+              "id": "csv 1.4.0",
               "target": "csv"
             },
             {
@@ -22598,11 +22596,6 @@
               "target": "proptest"
             },
             {
-              "id": "prost 0.12.2",
-              "target": "prost",
-              "alias": "prost_0_12"
-            },
-            {
               "id": "prost 0.14.4",
               "target": "prost"
             },
@@ -22635,7 +22628,7 @@
               "target": "quinn_udp"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -22671,7 +22664,7 @@
               "target": "rcgen"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -22804,7 +22797,7 @@
               "target": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -22908,7 +22901,7 @@
               "target": "subtle"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -23594,11 +23587,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -24426,7 +24419,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -24816,7 +24809,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -24967,7 +24960,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -25031,11 +25024,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -25175,11 +25168,11 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             }
           ],
@@ -25233,11 +25226,11 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             }
           ],
@@ -25299,7 +25292,7 @@
               "target": "anstream"
             },
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             },
             {
@@ -25311,7 +25304,7 @@
               "target": "humantime"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -25410,11 +25403,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -25843,7 +25836,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -25855,7 +25848,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -25940,7 +25933,7 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -25948,7 +25941,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -26192,7 +26185,7 @@
               "target": "bytes"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -26236,7 +26229,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -26559,7 +26552,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -27023,11 +27016,11 @@
               "target": "bit_set"
             },
             {
-              "id": "regex-automata 0.4.13",
+              "id": "regex-automata 0.4.16",
               "target": "regex_automata"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
@@ -27035,6 +27028,71 @@
         },
         "edition": "2018",
         "version": "0.17.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "fancy-regex 0.18.0": {
+      "name": "fancy-regex",
+      "version": "0.18.0",
+      "package_url": "https://github.com/fancy-regex/fancy-regex",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/fancy-regex/0.18.0/download",
+          "sha256": "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "fancy_regex",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "fancy_regex",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "perf",
+            "std",
+            "unicode",
+            "variable-lookbehinds"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bit-set 0.8.0",
+              "target": "bit_set"
+            },
+            {
+              "id": "regex-automata 0.4.16",
+              "target": "regex_automata"
+            },
+            {
+              "id": "regex-syntax 0.8.11",
+              "target": "regex_syntax"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.18.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -28148,11 +28206,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -29149,11 +29207,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -31033,7 +31091,7 @@
               "target": "derive_builder"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -31041,7 +31099,7 @@
               "target": "num_order"
             },
             {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             },
             {
@@ -31049,7 +31107,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -31063,7 +31121,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pest_derive 2.7.1",
+              "id": "pest_derive 2.8.7",
               "target": "pest_derive"
             }
           ],
@@ -33238,7 +33296,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -33272,7 +33330,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -34134,7 +34192,7 @@
               "target": "hyper"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -34226,7 +34284,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -35262,7 +35320,7 @@
               "target": "chacha20poly1305"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -35374,7 +35432,7 @@
               "target": "rcgen"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -35406,7 +35464,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -35594,7 +35652,7 @@
               "target": "candid"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -36339,11 +36397,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -36402,11 +36460,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -36848,7 +36906,7 @@
               "target": "chacha20poly1305"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -36880,7 +36938,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -36980,11 +37038,11 @@
               "target": "chacha20poly1305"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -37519,7 +37577,7 @@
               "target": "candid"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -37607,7 +37665,7 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -37627,7 +37685,7 @@
               "target": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -38287,7 +38345,7 @@
               "target": "leb128"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -39239,7 +39297,7 @@
               "target": "candid_parser"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -39259,7 +39317,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -40316,11 +40374,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -40876,7 +40934,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -41297,7 +41355,7 @@
               "target": "ahash"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -41325,7 +41383,7 @@
               "target": "itoa"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -41653,11 +41711,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -41835,7 +41893,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -42467,7 +42525,7 @@
         "deps": {
           "common": [
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             }
           ],
@@ -42956,7 +43014,7 @@
               "target": "jni_sys"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -43043,7 +43101,7 @@
               "target": "jni_sys"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -43155,7 +43213,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -43163,7 +43221,7 @@
               "target": "simd_cesu8"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -43318,11 +43376,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -43496,7 +43554,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -43548,7 +43606,7 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             },
             {
@@ -43562,7 +43620,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pest_derive 2.7.1",
+              "id": "pest_derive 2.8.7",
               "target": "pest_derive"
             }
           ],
@@ -43625,7 +43683,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -43720,11 +43778,11 @@
               "target": "referencing"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
@@ -43732,7 +43790,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -44065,7 +44123,7 @@
               "target": "petgraph"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -44178,7 +44236,7 @@
               "target": "pico_args"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -44270,11 +44328,11 @@
               "target": "petgraph"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
@@ -44368,25 +44426,25 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ]
@@ -44460,25 +44518,25 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "regex 1.12.2",
+                "id": "regex 1.13.1",
                 "target": "regex"
               }
             ]
@@ -44791,391 +44849,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "lexical-core 0.8.5": {
-      "name": "lexical-core",
-      "version": "0.8.5",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-core/0.8.5/download",
-          "sha256": "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_core",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "floats",
-            "integers",
-            "lexical-parse-float",
-            "lexical-parse-integer",
-            "lexical-write-float",
-            "lexical-write-integer",
-            "parse",
-            "parse-floats",
-            "parse-integers",
-            "std",
-            "write",
-            "write-floats",
-            "write-integers"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lexical-parse-float 0.8.5",
-              "target": "lexical_parse_float"
-            },
-            {
-              "id": "lexical-parse-integer 0.8.6",
-              "target": "lexical_parse_integer"
-            },
-            {
-              "id": "lexical-util 0.8.5",
-              "target": "lexical_util"
-            },
-            {
-              "id": "lexical-write-float 0.8.5",
-              "target": "lexical_write_float"
-            },
-            {
-              "id": "lexical-write-integer 0.8.5",
-              "target": "lexical_write_integer"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "lexical-parse-float 0.8.5": {
-      "name": "lexical-parse-float",
-      "version": "0.8.5",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-parse-float/0.8.5/download",
-          "sha256": "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_parse_float",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_parse_float",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lexical-parse-integer 0.8.6",
-              "target": "lexical_parse_integer"
-            },
-            {
-              "id": "lexical-util 0.8.5",
-              "target": "lexical_util"
-            },
-            {
-              "id": "static_assertions 1.1.0",
-              "target": "static_assertions"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "lexical-parse-integer 0.8.6": {
-      "name": "lexical-parse-integer",
-      "version": "0.8.6",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-parse-integer/0.8.6/download",
-          "sha256": "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_parse_integer",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_parse_integer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lexical-util 0.8.5",
-              "target": "lexical_util"
-            },
-            {
-              "id": "static_assertions 1.1.0",
-              "target": "static_assertions"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.6"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "lexical-util 0.8.5": {
-      "name": "lexical-util",
-      "version": "0.8.5",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-util/0.8.5/download",
-          "sha256": "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_util",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "floats",
-            "integers",
-            "parse",
-            "parse-floats",
-            "parse-integers",
-            "std",
-            "write",
-            "write-floats",
-            "write-integers"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "static_assertions 1.1.0",
-              "target": "static_assertions"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "lexical-write-float 0.8.5": {
-      "name": "lexical-write-float",
-      "version": "0.8.5",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-write-float/0.8.5/download",
-          "sha256": "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_write_float",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_write_float",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lexical-util 0.8.5",
-              "target": "lexical_util"
-            },
-            {
-              "id": "lexical-write-integer 0.8.5",
-              "target": "lexical_write_integer"
-            },
-            {
-              "id": "static_assertions 1.1.0",
-              "target": "static_assertions"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "lexical-write-integer 0.8.5": {
-      "name": "lexical-write-integer",
-      "version": "0.8.5",
-      "package_url": "https://github.com/Alexhuszagh/rust-lexical",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lexical-write-integer/0.8.5/download",
-          "sha256": "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lexical_write_integer",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lexical_write_integer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lexical-util 0.8.5",
-              "target": "lexical_util"
-            },
-            {
-              "id": "static_assertions 1.1.0",
-              "target": "static_assertions"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "libc 0.2.186": {
       "name": "libc",
       "version": "0.2.186",
@@ -45331,7 +45004,7 @@
               "target": "libcryptsetup_rs_sys"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -45339,7 +45012,7 @@
               "target": "per_thread_mutex"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -47461,14 +47134,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "log 0.4.28": {
+    "log 0.4.33": {
       "name": "log",
-      "version": "0.4.28",
+      "version": "0.4.33",
       "package_url": "https://github.com/rust-lang/log",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/log/0.4.28/download",
-          "sha256": "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+          "url": "https://static.crates.io/crates/log/0.4.33/download",
+          "sha256": "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
         }
       },
       "targets": [
@@ -47497,7 +47170,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.28"
+        "version": "0.4.33"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -47721,7 +47394,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -47729,7 +47402,7 @@
               "target": "regex_syntax"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -47793,15 +47466,15 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -47861,7 +47534,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -48626,7 +48299,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -48760,7 +48433,7 @@
         "deps": {
           "common": [
             {
-              "id": "regex-automata 0.4.13",
+              "id": "regex-automata 0.4.16",
               "target": "regex_automata"
             }
           ],
@@ -48944,7 +48617,7 @@
               "target": "ipnetwork"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -49009,7 +48682,7 @@
               "target": "ipnetwork"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -49583,7 +49256,7 @@
               "target": "axum_otel_metrics"
             },
             {
-              "id": "clap 4.5.53",
+              "id": "clap 4.6.2",
               "target": "clap"
             },
             {
@@ -49631,7 +49304,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -49659,7 +49332,7 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -49978,7 +49651,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -49996,6 +49669,90 @@
         "BlueOak-1.0.0"
       ],
       "license_file": "LICENSE.md"
+    },
+    "minicov 0.3.8": {
+      "name": "minicov",
+      "version": "0.3.8",
+      "package_url": "https://github.com/Amanieu/minicov",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/minicov/0.3.8/download",
+          "sha256": "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "minicov",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "minicov",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "minicov 0.3.8",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.8"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.2.48",
+              "target": "cc"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "Apache-2.0/MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "minimal-lexical 0.2.1": {
       "name": "minimal-lexical",
@@ -50188,25 +49945,12 @@
             "net",
             "os-poll"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "os-ext"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "os-ext"
-            ],
-            "x86_64-apple-darwin": [
-              "os-ext"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "os-ext"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -50303,13 +50047,13 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               }
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               }
             ],
@@ -50344,13 +50088,13 @@
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               }
             ]
@@ -50594,11 +50338,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -50681,11 +50425,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -50789,7 +50533,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -50797,11 +50541,11 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -51039,7 +50783,7 @@
               "target": "httparse"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -51212,11 +50956,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -51316,7 +51060,7 @@
               "target": "libc"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -51380,7 +51124,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -51477,7 +51221,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -51646,8 +51390,6 @@
             "default",
             "ioctl",
             "memoffset",
-            "process",
-            "signal",
             "socket"
           ],
           "selects": {}
@@ -53540,11 +53282,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -54294,14 +54036,53 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "oorandom 11.1.3": {
-      "name": "oorandom",
-      "version": "11.1.3",
-      "package_url": "https://sr.ht/~icefox/oorandom/",
+    "once_cell_polyfill 1.70.2": {
+      "name": "once_cell_polyfill",
+      "version": "1.70.2",
+      "package_url": "https://github.com/polyfill-rs/once_cell_polyfill",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/oorandom/11.1.3/download",
-          "sha256": "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+          "url": "https://static.crates.io/crates/once_cell_polyfill/1.70.2/download",
+          "sha256": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "once_cell_polyfill",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "once_cell_polyfill",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "1.70.2"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "oorandom 11.1.5": {
+      "name": "oorandom",
+      "version": "11.1.5",
+      "package_url": "https://hg.sr.ht/~icefox/oorandom",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/oorandom/11.1.5/download",
+          "sha256": "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
         }
       },
       "targets": [
@@ -54324,7 +54105,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "11.1.3"
+        "version": "11.1.5"
       },
       "license": "MIT",
       "license_ids": [
@@ -54490,7 +54271,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -54719,11 +54500,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -55985,51 +55766,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "os_str_bytes 6.5.1": {
-      "name": "os_str_bytes",
-      "version": "6.5.1",
-      "package_url": "https://github.com/dylni/os_str_bytes",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/os_str_bytes/6.5.1/download",
-          "sha256": "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "os_str_bytes",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "os_str_bytes",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "raw_os_str"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "6.5.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "outref 0.5.2": {
       "name": "outref",
       "version": "0.5.2",
@@ -56465,7 +56201,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -56884,11 +56620,11 @@
         "deps": {
           "common": [
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
@@ -56949,15 +56685,15 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
@@ -56965,7 +56701,7 @@
               "target": "structmeta"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -57256,7 +56992,7 @@
               "target": "libc"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -57547,7 +57283,7 @@
               "target": "libc"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             }
           ],
@@ -57609,14 +57345,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pest 2.7.1": {
+    "pest 2.8.7": {
       "name": "pest",
-      "version": "2.7.1",
+      "version": "2.8.7",
       "package_url": "https://github.com/pest-parser/pest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pest/2.7.1/download",
-          "sha256": "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+          "url": "https://static.crates.io/crates/pest/2.8.7/download",
+          "sha256": "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
         }
       },
       "targets": [
@@ -57641,6 +57377,7 @@
         "crate_features": {
           "common": [
             "default",
+            "memchr",
             "std"
           ],
           "selects": {}
@@ -57648,8 +57385,8 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.68",
-              "target": "thiserror"
+              "id": "memchr 2.7.4",
+              "target": "memchr"
             },
             {
               "id": "ucd-trie 0.1.6",
@@ -57659,23 +57396,23 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.8.7"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pest_derive 2.7.1": {
+    "pest_derive 2.8.7": {
       "name": "pest_derive",
-      "version": "2.7.1",
+      "version": "2.8.7",
       "package_url": "https://github.com/pest-parser/pest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pest_derive/2.7.1/download",
-          "sha256": "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+          "url": "https://static.crates.io/crates/pest_derive/2.8.7/download",
+          "sha256": "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
         }
       },
       "targets": [
@@ -57707,34 +57444,34 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             },
             {
-              "id": "pest_generator 2.7.1",
+              "id": "pest_generator 2.8.7",
               "target": "pest_generator"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.8.7"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pest_generator 2.7.1": {
+    "pest_generator 2.8.7": {
       "name": "pest_generator",
-      "version": "2.7.1",
+      "version": "2.8.7",
       "package_url": "https://github.com/pest-parser/pest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pest_generator/2.7.1/download",
-          "sha256": "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+          "url": "https://static.crates.io/crates/pest_generator/2.8.7/download",
+          "sha256": "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
         }
       },
       "targets": [
@@ -57765,11 +57502,11 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             },
             {
-              "id": "pest_meta 2.7.1",
+              "id": "pest_meta 2.8.7",
               "target": "pest_meta"
             },
             {
@@ -57777,34 +57514,34 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.8.7"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pest_meta 2.7.1": {
+    "pest_meta 2.8.7": {
       "name": "pest_meta",
-      "version": "2.7.1",
+      "version": "2.8.7",
       "package_url": "https://github.com/pest-parser/pest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pest_meta/2.7.1/download",
-          "sha256": "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+          "url": "https://static.crates.io/crates/pest_meta/2.8.7/download",
+          "sha256": "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
         }
       },
       "targets": [
@@ -57835,34 +57572,30 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.8.7"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pest_vm 2.7.1": {
+    "pest_vm 2.8.7": {
       "name": "pest_vm",
-      "version": "2.7.1",
+      "version": "2.8.7",
       "package_url": "https://github.com/pest-parser/pest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pest_vm/2.7.1/download",
-          "sha256": "3c590ba0f5dbc3b72b0b22fe5a11a69a43ff984cce83928dfaa615eb87594d6a"
+          "url": "https://static.crates.io/crates/pest_vm/2.8.7/download",
+          "sha256": "33086e10724117cc9ee44f0d9ff903fb38502aa78ef617a0ca32a2ab42fa8f5d"
         }
       },
       "targets": [
@@ -57887,20 +57620,20 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.7.1",
+              "id": "pest 2.8.7",
               "target": "pest"
             },
             {
-              "id": "pest_meta 2.7.1",
+              "id": "pest_meta 2.8.7",
               "target": "pest_meta"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.8.7"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -58389,11 +58122,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -58637,11 +58370,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -59748,11 +59481,11 @@
               "target": "libc"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
-              "id": "nix 0.27.1",
+              "id": "nix 0.30.1",
               "target": "nix"
             },
             {
@@ -59764,7 +59497,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "prost 0.12.2",
+              "id": "prost 0.14.4",
               "target": "prost"
             },
             {
@@ -59812,7 +59545,7 @@
         "deps": {
           "common": [
             {
-              "id": "prost-build 0.12.2",
+              "id": "prost-build 0.14.4",
               "target": "prost_build"
             },
             {
@@ -59962,7 +59695,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.8",
+              "id": "anstyle 1.0.14",
               "target": "anstyle"
             },
             {
@@ -59982,7 +59715,7 @@
               "target": "predicates_core"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             }
           ],
@@ -60188,7 +59921,7 @@
               "target": "arrayvec"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -60445,7 +60178,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -60860,7 +60593,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -60961,7 +60694,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             }
           ],
@@ -61033,7 +60766,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             }
           ],
@@ -61092,11 +60825,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -61838,7 +61571,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -61850,7 +61583,7 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             }
           ],
@@ -61943,7 +61676,7 @@
               "target": "rand_xorshift"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             },
             {
@@ -62007,11 +61740,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -62026,70 +61759,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "prost 0.12.2": {
-      "name": "prost",
-      "version": "0.12.2",
-      "package_url": "https://github.com/tokio-rs/prost",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/prost/0.12.2/download",
-          "sha256": "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "prost",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "prost",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "prost-derive",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "prost-derive 0.12.2",
-              "target": "prost_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "prost 0.14.4": {
       "name": "prost",
@@ -62155,114 +61824,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "prost-build 0.12.2": {
-      "name": "prost-build",
-      "version": "0.12.2",
-      "package_url": "https://github.com/tokio-rs/prost",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/prost-build/0.12.2/download",
-          "sha256": "1fa3d084c8704911bfefb2771be2f9b6c5c0da7343a71e0021ee3c665cada738"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "prost_build",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "prost_build",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "format",
-            "prettyplease",
-            "syn"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            },
-            {
-              "id": "heck 0.4.1",
-              "target": "heck"
-            },
-            {
-              "id": "itertools 0.11.0",
-              "target": "itertools"
-            },
-            {
-              "id": "log 0.4.28",
-              "target": "log"
-            },
-            {
-              "id": "multimap 0.8.3",
-              "target": "multimap"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "petgraph 0.6.3",
-              "target": "petgraph"
-            },
-            {
-              "id": "prettyplease 0.2.37",
-              "target": "prettyplease"
-            },
-            {
-              "id": "prost 0.12.2",
-              "target": "prost"
-            },
-            {
-              "id": "prost-types 0.12.2",
-              "target": "prost_types"
-            },
-            {
-              "id": "regex 1.12.2",
-              "target": "regex"
-            },
-            {
-              "id": "syn 2.0.110",
-              "target": "syn"
-            },
-            {
-              "id": "tempfile 3.23.0",
-              "target": "tempfile"
-            },
-            {
-              "id": "which 4.4.0",
-              "target": "which"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.12.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "prost-build 0.14.4": {
       "name": "prost-build",
       "version": "0.14.4",
@@ -62311,7 +61872,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -62343,11 +61904,11 @@
               "target": "pulldown_cmark_to_cmark"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -62359,69 +61920,6 @@
         },
         "edition": "2021",
         "version": "0.14.4"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "prost-derive 0.12.2": {
-      "name": "prost-derive",
-      "version": "0.12.2",
-      "package_url": "https://github.com/tokio-rs/prost",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/prost-derive/0.12.2/download",
-          "sha256": "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "prost_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "prost_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.100",
-              "target": "anyhow"
-            },
-            {
-              "id": "itertools 0.11.0",
-              "target": "itertools"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.42",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.110",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.12.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -62473,11 +61971,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -62485,53 +61983,6 @@
         },
         "edition": "2021",
         "version": "0.14.4"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "prost-types 0.12.2": {
-      "name": "prost-types",
-      "version": "0.12.2",
-      "package_url": "https://github.com/tokio-rs/prost",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/prost-types/0.12.2/download",
-          "sha256": "8339f32236f590281e2f6368276441394fcd1b2133b549cc895d0ae80f2f9a52"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "prost_types",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "prost_types",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "prost 0.12.2",
-              "target": "prost"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.12.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -63038,7 +62489,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -63093,11 +62544,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -63347,7 +62798,7 @@
               "target": "cranelift_bitset"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -63412,11 +62863,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -63741,7 +63192,7 @@
               "target": "env_logger"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -64087,14 +63538,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quote 1.0.42": {
+    "quote 1.0.46": {
       "name": "quote",
-      "version": "1.0.42",
+      "version": "1.0.46",
       "package_url": "https://github.com/dtolnay/quote",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/quote/1.0.42/download",
-          "sha256": "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+          "url": "https://static.crates.io/crates/quote/1.0.46/download",
+          "sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
         }
       },
       "targets": [
@@ -64142,14 +63593,14 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.0.42"
+        "edition": "2021",
+        "version": "1.0.46"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -65869,11 +65320,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -65947,7 +65398,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -66021,7 +65472,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -66044,14 +65495,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "regex 1.12.2": {
+    "regex 1.13.1": {
       "name": "regex",
-      "version": "1.12.2",
+      "version": "1.13.1",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex/1.12.2/download",
-          "sha256": "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+          "url": "https://static.crates.io/crates/regex/1.13.1/download",
+          "sha256": "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
         }
       },
       "targets": [
@@ -66106,18 +65557,18 @@
               "target": "memchr"
             },
             {
-              "id": "regex-automata 0.4.13",
+              "id": "regex-automata 0.4.16",
               "target": "regex_automata"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.12.2"
+        "version": "1.13.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66210,14 +65661,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-automata 0.4.13": {
+    "regex-automata 0.4.16": {
       "name": "regex-automata",
-      "version": "0.4.13",
+      "version": "0.4.16",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-automata/0.4.13/download",
-          "sha256": "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+          "url": "https://static.crates.io/crates/regex-automata/0.4.16/download",
+          "sha256": "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
         }
       },
       "targets": [
@@ -66242,14 +65693,17 @@
         "crate_features": {
           "common": [
             "alloc",
+            "dfa",
             "dfa-build",
             "dfa-onepass",
             "dfa-search",
             "hybrid",
             "meta",
+            "nfa",
             "nfa-backtrack",
             "nfa-pikevm",
             "nfa-thompson",
+            "perf",
             "perf-inline",
             "perf-literal",
             "perf-literal-multisubstring",
@@ -66266,28 +65720,7 @@
             "unicode-segment",
             "unicode-word-boundary"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "dfa",
-              "nfa",
-              "perf"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "dfa",
-              "nfa",
-              "perf"
-            ],
-            "x86_64-apple-darwin": [
-              "dfa",
-              "nfa",
-              "perf"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "dfa",
-              "nfa",
-              "perf"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -66300,14 +65733,14 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.13"
+        "version": "0.4.16"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66364,11 +65797,11 @@
               "target": "nohash"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
-              "id": "regex-syntax 0.8.5",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
@@ -66514,8 +65947,6 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "std",
             "unicode",
             "unicode-age",
             "unicode-bool",
@@ -66537,14 +65968,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-syntax 0.8.5": {
+    "regex-syntax 0.8.11": {
       "name": "regex-syntax",
-      "version": "0.8.5",
-      "package_url": "https://github.com/rust-lang/regex/tree/master/regex-syntax",
+      "version": "0.8.11",
+      "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-syntax/0.8.5/download",
-          "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+          "url": "https://static.crates.io/crates/regex-syntax/0.8.11/download",
+          "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
         }
       },
       "targets": [
@@ -66582,7 +66013,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.5"
+        "version": "0.8.11"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -66895,7 +66326,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               },
               {
@@ -66925,7 +66356,7 @@
                 "target": "js_sys"
               },
               {
-                "id": "serde_json 1.0.145",
+                "id": "serde_json 1.0.150",
                 "target": "serde_json"
               },
               {
@@ -67087,7 +66518,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -67224,7 +66655,7 @@
                 "target": "hyper_util"
               },
               {
-                "id": "log 0.4.28",
+                "id": "log 0.4.33",
                 "target": "log"
               },
               {
@@ -67497,7 +66928,7 @@
               "target": "nix"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -68145,7 +67576,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -68200,11 +67631,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -68364,7 +67795,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -68467,7 +67898,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             }
           ],
@@ -68721,11 +68152,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -68737,7 +68168,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -69124,7 +68555,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -69848,7 +69279,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -69954,7 +69385,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -70084,7 +69515,7 @@
               "target": "brotli_decompressor"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -70206,7 +69637,7 @@
               "target": "blocking"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -70222,7 +69653,7 @@
               "target": "http"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -70238,7 +69669,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -70622,7 +70053,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -70737,7 +70168,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -71489,7 +70920,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -71626,7 +71057,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -71705,7 +71136,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -71764,7 +71195,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -71815,7 +71246,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -71823,7 +71254,7 @@
               "target": "serde_derive_internals"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -72624,11 +72055,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -72916,7 +72347,7 @@
               "target": "fxhash"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -73191,14 +72622,14 @@
       ],
       "license_file": "LICENSE.md"
     },
-    "serde-wasm-bindgen 0.5.0": {
+    "serde-wasm-bindgen 0.6.5": {
       "name": "serde-wasm-bindgen",
-      "version": "0.5.0",
-      "package_url": "https://github.com/cloudflare/serde-wasm-bindgen",
+      "version": "0.6.5",
+      "package_url": "https://github.com/RReverser/serde-wasm-bindgen",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde-wasm-bindgen/0.5.0/download",
-          "sha256": "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+          "url": "https://static.crates.io/crates/serde-wasm-bindgen/0.6.5/download",
+          "sha256": "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
         }
       },
       "targets": [
@@ -73238,7 +72669,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.0"
+        "version": "0.6.5"
       },
       "license": "MIT",
       "license_ids": [
@@ -73494,11 +72925,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -73550,11 +72981,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -73570,14 +73001,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_json 1.0.145": {
+    "serde_json 1.0.150": {
       "name": "serde_json",
-      "version": "1.0.145",
+      "version": "1.0.150",
       "package_url": "https://github.com/serde-rs/json",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_json/1.0.145/download",
-          "sha256": "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+          "url": "https://static.crates.io/crates/serde_json/1.0.150/download",
+          "sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
         }
       },
       "targets": [
@@ -73633,16 +73064,16 @@
               "target": "memchr"
             },
             {
-              "id": "ryu 1.0.15",
-              "target": "ryu"
-            },
-            {
               "id": "serde_core 1.0.228",
               "target": "serde_core"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "build_script_build"
+            },
+            {
+              "id": "zmij 1.0.23",
+              "target": "zmij"
             }
           ],
           "selects": {
@@ -73655,7 +73086,7 @@
           }
         },
         "edition": "2021",
-        "version": "1.0.145"
+        "version": "1.0.150"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -73815,7 +73246,7 @@
         "deps": {
           "common": [
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -73871,11 +73302,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -74176,7 +73607,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -74236,11 +73667,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -75402,9 +74833,7 @@
         ],
         "crate_features": {
           "common": [
-            "mio-0_8",
             "mio-1_0",
-            "support-v0_8",
             "support-v1_0"
           ],
           "selects": {}
@@ -75414,11 +74843,6 @@
             {
               "id": "libc 0.2.186",
               "target": "libc"
-            },
-            {
-              "id": "mio 0.8.10",
-              "target": "mio",
-              "alias": "mio_0_8"
             },
             {
               "id": "mio 1.0.2",
@@ -75954,7 +75378,7 @@
               "target": "colored"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -76067,7 +75491,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -76444,11 +75868,11 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -76532,7 +75956,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -76652,7 +76076,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -76990,11 +76414,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -77158,11 +76582,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78197,7 +77621,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             }
           ],
@@ -78325,11 +77749,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78390,11 +77814,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78455,11 +77879,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78511,11 +77935,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78795,11 +78219,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78863,11 +78287,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78931,11 +78355,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -78999,11 +78423,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -79050,7 +78474,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -79366,7 +78790,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -79401,14 +78825,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "syn 2.0.110": {
+    "syn 2.0.119": {
       "name": "syn",
-      "version": "2.0.110",
+      "version": "2.0.119",
       "package_url": "https://github.com/dtolnay/syn",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.110/download",
-          "sha256": "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+          "url": "https://static.crates.io/crates/syn/2.0.119/download",
+          "sha256": "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
         }
       },
       "targets": [
@@ -79465,7 +78889,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -79476,7 +78900,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.110"
+        "version": "2.0.119"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -79620,11 +79044,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -80231,7 +79655,7 @@
               "target": "libsystemd_sys"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -80442,11 +79866,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -80908,7 +80332,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -81439,7 +80863,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -81447,7 +80871,7 @@
               "target": "structmeta"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -81566,44 +80990,6 @@
         "MIT"
       ],
       "license_file": null
-    },
-    "textwrap 0.16.0": {
-      "name": "textwrap",
-      "version": "0.16.0",
-      "package_url": "https://github.com/mgeisler/textwrap",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/textwrap/0.16.0/download",
-          "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "textwrap",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "textwrap",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.16.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "thiserror 1.0.68": {
       "name": "thiserror",
@@ -81808,11 +81194,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -81864,11 +81250,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -82686,7 +82072,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -82883,11 +82269,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -83143,11 +82529,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -83551,7 +82937,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -83813,7 +83199,7 @@
               "target": "futures_util"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -83881,7 +83267,7 @@
               "target": "futures_util"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -83949,7 +83335,7 @@
               "target": "futures_util"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -84584,11 +83970,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -84714,11 +84100,11 @@
               "target": "prost_types"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -85729,7 +85115,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -85856,11 +85242,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -86086,7 +85472,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -86492,7 +85878,7 @@
               "target": "once_cell"
             },
             {
-              "id": "regex-automata 0.4.13",
+              "id": "regex-automata 0.4.16",
               "target": "regex_automata"
             },
             {
@@ -86500,7 +85886,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -86586,7 +85972,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -87050,7 +86436,7 @@
               "target": "httparse"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -87144,7 +86530,7 @@
               "target": "httparse"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -87234,7 +86620,7 @@
               "target": "httparse"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -87558,7 +86944,7 @@
         "deps": {
           "common": [
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -88840,14 +88226,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "utf8parse 0.2.1": {
+    "utf8parse 0.2.2": {
       "name": "utf8parse",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/alacritty/vte",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/utf8parse/0.2.1/download",
-          "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+          "url": "https://static.crates.io/crates/utf8parse/0.2.2/download",
+          "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
         }
       },
       "targets": [
@@ -88876,7 +88262,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -89353,7 +88739,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "chrono 0.4.42",
+              "id": "chrono 0.4.45",
               "target": "chrono"
             },
             {
@@ -89369,7 +88755,7 @@
               "target": "ordered_float"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -89377,7 +88763,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -89746,7 +89132,7 @@
               "target": "leb128"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -89827,7 +89213,7 @@
               "target": "leb128"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -89900,11 +89286,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -90036,7 +89422,7 @@
               "target": "hyper"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -90072,7 +89458,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -90459,7 +89845,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
@@ -90519,11 +89905,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -90611,6 +89997,216 @@
           "**"
         ],
         "links": "wasm_bindgen"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "wasm-bindgen-test 0.3.76": {
+      "name": "wasm-bindgen-test",
+      "version": "0.3.76",
+      "package_url": "https://github.com/wasm-bindgen/wasm-bindgen",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-bindgen-test/0.3.76/download",
+          "sha256": "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_bindgen_test",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_bindgen_test",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cast 0.3.0",
+              "target": "cast"
+            },
+            {
+              "id": "js-sys 0.3.103",
+              "target": "js_sys"
+            },
+            {
+              "id": "libm 0.2.16",
+              "target": "libm"
+            },
+            {
+              "id": "nu-ansi-term 0.50.1",
+              "target": "nu_ansi_term"
+            },
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
+            },
+            {
+              "id": "oorandom 11.1.5",
+              "target": "oorandom"
+            },
+            {
+              "id": "serde 1.0.228",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.150",
+              "target": "serde_json"
+            },
+            {
+              "id": "wasm-bindgen 0.2.126",
+              "target": "wasm_bindgen"
+            },
+            {
+              "id": "wasm-bindgen-futures 0.4.76",
+              "target": "wasm_bindgen_futures"
+            },
+            {
+              "id": "wasm-bindgen-test-shared 0.2.126",
+              "target": "wasm_bindgen_test_shared"
+            }
+          ],
+          "selects": {
+            "cfg(all(target_arch = \"wasm32\", wasm_bindgen_unstable_test_coverage))": [
+              {
+                "id": "minicov 0.3.8",
+                "target": "minicov"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.89",
+              "target": "async_trait"
+            },
+            {
+              "id": "wasm-bindgen-test-macro 0.3.76",
+              "target": "wasm_bindgen_test_macro"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.3.76"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "wasm-bindgen-test-macro 0.3.76": {
+      "name": "wasm-bindgen-test-macro",
+      "version": "0.3.76",
+      "package_url": "https://github.com/wasm-bindgen/wasm-bindgen",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-bindgen-test-macro/0.3.76/download",
+          "sha256": "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "wasm_bindgen_test_macro",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_bindgen_test_macro",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.46",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.119",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.3.76"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "wasm-bindgen-test-shared 0.2.126": {
+      "name": "wasm-bindgen-test-shared",
+      "version": "0.2.126",
+      "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/test-shared",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-bindgen-test-shared/0.2.126/download",
+          "sha256": "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_bindgen_test_shared",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_bindgen_test_shared",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.126"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -91894,7 +91490,7 @@
               "target": "libc"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -92156,7 +91752,7 @@
               "target": "indexmap"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -92394,7 +91990,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -92819,7 +92415,7 @@
               "target": "cranelift_codegen"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -92893,11 +92489,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -92952,7 +92548,7 @@
               "target": "gimli"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -93198,6 +92794,7 @@
             "WritableStream",
             "WritableStreamDefaultController",
             "WritableStreamDefaultWriter",
+            "console",
             "default",
             "std"
           ],
@@ -94324,11 +93921,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -94380,11 +93977,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -97877,7 +97474,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -98171,7 +97768,7 @@
               "target": "prettyplease"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -98279,11 +97876,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -98375,7 +97972,7 @@
               "target": "indexmap"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -98383,7 +97980,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -98477,7 +98074,7 @@
               "target": "indexmap"
             },
             {
-              "id": "log 0.4.28",
+              "id": "log 0.4.33",
               "target": "log"
             },
             {
@@ -98489,7 +98086,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             },
             {
@@ -98576,7 +98173,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "regex 1.12.2",
+              "id": "regex 1.13.1",
               "target": "regex"
             },
             {
@@ -98777,7 +98374,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.145",
+              "id": "serde_json 1.0.150",
               "target": "serde_json"
             }
           ],
@@ -99499,11 +99096,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -99615,11 +99212,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -99726,11 +99323,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
@@ -99842,11 +99439,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -99965,11 +99562,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.42",
+              "id": "quote 1.0.46",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.110",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
@@ -99983,6 +99580,76 @@
         "Unicode-3.0"
       ],
       "license_file": "LICENSE"
+    },
+    "zmij 1.0.23": {
+      "name": "zmij",
+      "version": "1.0.23",
+      "package_url": "https://github.com/dtolnay/zmij",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zmij/1.0.23/download",
+          "sha256": "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "zmij",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zmij",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "zmij 1.0.23",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.23"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE-MIT"
     },
     "zstd 0.12.4": {
       "name": "zstd",
@@ -100456,6 +100123,7 @@
     "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
       "wasm32-unknown-unknown"
     ],
+    "cfg(all(target_arch = \"wasm32\", wasm_bindgen_unstable_test_coverage))": [],
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
@@ -100736,14 +100404,14 @@
     "candid_parser 0.1.4",
     "cargo_metadata 0.14.2",
     "cc 1.2.48",
-    "cddl 0.9.4",
+    "cddl 0.10.6",
     "cfg-if 1.0.0",
     "chacha20poly1305 0.10.1",
     "chrono 0.4.41",
-    "chrono 0.4.42",
+    "chrono 0.4.45",
     "ciborium 0.2.1",
     "cidr 0.2.3",
-    "clap 4.5.53",
+    "clap 4.6.2",
     "colored 2.0.4",
     "comparable 0.5.4",
     "console 0.11.3",
@@ -100752,7 +100420,7 @@
     "criterion 0.5.1",
     "crossbeam 0.8.4",
     "crossbeam-channel 0.5.15",
-    "csv 1.2.2",
+    "csv 1.4.0",
     "ctrlc 3.4.5",
     "curve25519-dalek 4.1.3",
     "cvt 0.1.2",
@@ -100920,7 +100588,6 @@
     "prometheus-parse 0.2.4",
     "proptest 1.6.0",
     "proptest-derive 0.5.0",
-    "prost 0.12.2",
     "prost 0.14.4",
     "prost-build 0.14.4",
     "protobuf 3.7.2",
@@ -100929,7 +100596,7 @@
     "quickcheck 1.0.3",
     "quinn 0.11.11",
     "quinn-udp 0.5.5",
-    "quote 1.0.42",
+    "quote 1.0.46",
     "rand 0.8.6",
     "rand_chacha 0.3.1",
     "rand_distr 0.4.3",
@@ -100938,7 +100605,7 @@
     "ratelimit 0.9.1",
     "rayon 1.10.0",
     "rcgen 0.13.1",
-    "regex 1.12.2",
+    "regex 1.13.1",
     "regex-lite 0.1.8",
     "reqwest 0.13.4",
     "rexpect 0.6.2",
@@ -100974,7 +100641,7 @@
     "serde-bytes-repr 0.1.5",
     "serde_bytes 0.11.15",
     "serde_cbor 0.11.2",
-    "serde_json 1.0.145",
+    "serde_json 1.0.150",
     "serde_regex 1.1.0",
     "serde_with 1.14.0",
     "serde_yaml 0.9.34+deprecated",
@@ -101001,7 +100668,7 @@
     "strum_macros 0.26.4",
     "stubborn-io 0.3.2",
     "subtle 2.6.1",
-    "syn 2.0.110",
+    "syn 2.0.119",
     "sys-mount 3.0.1",
     "syscalls 0.6.18",
     "sysinfo 0.37.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -215,7 +215,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -420,7 +420,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.1",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -430,15 +445,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -454,12 +478,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -557,7 +582,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -622,7 +647,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -634,7 +659,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -646,7 +671,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -782,7 +807,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -814,7 +839,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -831,7 +856,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1085,7 +1110,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1096,7 +1121,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1213,6 +1238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,11 +1273,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-url"
-version = "2.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9fb9fb058cc3063b5fc88d9a21eefa2735871498a04e1650da76ed511c8569"
+checksum = "261c4eaab63106ddf34d377f47e5428aa863b61e4a647c872778d9caf8e2c819"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.22.1",
 ]
 
 [[package]]
@@ -1315,7 +1346,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1335,7 +1366,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1355,7 +1386,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1518,7 +1549,7 @@ checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1620,7 +1651,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1835,7 +1866,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1940,7 +1971,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2013,7 +2044,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2024,7 +2055,7 @@ checksum = "48a3da76f989cd350b7342c64c6c6008341bb6186f6832ef04e56dc50ba0fd76"
 dependencies = [
  "anyhow",
  "candid",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "convert_case 0.6.0",
  "hex",
  "lalrpop 0.20.0",
@@ -2043,7 +2074,7 @@ checksum = "75daa0ef508c92f38dd0eaaaae7d13f317b68ab73c875068257348574a6bcce2"
 dependencies = [
  "anyhow",
  "candid",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "convert_case 0.6.0",
  "handlebars",
  "hex",
@@ -2081,7 +2112,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2141,35 +2172,44 @@ dependencies = [
 
 [[package]]
 name = "cddl"
-version = "0.9.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc18488a72cef88de14f00d3db73f57a9511d53ae8dd72204a4bf8bc19309d7"
+checksum = "69f7305ff73327bd9ce5e5cdd81223dd91b4969e260ea6cdb8f1da94390be191"
 dependencies = [
  "abnf_to_pest",
  "base16",
+ "base45",
  "base64-url",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "ciborium",
- "clap 3.2.25",
- "codespan-reporting",
+ "ciborium-io",
+ "ciborium-ll",
+ "clap",
+ "codespan-reporting 0.13.1",
  "console_error_panic_hook",
- "crossterm 0.27.0",
+ "csv",
  "data-encoding",
  "displaydoc",
+ "fancy-regex 0.18.0",
+ "hex",
  "hexf-parse",
- "itertools 0.11.0",
- "lexical-core",
+ "itertools 0.15.0",
+ "js-sys",
  "log",
+ "pest",
+ "pest_derive",
  "pest_meta",
  "pest_vm",
  "regex",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.11",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "simplelog",
  "uriparse",
  "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -2244,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2313,82 +2353,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.49",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
- "clap_lex 0.7.5",
+ "clap_lex",
  "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clocksource"
@@ -2427,6 +2428,17 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2874,7 +2886,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.53",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2967,22 +2979,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "libc",
- "mio 0.8.10",
- "parking_lot 0.12.5",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
@@ -3064,7 +3060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3079,21 +3075,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -3143,7 +3139,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3233,7 +3229,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3247,7 +3243,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3260,7 +3256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3282,7 +3278,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3293,7 +3289,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3304,7 +3300,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3449,7 +3445,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3481,7 +3477,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3492,7 +3488,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3513,7 +3509,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3523,7 +3519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3558,7 +3554,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.110",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -3700,10 +3696,10 @@ dependencies = [
  "cfg-if",
  "chacha20poly1305",
  "chrono 0.4.41",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "ciborium",
  "cidr",
- "clap 4.5.53",
+ "clap",
  "colored 2.0.4",
  "comparable",
  "console 0.11.3",
@@ -3880,9 +3876,8 @@ dependencies = [
  "prometheus-parse",
  "proptest",
  "proptest-derive",
- "prost 0.12.2",
- "prost 0.14.4",
- "prost-build 0.14.4",
+ "prost",
+ "prost-build",
  "protobuf 3.7.2",
  "publicsuffix",
  "qrcode",
@@ -3961,7 +3956,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "stubborn-io",
  "subtle",
- "syn 2.0.110",
+ "syn 2.0.119",
  "sys-mount",
  "syscalls",
  "sysinfo",
@@ -4097,7 +4092,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4335,7 +4330,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4375,7 +4370,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
 dependencies = [
- "anstream",
+ "anstream 0.6.15",
  "anstyle",
  "env_filter",
  "humantime",
@@ -4399,7 +4394,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4516,7 +4511,7 @@ checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
 dependencies = [
  "arrayvec 0.7.4",
  "bytes",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "elliptic-curve",
  "ethabi",
  "generic-array",
@@ -4655,8 +4650,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set 0.8.0",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.16",
+ "regex-syntax 0.8.11",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata 0.4.16",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -4835,7 +4841,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4998,7 +5004,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6064,7 +6070,7 @@ dependencies = [
  "bytes",
  "candid",
  "chacha20poly1305",
- "clap 4.5.53",
+ "clap",
  "derive-new",
  "flate2",
  "fqdn",
@@ -6090,8 +6096,8 @@ dependencies = [
  "nix 0.30.1",
  "ppp",
  "prometheus 0.14.0",
- "prost 0.14.4",
- "prost-types 0.14.4",
+ "prost",
+ "prost-types",
  "rand 0.8.6",
  "rcgen 0.14.5",
  "regex",
@@ -6143,7 +6149,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "candid",
- "clap 4.5.53",
+ "clap",
  "derive-new",
  "fqdn",
  "hickory-proto",
@@ -6291,7 +6297,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6304,7 +6310,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6387,7 +6393,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "chacha20poly1305",
- "clap 4.5.53",
+ "clap",
  "derive-new",
  "fqdn",
  "ic-bn-lib",
@@ -6417,8 +6423,8 @@ dependencies = [
  "axum 0.8.9",
  "candid",
  "chacha20poly1305",
- "chrono 0.4.42",
- "clap 4.5.53",
+ "chrono 0.4.45",
+ "clap",
  "derive-new",
  "fqdn",
  "humantime",
@@ -6524,7 +6530,7 @@ dependencies = [
  "axum-extra 0.12.6",
  "bytes",
  "candid",
- "clap 4.5.53",
+ "clap",
  "ctrlc",
  "derive-new",
  "fqdn",
@@ -6867,7 +6873,7 @@ dependencies = [
  "anyhow",
  "candid",
  "candid_parser 0.2.4",
- "clap 4.5.53",
+ "clap",
  "libflate",
  "parse-display",
  "rustc-demangle",
@@ -7062,7 +7068,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7227,7 +7233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a5d75fee4d36809e6b021e4b96b686e763d365ffdb03af2bd00786353f84fe"
 dependencies = [
  "ahash 0.8.11",
- "clap 4.5.53",
+ "clap",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 6.1.0",
@@ -7296,7 +7302,7 @@ dependencies = [
  "indoc 2.0.7",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7544,7 +7550,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7569,7 +7575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7635,7 +7641,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "fraction",
  "getrandom 0.3.4",
  "idna 1.0.3",
@@ -7645,7 +7651,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -7747,7 +7753,7 @@ dependencies = [
  "lalrpop-util 0.22.1",
  "petgraph 0.7.1",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "sha3",
  "string_cache",
  "term 1.0.2",
@@ -7820,70 +7826,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -8193,9 +8135,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -8235,7 +8177,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8249,8 +8191,8 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.5",
- "syn 2.0.110",
+ "regex-syntax 0.8.11",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8399,7 +8341,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.13",
+ "regex-automata 0.4.16",
 ]
 
 [[package]]
@@ -8526,7 +8468,7 @@ source = "git+https://github.com/dfinity/metrics-proxy.git?rev=b6933ed79ac07baee
 dependencies = [
  "axum 0.7.9",
  "axum-otel-metrics",
- "clap 4.5.53",
+ "clap",
  "duration-string",
  "exitcode",
  "futures-util",
@@ -8593,6 +8535,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -8682,7 +8634,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8694,7 +8646,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8788,7 +8740,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9143,7 +9095,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9241,10 +9193,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.3"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -9312,7 +9270,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9393,7 +9351,7 @@ dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry-proto",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.4",
+ "prost",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -9421,7 +9379,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.4",
+ "prost",
  "tonic",
  "tonic-prost",
 ]
@@ -9530,12 +9488,6 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "outref"
@@ -9675,7 +9627,7 @@ checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -9687,9 +9639,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "structmeta 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9790,19 +9742,19 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
- "thiserror 1.0.68",
+ "memchr",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.1"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -9810,33 +9762,31 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.1"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.1"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
- "once_cell",
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
 name = "pest_vm"
-version = "2.7.1"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c590ba0f5dbc3b72b0b22fe5a11a69a43ff984cce83928dfaa615eb87594d6a"
+checksum = "33086e10724117cc9ee44f0d9ff903fb38502aa78ef617a0ca32a2ab42fa8f5d"
 dependencies = [
  "pest",
  "pest_meta",
@@ -9932,7 +9882,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9976,7 +9926,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10162,10 +10112,10 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix 0.30.1",
  "once_cell",
- "prost 0.12.2",
- "prost-build 0.12.2",
+ "prost",
+ "prost-build",
  "sha2 0.10.9",
  "smallvec",
  "spin 0.10.1",
@@ -10277,7 +10227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10376,7 +10326,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10479,7 +10429,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2aa5feb83bf4b2c8919eaf563f51dbab41183de73ba2353c0e03cd7b6bd892"
 dependencies = [
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "itertools 0.10.5",
  "once_cell",
  "regex",
@@ -10499,7 +10449,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -10513,17 +10463,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
-dependencies = [
- "bytes",
- "prost-derive 0.12.2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10533,29 +10473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.4",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa3d084c8704911bfefb2771be2f9b6c5c0da7343a71e0021ee3c665cada738"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.11.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph 0.6.3",
- "prettyplease",
- "prost 0.12.2",
- "prost-types 0.12.2",
- "regex",
- "syn 2.0.110",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -10570,26 +10488,13 @@ dependencies = [
  "multimap",
  "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.4",
- "prost-types 0.14.4",
+ "prost",
+ "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.110",
+ "syn 2.0.119",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]
@@ -10602,16 +10507,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8339f32236f590281e2f6368276441394fcd1b2133b549cc895d0ae80f2f9a52"
-dependencies = [
- "prost 0.12.2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10620,7 +10516,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.4",
+ "prost",
 ]
 
 [[package]]
@@ -10701,7 +10597,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10754,7 +10650,7 @@ checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10867,9 +10763,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -11020,7 +10916,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "crossterm",
  "indoc 2.0.7",
  "instability",
  "itertools 0.13.0",
@@ -11157,7 +11053,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11191,14 +11087,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.16",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -11215,13 +11111,13 @@ checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -11235,7 +11131,7 @@ dependencies = [
  "itertools 0.13.0",
  "nohash",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -11258,9 +11154,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -11515,7 +11411,7 @@ checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11562,7 +11458,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
 dependencies = [
- "chrono 0.4.42",
+ "chrono 0.4.45",
 ]
 
 [[package]]
@@ -11611,7 +11507,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.110",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -11798,7 +11694,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "blocking",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "futures",
  "futures-rustls",
  "http 1.3.1",
@@ -12076,7 +11972,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12202,7 +12098,7 @@ checksum = "95d159bf5e6b8c35033c3742a00cb8e7370a217af82e5d304a0d3ce4930e41fe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "thiserror 1.0.68",
 ]
 
@@ -12294,9 +12190,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -12339,7 +12235,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12350,20 +12246,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -12407,7 +12303,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12448,7 +12344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
  "base64 0.22.1",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
@@ -12481,7 +12377,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12674,7 +12570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.10",
  "mio 1.0.2",
  "signal-hook",
 ]
@@ -12928,7 +12823,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12959,7 +12854,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13155,7 +13050,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13167,7 +13062,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13178,7 +13073,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13189,7 +13084,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13238,7 +13133,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13251,7 +13146,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13264,7 +13159,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13276,7 +13171,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13337,9 +13232,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13369,7 +13264,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13502,7 +13397,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13663,7 +13558,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13684,12 +13579,6 @@ dependencies = [
  "drawille",
  "rgb",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -13717,7 +13606,7 @@ checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13728,7 +13617,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13882,7 +13771,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13921,7 +13810,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14176,7 +14065,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14186,7 +14075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.4",
+ "prost",
  "tonic",
 ]
 
@@ -14198,10 +14087,10 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.14.4",
- "prost-types 0.14.4",
+ "prost-build",
+ "prost-types",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -14212,8 +14101,8 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
 dependencies = [
- "prost 0.14.4",
- "prost-types 0.14.4",
+ "prost",
+ "prost-types",
  "tonic",
 ]
 
@@ -14403,7 +14292,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14518,7 +14407,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.13",
+ "regex-automata 0.4.16",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -14607,7 +14496,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
 dependencies = [
- "crossterm 0.28.1",
+ "crossterm",
  "ratatui",
  "unicode-width 0.2.0",
 ]
@@ -14905,9 +14794,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -14976,7 +14865,7 @@ checksum = "772206835b5bca8719825d2ab9e6fb160cbfce8ac1dc0e5dffe22cbe77254468"
 dependencies = [
  "bytes",
  "cfg-if",
- "chrono 0.4.42",
+ "chrono 0.4.45",
  "getrandom 0.3.4",
  "jsonschema",
  "lalrpop 0.22.1",
@@ -15077,7 +14966,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15186,7 +15075,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -15198,6 +15087,45 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "wasm-encoder"
@@ -15573,7 +15501,7 @@ checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15808,7 +15736,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15819,7 +15747,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -16283,7 +16211,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.110",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -16299,7 +16227,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -16506,7 +16434,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -16527,7 +16455,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -16547,7 +16475,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -16568,7 +16496,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -16590,8 +16518,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,8 +883,8 @@ dependencies = [
  "hex",
  "ic-utils 0.9.0",
  "ic-utils-rustfmt",
- "prost 0.14.3",
- "prost-build 0.14.3",
+ "prost",
+ "prost-build",
  "rand 0.8.6",
  "serde",
  "sev",
@@ -1148,7 +1148,7 @@ name = "bare_metal_deployment"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "deterministic_ips",
  "grub",
  "http 1.4.0",
@@ -1177,6 +1177,12 @@ name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base58ck"
@@ -1997,7 +2003,7 @@ checksum = "48a3da76f989cd350b7342c64c6c6008341bb6186f6832ef04e56dc50ba0fd76"
 dependencies = [
  "anyhow",
  "candid",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "convert_case 0.6.0",
  "hex",
  "lalrpop 0.20.2",
@@ -2174,26 +2180,32 @@ dependencies = [
 
 [[package]]
 name = "cddl"
-version = "0.9.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498e60dd4fd981287be993aa72fcac506e97bbf467c53a9e8e5985e0390108db"
+checksum = "69f7305ff73327bd9ce5e5cdd81223dd91b4969e260ea6cdb8f1da94390be191"
 dependencies = [
  "abnf_to_pest",
  "base16",
+ "base45",
  "base64-url",
  "chrono",
  "ciborium",
- "clap 3.2.25",
- "codespan-reporting",
+ "ciborium-io",
+ "ciborium-ll",
+ "clap",
+ "codespan-reporting 0.13.1",
  "console_error_panic_hook",
- "crossterm",
+ "csv",
  "data-encoding",
  "displaydoc",
+ "fancy-regex 0.18.0",
+ "hex",
  "hexf-parse",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "js-sys",
- "lexical-core",
  "log",
+ "pest",
+ "pest_derive",
  "pest_meta",
  "pest_vm",
  "regex",
@@ -2272,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2335,29 +2347,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
- "clap_derive 4.6.0",
+ "clap_derive",
 ]
 
 [[package]]
@@ -2368,21 +2363,8 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
- "clap_lex 1.1.0",
+ "clap_lex",
  "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2391,19 +2373,10 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -2459,6 +2432,17 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2597,7 +2581,7 @@ dependencies = [
  "anyhow",
  "askama",
  "base64 0.13.1",
- "clap 4.6.0",
+ "clap",
  "config_types",
  "deterministic_ips",
  "fs_extra",
@@ -3040,7 +3024,7 @@ dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
- "heck 0.5.0",
+ "heck",
  "pulley-interpreter",
 ]
 
@@ -3139,7 +3123,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.6.0",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -3618,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datasize"
@@ -3848,7 +3832,7 @@ name = "deterministic_ips"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "config_types",
  "ic-crypto-sha2",
  "macaddr",
@@ -3887,7 +3871,7 @@ name = "dflate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "libc",
  "tar",
 ]
@@ -3952,7 +3936,7 @@ name = "dfn_protobuf"
 version = "0.9.0"
 dependencies = [
  "on_wire",
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -4050,7 +4034,7 @@ name = "diroid"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "walkdir",
 ]
 
@@ -4734,6 +4718,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,7 +5330,7 @@ dependencies = [
 name = "grub"
 version = "1.0.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "ic-sys",
  "regex",
  "strum 0.26.3",
@@ -5349,7 +5344,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "attestation",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "hex",
@@ -5439,7 +5434,7 @@ version = "0.0.0"
 dependencies = [
  "attestation",
  "der",
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -5479,7 +5474,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "askama",
- "clap 4.6.0",
+ "clap",
  "command_runner",
  "config_tool",
  "config_types",
@@ -5515,7 +5510,7 @@ name = "guestos_tool"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "ic_os_logging",
@@ -5725,12 +5720,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -5924,7 +5913,7 @@ name = "hostos_tool"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "command_runner",
  "config_tool",
  "config_types",
@@ -6053,7 +6042,7 @@ name = "httpbin-rs"
 version = "0.9.0"
 dependencies = [
  "axum",
- "clap 4.6.0",
+ "clap",
  "hyper 1.8.1",
  "hyper-util",
  "rand 0.8.6",
@@ -6274,8 +6263,8 @@ dependencies = [
 name = "ic-adapter-metrics-service"
 version = "0.9.0"
 dependencies = [
- "prost 0.14.3",
- "prost-build 0.14.3",
+ "prost",
+ "prost-build",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -6291,7 +6280,7 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "chrono",
- "clap 4.6.0",
+ "clap",
  "cycles-minting-canister",
  "futures",
  "hex",
@@ -6345,7 +6334,7 @@ dependencies = [
  "maplit",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "serde",
  "serde_json",
@@ -6524,7 +6513,7 @@ version = "0.9.0"
 dependencies = [
  "bincode",
  "byteorder",
- "clap 4.6.0",
+ "clap",
  "criterion",
  "ic-config",
  "ic-crypto-test-utils-canister-threshold-sigs",
@@ -6551,7 +6540,7 @@ dependencies = [
  "lmdb-rkv-sys",
  "nix 0.24.3",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rocksdb",
  "serde",
@@ -6571,7 +6560,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.6.0",
+ "clap",
  "ic-config",
  "ic-crypto-utils-threshold-sig-der",
  "ic-interfaces-registry",
@@ -6616,7 +6605,7 @@ dependencies = [
  "phantom_newtype",
  "proptest",
  "proptest-derive",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -6630,7 +6619,7 @@ name = "ic-base-types-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -6674,7 +6663,7 @@ dependencies = [
  "bytes",
  "candid",
  "chacha20poly1305",
- "clap 4.6.0",
+ "clap",
  "derive-new",
  "flate2",
  "fqdn",
@@ -6700,8 +6689,8 @@ dependencies = [
  "nix 0.30.1",
  "ppp",
  "prometheus",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost",
+ "prost-types",
  "rand 0.8.6",
  "rcgen 0.14.7",
  "regex",
@@ -6753,7 +6742,7 @@ dependencies = [
  "async-trait",
  "axum",
  "candid",
- "clap 4.6.0",
+ "clap",
  "derive-new",
  "fqdn",
  "hickory-proto",
@@ -6790,7 +6779,7 @@ dependencies = [
  "axum-extra 0.10.3",
  "bytes",
  "candid",
- "clap 4.6.0",
+ "clap",
  "dashmap",
  "derive-new",
  "ethnum",
@@ -6896,7 +6885,7 @@ dependencies = [
  "ic-registry-routing-table",
  "ic-registry-subnet-type",
  "ic-system-test-driver",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "reqwest",
  "slog",
@@ -6929,7 +6918,7 @@ name = "ic-btc-adapter"
 version = "0.9.0"
 dependencies = [
  "bitcoin-dogecoin",
- "clap 4.6.0",
+ "clap",
  "criterion",
  "flate2",
  "futures",
@@ -6954,7 +6943,7 @@ dependencies = [
  "parking_lot",
  "primitive-types",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "scrypt",
  "serde",
@@ -7070,7 +7059,7 @@ dependencies = [
  "mockall 0.13.1",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "slog",
  "thiserror 2.0.18",
 ]
@@ -7103,7 +7092,7 @@ dependencies = [
 name = "ic-btc-service"
 version = "0.9.0"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -7145,7 +7134,7 @@ dependencies = [
  "ic-types",
  "ic-validator",
  "itertools 0.12.1",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rustls 0.23.37",
@@ -7876,7 +7865,7 @@ dependencies = [
  "num-traits",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
@@ -7953,7 +7942,7 @@ dependencies = [
  "ic-types-test-utils",
  "num-traits",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rayon",
  "slog",
  "strum 0.26.3",
@@ -7973,7 +7962,7 @@ dependencies = [
  "ic-types",
  "ic-types-test-utils",
  "phantom_newtype",
- "prost 0.14.3",
+ "prost",
  "slog",
 ]
 
@@ -8010,7 +7999,7 @@ dependencies = [
  "ic-test-utilities-types",
  "ic-types",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rayon",
  "slog",
 ]
@@ -8086,7 +8075,7 @@ dependencies = [
  "mockall 0.13.1",
  "phantom_newtype",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "slog",
  "tokio",
@@ -8157,7 +8146,7 @@ version = "0.9.0"
 dependencies = [
  "assert_matches",
  "bincode",
- "clap 4.6.0",
+ "clap",
  "criterion",
  "hex",
  "ic-adapter-metrics-server",
@@ -8234,7 +8223,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-derive",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rsa",
@@ -8508,7 +8497,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-derive",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
@@ -8559,7 +8548,7 @@ name = "ic-crypto-internal-csp-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -9200,7 +9189,7 @@ dependencies = [
  "ic-protobuf",
  "maplit",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "serde",
  "serde_bytes",
@@ -9294,7 +9283,7 @@ dependencies = [
 name = "ic-cup-explorer"
 version = "0.9.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-base-types",
  "ic-canister-client",
@@ -9309,7 +9298,7 @@ dependencies = [
  "ic-registry-keys",
  "ic-registry-nns-data-provider",
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "serde",
  "tempfile",
  "tokio",
@@ -9329,7 +9318,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "chacha20poly1305",
- "clap 4.6.0",
+ "clap",
  "derive-new",
  "fqdn",
  "ic-bn-lib",
@@ -9360,7 +9349,7 @@ dependencies = [
  "candid",
  "chacha20poly1305",
  "chrono",
- "clap 4.6.0",
+ "clap",
  "derive-new",
  "fqdn",
  "humantime",
@@ -9418,7 +9407,7 @@ name = "ic-custom-metrics"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "ic-os-metrics-utils",
  "prometheus",
 ]
@@ -9549,7 +9538,7 @@ dependencies = [
  "bincode",
  "candid",
  "canister-test",
- "clap 4.6.0",
+ "clap",
  "criterion",
  "embedders_bench",
  "ic-base-types",
@@ -9630,7 +9619,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-types",
  "pocket-ic",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "serde",
  "tokio",
@@ -9774,7 +9763,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_matches",
- "clap 4.6.0",
+ "clap",
  "ic-crypto-test-utils-reproducible-rng",
  "ic-sys",
  "ic_os_logging",
@@ -9799,7 +9788,7 @@ dependencies = [
  "axum-extra 0.12.6",
  "bytes",
  "candid",
- "clap 4.6.0",
+ "clap",
  "ctrlc",
  "derive-new",
  "fqdn",
@@ -9993,7 +9982,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "reqwest",
  "rstest",
  "rustls 0.23.37",
@@ -10055,7 +10044,7 @@ dependencies = [
  "ic-types",
  "maplit",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "reqwest",
  "serde",
  "serde_json",
@@ -10119,7 +10108,7 @@ version = "0.9.0"
 dependencies = [
  "async-stream",
  "bytes",
- "clap 4.6.0",
+ "clap",
  "futures",
  "http 1.4.0",
  "http-body-util",
@@ -10248,7 +10237,7 @@ dependencies = [
 name = "ic-https-outcalls-service"
 version = "0.9.0"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -10377,7 +10366,7 @@ dependencies = [
  "axum",
  "candid",
  "ciborium",
- "clap 4.6.0",
+ "clap",
  "futures",
  "hex",
  "ic-agent 0.49.0",
@@ -10437,7 +10426,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-agent 0.49.0",
  "ic-ed25519 0.6.0",
@@ -10840,7 +10829,7 @@ name = "ic-interfaces-registry"
 version = "0.9.0"
 dependencies = [
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "serde",
 ]
 
@@ -11162,7 +11151,7 @@ dependencies = [
  "assert_matches",
  "candid",
  "candid_parser",
- "clap 4.6.0",
+ "clap",
  "futures",
  "hex",
  "maplit",
@@ -11468,7 +11457,7 @@ dependencies = [
  "icrc-ledger-types",
  "mockall 0.13.1",
  "pocket-ic",
- "prost 0.14.3",
+ "prost",
  "rust_decimal",
  "serde",
  "tokio",
@@ -11481,7 +11470,7 @@ dependencies = [
  "ic-crypto-sha2",
  "ic-stable-structures 0.6.9",
  "lazy_static",
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -11544,7 +11533,7 @@ dependencies = [
  "num-traits",
  "priority-queue",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -11739,7 +11728,7 @@ dependencies = [
  "num-traits",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "rust_decimal",
  "rust_decimal_macros",
@@ -11793,7 +11782,7 @@ dependencies = [
  "ic-base-types",
  "ic-nervous-system-proto-protobuf-generator",
  "ic-test-utilities-compare-dirs",
- "prost 0.14.3",
+ "prost",
  "rust_decimal",
  "serde",
  "tempfile",
@@ -11804,7 +11793,7 @@ name = "ic-nervous-system-proto-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -11877,7 +11866,7 @@ name = "ic-nervous-system-submit-motion-proposal"
 version = "0.9.0"
 dependencies = [
  "candid",
- "clap 4.6.0",
+ "clap",
  "ic-agent 0.49.0",
  "ic-certification 3.1.0",
  "ic-identity-hsm",
@@ -11943,7 +11932,7 @@ dependencies = [
 name = "ic-nervous-system-tools-neuron-subaccount"
 version = "0.9.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-base-types",
  "ic-nervous-system-common",
@@ -11958,7 +11947,7 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "canister-test",
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-agent 0.49.0",
  "ic-certification 3.1.0",
@@ -12043,7 +12032,7 @@ dependencies = [
  "ic-stable-structures 0.6.9",
  "ic-test-utilities-compare-dirs",
  "num-traits",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_bytes",
  "tempfile",
@@ -12054,7 +12043,7 @@ name = "ic-nns-common-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12206,7 +12195,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus-parse",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "registry-canister",
@@ -12238,7 +12227,7 @@ dependencies = [
  "ic-sns-swap",
  "ic-utils 0.9.0",
  "icp-ledger",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_bytes",
  "strum 0.26.3",
@@ -12282,7 +12271,7 @@ name = "ic-nns-governance-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12308,7 +12297,7 @@ dependencies = [
  "ic-nns-test-utils-macros",
  "ic-secp256k1",
  "ic-test-utilities-compare-dirs",
- "prost 0.14.3",
+ "prost",
  "serde",
  "sha3",
  "tempfile",
@@ -12323,7 +12312,7 @@ name = "ic-nns-gtc-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12377,7 +12366,7 @@ dependencies = [
  "maplit",
  "on_wire",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "serde",
  "serde_bytes",
@@ -12405,7 +12394,7 @@ name = "ic-nns-handler-root-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12413,7 +12402,7 @@ name = "ic-nns-init"
 version = "0.9.0"
 dependencies = [
  "canister-test",
- "clap 4.6.0",
+ "clap",
  "ic-base-types",
  "ic-canister-client",
  "ic-interfaces-registry",
@@ -12513,7 +12502,7 @@ dependencies = [
  "pocket-ic",
  "pretty_assertions",
  "prometheus-parse",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "regex",
  "registry-canister",
@@ -12596,7 +12585,7 @@ dependencies = [
  "num-traits",
  "on_wire",
  "prometheus-parse",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "registry-canister",
  "serde",
@@ -12631,7 +12620,7 @@ dependencies = [
 name = "ic-nns-test-utils-prepare-golden-state"
 version = "0.0.1"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "tempfile",
 ]
 
@@ -12671,7 +12660,7 @@ dependencies = [
  "mockall 0.13.1",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "rewards-calculation",
  "rust_decimal",
  "serde_json",
@@ -12697,7 +12686,7 @@ name = "ic-node-rewards-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12784,7 +12773,7 @@ dependencies = [
  "async-trait",
  "lazy_static",
  "pprof",
- "prost 0.12.6",
+ "prost",
  "regex",
  "thiserror 2.0.18",
  "tokio",
@@ -12796,7 +12785,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "clap 4.6.0",
+ "clap",
  "fs_extra",
  "ic-config",
  "ic-crypto-node-key-generation",
@@ -12826,7 +12815,7 @@ dependencies = [
  "json5",
  "maplit",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "reqwest",
  "serde",
@@ -12852,7 +12841,7 @@ dependencies = [
  "ic-protobuf-generator",
  "ic-test-utilities-compare-dirs",
  "maplit",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_json",
  "slog",
@@ -12865,7 +12854,7 @@ name = "ic-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -12945,7 +12934,7 @@ dependencies = [
  "ic-types-test-utils",
  "phantom_newtype",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "quinn",
  "rstest",
  "rustls 0.23.37",
@@ -12980,7 +12969,7 @@ name = "ic-recovery"
 version = "0.9.0"
 dependencies = [
  "assert_matches",
- "clap 4.6.0",
+ "clap",
  "futures",
  "hex",
  "ic-artifact-pool",
@@ -13008,7 +12997,7 @@ dependencies = [
  "ic-test-utilities-tmpdir",
  "ic-test-utilities-types",
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "reqwest",
  "serde",
  "serde_cbor",
@@ -13028,7 +13017,7 @@ name = "ic-regedit"
 version = "0.9.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-crypto-utils-threshold-sig-der",
@@ -13042,7 +13031,7 @@ dependencies = [
  "ic-registry-provisional-whitelist",
  "ic-registry-subnet-type",
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_json",
  "tempfile",
@@ -13075,7 +13064,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-stable-structures 0.6.9",
  "lazy_static",
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -13091,7 +13080,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-stable-structures 0.6.9",
  "ic-types",
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -13148,7 +13137,7 @@ version = "0.9.0"
 dependencies = [
  "ic-registry-common-proto-generator",
  "ic-test-utilities-compare-dirs",
- "prost 0.14.3",
+ "prost",
  "tempfile",
 ]
 
@@ -13157,7 +13146,7 @@ name = "ic-registry-common-proto-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -13215,7 +13204,7 @@ dependencies = [
  "ic-registry-local-store-artifacts",
  "ic-sys",
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "tempfile",
 ]
@@ -13250,7 +13239,7 @@ dependencies = [
  "mockall 0.13.1",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "serde",
  "tokio",
@@ -13306,7 +13295,7 @@ name = "ic-registry-replicator"
 version = "0.9.0"
 dependencies = [
  "candid",
- "clap 4.6.0",
+ "clap",
  "ic-certification-test-utils",
  "ic-config",
  "ic-crypto-test-utils-reproducible-rng",
@@ -13335,7 +13324,7 @@ dependencies = [
  "ic-types-test-utils",
  "pocket-ic",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rstest",
  "slog",
@@ -13350,7 +13339,7 @@ name = "ic-registry-resource-limits"
 version = "0.9.0"
 dependencies = [
  "candid",
- "clap 4.6.0",
+ "clap",
  "ic-protobuf",
  "ic-types",
  "serde",
@@ -13405,7 +13394,7 @@ dependencies = [
  "lazy_static",
  "mockall 0.13.1",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "serde",
  "tempfile",
  "tokio",
@@ -13416,7 +13405,7 @@ name = "ic-registry-transport-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -13425,7 +13414,7 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "candid",
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-agent 0.49.0",
  "ic-artifact-pool",
@@ -13475,7 +13464,7 @@ dependencies = [
  "mockall 0.13.1",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "rayon",
  "serde",
  "serde_json",
@@ -13494,7 +13483,7 @@ version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "canister-test",
- "clap 4.6.0",
+ "clap",
  "criterion",
  "hex",
  "ic-artifact-pool",
@@ -13637,7 +13626,7 @@ dependencies = [
  "ic-types-cycles",
  "ic-utils 0.9.0",
  "maplit",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "slog-scope",
  "tempfile",
@@ -13698,7 +13687,7 @@ dependencies = [
  "phantom_newtype",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
@@ -13757,7 +13746,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "candid",
- "clap 4.6.0",
+ "clap",
  "dfn_protobuf",
  "futures",
  "hex",
@@ -13797,7 +13786,7 @@ dependencies = [
  "on_wire",
  "pocket-ic",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand_chacha 0.3.1",
  "registry-canister",
  "reqwest",
@@ -13974,7 +13963,7 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "candid-utils",
- "clap 4.6.0",
+ "clap",
  "cycles-minting-canister",
  "dfx-core-vendored",
  "futures",
@@ -14026,7 +14015,7 @@ dependencies = [
  "candid",
  "candid-utils",
  "candid_parser",
- "clap 4.6.0",
+ "clap",
  "comparable",
  "futures",
  "hex",
@@ -14081,8 +14070,8 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "proptest",
- "prost 0.14.3",
- "prost-build 0.14.3",
+ "prost",
+ "prost-build",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rust_decimal",
@@ -14105,7 +14094,7 @@ version = "0.9.0"
 dependencies = [
  "bytes",
  "candid",
- "clap 4.6.0",
+ "clap",
  "comparable",
  "ic-base-types",
  "ic-nervous-system-proto",
@@ -14115,7 +14104,7 @@ dependencies = [
  "ic-utils 0.9.0",
  "icp-ledger",
  "itertools 0.12.1",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -14160,7 +14149,7 @@ name = "ic-sns-governance-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -14214,7 +14203,7 @@ dependencies = [
  "maplit",
  "num-traits",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -14225,7 +14214,7 @@ name = "ic-sns-init-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -14284,7 +14273,7 @@ dependencies = [
  "pretty-bytes",
  "pretty_assertions",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rust_decimal",
  "rust_decimal_macros",
@@ -14323,7 +14312,7 @@ dependencies = [
  "ic-test-utilities-compare-dirs",
  "icrc-ledger-types",
  "maplit",
- "prost 0.14.3",
+ "prost",
  "serde",
  "tempfile",
  "tokio",
@@ -14334,7 +14323,7 @@ name = "ic-sns-root-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -14377,7 +14366,7 @@ dependencies = [
  "maplit",
  "pretty_assertions",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -14396,7 +14385,7 @@ dependencies = [
  "ic-base-types",
  "ic-nervous-system-proto",
  "ic-utils 0.9.0",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_bytes",
 ]
@@ -14406,7 +14395,7 @@ name = "ic-sns-swap-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -14451,7 +14440,7 @@ dependencies = [
  "maplit",
  "num-traits",
  "on_wire",
- "prost 0.14.3",
+ "prost",
  "tokio",
 ]
 
@@ -14462,7 +14451,7 @@ dependencies = [
  "anyhow",
  "candid",
  "canister-test",
- "clap 4.6.0",
+ "clap",
  "dfx-core-vendored",
  "futures",
  "hex",
@@ -14549,7 +14538,7 @@ dependencies = [
  "icrc-ledger-types",
  "maplit",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "serde",
  "serde_bytes",
@@ -14563,7 +14552,7 @@ name = "ic-sns-wasm-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -14612,7 +14601,7 @@ dependencies = [
  "libc",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "scoped_threadpool",
  "slog",
  "test-strategy 0.4.5",
@@ -14624,7 +14613,7 @@ version = "0.9.0"
 dependencies = [
  "candid",
  "ciborium",
- "clap 4.6.0",
+ "clap",
  "fs_extra",
  "hex",
  "ic-artifact-pool",
@@ -14750,7 +14739,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "scoped_threadpool",
@@ -14787,7 +14776,7 @@ dependencies = [
  "ic-types-test-utils",
  "mockall 0.13.1",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "slog",
  "thiserror 2.0.18",
@@ -14802,7 +14791,7 @@ dependencies = [
 name = "ic-state-tool"
 version = "0.9.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "hex",
  "ic-config",
  "ic-logger",
@@ -14815,7 +14804,7 @@ dependencies = [
  "ic-state-machine-tests",
  "ic-state-manager",
  "ic-types",
- "prost 0.14.3",
+ "prost",
  "slog",
  "slog-term",
  "tempfile",
@@ -14827,7 +14816,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.6.0",
+ "clap",
  "csv",
  "hex",
  "ic-agent 0.49.0",
@@ -14872,7 +14861,7 @@ dependencies = [
  "libc",
  "nix 0.24.3",
  "phantom_newtype",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "tempfile",
  "thiserror 2.0.18",
@@ -14894,7 +14883,7 @@ dependencies = [
  "candid",
  "canister-test",
  "chrono",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "crossbeam-channel",
@@ -15122,7 +15111,7 @@ dependencies = [
  "ic-types",
  "mockall 0.13.1",
  "phantom_newtype",
- "prost 0.14.3",
+ "prost",
  "serde",
  "strum 0.26.3",
 ]
@@ -15280,7 +15269,7 @@ version = "0.9.0"
 dependencies = [
  "assert_matches",
  "ic-protobuf",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -15565,7 +15554,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rstest",
@@ -15873,7 +15862,7 @@ checksum = "04a4c6c1f1f7a2126be36fe51cdbc1c8991214f231811dca7ec1971d15cb6f91"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.6.0",
+ "clap",
  "libflate",
  "rustc-demangle",
  "serde",
@@ -16112,7 +16101,7 @@ dependencies = [
  "ic-types",
  "ic_consensus_system_test_utils",
  "ic_consensus_threshold_sig_system_test_utils",
- "prost 0.14.3",
+ "prost",
  "serde_json",
  "slog",
  "ssh2",
@@ -16147,7 +16136,7 @@ dependencies = [
  "ic_consensus_threshold_sig_system_test_utils",
  "leb128",
  "openssh-keys",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "registry-canister",
  "reqwest",
@@ -16196,7 +16185,7 @@ dependencies = [
  "ic_consensus_system_test_utils",
  "ic_consensus_threshold_sig_system_test_utils",
  "k256",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "registry-canister",
@@ -16371,7 +16360,7 @@ dependencies = [
 name = "icp-config"
 version = "0.9.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "eyre",
  "ic-config",
  "ic-embedders",
@@ -16417,7 +16406,7 @@ dependencies = [
  "on_wire",
  "pocket-ic",
  "proptest",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
@@ -16792,7 +16781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
 dependencies = [
  "ahash 0.8.12",
- "clap 4.6.0",
+ "clap",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -17235,7 +17224,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -17483,64 +17472,7 @@ name = "ledger-canister-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
-]
-
-[[package]]
-name = "lexical-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
-dependencies = [
- "lexical-util",
+ "prost-build",
 ]
 
 [[package]]
@@ -17881,9 +17813,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -18027,7 +17959,7 @@ name = "manual_guestos_recovery"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "grub",
  "ratatui",
  "scopeguard",
@@ -18657,7 +18589,7 @@ name = "nft_exporter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "ic-os-metrics-utils",
  "prometheus",
  "serde",
@@ -18788,7 +18720,7 @@ dependencies = [
  "nns_dapp",
  "num-traits",
  "on_wire",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "reqwest",
  "serde",
@@ -19348,7 +19280,7 @@ dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry-proto",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.3",
+ "prost",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -19363,7 +19295,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
 ]
@@ -19434,7 +19366,7 @@ dependencies = [
  "attestation",
  "backoff",
  "candid",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "der",
@@ -19499,7 +19431,7 @@ dependencies = [
  "nix 0.24.3",
  "pem",
  "prometheus",
- "prost 0.14.3",
+ "prost",
  "qrcode",
  "rand 0.8.6",
  "rcgen 0.13.2",
@@ -19582,12 +19514,6 @@ dependencies = [
  "wat",
  "xnet-slo-test-lib",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "outref"
@@ -19696,7 +19622,7 @@ name = "partition_tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "gpt",
  "indoc 1.0.9",
  "itertools 0.12.1",
@@ -20137,7 +20063,7 @@ dependencies = [
  "icrc-ledger-types",
  "k256",
  "maplit",
- "prost 0.14.3",
+ "prost",
  "registry-canister",
  "reqwest",
  "schemars 0.8.22",
@@ -20175,7 +20101,7 @@ dependencies = [
  "bytes",
  "candid",
  "candid_parser",
- "clap 4.6.0",
+ "clap",
  "ctrlc",
  "cycles-minting-canister",
  "flate2",
@@ -20384,10 +20310,10 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix 0.30.1",
  "once_cell",
- "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost",
+ "prost-build",
  "sha2 0.10.9",
  "smallvec",
  "spin 0.10.0",
@@ -20670,43 +20596,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph 0.6.5",
- "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "regex",
- "syn 2.0.117",
- "tempfile",
+ "prost-derive",
 ]
 
 [[package]]
@@ -20715,32 +20610,19 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost",
+ "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -20758,20 +20640,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -21190,7 +21063,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.6.0",
+ "clap",
  "ic-agent 0.49.0",
  "k256",
  "rate-limits-api",
@@ -21540,7 +21413,7 @@ dependencies = [
  "on_wire",
  "pocket-ic",
  "pretty_assertions",
- "prost 0.14.3",
+ "prost",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -21560,7 +21433,7 @@ name = "registry-canister-protobuf-generator"
 version = "0.9.0"
 dependencies = [
  "ic-utils-rustfmt",
- "prost-build 0.14.3",
+ "prost-build",
 ]
 
 [[package]]
@@ -21595,7 +21468,7 @@ dependencies = [
  "anyhow",
  "candid",
  "chrono",
- "clap 4.6.0",
+ "clap",
  "colored 2.2.0",
  "futures",
  "ic-agent 0.49.0",
@@ -21636,7 +21509,7 @@ name = "remote_attestation_shared"
 version = "0.0.0"
 dependencies = [
  "attestation",
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -22848,9 +22721,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -23009,7 +22882,7 @@ name = "setupos-disable-checks"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "indoc 1.0.9",
  "linux_kernel_command_line",
  "partition_tools",
@@ -23022,7 +22895,7 @@ name = "setupos-image-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "partition_tools",
@@ -23036,7 +22909,7 @@ name = "setupos_tool"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "clap 4.6.0",
+ "clap",
  "config_tool",
  "config_types",
  "deterministic_ips",
@@ -23522,7 +23395,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -23881,7 +23754,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -23894,7 +23767,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -23906,7 +23779,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -24301,12 +24174,6 @@ dependencies = [
  "drawille",
  "rgb",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -24789,7 +24656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost",
  "tonic",
 ]
 
@@ -24801,8 +24668,8 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.14.3",
- "prost-types 0.14.3",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.117",
  "tempfile",
@@ -24815,8 +24682,8 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost",
+ "prost-types",
  "tonic",
 ]
 
@@ -25530,7 +25397,7 @@ dependencies = [
 name = "vsock_guest"
 version = "1.0.0"
 dependencies = [
- "clap 4.6.0",
+ "clap",
  "vsock_lib",
 ]
 
@@ -25616,7 +25483,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -25891,7 +25758,7 @@ name = "wasm_fuzzers"
 version = "0.9.0"
 dependencies = [
  "arbitrary",
- "clap 4.6.0",
+ "clap",
  "futures",
  "ic-config",
  "ic-cycles-account-manager",
@@ -26787,7 +26654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -26798,7 +26665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -626,6 +626,7 @@ bytes = "1.9.0"
 canbench-rs = "0.6.0"
 candid = { version = "0.10.31" }
 candid_parser = { version = "0.1.2" }
+cddl = "0.10.6"
 chrono = { version = "0.4.42", default-features = false, features = [
     "alloc",
     "clock",

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -267,7 +267,7 @@ crate.spec(
 )
 crate.spec(
     package = "cddl",
-    version = "^0.9.4",
+    version = "^0.10.6",
 )
 crate.spec(
     package = "cfg-if",
@@ -1258,13 +1258,6 @@ crate.spec(
 crate.spec(
     package = "proptest-derive",
     version = "^0.5.0",
-)
-
-# why are both needed?
-crate.spec(
-    package = "prost",
-    package_alias = "prost_0_12",
-    version = "^0.12.2",
 )
 crate.spec(
     package = "prost",

--- a/rs/ledger_suite/icrc1/ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/ledger/Cargo.toml
@@ -41,7 +41,7 @@ leb128 = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 candid_parser = { workspace = true }
-cddl = "0.9.4"
+cddl = { workspace = true }
 ciborium = { workspace = true }
 ic-agent = { workspace = true }
 ic-cbor = { workspace = true }

--- a/rs/ledger_suite/tests/sm-tests/Cargo.toml
+++ b/rs/ledger_suite/tests/sm-tests/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }
 candid = { workspace = true }
-cddl = "0.9.4"
+cddl = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ic-agent = { workspace = true }

--- a/rs/monitoring/pprof/BUILD.bazel
+++ b/rs/monitoring/pprof/BUILD.bazel
@@ -15,7 +15,7 @@ rust_library(
         # Keep sorted.
         "@crate_index//:lazy_static",
         "@crate_index//:pprof",
-        "@crate_index//:prost_0_12",
+        "@crate_index//:prost",
         "@crate_index//:regex",
         "@crate_index//:thiserror",
         "@crate_index//:tokio",

--- a/rs/monitoring/pprof/Cargo.toml
+++ b/rs/monitoring/pprof/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 async-trait = { workspace = true }
 lazy_static = { workspace = true }
 pprof = { workspace = true }
-prost = "^0.12"
+prost = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
The `cddl` crate was pulling in lots of outdated dependencies. By bumping it, we can simplify our dependency graph a fair bit:

Crates deduplicated: clap, clap_derive, clap_lex, heck, prost, prost-build, prost-derive, prost-type
Crates removed: lexical-core, lexical-parse-float, lexical-parse-integer, lexical-util, lexical-write-float, lexical-write-integer, os_str_bytes, textwrap