### PR TITLE
chore: bump rust to 1.97.1

### DIFF
--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -22,7 +22,7 @@ archive_override(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
-    versions = ["1.97.0"],
+    versions = ["1.97.1"],
 )
 
 # Repin with `CARGO_BAZEL_REPIN=true bazel build @crate_index//...`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 targets = ["wasm32-unknown-unknown"]
 profile = "default"
 components = []


### PR DESCRIPTION
https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/