### PR TITLE
chore: do not run `@@+mainnet_icos_images+...//:guest-img` remotely

### DIFF
--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -78,7 +78,10 @@ genrule(
     name = "guest-img",
     srcs = ["disk-img.tar.zst"],
     outs = ["guest-img.tar.zst"],
-    tags = [ "manual" ],
+    # no-remote-exec because the setupOS image input is a multi gigabyte file
+    # which would then have to be copied to the remote worker.
+    # Additionally Namespace had a /tmp of only 1G which was too small to extract the setupOS image to.
+    tags = [ "manual", "no-remote-exec" ],
     cmd = \"""#!/bin/bash
         $(location @@//rs/ic_os/build_tools/partition_tools:extract-guestos) --image $< $@
     \""",

--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -80,7 +80,6 @@ genrule(
     outs = ["guest-img.tar.zst"],
     # no-remote-exec because the setupOS image input is a multi gigabyte file
     # which would then have to be copied to the remote worker.
-    # Additionally Namespace had a /tmp of only 1G which was too small to extract the setupOS image to.
     tags = [ "manual", "no-remote-exec" ],
     cmd = \"""#!/bin/bash
         $(location @@//rs/ic_os/build_tools/partition_tools:extract-guestos) --image $< $@


### PR DESCRIPTION
The `@@+mainnet_icos_images+...//:guest-img` targets have 2.4G setupOS images as input. Running this remotely would mean these multi gigabyte inputs would have to be copied to the remote worker. Additionally Namespace currently has a 1G `/tmp` which causes the `:guest-img` action to run into a `No space left on device` error since it attempts to extract the 2.4G setupOS image under `/tmp`. So to work around both issues we forbid the action to run remotely (tag: `no-remote-exec`).