### PR TITLE
feat: [NODE-1859] Update config, regardless of NO keys

### DIFF
--- a/rs/ic_os/config/tool/src/main.rs
+++ b/rs/ic_os/config/tool/src/main.rs
@@ -264,6 +264,12 @@ pub fn main() -> Result<()> {
             let mut hostos_config: HostOSConfig =
                 config_tool::deserialize_config(&hostos_config_json_path)?;
 
+            if hostos_config.config_version == CONFIG_VERSION {
+                println!("Config already up to date. Skipping update.");
+
+                return Ok(());
+            }
+
             // Fill the NO key from the old keyfile, only if missing.
             if hostos_config
                 .icos_settings

--- a/rs/ic_os/config/tool/src/main.rs
+++ b/rs/ic_os/config/tool/src/main.rs
@@ -264,33 +264,28 @@ pub fn main() -> Result<()> {
             let mut hostos_config: HostOSConfig =
                 config_tool::deserialize_config(&hostos_config_json_path)?;
 
-            if !node_operator_private_key_path.exists() {
-                println!(
-                    "Node operator private key file not found at {}. Skipping update.",
-                    node_operator_private_key_path.display()
-                );
-                return Ok(());
-            }
-
+            // Fill the NO key from the old keyfile, only if missing.
             if hostos_config
                 .icos_settings
                 .node_operator_private_key
-                .is_some()
+                .is_none()
             {
-                println!("Node operator private key already present in config. Skipping update.");
-                return Ok(());
+                hostos_config.icos_settings.node_operator_private_key =
+                    fs::read_to_string(&node_operator_private_key_path)
+                        .map_err(|_| {
+                            println!(
+                                "Node operator private key file not found at {}.",
+                                node_operator_private_key_path.display()
+                            )
+                        })
+                        .ok();
             }
 
-            let node_operator_private_key = fs::read_to_string(&node_operator_private_key_path)
-                .context("unable to read node operator private key")?;
-
-            hostos_config.icos_settings.node_operator_private_key = Some(node_operator_private_key);
             hostos_config.config_version = CONFIG_VERSION.to_string();
-
             serialize_and_write_config(&hostos_config_json_path, &hostos_config)?;
 
             println!(
-                "HostOS config updated with node operator private key and written to {}",
+                "HostOS config updated and written to {}",
                 hostos_config_json_path.display()
             );
 

--- a/rs/ic_os/config/tool/src/setupos/deployment_json.rs
+++ b/rs/ic_os/config/tool/src/setupos/deployment_json.rs
@@ -63,25 +63,6 @@ mod test {
     use super::*;
     use config_types::HostOSDevSettings;
     use once_cell::sync::Lazy;
-    use serde_json::{Value, json};
-
-    static DEPLOYMENT_VALUE: Lazy<Value> = Lazy::new(|| {
-        json!({
-              "deployment": {
-                "deployment_environment": "mainnet",
-                "mgmt_mac": null
-              },
-              "nns": {
-                "urls": ["https://icp-api.io", "https://icp0.io", "https://ic0.app"]
-              },
-              "dev_vm_resources": {
-                "memory": "16",
-                "cpu": "kvm",
-                "nr_of_vcpus": 64
-              }
-            }
-        )
-    });
 
     const DEPLOYMENT_STR: &str = r#"{
   "deployment": {
@@ -119,14 +100,19 @@ mod test {
 
     #[test]
     fn deserialize_deployment() {
-        let parsed_deployment = { serde_json::from_str(DEPLOYMENT_STR).unwrap() };
+        let parsed_deployment = serde_json::from_str(DEPLOYMENT_STR).unwrap();
 
         assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
 
-        // Exercise DeserializeOwned using serde_json::from_value.
-        // DeserializeOwned is used by serde_json::from_reader, which is the
+        // Exercise DeserializeOwned using serde_json::from_reader. This is the
         // main entrypoint of this code, in practice.
-        let parsed_deployment = { serde_json::from_value(DEPLOYMENT_VALUE.clone()).unwrap() };
+        let parsed_deployment = serde_json::from_reader(DEPLOYMENT_STR.as_bytes()).unwrap();
+
+        assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
+
+        // Exercise DeserializeOwned using serde_json::from_reader. This is the
+        // main entrypoint of this code, in practice.
+        let parsed_deployment = serde_json::from_reader(DEPLOYMENT_STR.as_bytes()).unwrap();
 
         assert_eq!(*DEPLOYMENT_STRUCT, parsed_deployment);
     }

--- a/rs/ic_os/config/types/compatibility_tests/BUILD.bazel
+++ b/rs/ic_os/config/types/compatibility_tests/BUILD.bazel
@@ -47,6 +47,7 @@ rust_test(
     deps = [
         ":config_types_compatibility_lib",
         "//rs/ic_os/config/types:config_types",
+        "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],
 )

--- a/rs/ic_os/config/types/compatibility_tests/tests/compatibility_tests.rs
+++ b/rs/ic_os/config/types/compatibility_tests/tests/compatibility_tests.rs
@@ -13,11 +13,41 @@ fn test_backwards_compatibility() {
 
         if filename.starts_with("hostos_") {
             serde_json::from_str::<HostOSConfig>(&config_json).unwrap_or_else(|e| {
-                panic!("Failed to deserialize historical HostOSConfig from {filename}: {e}")
+                panic!(
+                    "Failed to deserialize historical HostOSConfig from borrowed {filename}: {e}"
+                )
+            });
+
+            // Exercise DeserializeOwned using serde_json::from_reader. This is
+            // the main entrypoint of this code, in practice.
+            let config = serde_json::from_reader::<_, HostOSConfig>(config_json.as_bytes())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to deserialize historical HostOSConfig from owned {filename}: {e}"
+                    )
+                });
+
+            serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
+                panic!("Failed to serialize HostOSConfig sourced from {filename}: {e}")
             });
         } else if filename.starts_with("guestos_") {
             serde_json::from_str::<GuestOSConfig>(&config_json).unwrap_or_else(|e| {
-                panic!("Failed to deserialize historical GuestOSConfig from {filename}: {e}")
+                panic!(
+                    "Failed to deserialize historical GuestOSConfig from borrowed {filename}: {e}"
+                )
+            });
+
+            // Exercise DeserializeOwned using serde_json::from_reader. This is
+            // the main entrypoint of this code, in practice.
+            let config = serde_json::from_reader::<_, GuestOSConfig>(config_json.as_bytes())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to deserialize historical GuestOSConfig from owned {filename}: {e}"
+                    )
+                });
+
+            serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
+                panic!("Failed to serialize GuestOSConfig sourced from {filename}: {e}")
             });
         }
 


### PR DESCRIPTION
Bring the HostOS config versions up to the latest version, regardless of the state of the Node Operator private key. (In file, in config, or neither.)