### PR TITLE
test(https-outcalls): remove requires-network from adapter integration tests

### DIFF
--- a/rs/https_outcalls/adapter/BUILD.bazel
+++ b/rs/https_outcalls/adapter/BUILD.bazel
@@ -233,7 +233,6 @@ rust_test(
 rust_test_suite(
     name = "adapter_integration",
     srcs = glob(["tests/**/*.rs"]),
-    tags = ["requires-network"],
     deps = [
         # Keep sorted.
         ":adapter",
@@ -277,7 +276,6 @@ rust_test_suite(
     name = "adapter_integration_with_http",
     srcs = glob(["tests/**/*.rs"]),
     crate_features = ["http"],
-    tags = ["requires-network"],
     deps = [
         # Keep sorted.
         ":adapter_with_http",

--- a/rs/https_outcalls/adapter/tests/server_test.rs
+++ b/rs/https_outcalls/adapter/tests/server_test.rs
@@ -749,16 +749,17 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
         let addr = listener.local_addr().unwrap();
 
         // Fill the accept queue with connections that are never accepted. We
-        // keep the successful ones alive so the queue stays full; the first
-        // connect that starts to hang tells us the queue is saturated.
+        // keep the successful ones alive so the queue stays full; the queue is
+        // saturated once a fresh connect no longer completes but hangs.
         //
-        // The loop is self-terminating (it breaks as soon as a connect hangs),
+        // The loop is self-terminating (it stops as soon as a connect hangs),
         // so the bound is just a safety cap to avoid running away. With
         // `listen(1)` the queue saturates after `backlog + 1 = 2` connects on
         // Linux (`sk_acceptq_is_full`), so the 3rd connect already hangs; 16
         // leaves a generous margin and is far above any real accept-queue
         // capacity for this backlog.
         let mut blockers = Vec::new();
+        let mut saturated = false;
         for _ in 0..16 {
             match tokio::time::timeout(
                 std::time::Duration::from_millis(200),
@@ -766,12 +767,29 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             )
             .await
             {
+                // Connect succeeded quickly: still room in the queue, keep it
+                // alive and keep filling.
                 Ok(Ok(stream)) => blockers.push(stream),
-                // Either the connect started to hang (queue full) or errored;
-                // in both cases the queue is saturated, so stop filling it.
-                _ => break,
+                // Connect hung past the probe timeout: the queue is saturated
+                // and further SYNs are being dropped, which is exactly the
+                // state we need for the adapter's connect to time out.
+                Err(_elapsed) => {
+                    saturated = true;
+                    break;
+                }
+                // An immediate connect error means the queue is *not*
+                // saturated (e.g. the connection was refused). Failing here
+                // rather than proceeding keeps the test deterministic and
+                // surfaces the real cause instead of a confusing downstream
+                // failure.
+                Ok(Err(e)) => panic!("unexpected error while filling accept queue: {e}"),
             }
         }
+        assert!(
+            saturated,
+            "accept queue never saturated after {} connects; cannot exercise the connect timeout",
+            blockers.len()
+        );
 
         let mut client = spawn_grpc_server(server_config);
 

--- a/rs/https_outcalls/adapter/tests/server_test.rs
+++ b/rs/https_outcalls/adapter/tests/server_test.rs
@@ -723,7 +723,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
 
     #[tokio::test]
     async fn test_connect_timeout() {
-        // Test that adapter hits connect timeout when connecting to unreachable host.
+        // Test that adapter hits connect timeout when connecting to a host that
+        // accepts no new connections (simulates an unreachable host).
         let path = "/tmp/canister-http-test-".to_string() + &Uuid::new_v4().to_string();
         let server_config = Config {
             http_connect_timeout_secs: 1,
@@ -733,12 +734,50 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgob29X4H4m2XOkSZE
             ..Default::default()
         };
 
-        let _url = start_server(CERT_INIT.get_or_init(generate_certs));
+        // Bind a loopback listener with a minimal backlog and never accept from
+        // it. Once its accept queue is full the kernel silently drops further
+        // SYNs (see `tcp_conn_request`/`sk_acceptq_is_full`), so a fresh TCP
+        // connect neither completes nor is refused: it hangs until the adapter's
+        // connect timeout fires. This exercises the connect-timeout path using
+        // only loopback, so the test does not require network egress. (A
+        // non-routable address like 10.255.255.1 only times out when a default
+        // route exists to black-hole the packets; without one the OS returns an
+        // immediate "network unreachable" error instead.)
+        let socket = TcpSocket::new_v4().unwrap();
+        socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener = socket.listen(1).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Fill the accept queue with connections that are never accepted. We
+        // keep the successful ones alive so the queue stays full; the first
+        // connect that starts to hang tells us the queue is saturated.
+        //
+        // The loop is self-terminating (it breaks as soon as a connect hangs),
+        // so the bound is just a safety cap to avoid running away. With
+        // `listen(1)` the queue saturates after `backlog + 1 = 2` connects on
+        // Linux (`sk_acceptq_is_full`), so the 3rd connect already hangs; 16
+        // leaves a generous margin and is far above any real accept-queue
+        // capacity for this backlog.
+        let mut blockers = Vec::new();
+        for _ in 0..16 {
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                tokio::net::TcpStream::connect(addr),
+            )
+            .await
+            {
+                Ok(Ok(stream)) => blockers.push(stream),
+                // Either the connect started to hang (queue full) or errored;
+                // in both cases the queue is saturated, so stop filling it.
+                _ => break,
+            }
+        }
+
         let mut client = spawn_grpc_server(server_config);
 
-        // Non routable address that causes a connect timeout.
+        // Connecting to the saturated listener hangs and triggers the connect timeout.
         let request = tonic::Request::new(HttpsOutcallRequest {
-            url: "https://10.255.255.1".to_string(),
+            url: format!("https://{addr}"),
             headers: Vec::new(),
             method: HttpMethod::Head as i32,
             body: "hello".to_string().as_bytes().to_vec(),


### PR DESCRIPTION
## Why

Use of the `requires-network` tag should be minimised to ensure tests are hermetic.

The `test_connect_timeout` integration test in `rs/https_outcalls/adapter/tests/server_test.rs` connected to the non-routable address `10.255.255.1` to trigger the adapter's connect timeout. That address only *times out* when a default route exists to black-hole the SYNs; without network egress the OS returns an immediate `NetworkUnreachable` error instead of the expected `TimedOut`. Because of this the whole integration suite carried the `requires-network` tag.

## What

Replace the non-routable address with a saturated loopback listener:

- Bind a `127.0.0.1` listener with `listen(1)` and never accept.
- Fill its accept queue with a few connections that are kept alive.
- Once the queue is full the Linux kernel silently drops further SYNs (`tcp_conn_request` → `sk_acceptq_is_full` → `goto drop`, before any SYN-ACK), so a fresh connect neither completes nor is refused — it hangs until the adapter's 1s connect timeout fires, yielding the same `ConnectError("tcp connect error", …, Custom { kind: TimedOut, error: Elapsed(()) })` the test already asserts on.

This uses only loopback, so both `adapter_integration` and `adapter_integration_with_http` can drop `requires-network`.

The fill loop is self-terminating (breaks as soon as a connect hangs); its bound of `16` is just a safety cap — with `listen(1)` the queue saturates after `backlog + 1 = 2` connects on Linux.

## Testing

Both suites pass with network access blocked, simulating a no-network CI sandbox:

```
bazel test //rs/https_outcalls/adapter:adapter_integration_with_http_tests/server_test_test \
  --nocache_test_results --sandbox_default_allow_network=false   # PASSED
bazel test //rs/https_outcalls/adapter:adapter_integration_tests/server_test_test \
  --nocache_test_results --sandbox_default_allow_network=false   # PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)