### PR TITLE
test(nns_delegation_manager): make CloudEngine API BN test hermetic

### DIFF
--- a/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
+++ b/rs/http_endpoints/nns_delegation_manager/BUILD.bazel
@@ -57,9 +57,6 @@ rust_test(
         "RUST_TEST_THREADS": "4",
     },
     exec_properties = {"cpu": "4"},
-    tags = [
-        "requires-network",
-    ],
     deps = [
         "//rs/certification/test-utils",
         "//rs/crypto/tls_interfaces",

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -661,7 +661,11 @@ mod tests {
     const VERIFIED_APP_NODE_ID: NodeId = ic_test_utilities_types::ids::NODE_4;
     const CLOUD_ENGINE_NODE_ID: NodeId = ic_test_utilities_types::ids::NODE_5;
     const API_BN_ID: NodeId = ic_test_utilities_types::ids::NODE_6;
-    const API_BN_DOMAIN: &str = "domain.invalid";
+    // An IPv6 loopback literal. `hickory`'s `lookup_ip` short-circuits IP literals and returns
+    // them without contacting any nameserver, so the CloudEngine code path resolves this offline
+    // (making the test hermetic) and then tries to connect to `[::1]:443`, where nothing is
+    // listening, yielding a fast connection-refused error inside the sandbox.
+    const API_BN_DOMAIN: &str = "::1";
 
     // Get a free port on this host to which we can connect transport to.
     fn get_free_localhost_socket_addr() -> SocketAddr {
@@ -1263,10 +1267,14 @@ mod tests {
         )
         .await;
 
-        // Since the API BN is configured with a domain that does not resolve, we expect the
-        // connection to fail with a name resolution error, which indicates that we indeed tried to
-        // connect to the API BN instead of an NNS node.
-        assert_matches!(response, Err(err) if format!("{err:?}").contains("NoRecordsFound"));
+        // The API BN is configured with a loopback domain (`::1`) where nothing is listening on
+        // port 443 (the port hard-coded for API BNs). We therefore expect the connection to be
+        // refused. This indicates that we indeed tried to connect to the API BN (on port 443)
+        // instead of an NNS node (which would have connected to the mocked node's endpoint).
+        assert_matches!(
+            response,
+            Err(err) if format!("{err:?}").contains("Could not connect to node [::1]:443")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Use of the `requires-network` tag should be minimised to ensure tests are hermetic.

`load_root_delegation_on_cloud_engine_should_contact_api_bn_test` asserted that resolving the non-existing API BN domain (`domain.invalid`) fails with `NoRecordsFound` (NXDOMAIN). That relies on a reachable nameserver honestly answering NXDOMAIN, which the Bazel sandbox netns does not have, so offline the lookup times out (`Timed out while connecting … after 10s`) instead. Hence the test needed the `requires-network` tag.

This is a simpler, purely test-side alternative to the previously-closed #10693 (which added a stub DNS server and injected a resolver into production `connect()`).

## Fix

No production changes. Two test-side changes:

- Set the test-only `API_BN_DOMAIN` constant to the IPv6 loopback literal `::1`. `hickory`'s `lookup_ip` short-circuits IP literals and returns them without contacting any nameserver, so the CloudEngine code path resolves it offline. An IPv6 literal is used because the branch sets `ip_strategy = Ipv6Only`.
- The code then connects to `[::1]:443` (443 is hard-coded for API BNs), where nothing is listening, so loopback returns a fast connection-refused. The test asserts the error contains `Could not connect to node [::1]:443`.

This still proves we took the API BN path (port 443, the `::1` domain) rather than the NNS path (which would have connected to the mocked node's endpoint).

The `requires-network` tag is removed.

## Verification

- The test passes in ~0.2s under the default network-isolated sandbox (`--nosandbox_default_allow_network`), confirming it is hermetic.
- The full `//rs/http_endpoints/nns_delegation_manager:nns_delegation_manager_test` target passes.
- `rustfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)