### PR TITLE
test(http_utils): run resuming_download_test without network

### DIFF
--- a/rs/http_utils/BUILD.bazel
+++ b/rs/http_utils/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
-load("//rs/tests:common.bzl", "MAINNET_ENV")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,14 +37,10 @@ rust_test(
 rust_test(
     name = "resuming_download_test",
     srcs = glob(["tests/**/*.rs"]),
-    env = MAINNET_ENV,
-    tags = [
-        "long_test",  # this test doesn't necessarily take long but it downloads a big image from download proxy so, to save bandwidth, we don't want to do that for every update to every PR and only run this on pushes to master.
-        "requires-network",
-    ],
     deps = [
         ":http_utils",
         "@crate_index//:assert_matches",
+        "@crate_index//:tempfile",
         "@crate_index//:tokio",
     ],
 )

--- a/rs/http_utils/tests/large_file_download_from.rs
+++ b/rs/http_utils/tests/large_file_download_from.rs
@@ -1,42 +1,128 @@
-use std::{path::PathBuf, str::FromStr};
+use std::sync::Arc;
+use std::time::Duration;
 
 use assert_matches::assert_matches;
-use ic_http_utils::file_downloader::{FileDownloadError, FileDownloader};
+use ic_http_utils::file_downloader::{FileDownloadError, FileDownloader, compute_sha256_hex};
+use tempfile::tempdir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
-async fn get_hash(downloader: FileDownloader, version: &str) -> String {
-    let url =
-        format!("https://download.dfinity.systems/ic/{version}/guest-os/update-img/SHA256SUMS");
+/// Total size of the bogus file served by the local test web-server.
+const FILE_SIZE: usize = 512 * 1024;
+/// Number of bytes the server hands out per request before stalling, forcing
+/// the downloader to time out and later resume the download.
+const CHUNK_SIZE: usize = 128 * 1024;
 
-    let file_path = std::path::Path::new("/tmp/shasums");
-    downloader
-        .download_file(&url, file_path, None)
-        .await
-        .unwrap();
-
-    std::fs::read_to_string(file_path)
-        .unwrap()
-        .lines()
-        .find(|line| line.ends_with("update-img.tar.zst"))
-        .map(|line| line.split_once(' ').unwrap().0)
-        .unwrap()
-        .to_string()
+/// Fill a buffer with deterministic pseudo-random data (xorshift64).
+fn bogus_data(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut data = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        data.push((state & 0xff) as u8);
+    }
+    data
 }
 
+/// Read the HTTP request headers from `stream` and return the start offset
+/// requested via the `Range: bytes=<offset>-` header (0 if absent).
+async fn read_request_offset(stream: &mut TcpStream) -> usize {
+    let mut buf = Vec::new();
+    let mut byte = [0_u8; 1];
+    // Read until the end of the HTTP request headers.
+    while !buf.ends_with(b"\r\n\r\n") {
+        if stream.read_exact(&mut byte).await.is_err() {
+            break;
+        }
+        buf.push(byte[0]);
+    }
+    let request = String::from_utf8_lossy(&buf);
+    request
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("range") {
+                value
+                    .trim()
+                    .trim_start_matches("bytes=")
+                    .trim_end_matches('-')
+                    .parse()
+                    .ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}
+
+/// Handle a single connection: serve at most `CHUNK_SIZE` bytes starting at the
+/// requested offset. If bytes remain afterwards, stall so that the client times
+/// out (leaving the partial file on disk to be resumed). Otherwise serve the
+/// remaining bytes and let the response complete normally.
+async fn handle_connection(mut stream: TcpStream, data: Arc<Vec<u8>>) {
+    let offset = read_request_offset(&mut stream).await.min(data.len());
+    let remaining = data.len() - offset;
+    let to_send = remaining.min(CHUNK_SIZE);
+
+    // Advertise the full remaining length so the client keeps waiting for the
+    // bytes we withhold when stalling.
+    let header =
+        format!("HTTP/1.1 200 OK\r\nContent-Length: {remaining}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(header.as_bytes()).await.is_err() {
+        return;
+    }
+    if stream
+        .write_all(&data[offset..offset + to_send])
+        .await
+        .is_err()
+    {
+        return;
+    }
+    let _ = stream.flush().await;
+
+    if to_send < remaining {
+        // Withhold the rest of the body so the download times out, keeping the
+        // partial file on disk for the next (resuming) request.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+}
+
+/// Verify that `FileDownloader` correctly resumes an interrupted download.
+///
+/// Rather than downloading a real (large) image over the network, this test
+/// serves a bogus file of random data from a local web-server. The server hands
+/// out the file in pieces, stalling in between so that the downloader times out
+/// repeatedly. Each timeout must leave the already-downloaded bytes on disk so
+/// that the next request resumes where the previous one left off, until the
+/// whole file has been fetched and its hash matches.
 #[tokio::test]
-async fn test_large_file_download() {
-    // Known commit where the artifacts have been uploaded
-    let version = "6a5718d4e45acc80a26506f34d1525c482330b56".to_string();
+async fn test_resuming_download() {
+    let data = Arc::new(bogus_data(FILE_SIZE));
 
-    // Use a normal downloader since hash is required for further testing.
-    let downloader = FileDownloader::new_with_timeout(None, std::time::Duration::from_secs(30));
-    let hash = get_hash(downloader, version.as_ref()).await;
+    let dir = tempdir().unwrap();
 
-    let url = format!(
-        "https://download.dfinity.systems/ic/{version}/guest-os/update-img/update-img.tar.zst"
-    );
-    let downloader = FileDownloader::new_with_timeout(None, std::time::Duration::from_secs(2));
+    // Compute the expected hash of the full file.
+    let source_path = dir.path().join("source");
+    std::fs::write(&source_path, data.as_ref()).unwrap();
+    let hash = compute_sha256_hex(&source_path).unwrap();
 
-    let output = PathBuf::from_str("/tmp/replica").unwrap();
+    // Start a local web-server serving the bogus file with stalls.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server_data = data.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio::spawn(handle_connection(stream, server_data.clone()));
+        }
+    });
+
+    let url = format!("http://{addr}/");
+    let downloader = FileDownloader::new_with_timeout(None, Duration::from_secs(2));
+
+    let output = dir.path().join("download");
     let mut last_iteration_size = 0;
     loop {
         let response = downloader
@@ -51,8 +137,13 @@ async fn test_large_file_download() {
         let metadata = std::fs::metadata(&output).unwrap();
         assert!(
             metadata.len() > last_iteration_size,
-            "No data downloaded in this iteration, meaning that either s3 has a bug, timeout is too low or there is a bug in the code"
+            "No data downloaded in this iteration, meaning that either the server has a bug, the timeout is too low or there is a bug in the code"
         );
         last_iteration_size = metadata.len();
     }
+
+    // The fully downloaded file must match the served bogus file.
+    assert_eq!(std::fs::read(&output).unwrap(), *data);
+
+    server.abort();
 }


### PR DESCRIPTION
## Why

The `//rs/http_utils:resuming_download_test` downloaded a real GuestOS image from `download.dfinity.systems`, which required the `requires-network` tag. To avoid spending bandwidth on every PR it was also marked `long_test`, so it only ran on pushes to `master`.

Use of the `requires-network` tag should be minimised to ensure tests are hermetic.

## What

`rs/http_utils/tests/large_file_download_from.rs` now serves a bogus file (512 KiB of deterministic pseudo-random data, no new deps) from a small local `tokio` web-server instead of downloading a real URL:

- The server honours the downloader's `Range: bytes=<offset>-` header, hands out 128 KiB per request, then **stalls** (holds the connection open) while bytes remain. This forces the downloader's chunk timeout to fire (`FileDownloadError::TimeoutError`), leaving the partial file on disk.
- The test loop asserts each iteration makes progress (resuming from the previous offset) until the final request serves the remaining bytes and the hash matches, then asserts the downloaded file equals the served data.

This exercises the same resuming-download logic as before, but entirely in-process without any network access.

`rs/http_utils/BUILD.bazel`:
- Removed the `requires-network` tag.
- Removed the now-obsolete `long_test` tag (its justification — bandwidth for downloading a big image — no longer applies), so the test runs on regular PRs.
- Removed `env = MAINNET_ENV` and its `load` (the env vars were never read by the test).
- Added `@crate_index//:tempfile` to the test deps (already a dev-dependency in `Cargo.toml`, so no repin needed).

## Testing

`rustfmt`, `cargo check`, `cargo clippy` (with the project's flags), and `bazel test //rs/http_utils:resuming_download_test` all pass — the test runs in the linux sandbox with no network in ~6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)