### PR TITLE
chore: use workspace crates everywhere

### DIFF
--- a/packages/canlog_derive/Cargo.toml
+++ b/packages/canlog_derive/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/canlog"
 
 [dependencies]
 syn = { workspace = true }
-quote = "1.0.40"
-proc-macro2 = "1.0.94"
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 darling = "0.20.11"
 
 [lib]

--- a/packages/ic-dummy-getrandom-for-wasm/Cargo.toml
+++ b/packages/ic-dummy-getrandom-for-wasm/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 documentation.workspace = true
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["custom"] }
+getrandom = { workspace = true, features = ["custom"] }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
-getrandom = { version = "0.2" }
+getrandom = { workspace = true }

--- a/packages/ic-ed25519/Cargo.toml
+++ b/packages/ic-ed25519/Cargo.toml
@@ -14,7 +14,7 @@ documentation.workspace = true
 curve25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
 hex-literal = "0.4"
-hkdf = "0.12"
+hkdf = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false }
 pem = { workspace = true }
 rand = { workspace = true, optional = true }

--- a/packages/ic-heap-bytes-derive/Cargo.toml
+++ b/packages/ic-heap-bytes-derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 darling = "0.20.11"
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { version = "2.0.100", features = ["derive"] }
+syn = { workspace = true, features = ["derive"] }

--- a/packages/ic-hpke/Cargo.toml
+++ b/packages/ic-hpke/Cargo.toml
@@ -14,6 +14,6 @@ documentation.workspace = true
 hpke = { version = "0.12", default-features = false, features = [ "p384", "alloc" ] }
 
 [dev-dependencies]
-hex = "0.4"
+hex = { workspace = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 rand_chacha = { version = "0.3", default-features = false }

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -16,7 +16,7 @@ candid = { workspace = true }
 ic-http-types = { version = "0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }
 pocket-ic = { version = "15.0.0", path = "../../packages/pocket-ic", optional = true }
-regex = "1.11.0"
+regex = { workspace = true }
 
 [features]
 pocket_ic = [

--- a/packages/ic-pub-key/Cargo.toml
+++ b/packages/ic-pub-key/Cargo.toml
@@ -25,4 +25,4 @@ ic-cdk-management-canister = { workspace = true, optional = true }
 ic-management-canister-types = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4"
+hex = { workspace = true }

--- a/packages/ic-secp256k1/Cargo.toml
+++ b/packages/ic-secp256k1/Cargo.toml
@@ -30,5 +30,5 @@ bip32 = "0.5"
 bitcoin = { workspace = true }
 hex = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false, features = ["convert"] }
-secp256k1 = { version = "0.29", features = ["global-context", "std", "rand"] }
+secp256k1 = { workspace = true, features = ["global-context", "std", "rand"] }
 wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }

--- a/packages/ic-signature-verification/Cargo.toml
+++ b/packages/ic-signature-verification/Cargo.toml
@@ -20,9 +20,9 @@ ic-verify-bls-signature = { version = "0.6", default-features = false, features 
 ] }
 ic_principal = "0.1"
 serde = { workspace = true }
-serde_bytes = "0.11"
-serde_cbor = "0.11"
-sha2 = "0.10"
+serde_bytes = { workspace = true }
+serde_cbor = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -32,7 +32,7 @@ ic-certification = { workspace = true }
 ic-management-canister-types = { workspace = true }
 ic-transport-types = { workspace = true }
 reqwest = { workspace = true }
-schemars = "0.8.16"
+schemars = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/bitcoin/ckbtc/minter/Cargo.toml
+++ b/rs/bitcoin/ckbtc/minter/Cargo.toml
@@ -43,7 +43,7 @@ minicbor = { workspace = true }
 minicbor-derive = { workspace = true }
 num-traits = { workspace = true }
 ripemd = "0.1.1"
-scopeguard = "1.1.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/bitcoin/validation/Cargo.toml
+++ b/rs/bitcoin/validation/Cargo.toml
@@ -12,6 +12,6 @@ version.workspace = true
 bitcoin = { workspace = true }
 
 [dev-dependencies]
-csv = "1.1"
+csv = { workspace = true }
 rstest = { workspace = true }
 hex = { workspace = true }

--- a/rs/boundary_node/ic_boundary/Cargo.toml
+++ b/rs/boundary_node/ic_boundary/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-arc-swap = "1.7.1"
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
@@ -88,6 +88,6 @@ url = { workspace = true }
 x509-parser = { workspace = true }
 
 [dev-dependencies]
-indoc = "1.0"
+indoc = { workspace = true }
 tempfile = { workspace = true }
 tokio-tungstenite = "0.26"

--- a/rs/boundary_node/rate_limits/api/Cargo.toml
+++ b/rs/boundary_node/rate_limits/api/Cargo.toml
@@ -15,11 +15,11 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-serde_regex = "1.1"
+serde_regex = { workspace = true }
 serde_yaml = { workspace = true }
 
 [dev-dependencies]
-indoc = "1.0"
+indoc = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/rs/canonical_state/Cargo.toml
+++ b/rs/canonical_state/Cargo.toml
@@ -18,7 +18,7 @@ ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-types = { path = "../types/types" }
 ic-types-cycles = { path = "../types/cycles" }
-leb128 = "0.2.1"
+leb128 = { workspace = true }
 phantom_newtype = { path = "../phantom_newtype" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/rs/canonical_state/tree_hash/Cargo.toml
+++ b/rs/canonical_state/tree_hash/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 ic-crypto-tree-hash = { path = "../../crypto/tree_hash" }
 ic-utils = { path = "../../utils" }
 itertools = { workspace = true }
-leb128 = "0.2.1"
+leb128 = { workspace = true }
 scoped_threadpool = "0.1.*"
 thiserror = { workspace = true }
 

--- a/rs/certification/Cargo.toml
+++ b/rs/certification/Cargo.toml
@@ -23,7 +23,7 @@ ic-base-types = { path = "../types/base_types" }
 ic-certification-test-utils = { path = "test-utils" }
 ic-crypto-internal-types = { path = "../crypto/internal/crypto_lib/types" }
 ic-crypto-test-utils-reproducible-rng = { path = "../crypto/test_utils//reproducible_rng" }
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 

--- a/rs/certification/test-utils/Cargo.toml
+++ b/rs/certification/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ ic-crypto-internal-types = { path = "../../crypto/internal/crypto_lib/types" }
 ic-crypto-tree-hash = { path = "../../crypto/tree_hash" }
 ic-crypto-utils-threshold-sig-der = { path = "../../crypto/utils/threshold_sig_der" }
 ic-types = { path = "../../types/types" }
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/test_utils/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 assert_matches = { workspace = true }
 ed25519-dalek = { workspace = true }
 bitcoin = { workspace = true }
-hex = "0.4"
+hex = { workspace = true }
 secp256k1 = { workspace = true }
 ic-crypto-internal-threshold-sig-canister-threshold-sig = { path = ".." }
 ic-crypto-sha2 = { path = "../../../../../sha2" }

--- a/rs/ethereum/cketh/minter/Cargo.toml
+++ b/rs/ethereum/cketh/minter/Cargo.toml
@@ -44,7 +44,7 @@ num-bigint = { workspace = true }
 num-traits = { workspace = true }
 phantom_newtype = { path = "../../../phantom_newtype" }
 rlp = "0.5.2"
-scopeguard = "1.1.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/ethereum/ledger-suite-orchestrator/Cargo.toml
+++ b/rs/ethereum/ledger-suite-orchestrator/Cargo.toml
@@ -32,7 +32,7 @@ ic-stable-structures = { workspace = true }
 ic0 = { workspace = true }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 num-traits = { workspace = true }
-scopeguard = "1.1.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/ic_os/build_tools/partition_tools/Cargo.toml
+++ b/rs/ic_os/build_tools/partition_tools/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 gpt = { workspace = true }
 tar = { workspace = true }
-indoc = "1.0.9"
+indoc = { workspace = true }
 itertools = { workspace = true }
 pcre2 = "0.2.6"
 tempfile = { workspace = true }

--- a/rs/ic_os/config/tool/Cargo.toml
+++ b/rs/ic_os/config/tool/Cargo.toml
@@ -14,7 +14,7 @@ utils = { path = "../../utils" }
 url = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
-serde_with = "1.6.2"
+serde_with = { workspace = true }
 regex = { workspace = true }
 ic-config = { path = "../../../config" }
 config_types = { path = "../types" }

--- a/rs/ic_os/metrics/nft_exporter/Cargo.toml
+++ b/rs/ic_os/metrics/nft_exporter/Cargo.toml
@@ -9,4 +9,4 @@ clap = { workspace = true }
 ic-os-metrics-utils = { path = "../utils" }
 prometheus = { workspace = true }
 serde = { workspace = true }
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/rs/ic_os/networking/network/Cargo.toml
+++ b/rs/ic_os/networking/network/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = { workspace = true }
 config_types = { path = "../../config/types" }
 deterministic_ips = { path = "../deterministic_ips" }
 macaddr = { workspace = true }
-ping = { version = "^0.5.0" }
+ping = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 utils = { path = "../../utils" }

--- a/rs/ic_os/sev/attestation/Cargo.toml
+++ b/rs/ic_os/sev/attestation/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["custom"] }
+getrandom = { workspace = true, features = ["custom"] }
 
 [dev-dependencies]
 attestation_testing = { path = "testing" }

--- a/rs/ic_os/vsock/vsock_lib/Cargo.toml
+++ b/rs/ic_os/vsock/vsock_lib/Cargo.toml
@@ -19,4 +19,4 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 vsock = "0.4"
 ic-http-utils = { path = "../../../http_utils" }
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }

--- a/rs/ledger_suite/icp/Cargo.toml
+++ b/rs/ledger_suite/icp/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-comparable = { version = "0.5", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 crc32fast = "1.2.0"
 dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 hex = { workspace = true }

--- a/rs/ledger_suite/icp/index/Cargo.toml
+++ b/rs/ledger_suite/icp/index/Cargo.toml
@@ -26,7 +26,7 @@ ic-stable-structures = { workspace = true }
 icp-ledger = { path = ".." }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 num-traits = { workspace = true }
-scopeguard = "1.1.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/ledger_suite/icrc1/index-ng/Cargo.toml
+++ b/rs/ledger_suite/icrc1/index-ng/Cargo.toml
@@ -29,7 +29,7 @@ ic-metrics-encoder = "1.1"
 ic-stable-structures = { workspace = true }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 num-traits = { workspace = true }
-scopeguard = "1.1.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/rs/ledger_suite/icrc1/test_utils/Cargo.toml
+++ b/rs/ledger_suite/icrc1/test_utils/Cargo.toml
@@ -24,4 +24,4 @@ rand_chacha = { workspace = true }
 rosetta-core = { path = "../../../rosetta-api/common/rosetta_core" }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-strum = "0.26.3"
+strum = { workspace = true }

--- a/rs/nervous_system/clients/Cargo.toml
+++ b/rs/nervous_system/clients/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 candid = { workspace = true }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-cdk = { workspace = true }
-ic-xrc-types = "1.0.0"
+ic-xrc-types = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-error-types = { path = "../../../packages/ic-error-types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }

--- a/rs/nervous_system/initial_supply/Cargo.toml
+++ b/rs/nervous_system/initial_supply/Cargo.toml
@@ -13,7 +13,7 @@ ic-base-types = { path = "../../types/base_types" }
 ic-nervous-system-runtime = { path = "../runtime" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 lazy_static = { workspace = true }
-num-bigint = "0.4"
+num-bigint = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/rs/nervous_system/instruction_stats_update_attribute/Cargo.toml
+++ b/rs/nervous_system/instruction_stats_update_attribute/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-quote = "1"
+quote = { workspace = true }
 syn = { workspace = true }
 
 [dev-dependencies]

--- a/rs/nervous_system/proto/Cargo.toml
+++ b/rs/nervous_system/proto/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-comparable = { version = "0.5.1", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 ic-base-types = { path = "../../types/base_types" }
 prost = { workspace = true }
 rust_decimal = "1.36.0"

--- a/rs/nervous_system/query_instruction_logger/Cargo.toml
+++ b/rs/nervous_system/query_instruction_logger/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-quote = "1"
+quote = { workspace = true }
 syn = { workspace = true }
 
 [dev-dependencies]

--- a/rs/nns/common/Cargo.toml
+++ b/rs/nns/common/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 candid = { workspace = true }
-comparable = { version = "0.5", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 ic-base-types = { path = "../../types/base_types" }
 ic-cdk = { workspace = true }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -62,7 +62,7 @@ ic-nervous-system-timers = { path = "../../nervous_system/timers" }
 ic-neurons-fund = { path = "../../nervous_system/neurons_fund" }
 ic-nns-common = { path = "../common" }
 ic-nns-constants = { path = "../constants" }
-ic-xrc-types = "1.0.0"
+ic-xrc-types = { workspace = true }
 ic-nns-governance-api = { path = "./api" }
 ic-nns-governance-conversions = { path = "./conversions" }
 ic-nns-governance-derive-self-describing = { path = "./derive_self_describing" }
@@ -97,7 +97,7 @@ rand_chacha = { workspace = true }
 registry-canister = { path = "../../registry/canister" }
 strum_macros = { workspace = true }
 strum = { workspace = true }
-comparable = { version = "0.5", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 canbench-rs = { workspace = true, optional = true }
 
 local_key = { path = "../../tla_instrumentation/local_key", optional = true }
@@ -105,7 +105,7 @@ tla_instrumentation = { path = "../../tla_instrumentation/tla_instrumentation", 
 tla_instrumentation_proc_macros = { path = "../../tla_instrumentation/tla_instrumentation_proc_macros", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-csv = "1.1"
+csv = { workspace = true }
 ic-nervous-system-common-test-keys = { path = "../../nervous_system/common/test_keys" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/rs/nns/governance/init/Cargo.toml
+++ b/rs/nns/governance/init/Cargo.toml
@@ -21,4 +21,4 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-csv = "1.1"
+csv = { workspace = true }

--- a/rs/orchestrator/Cargo.toml
+++ b/rs/orchestrator/Cargo.toml
@@ -57,7 +57,7 @@ ic-registry-replicator = { path = "./registry_replicator" }
 ic-sys = { path = "../sys" }
 ic-types = { path = "../types/types" }
 idna = { workspace = true }
-indoc = "1.0.9"
+indoc = { workspace = true }
 mockall = { workspace = true }
 nix = { workspace = true }
 prometheus = { workspace = true }

--- a/rs/prep/Cargo.toml
+++ b/rs/prep/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-fs_extra = "1.2.0"
+fs_extra = { workspace = true }
 ic-config = { path = "../config" }
 ic-limits = { path = "../limits" }
 ic-crypto-node-key-generation = { path = "../crypto/node_key_generation" }

--- a/rs/registry/admin/Cargo.toml
+++ b/rs/registry/admin/Cargo.toml
@@ -56,7 +56,7 @@ ic-registry-transport = { path = "../transport" }
 ic-sns-init = { path = "../../sns/init" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }
 ic-types = { path = "../../types/types" }
-indexmap = "2.2.6"                                                                        # TODO: consider using the std's BTreeMap instead
+indexmap = { workspace = true }                                                           # TODO: consider using the std's BTreeMap instead
 itertools = { workspace = true }
 maplit = "1.0.2"
 pretty_assertions = { workspace = true }

--- a/rs/registry/canister-client/Cargo.toml
+++ b/rs/registry/canister-client/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-futures = "0.3.31"
+futures = { workspace = true }
 ic-cdk = { workspace = true }
 ic-interfaces-registry = { path = "../../interfaces/registry" }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -52,9 +52,9 @@ ic-stable-structures = { workspace = true }
 ic-types = { path = "../../types/types" }
 ic-nervous-system-time-helpers = { path = "../../nervous_system/time_helpers" }
 idna = { workspace = true }
-ipnet = "2.5.0"
+ipnet = { workspace = true }
 lazy_static = { workspace = true }
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 maplit = "1.0.2"
 on_wire = { path = "../../rust_canisters/on_wire" }
 prost = { workspace = true }
@@ -67,7 +67,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["custom"] }
+getrandom = { workspace = true, features = ["custom"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 assert_matches = { workspace = true }

--- a/rs/registry/nns_data_provider/Cargo.toml
+++ b/rs/registry/nns_data_provider/Cargo.toml
@@ -33,7 +33,7 @@ ic-nervous-system-agent = { path = "../../nervous_system/agent" }
 ic-nervous-system-chunks = { path = "../../nervous_system/chunks" }
 ic-nervous-system-integration-tests = { path = "../../nervous_system/integration_tests" }
 ic-nns-test-utils = { path = "../../nns/test_utils" }
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 pretty_assertions = { workspace = true }
 tokio = { workspace = true }

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -39,7 +39,7 @@ num-traits = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-rolling-file = "0.2.0"
+rolling-file = { workspace = true }
 rosetta-core = { path = "../common/rosetta_core" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 tokio-rusqlite = "0.7"

--- a/rs/rust_canisters/stable_memory_integrity/Cargo.toml
+++ b/rs/rust_canisters/stable_memory_integrity/Cargo.toml
@@ -15,7 +15,7 @@ ic-cdk = { workspace = true }
 ic-state-machine-tests = { path = "../../state_machine_tests" }
 ic-types = { path = "../../types/types" }
 ic-types-cycles = { path = "../../types/cycles" }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 proptest = { workspace = true }
 serde = { workspace = true }
 

--- a/rs/sns/audit/Cargo.toml
+++ b/rs/sns/audit/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 candid = { workspace = true }
 colored = "2.0.0"
-csv = "1.1"
+csv = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-nervous-system-agent = { path = "../../nervous_system/agent" }

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -32,7 +32,7 @@ base64 = { workspace = true }
 candid = { workspace = true }
 candid-utils = { path = "../../nervous_system/candid_utils" }
 clap = { workspace = true }
-comparable = { version = "0.5", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }

--- a/rs/sns/governance/api/Cargo.toml
+++ b/rs/sns/governance/api/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 bytes = { workspace = true }
 candid = { workspace = true }
 clap = { workspace = true }
-comparable = { version = "0.5", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 ic-base-types = { path = "../../../types/base_types" }
 ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-nns-common = { path = "../../../nns/common" }

--- a/rs/sns/root/Cargo.toml
+++ b/rs/sns/root/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = { workspace = true }
 build-info = { workspace = true }
 
 candid = { workspace = true }
-comparable = { version = "0.5.1", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-canister-log = { path = "../../rust_canisters/canister_log" }

--- a/rs/sns/swap/Cargo.toml
+++ b/rs/sns/swap/Cargo.toml
@@ -22,7 +22,7 @@ build-info = { workspace = true }
 
 async-trait = { workspace = true }
 candid = { workspace = true }
-comparable = { version = "0.5.1", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-canister-log = { path = "../../rust_canisters/canister_log" }

--- a/rs/sns/swap/proto_library/Cargo.toml
+++ b/rs/sns/swap/proto_library/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-comparable = { version = "0.5.1", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 ic-base-types = { path = "../../../types/base_types" }
 ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-utils = { path = "../../../utils" }

--- a/rs/sns/treasury_manager/mock/Cargo.toml
+++ b/rs/sns/treasury_manager/mock/Cargo.toml
@@ -16,4 +16,4 @@ sns-treasury-manager = { path = "../../treasury_manager" }
 ic-canister-log = "0.2.0"
 
 [dev-dependencies]
-candid_parser = "0.1.2"
+candid_parser = { workspace = true }

--- a/rs/tests/consensus/utils/Cargo.toml
+++ b/rs/tests/consensus/utils/Cargo.toml
@@ -29,7 +29,7 @@ ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
 ic-system-test-driver = { path = "../../driver" }
 ic-types = { path = "../../../types/types" }
 ic_consensus_threshold_sig_system_test_utils = { path = "../tecdsa/utils" }
-leb128 = "0.2.5"
+leb128 = { workspace = true }
 openssh-keys = "0.5.0"
 prost = { workspace = true }
 rand = { workspace = true }

--- a/rs/tests/driver/Cargo.toml
+++ b/rs/tests/driver/Cargo.toml
@@ -85,7 +85,7 @@ lazy_static = { workspace = true }
 libc = { workspace = true }
 macaddr = { workspace = true }
 nix = { workspace = true }
-num_cpus = "1.13.1"
+num_cpus = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 phantom_newtype = { path = "../../phantom_newtype" }
 rand = { workspace = true }
@@ -94,7 +94,7 @@ rcgen = { workspace = true }
 regex = { workspace = true }
 registry-canister = { path = "../../registry/canister" }
 reqwest = { workspace = true }
-ring = { version = "0.17.7", features = ["std"] }
+ring = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/tests/node/Cargo.toml
+++ b/rs/tests/node/Cargo.toml
@@ -16,7 +16,7 @@ ic-registry-canister-api = { path = "../../registry/canister/api" }
 ic-registry-subnet-type = { path = "../../registry/subnet_type" }
 ic_consensus_system_test_utils = { path = "../consensus/utils" }
 ic-system-test-driver = { path = "../driver" }
-indoc = "1.0.9"
+indoc = { workspace = true }
 nested = { path = "../nested" }
 k256 = { workspace = true }
 registry-canister = { path = "../../registry/canister" }

--- a/rs/tree_deserializer/Cargo.toml
+++ b/rs/tree_deserializer/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 ic-crypto-tree-hash = { path = "../crypto/tree_hash" }
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/rs/types/base_types/Cargo.toml
+++ b/rs/types/base_types/Cargo.toml
@@ -11,7 +11,7 @@ arbitrary = { workspace = true, optional = true }
 byte-unit = "4.0.14"
 bytes = { workspace = true }
 candid = { workspace = true }
-comparable = { version = "0.5.1", features = ["derive"] }
+comparable = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-heap-bytes = { path = "../../../packages/ic-heap-bytes" }

--- a/rs/validator/ingress_message/Cargo.toml
+++ b/rs/validator/ingress_message/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-getrandom = { version = "0.2", optional = true }
+getrandom = { workspace = true, optional = true }
 hex = { workspace = true }
 ic-crypto-interfaces-sig-verification = { path = "../../crypto/interfaces/sig_verification" }
 ic-crypto-standalone-sig-verifier = { path = "../../crypto/standalone-sig-verifier" }


### PR DESCRIPTION
This edits all Cargo.tomls to use the (top-level) workspace crates whenever instead of locally defined ones, whenever the versions are the same. This prevents version drift in the future if the workspace crates are updated, while at the same time keeping the same version that is currently in use (i.e. local crates that differ in version with the workspace are left untouched for now). This is basically a no-op.