### PR TITLE
chore: move all crate definitions into workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -613,19 +613,27 @@ axum-extra = { version = "0.10.1", features = ["typed-header"] }
 axum-server = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 backoff = "0.4"
 base64 = { version = "0.13.1" }
+bech32 = "^0.9.0"
 bincode = "1.3.3"
+bip32 = "0.5.0"
+bit-vec = "^0.6.3"
 bitcoin = { package = "bitcoin-dogecoin", version = "0.32.7-doge.0", features = [
     "default",
     "rand",
     "serde",
 ] }
 # build-info and build-info-build MUST be kept in sync!
+bs58 = "^0.5.0"
 build-info = { git = "https://github.com/dfinity-lab/build-info", rev = "701a696844fba5c87df162fbbc1ccef96f27c9d7" }
 build-info-build = { git = "https://github.com/dfinity-lab/build-info", rev = "701a696844fba5c87df162fbbc1ccef96f27c9d7", default-features = false }
+by_address = "^1.1.0"
+byteorder = "^1.3.4"
 bytes = "1.9.0"
+cached = { version = "0.49", default-features = false }
 canbench-rs = "0.6.0"
 candid = { version = "0.10.31" }
 candid_parser = { version = "0.1.2" }
+cargo_metadata = "^0.14.2"
 chrono = { version = "0.4.42", default-features = false, features = [
     "alloc",
     "clock",
@@ -633,7 +641,9 @@ chrono = { version = "0.4.42", default-features = false, features = [
 ] }
 ciborium = "0.2.1"
 clap = { version = "4.5.20", features = ["derive", "string"] }
+colored = "^2.0.0"
 comparable = { version = "0.5", features = ["derive"] }
+crc32fast = "^1.2.0"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 crossbeam-channel = "0.5.15"
 csv = "^1.1"
@@ -641,6 +651,8 @@ curve25519-dalek = { version = "4.1.3", features = [
     "group",
     "precomputed-tables",
 ] }
+cvt = "^0.1.1"
+darling = "^0.20.11"
 der = { version = "0.7", default-features = false, features = ["derive"] }
 derive-new = "0.7.0"
 devicemapper = "0.34"
@@ -653,6 +665,8 @@ ed25519-dalek = { version = "2.2.0", features = [
     "pem",
     "hazmat",
 ] }
+escargot = "0.5.7"
+ethers-core = "^2.0.7"
 ethnum = { version = "1.5.3", features = ["serde"] }
 evm_rpc_client = "0.4.0"
 evm_rpc_types = "3.1.0"
@@ -665,8 +679,10 @@ getrandom = { version = "0.2", features = ["custom"] }
 goldenfile = "1.8.0"
 gpt = "4.1"
 hex = { version = "0.4.3", features = ["serde"] }
+hex-literal = "^0.4.1"
 hickory-resolver = "0.26.1"
 hkdf = "^0.12"
+hmac = "^0.12"
 http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
@@ -682,6 +698,9 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = [
 ] }
 hyper-socks2 = { version = "0.9.1", default-features = false }
 hyper-util = { version = "0.1.12", features = ["full"] }
+ic-canister-log = "^0.2.0"
+ic-certified-map = "^0.3.1"
+ic-metrics-encoder = "^1.1.1"
 ic0 = "1.0.0"
 ic-agent = { version = "0.49.0", features = ["pem"] }
 ic-bn-lib = { version = "0.2.3", features = ["acme-alpn"] }
@@ -717,6 +736,7 @@ ic_bls12_381 = { version = "0.10.1", default-features = false, features = [
 ic_principal = { version = "0.1.1", default-features = false }
 idna = "1.0.2"
 indexmap = "2.10.0"
+indicatif = "^0.17.3"
 indoc = "1.0.9"
 inferno = "0.12.0"
 inotify = { version = "0.11.2", default-features = false, features = [
@@ -724,6 +744,7 @@ inotify = { version = "0.11.2", default-features = false, features = [
 ] }
 ipnet = { version = "2.10.1", features = ["serde"] }
 itertools = "0.12.0"
+json5 = "^0.4.1"
 jsonrpc = "0.18.0"
 k256 = { version = "0.13.4", default-features = false, features = [
     "arithmetic",
@@ -739,6 +760,7 @@ leb128 = "0.2.5"
 libc = "0.2.158"
 libcryptsetup-rs = "0.15"
 libflate = "2.1.0"
+libfuzzer-sys = "0.4.7"
 libnss = "0.5.0"
 lmdb-rkv = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "64eb770caa940f215190d86d61e4c132511be5e2" }
 lmdb-rkv-sys = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "64eb770caa940f215190d86d61e4c132511be5e2" }
@@ -746,6 +768,7 @@ local-ip-address = "0.5.6"
 loopdev-3 = "0.5"
 lzma-sys = { version = "0.1.20", features = ["static"] }
 macaddr = "1.0"
+maplit = "^1.0.2"
 memchr = "2.7"
 memmap2 = "0.9.5"
 minicbor = { version = "0.19.1", features = ["alloc", "derive"] }
@@ -759,6 +782,7 @@ num-bigint = "0.4.6"
 num-traits = { version = "0.2.12", features = ["libm"] }
 num_cpus = "1.16.0"
 object = "0.37.3"
+once_cell = "^1.8"
 opentelemetry = { version = "0.32.0", features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
     "grpc-tonic",
@@ -777,6 +801,7 @@ pairing = "0.23"
 parking_lot = "0.12.3"
 paste = "1.0.15"
 pem = { version = "^3", default-features = false, features = ["std"] }
+pin-project-lite = "^0.2"
 ping = "0.5.0"
 pkcs8 = "0.10.2"
 pprof = { git = "https://github.com/dfinity/pprof-rs", rev = "7f5228262196e3eb9c8d1ddbaca984787dea331a", default-features = false, features = [
@@ -786,6 +811,7 @@ pprof = { git = "https://github.com/dfinity/pprof-rs", rev = "7f5228262196e3eb9c
 ] }
 predicates = "3.1.2"
 pretty_assertions = "1.4.0"
+priority-queue = "1.3.1"
 proc-macro2 = "1.0.89"
 procfs = { version = "^0.17", default-features = false }
 prometheus = { version = "0.14.0", features = ["process"] }
@@ -806,6 +832,8 @@ quinn-udp = "0.5.5"
 quote = "1.0.37"
 rand = { version = "0.8.6", features = ["small_rng"] }
 rand_chacha = "0.3.1"
+rand_distr = "^0.4"
+rand_pcg = "^0.3.1"
 ratatui = "0.29"
 rayon = "1.10.0"
 rcgen = { version = "0.13.1", features = ["zeroize"] }
@@ -821,20 +849,29 @@ reqwest = { version = "0.13", default-features = false, features = [
     "socks",
     "stream",
 ] }
+rgb = "^0.8.37"
 ring = { version = "^0.17.7", features = ["std"] }
 rolling-file = "0.2.0"
 rsa = { version = "0.9.6", features = ["sha2", "getrandom"] }
 rstest = "0.19.0"
+rusqlite = "0.37.0"
 rust-ini = "0.21.1"
+rust_decimal = "^1.36.0"
+rust_decimal_macros = "^1.36.0"
 rustc-demangle = { version = "0.1.16" }
+rustc-hash = "^1.1.0"
 rustls = { version = "0.23.18", default-features = false, features = [
     "aws_lc_rs",
     "std",
     "brotli",
     "tls12",
 ] }
+rustls-pemfile = "^2.1.2"
+rusty-fork = "^0.3.0"
 schemars = { version = "0.8.21", features = ["derive"] }
+scoped_threadpool = "^0.1.9"
 scopeguard = "1.2.0"
+scraper = "^0.17.1"
 secp256k1 = { version = "0.29", features = ["global-context", "rand", "std"] }
 securefmt = "0.1.5"
 semver = { version = "1.0.9", features = ["serde"] }
@@ -860,6 +897,7 @@ slog = { version = "2.7.0", features = [
     "release_max_level_trace",
 ] }
 slog-async = { version = "2.8.0", features = ["nested-values"] }
+slog-envlogger = "^2.2.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.1"
 slotmap = "1.0.7"
@@ -875,7 +913,9 @@ sysinfo = "0.37"
 systemd = "0.10"
 tar = "0.4.39"
 tempfile = "3.20"
+textplots = "^0.8"
 thiserror = "2.0.18"
+thousands = "^0.2.0"
 threadpool = "1.8.1"
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 tikv-jemallocator = "0.7"
@@ -903,6 +943,7 @@ tower-http = { version = "0.6.4", features = [
     "compression-full",
     "tracing",
 ] }
+tower-test = "^0.4.0"
 tower_governor = "0.8.0"
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
@@ -927,12 +968,14 @@ walrus = "0.23.3"
 wasm-encoder = { version = "0.251.0", features = ["wasmparser"] }
 wasmparser = "0.251.0"
 wasmprinter = "0.251.0"
+wasmtime = { version = "45.0.0", default-features = false, features = ["cranelift", "gc", "gc-null", "parallel-compilation", "runtime"] }
 wast = "251.0.0"
 wat = "~1.251.0"
 webpki-roots = "1.0.6"
 which = "6.0.3"
 wirm = { version = "4.0.4", features = ["parallel"] }
 wsl = "0.1.0"
+wycheproof = { version = "0.6", default-features = false }
 x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
 x509-parser = { version = "0.18.1" }
 xz2 = { version = "0.1.7", features = ["static"] }

--- a/packages/canlog/Cargo.toml
+++ b/packages/canlog/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/canlog"
 [dependencies]
 candid = { workspace = true }
 canlog_derive = { version = "=0.1.0", path = "../canlog_derive", optional = true }
-ic-canister-log = "0.2.0"
+ic-canister-log = { workspace = true }
 ic0 = { workspace = true }
 regex-lite = { workspace = true }
 serde = { workspace = true }

--- a/packages/canlog_derive/Cargo.toml
+++ b/packages/canlog_derive/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/canlog"
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-darling = "0.20.11"
+darling = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/packages/ic-ed25519/Cargo.toml
+++ b/packages/ic-ed25519/Cargo.toml
@@ -13,7 +13,7 @@ documentation.workspace = true
 [dependencies]
 curve25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
-hex-literal = "0.4"
+hex-literal = { workspace = true }
 hkdf = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false }
 pem = { workspace = true }
@@ -32,7 +32,7 @@ hex = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false, features = ["convert"] }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["eddsa"] }
+wycheproof = { workspace = true, features = ["eddsa"] }
 
 [[bench]]
 name = "ed25519"

--- a/packages/ic-heap-bytes-derive/Cargo.toml
+++ b/packages/ic-heap-bytes-derive/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-darling = "0.20.11"
+darling = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["derive"] }

--- a/packages/ic-secp256k1/Cargo.toml
+++ b/packages/ic-secp256k1/Cargo.toml
@@ -13,8 +13,8 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex-literal = "0.4"
-hmac = "0.12"
+hex-literal = { workspace = true }
+hmac = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false }
 k256 = { workspace = true }
 num-bigint = { workspace = true }
@@ -26,9 +26,9 @@ sha2 = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-bip32 = "0.5"
+bip32 = { workspace = true }
 bitcoin = { workspace = true }
 hex = { workspace = true }
 ic_principal = { version = "0.1.1", default-features = false, features = ["convert"] }
 secp256k1 = { workspace = true, features = ["global-context", "std", "rand"] }
-wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }
+wycheproof = { workspace = true, features = ["ecdsa"] }

--- a/packages/ic-secp256r1/Cargo.toml
+++ b/packages/ic-secp256r1/Cargo.toml
@@ -13,7 +13,7 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hmac = "0.12"
+hmac = { workspace = true }
 num-bigint = { workspace = true }
 p256 = { workspace = true }
 pem = { workspace = true }
@@ -25,6 +25,6 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
-hex-literal = "0.4"
+hex-literal = { workspace = true }
 rand_chacha = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }
+wycheproof = { workspace = true, features = ["ecdsa"] }

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -13,7 +13,7 @@ documentation.workspace = true
 [dependencies]
 base32 = "0.4.0"
 candid = { workspace = true }
-crc32fast = "1.2.0"
+crc32fast = { workspace = true }
 hex = { workspace = true }
 ic-stable-structures = { workspace = true, optional = true }
 icrc-cbor = { path = "../icrc-cbor", version = "0.1.0" }

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -85,5 +85,5 @@ ic-registry-proto-data-provider = { path = "../../rs/registry/proto_data_provide
 ic-registry-transport = { path = "../../rs/registry/transport" }
 ic-types = { path = "../../rs/types/types" }
 ic-universal-canister = { path = "../../rs/universal_canister/lib" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 prost = { workspace = true }

--- a/rs/artifact_pool/Cargo.toml
+++ b/rs/artifact_pool/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 bincode = { workspace = true }
-byteorder = "1.3.4"
+byteorder = { workspace = true }
 clap = { workspace = true }
 ic-config = { path = "../config" }
 ic-interfaces = { path = "../interfaces" }
@@ -51,7 +51,7 @@ ic-test-utilities-time = { path = "../test_utilities/time" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 rand = { workspace = true }
 slog-async = { workspace = true }
-slog-envlogger = "2.2.0"
+slog-envlogger = { workspace = true }
 slog-term = { workspace = true }
 
 [[bench]]

--- a/rs/bitcoin/checker/Cargo.toml
+++ b/rs/bitcoin/checker/Cargo.toml
@@ -27,7 +27,7 @@ ic-canister-log = { path = "../../rust_canisters/canister_log" }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-cdk = { workspace = true }
 ic-management-canister-types = { workspace = true }
-ic-metrics-encoder = "1.1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -46,4 +46,4 @@ ic-universal-canister = { path = "../../universal_canister/lib" }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 proptest = { workspace = true }
 tokio = { workspace = true }
-scraper = "0.17.1"
+scraper = { workspace = true }

--- a/rs/bitcoin/ckbtc/minter/Cargo.toml
+++ b/rs/bitcoin/ckbtc/minter/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = { workspace = true }
-bech32 = "0.9.0"
-bs58 = "0.5.0"
+bech32 = { workspace = true }
+bs58 = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }
 canlog = { path = "../../../../packages/canlog" }
@@ -31,7 +31,7 @@ ic-icrc1 = { path = "../../../ledger_suite/icrc1" }
 ic-ledger-core = { path = "../../../ledger_suite/common/ledger_core" }
 ic-management-canister-types = { workspace = true }
 ic-management-canister-types-private = { path = "../../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-secp256k1 = { path = "../../../../packages/ic-secp256k1" }
 ic-stable-structures = { workspace = true }
 ic-utils-ensure = { path = "../../../utils/ensure" }
@@ -64,7 +64,7 @@ ic-state-machine-tests = { path = "../../../state_machine_tests" }
 ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
 ic-types-cycles = { path = "../../../types/cycles" }
 ic-types = { path = "../../../types/types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = { workspace = true }
 pocket-ic = { path = "../../../../packages/pocket-ic" }
 proptest = { workspace = true }

--- a/rs/bitcoin/mock/Cargo.toml
+++ b/rs/bitcoin/mock/Cargo.toml
@@ -7,7 +7,7 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-bech32 = "0.9.0"
+bech32 = { workspace = true }
 candid = { workspace = true }
 ic-btc-interface = { workspace = true }
 ic-cdk = { workspace = true }

--- a/rs/canister_sandbox/Cargo.toml
+++ b/rs/canister_sandbox/Cargo.toml
@@ -32,7 +32,7 @@ memory_tracker = { path = "../memory_tracker" }
 nix = { workspace = true }
 num-traits = { workspace = true }
 object = { workspace = true, optional = true }
-once_cell = "1.8"
+once_cell = { workspace = true }
 prometheus = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/rs/canonical_state/Cargo.toml
+++ b/rs/canonical_state/Cargo.toml
@@ -40,7 +40,7 @@ ic-test-utilities-types = { path = "../test_utilities/types" }
 ic-utils = { path = "../utils" }
 ic-wasm-types = { path = "../types/wasm_types" }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 test-strategy = "0.4.0"

--- a/rs/canonical_state/tree_hash/Cargo.toml
+++ b/rs/canonical_state/tree_hash/Cargo.toml
@@ -11,7 +11,7 @@ ic-crypto-tree-hash = { path = "../../crypto/tree_hash" }
 ic-utils = { path = "../../utils" }
 itertools = { workspace = true }
 leb128 = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/rs/config/Cargo.toml
+++ b/rs/config/Cargo.toml
@@ -13,7 +13,7 @@ ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-sys = { path = "../sys" }
 ic-types-cycles = { path = "../types/cycles" }
 ic-types = { path = "../types/types" }
-json5 = "0.4.1"
+json5 = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 

--- a/rs/consensus/Cargo.toml
+++ b/rs/consensus/Cargo.toml
@@ -77,7 +77,7 @@ prost = { workspace = true }
 rstest = { workspace = true }
 serde_cbor = { workspace = true }
 slog-async = { workspace = true }
-slog-envlogger = "2.2.0"
+slog-envlogger = { workspace = true }
 slog-term = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/cross-chain/blob_store/Cargo.toml
+++ b/rs/cross-chain/blob_store/Cargo.toml
@@ -31,4 +31,4 @@ time = { workspace = true }
 assert_matches = { workspace = true }
 candid_parser = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
-scraper = "0.17.1"
+scraper = { workspace = true }

--- a/rs/cross-chain/proposal-cli/Cargo.toml
+++ b/rs/cross-chain/proposal-cli/Cargo.toml
@@ -13,7 +13,7 @@ candid_parser = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,4 +26,4 @@ url = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }

--- a/rs/crypto/Cargo.toml
+++ b/rs/crypto/Cargo.toml
@@ -94,7 +94,7 @@ ic-test-utilities-registry = { path = "../test_utilities/registry" }
 ic-test-utilities-time = { path = "../test_utilities/time" }
 ic-types-test-utils = { path = "../types/types_test_utils" }
 k256 = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256k1/Cargo.toml
@@ -22,4 +22,4 @@ hex = { workspace = true }
 ic-crypto-sha2 = { path = "../../../../sha2" }
 ic-crypto-test-utils-reproducible-rng = { path = "../../../../test_utils/reproducible_rng" }
 rand = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }
+wycheproof = { workspace = true, features = ["ecdsa"] }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ecdsa_secp256r1/Cargo.toml
@@ -22,4 +22,4 @@ assert_matches = { workspace = true }
 hex = { workspace = true }
 ic-crypto-sha2 = { path = "../../../../sha2" }
 ic-crypto-test-utils-reproducible-rng = { path = "../../../../test_utils/reproducible_rng" }
-wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }
+wycheproof = { workspace = true, features = ["ecdsa"] }

--- a/rs/crypto/internal/crypto_lib/basic_sig/ed25519/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/ed25519/Cargo.toml
@@ -28,4 +28,4 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_cbor = { workspace = true }
 strum = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["eddsa"] }
+wycheproof = { workspace = true, features = ["eddsa"] }

--- a/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/basic_sig/rsa_pkcs1/Cargo.toml
@@ -21,4 +21,4 @@ simple_asn1 = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["rsa_sig"] }
+wycheproof = { workspace = true, features = ["rsa_sig"] }

--- a/rs/crypto/internal/crypto_lib/bls12_381/type/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/bls12_381/type/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cached = { version = "0.49", default-features = false }
+cached = { workspace = true }
 hex = { workspace = true }
 ic_bls12_381 = { workspace = true }
 itertools = { workspace = true }

--- a/rs/crypto/internal/crypto_lib/hmac/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/hmac/Cargo.toml
@@ -11,4 +11,4 @@ ic-crypto-sha2 = { path = "../../../sha2" }
 
 [dev-dependencies]
 hex = { workspace = true }
-wycheproof = { version = "0.6", default-features = false, features = ["hkdf", "mac"] }
+wycheproof = { workspace = true, features = ["hkdf", "mac"] }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-cached = { version = "0.49", default-features = false }
+cached = { workspace = true }
 hex = { workspace = true }
 ic-crypto-internal-bls12-381-type = { path = "../../bls12_381/type" }
 ic-crypto-internal-seed = { path = "../../seed" }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/Cargo.toml
@@ -13,7 +13,7 @@ curve25519-dalek = { workspace = true }
 fe-derive = { path = "fe-derive" }
 group = "0.13"
 hex = { workspace = true }
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }
 ic-crypto-internal-hmac = { path = "../../hmac" }
 ic-crypto-internal-seed = { path = "../../seed" }
 ic-crypto-internal-types = { path = "../../types" }
@@ -34,7 +34,7 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-bip32 = { version = "0.5", features = ["secp256k1"] }
+bip32 = { workspace = true, features = ["secp256k1"] }
 criterion = { workspace = true }
 ed25519-dalek = { workspace = true }
 ic-crypto-internal-threshold-sig-canister-threshold-sig-test-utils = { path = "test_utils" }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/fuzz/Cargo.toml
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 
 [dependencies]
 hex = { workspace = true }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { workspace = true }
 num-bigint = { workspace = true }
 subtle = { workspace = true }
 

--- a/rs/crypto/tls_interfaces/Cargo.toml
+++ b/rs/crypto/tls_interfaces/Cargo.toml
@@ -18,5 +18,5 @@ x509-parser = { workspace = true }
 assert_matches = { workspace = true }
 ic-crypto-test-utils-reproducible-rng = { path = "../test_utils/reproducible_rng" }
 ic-crypto-test-utils-tls = { path = "../test_utils/tls" }
-json5 = "0.4.1"
-maplit = "1.0"
+json5 = { workspace = true }
+maplit = { workspace = true }

--- a/rs/crypto/tree_hash/Cargo.toml
+++ b/rs/crypto/tree_hash/Cargo.toml
@@ -19,7 +19,7 @@ assert_matches = { workspace = true }
 criterion = { workspace = true }
 ic-crypto-test-utils-reproducible-rng = { path = "../test_utils/reproducible_rng" }
 ic-crypto-tree-hash-test-utils = { path = "test_utils" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 proptest = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/rs/crypto/tree_hash/fuzz/Cargo.toml
+++ b/rs/crypto/tree_hash/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ ic-canonical-state-tree-hash-test-utils = { path = "../../../canonical_state/tre
 ic-crypto-tree-hash = { path = ".." }
 ic-crypto-tree-hash-fuzz-check-witness-equality-utils = { path = "check_witness_equality_utils" }
 ic-protobuf = { path = "../../../protobuf" }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 

--- a/rs/depcheck/Cargo.toml
+++ b/rs/depcheck/Cargo.toml
@@ -6,4 +6,4 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo_metadata = "0.14.2"
+cargo_metadata = { workspace = true }

--- a/rs/dogecoin/ckdoge/minter/Cargo.toml
+++ b/rs/dogecoin/ckdoge/minter/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = { workspace = true }
 bitcoin = {workspace = true}
-bs58 = "0.5.0"
+bs58 = { workspace = true }
 candid = { workspace = true }
 candid_parser = { workspace = true }
 ciborium = { workspace = true }

--- a/rs/embedders/Cargo.toml
+++ b/rs/embedders/Cargo.toml
@@ -48,13 +48,7 @@ slog-term = { workspace = true }
 tempfile = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
-wasmtime = { version = "45.0.0", default-features = false, features = [
-    'cranelift',
-    'gc',
-    'gc-null',
-    'parallel-compilation',
-    'runtime',
-] }
+wasmtime = { workspace = true }
 wirm = { workspace = true }
 
 # Wasmtime depends on 0.4.2 but specifies 0.4.1 in the toml file.
@@ -77,7 +71,7 @@ ic-test-utilities-state = { path = "../test_utilities/state" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 insta = "1.8.0"
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 more-asserts = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }

--- a/rs/embedders/fuzz/Cargo.toml
+++ b/rs/embedders/fuzz/Cargo.toml
@@ -31,20 +31,14 @@ ic-types = { path = "../../types/types" }
 ic-types-cycles = { path = "../../types/cycles" }
 ic-wasm-types = { path = "../../types/wasm_types" }
 lazy_static = { workspace = true }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { workspace = true }
 num-traits = { workspace = true }
 tokio = { workspace = true }
 wasm-encoder = { workspace = true }
 wasm-smith = { version = "0.243.0", features = ["wasmparser"] }
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasmtime = { version = "45.0.0", default-features = false, features = [
-    'cranelift',
-    'gc',
-    'gc-null',
-    'parallel-compilation',
-    'runtime',
-] }
+wasmtime = { workspace = true }
 
 [features]
 fuzzing_code = []

--- a/rs/ethereum/cketh/minter/Cargo.toml
+++ b/rs/ethereum/cketh/minter/Cargo.toml
@@ -23,15 +23,15 @@ evm_rpc_client = { workspace = true }
 evm_rpc_types = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-hex-literal = "0.4.1"
-ic-canister-log = "0.2.0"
+hex-literal = { workspace = true }
+ic-canister-log = { workspace = true }
 ic-canister-runtime = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-http-types = { path = "../../../../packages/ic-http-types" }
 ic-ethereum-types = { path = "../../../../packages/ic-ethereum-types" }
 ic-management-canister-types-private = { path = "../../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-secp256k1 = { path = "../../../../packages/ic-secp256k1" }
 ic-sha3 = { workspace = true }
 ic-stable-structures = { workspace = true }
@@ -51,13 +51,13 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
-thousands = "0.2"
+thousands = { workspace = true }
 time = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 candid_parser = { workspace = true }
-ethers-core = "2.0.8"
+ethers-core = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true }
 ic-agent = { workspace = true }
@@ -67,11 +67,11 @@ ic-config = { path = "../../../config" }
 ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/reproducible_rng" }
 ic-ledger-suite-orchestrator-test-utils = { path = "../../ledger-suite-orchestrator/test_utils" }
 ic-state-machine-tests = { path = "../../../state_machine_tests" }
-maplit = "1"
+maplit = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-scraper = "0.17.1"
+scraper = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/rs/ethereum/cketh/test_utils/Cargo.toml
+++ b/rs/ethereum/cketh/test_utils/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 [dependencies]
 assert_matches = { workspace = true }
 candid = { workspace = true }
-ethers-core = "2.0.8"
+ethers-core = { workspace = true }
 evm_rpc_types = { workspace = true }
 hex = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }

--- a/rs/ethereum/ledger-suite-orchestrator/Cargo.toml
+++ b/rs/ethereum/ledger-suite-orchestrator/Cargo.toml
@@ -18,7 +18,7 @@ ciborium = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
-ic-canister-log = "0.2.0"
+ic-canister-log = { workspace = true }
 ic-cdk = { workspace = true }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-ethereum-types = { path = "../../../packages/ic-ethereum-types" }
@@ -27,7 +27,7 @@ ic-icrc1-index-ng = { path = "../../ledger_suite/icrc1/index-ng" }
 ic-icrc1-ledger = { path = "../../ledger_suite/icrc1/ledger" }
 ic-management-canister-types = { workspace = true }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 ic0 = { workspace = true }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
@@ -44,9 +44,9 @@ candid_parser = { workspace = true }
 ic-crypto-test-utils-reproducible-rng = { path = "../../crypto/test_utils/reproducible_rng" }
 ic-ledger-suite-orchestrator-test-utils = { path = "test_utils" }
 ic-state-machine-tests = { path = "../../state_machine_tests" }
-maplit = "1"
+maplit = { workspace = true }
 mockall = { workspace = true }
 paste = { workspace = true }
 proptest = { workspace = true }
-scraper = "0.17.1"
+scraper = { workspace = true }
 tokio = { workspace = true }

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -46,7 +46,7 @@ num-traits = { workspace = true }
 phantom_newtype = { path = "../phantom_newtype" }
 prometheus = { workspace = true }
 rand = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 slog = { workspace = true }
@@ -82,7 +82,7 @@ ic-universal-canister = { path = "../universal_canister/lib" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 libflate = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 proptest = { workspace = true }
 regex-lite = { workspace = true }
 rstest = { workspace = true }
@@ -92,7 +92,7 @@ wat = { workspace = true }
 wirm = { workspace = true }
 
 [build-dependencies]
-escargot = "0.5"
+escargot = { workspace = true }
 
 [features]
 default = []

--- a/rs/http_endpoints/public/Cargo.toml
+++ b/rs/http_endpoints/public/Cargo.toml
@@ -82,7 +82,7 @@ ic-test-utilities-consensus = { path = "../../test_utilities/consensus" }
 ic-test-utilities-state = { path = "../../test_utilities/state" }
 ic-test-utilities-time = { path = "../../test_utilities/time" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
@@ -90,7 +90,7 @@ reqwest = { workspace = true }
 rstest = { workspace = true }
 rustls = { workspace = true }
 serde_bytes = { workspace = true }
-tower-test = "0.4.0"
+tower-test = { workspace = true }
 
 [features]
 fuzzing_code = []

--- a/rs/http_endpoints/xnet/Cargo.toml
+++ b/rs/http_endpoints/xnet/Cargo.toml
@@ -39,6 +39,6 @@ ic-test-utilities = { path = "../../test_utilities" }
 ic-test-utilities-logger = { path = "../../test_utilities/logger" }
 ic-test-utilities-metrics = { path = "../../test_utilities/metrics" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 prost = { workspace = true }
 reqwest = { workspace = true }

--- a/rs/https_outcalls/adapter/Cargo.toml
+++ b/rs/https_outcalls/adapter/Cargo.toml
@@ -36,9 +36,9 @@ tower = { workspace = true }
 [dev-dependencies]
 async-stream = { workspace = true }
 bytes = { workspace = true }
-once_cell = "1.13.1"
+once_cell = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = "2.1.2"
+rustls-pemfile = { workspace = true }
 rstest = { workspace = true }
 socks5-impl = { version = "0.6", features = ["tokio"] }
 tempfile = { workspace = true }

--- a/rs/https_outcalls/client/Cargo.toml
+++ b/rs/https_outcalls/client/Cargo.toml
@@ -34,4 +34,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 ic-test-utilities-time = { path = "../../test_utilities/time" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
-tower-test = "0.4.0"
+tower-test = { workspace = true }

--- a/rs/ic_os/config/tool/Cargo.toml
+++ b/rs/ic_os/config/tool/Cargo.toml
@@ -31,7 +31,7 @@ securefmt = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-once_cell = "1.8"
+once_cell = { workspace = true }
 tempfile = { workspace = true }
 url = { workspace = true }
 

--- a/rs/ledger_suite/icp/Cargo.toml
+++ b/rs/ledger_suite/icp/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 [dependencies]
 candid = { workspace = true }
 comparable = { workspace = true, features = ["derive"] }
-crc32fast = "1.2.0"
+crc32fast = { workspace = true }
 dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 hex = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
@@ -43,7 +43,7 @@ ic-nns-test-utils-golden-nns-state = { path = "../../nns/test_utils/golden_nns_s
 ic-state-machine-tests = { path = "../../state_machine_tests" }
 ic-test-utilities-compare-dirs = { path = "../../test_utilities/compare_dirs" }
 ledger-canister-protobuf-generator = { path = "./protobuf_generator" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/rs/ledger_suite/icp/archive/Cargo.toml
+++ b/rs/ledger_suite/icp/archive/Cargo.toml
@@ -14,7 +14,7 @@ ic-cdk = { workspace = true }
 ic-http-types = { path = "../../../../packages/ic-http-types" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icp-ledger = { path = "../" }
 serde = { workspace = true }

--- a/rs/ledger_suite/icp/index/Cargo.toml
+++ b/rs/ledger_suite/icp/index/Cargo.toml
@@ -21,7 +21,7 @@ ic-http-types = { path = "../../../../packages/ic-http-types" }
 ic-icrc1-index-ng = { path = "../../icrc1/index-ng" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
-ic-metrics-encoder = "1.1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icp-ledger = { path = ".." }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }

--- a/rs/ledger_suite/icp/ledger/Cargo.toml
+++ b/rs/ledger_suite/icp/ledger/Cargo.toml
@@ -26,7 +26,7 @@ ic-icrc1 = { path = "../../icrc1" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
 ic-ledger-hash-of = { path = "../../../../packages/ic-ledger-hash-of" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icp-ledger = { path = "../" }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }

--- a/rs/ledger_suite/icrc1/archive/Cargo.toml
+++ b/rs/ledger_suite/icrc1/archive/Cargo.toml
@@ -17,7 +17,7 @@ ic-icrc1-tokens-u256 = { path = "../tokens_u256", optional = true }
 ic-icrc1-tokens-u64 = { path = "../tokens_u64" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 serde = { workspace = true }

--- a/rs/ledger_suite/icrc1/index-ng/Cargo.toml
+++ b/rs/ledger_suite/icrc1/index-ng/Cargo.toml
@@ -25,7 +25,7 @@ ic-icrc1-tokens-u256 = { path = "../tokens_u256", optional = true }
 ic-icrc1-tokens-u64 = { path = "../tokens_u64" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
-ic-metrics-encoder = "1.1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 num-traits = { workspace = true }

--- a/rs/ledger_suite/icrc1/ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/ledger/Cargo.toml
@@ -29,7 +29,7 @@ ic-icrc1-tokens-u64 = { path = "../tokens_u64" }
 ic-ledger-canister-core = { path = "../../common/ledger_canister_core" }
 ic-ledger-core = { path = "../../common/ledger_core" }
 ic-ledger-hash-of = { path = "../../../../packages/ic-ledger-hash-of" }
-ic-metrics-encoder = "1.1.1"
+ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types", features = ["storable"] }
 minicbor = { workspace = true }

--- a/rs/memory_tracker/Cargo.toml
+++ b/rs/memory_tracker/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bit-vec = "0.6.3"
+bit-vec = { workspace = true }
 ic-logger = { path = "../monitoring/logger" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-sys = { path = "../sys" }

--- a/rs/messaging/Cargo.toml
+++ b/rs/messaging/Cargo.toml
@@ -60,7 +60,7 @@ ic-test-utilities-state = { path = "../test_utilities/state" }
 ic-test-utilities-time = { path = "../test_utilities/time" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 messaging-test = { path = "../rust_canisters/messaging_test" }
 messaging-test-utils = { path = "../rust_canisters/messaging_test/utils" }
 mockall = { workspace = true }

--- a/rs/migration_canister/Cargo.toml
+++ b/rs/migration_canister/Cargo.toml
@@ -17,7 +17,7 @@ ic-limits = { path = "../limits" }
 ic-stable-structures = "0.7.0"
 itertools = { workspace = true }
 ic-management-canister-types = { workspace = true }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 strum = { workspace = true }

--- a/rs/nervous_system/canisters/Cargo.toml
+++ b/rs/nervous_system/canisters/Cargo.toml
@@ -25,7 +25,7 @@ icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 mockall = { workspace = true }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 
 [dev-dependencies]
 canister-test = { path = "../../rust_canisters/canister_test" }

--- a/rs/nervous_system/collections/union_multi_map/Cargo.toml
+++ b/rs/nervous_system/collections/union_multi_map/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.0.1"
 # This section intentionally left blank.
 
 [dev-dependencies]
-maplit = "1.0.2"
+maplit = { workspace = true }

--- a/rs/nervous_system/common/Cargo.toml
+++ b/rs/nervous_system/common/Cargo.toml
@@ -13,23 +13,23 @@ path = "src/lib.rs"
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true }
-by_address = "1.1.0"
+by_address = { workspace = true }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-base-types = { path = "../../types/base_types" }
 ic-canister-log = { path = "../../rust_canisters/canister_log" }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 icp-ledger = { path = "../../ledger_suite/icp" }
 ic-stable-structures = { workspace = true }
-json5 = "0.4.1"
+json5 = { workspace = true }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
-priority-queue = "1.3.1"
+priority-queue = { workspace = true }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/rs/nervous_system/governance/Cargo.toml
+++ b/rs/nervous_system/governance/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 ic-base-types = { path = "../../types/base_types" }
 ic-stable-structures = { workspace = true }
 ic_principal = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }

--- a/rs/nervous_system/histogram/Cargo.toml
+++ b/rs/nervous_system/histogram/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = { workspace = true }
 
 [dependencies]
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/rs/nervous_system/instruction_stats/Cargo.toml
+++ b/rs/nervous_system/instruction_stats/Cargo.toml
@@ -6,6 +6,6 @@ edition = { workspace = true }
 [dependencies]
 ic-nervous-system-histogram = { path = "../histogram" }
 ic-cdk = { workspace = true }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -41,8 +41,8 @@ lifeline = { path = "../../nns/handlers/lifeline/impl" }
 pretty_assertions = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
@@ -79,9 +79,9 @@ ic-test-utilities-load-wasm = { path = "../../test_utilities/load_wasm" }
 ic-types = { path = "../../types/types" }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 ic-xrc-types = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
 registry-canister = { path = "../../registry/canister" }
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 xrc-mock = { path = "../../rust_canisters/xrc_mock" }

--- a/rs/nervous_system/linear_map/Cargo.toml
+++ b/rs/nervous_system/linear_map/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.1"
 edition = { workspace = true }
 
 [dependencies]
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }

--- a/rs/nervous_system/neurons_fund/Cargo.toml
+++ b/rs/nervous_system/neurons_fund/Cargo.toml
@@ -10,8 +10,8 @@ name = "ic_neurons_fund"
 ic-cdk = { workspace = true }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 lazy_static = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/rs/nervous_system/neurons_fund/nfplot/Cargo.toml
+++ b/rs/nervous_system/neurons_fund/nfplot/Cargo.toml
@@ -12,13 +12,13 @@ path = "src/main.rs"
 
 [dependencies]
 candid = { workspace = true }
-colored = "2.0.0"
+colored = { workspace = true }
 ic-agent = { workspace = true }
 ic-neurons-fund = { path = "../" }
 ic-sns-governance = { path = "../../../sns/governance" }
 ic-sns-swap = { path = "../../../sns/swap" }
-rgb = "0.8.37"
-rust_decimal = "1.36.0"
+rgb = { workspace = true }
+rust_decimal = { workspace = true }
 serde = { workspace = true }
-textplots = { version = "0.8" }
+textplots = { workspace = true }
 tokio = { workspace = true }

--- a/rs/nervous_system/proto/Cargo.toml
+++ b/rs/nervous_system/proto/Cargo.toml
@@ -11,7 +11,7 @@ candid = { workspace = true }
 comparable = { workspace = true, features = ["derive"] }
 ic-base-types = { path = "../../types/base_types" }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/rs/nervous_system/proxied_canister_calls_tracker/Cargo.toml
+++ b/rs/nervous_system/proxied_canister_calls_tracker/Cargo.toml
@@ -11,6 +11,6 @@ ic-base-types = { path = "../../types/base_types" }
 ic-cdk = { workspace = true }
 
 [dev-dependencies]
-maplit = "1.0.2"
+maplit = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio = { workspace = true }

--- a/rs/nervous_system/timer_task/Cargo.toml
+++ b/rs/nervous_system/timer_task/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 candid = { workspace = true }
 ic-cdk = { workspace = true }
-ic-metrics-encoder = "1.1.1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-time-helpers = { path = "../time_helpers" }
 ic-nervous-system-timers = { path = "../timers" }
 futures = { workspace = true }

--- a/rs/nervous_system/tools/release-runscript/Cargo.toml
+++ b/rs/nervous_system/tools/release-runscript/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 candid = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-colored = "2.0.0"
+colored = { workspace = true }
 futures = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }
@@ -25,7 +25,7 @@ ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
 ic-nns-common = { path = "../../../nns/common" }
 ic-nns-constants = { path = "../../../nns/constants" }
 itertools = { workspace = true }
-rgb = "0.8.37"
+rgb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 candid = { workspace = true }
-colored = "2.0.0"
+colored = { workspace = true }
 futures = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }
@@ -23,7 +23,7 @@ ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
 ic-nns-common = { path = "../../../nns/common" }
 ic-nns-constants = { path = "../../../nns/constants" }
 reqwest = { workspace = true }
-rgb = "0.8.37"
+rgb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rs/nns/cmc/Cargo.toml
+++ b/rs/nns/cmc/Cargo.toml
@@ -20,7 +20,7 @@ ic-dummy-getrandom-for-wasm = { path = "../../../packages/ic-dummy-getrandom-for
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-management-canister-types = { workspace = true }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
@@ -42,7 +42,7 @@ yansi = "0.5.0"
 
 [dev-dependencies]
 candid_parser = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 futures = { workspace = true }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 serde_bytes = { workspace = true }

--- a/rs/nns/constants/Cargo.toml
+++ b/rs/nns/constants/Cargo.toml
@@ -8,4 +8,4 @@ documentation.workspace = true
 
 [dependencies]
 ic-base-types = { path = "../../types/base_types"}
-maplit = "1.0.2"
+maplit = { workspace = true }

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -39,7 +39,7 @@ ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-limits = { path = "../../limits" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
@@ -83,13 +83,13 @@ icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = { workspace = true }
 num-traits = { workspace = true }
 prometheus-parse = { workspace = true }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 rand = { workspace = true }

--- a/rs/nns/handlers/root/impl/Cargo.toml
+++ b/rs/nns/handlers/root/impl/Cargo.toml
@@ -25,7 +25,7 @@ ic-cdk = { workspace = true }
 ic-crypto-sha2 = { path = "../../../../crypto/sha2" }
 ic-http-types = { path = "../../../../../packages/ic-http-types" }
 ic-management-canister-types-private = { path = "../../../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-clients = { path = "../../../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../../../nervous_system/common" }
 ic-nervous-system-string = { path = "../../../../nervous_system/string" }
@@ -41,7 +41,7 @@ ic-registry-keys = { path = "../../../../registry/keys" }
 ic-registry-routing-table = { path = "../../../../registry/routing_table" }
 ic-registry-transport = { path = "../../../../registry/transport" }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 on_wire = { path = "../../../../rust_canisters/on_wire" }
 prost = { workspace = true }
 registry-canister = { path = "../../../../registry/canister" }

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -102,13 +102,13 @@ ic-types = { path = "../../types/types" }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 ic-xrc-types = { workspace = true }
 itertools = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 phantom_newtype = { path = "../../phantom_newtype" }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 rand = { workspace = true }
 registry-canister = { path = "../../registry/canister" }
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/nns/sns-wasm/Cargo.toml
+++ b/rs/nns/sns-wasm/Cargo.toml
@@ -20,7 +20,7 @@ ic-cdk = { workspace = true }
 ic-crypto-sha2 = { path = "../../crypto/sha2/" }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-proto = { path = "../../nervous_system/proto" }
@@ -35,7 +35,7 @@ ic-types = { path = "../../types/types" }
 ic-utils = { path = "../../utils" }
 ic-wasm = { workspace = true }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/rs/nns/test_utils/Cargo.toml
+++ b/rs/nns/test_utils/Cargo.toml
@@ -66,7 +66,7 @@ ic-xrc-types = { workspace = true }
 icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 lifeline = { path = "../handlers/lifeline/impl" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 prometheus-parse = { workspace = true }

--- a/rs/node_rewards/canister/Cargo.toml
+++ b/rs/node_rewards/canister/Cargo.toml
@@ -22,7 +22,7 @@ ic-cdk-timers = { workspace = true }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-interfaces-registry = { path = "../../interfaces/registry" }
 ic-management-canister-types = { workspace = true }
-ic-metrics-encoder = "1.1.1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-timer-task = { path = "../../nervous_system/timer_task" }
@@ -40,7 +40,7 @@ prost = { workspace = true }
 rewards-calculation = { path = "../rewards_calculation" }
 itertools = { workspace = true }
 chrono = { workspace = true }
-rust_decimal = "1.37.1"
+rust_decimal = { workspace = true }
 
 [dev-dependencies]
 candid_parser = { workspace = true }
@@ -48,7 +48,7 @@ futures-util = { workspace = true }
 ic-nervous-system-agent = { path = "../../nervous_system/agent", features = ["test"] }
 ic-nervous-system-integration-tests = { path = "../../nervous_system/integration_tests" }
 ic-nns-test-utils = { path = "../../nns/test_utils" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/rs/node_rewards/canister/api/Cargo.toml
+++ b/rs/node_rewards/canister/api/Cargo.toml
@@ -17,4 +17,4 @@ ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-protobuf = { path = "../../../protobuf" }
 serde = { workspace = true }
 chrono = { workspace = true }
-rust_decimal = "1.37.1"
+rust_decimal = { workspace = true }

--- a/rs/node_rewards/rewards_calculation/Cargo.toml
+++ b/rs/node_rewards/rewards_calculation/Cargo.toml
@@ -16,9 +16,9 @@ ic-nns-constants = { path = "../../nns/constants" }
 itertools = { workspace = true }
 ic-protobuf = { path = "../../protobuf" }
 lazy_static = { workspace = true }
-maplit = "1.0"
-rust_decimal = "1.37.1"
-rust_decimal_macros = "1.37.1"
+maplit = { workspace = true }
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 

--- a/rs/p2p/test_utils/Cargo.toml
+++ b/rs/p2p/test_utils/Cargo.toml
@@ -34,7 +34,7 @@ ic-test-utilities-registry = { path = "../../test_utilities/registry" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
 ic-types = { path = "../../types/types" }
 mockall = { workspace = true }
-pin-project-lite = "0.2"
+pin-project-lite = { workspace = true }
 quinn = { workspace = true }
 quinn-udp = { workspace = true }
 rcgen = { workspace = true }

--- a/rs/prep/Cargo.toml
+++ b/rs/prep/Cargo.toml
@@ -35,8 +35,8 @@ ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-registry-transport = { path = "../registry/transport" }
 ic-state-manager = { path = "../state_manager" }
 ic-types = { path = "../types/types" }
-json5 = "0.4.1"
-maplit = "1.0.2"
+json5 = { workspace = true }
+maplit = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }

--- a/rs/protobuf/Cargo.toml
+++ b/rs/protobuf/Cargo.toml
@@ -22,5 +22,5 @@ slog = { workspace = true }
 hex = { workspace = true }
 ic-protobuf-generator = { path = "./generator" }
 ic-test-utilities-compare-dirs = { path = "../test_utilities/compare_dirs" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/registry/admin/Cargo.toml
+++ b/rs/registry/admin/Cargo.toml
@@ -58,7 +58,7 @@ ic-sns-wasm = { path = "../../nns/sns-wasm" }
 ic-types = { path = "../../types/types" }
 indexmap = { workspace = true }                                                           # TODO: consider using the std's BTreeMap instead
 itertools = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 pretty_assertions = { workspace = true }
 prost = { workspace = true }
 registry-canister = { path = "../canister" }

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -22,13 +22,13 @@ futures = { workspace = true }
 hex = { workspace = true }
 ic-base-types = { path = "../../types/base_types/" }
 ic-cdk = { workspace = true }
-ic-certified-map = "0.3.1"
+ic-certified-map = { workspace = true }
 ic-crypto-node-key-validation = { path = "../../crypto/node_key_validation" }
 ic-crypto-sha2 = { path = "../../crypto/sha2/" }
 ic-crypto-utils-basic-sig = { path = "../../crypto/utils/basic_sig" }
 ic-crypto-utils-ni-dkg = { path = "../../crypto/utils/ni_dkg" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-chunks = { path = "../../nervous_system/chunks" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
@@ -55,7 +55,7 @@ idna = { workspace = true }
 ipnet = { workspace = true }
 lazy_static = { workspace = true }
 leb128 = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 prost = { workspace = true }
 serde = { workspace = true }
@@ -88,7 +88,7 @@ ic-test-utilities = { path = "../../test_utilities" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 lazy_static = { workspace = true }
-rand_distr = "0.4.0"
+rand_distr = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/rs/registry/node_provider_rewards/Cargo.toml
+++ b/rs/registry/node_provider_rewards/Cargo.toml
@@ -12,5 +12,5 @@ ic-cdk = { workspace = true }
 ic-protobuf = { path = "../../protobuf" }
 
 [dev-dependencies]
-maplit = "1.0.2"
+maplit = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/rs/replica_tests/Cargo.toml
+++ b/rs/replica_tests/Cargo.toml
@@ -54,4 +54,4 @@ ic-crypto-sha2 = { path = "../crypto/sha2" }
 ic-sys = { path = "../sys" }
 ic-test-utilities = { path = "../test_utilities" }
 ic-types-cycles = { path = "../types/cycles" }
-maplit = "1.0.2"
+maplit = { workspace = true }

--- a/rs/replicated_state/Cargo.toml
+++ b/rs/replicated_state/Cargo.toml
@@ -7,8 +7,8 @@ name = "ic-replicated-state"
 version.workspace = true
 
 [dependencies]
-bit-vec = "0.6.3"
-cvt = "0.1.1"
+bit-vec = { workspace = true }
+cvt = { workspace = true }
 ic-base-types = { path = "../types/base_types" }
 ic-btc-replica-types = { path = "../bitcoin/replica_types" }
 ic-certification-version = { path = "../canonical_state/certification_version" }
@@ -35,7 +35,7 @@ ic-wasm-types = { path = "../types/wasm_types" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 more-asserts = { workspace = true }
 nix = { workspace = true }
 phantom_newtype = { path = "../phantom_newtype" }
@@ -71,7 +71,7 @@ ic-test-utilities-metrics = { path = "../test_utilities/metrics" }
 ic-test-utilities-state = { path = "../test_utilities/state" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 proptest = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 serde_cbor = { workspace = true }
 test-strategy = "0.4.0"
 

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -40,7 +40,7 @@ registry-canister = { path = "../../registry/canister" }
 reqwest = { workspace = true }
 rolling-file = { workspace = true }
 rosetta-core = { path = "../common/rosetta_core" }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { workspace = true, features = ["bundled"] }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/Cargo.toml
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/Cargo.toml
@@ -14,7 +14,7 @@ dfn_protobuf = { path = "../../../rust_canisters/dfn_protobuf" }
 ic-agent = { workspace = true }
 ic-certification = { path = "../../../certification" }
 ic-crypto-sha2 = { path = "../../../crypto/sha2" }
-indicatif = "0.17.3"
+indicatif = { workspace = true }
 ic-ledger-canister-core = { path = "../../../ledger_suite/common/ledger_canister_core" }
 ic-ledger-core = { path = "../../../ledger_suite/common/ledger_core" }
 ic-ledger-hash-of = { path = "../../../../packages/ic-ledger-hash-of" }
@@ -23,7 +23,7 @@ icp-ledger = { path = "../../../ledger_suite/icp" }
 on_wire = { path = "../../../rust_canisters/on_wire" }
 reqwest = { workspace = true }
 rosetta-core = { path = "../../common/rosetta_core" }
-rusqlite = { version = "0.37", features = ["bundled", "hooks"] }
+rusqlite = { workspace = true, features = ["bundled", "hooks"] }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/test_utils/Cargo.toml
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/test_utils/Cargo.toml
@@ -13,5 +13,5 @@ ic-ledger-core = { path = "../../../../ledger_suite/common/ledger_core" }
 ic-types = { path = "../../../../types/types" }
 icp-ledger = { path = "../../../../ledger_suite/icp" }
 rand = { workspace = true }
-rand_distr = "0.4"
+rand_distr = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -32,7 +32,7 @@ ic-rosetta-api = { path = "../icp" }
 ic-sys = { path = "../../sys" }
 icrc-ledger-agent = { path = "../../../packages/icrc-ledger-agent" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
-indicatif = "0.17.3"
+indicatif = { workspace = true }
 lazy_static = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
@@ -41,7 +41,7 @@ rand = { workspace = true }
 reqwest = { workspace = true }
 rolling-file = { workspace = true }
 rosetta-core = { path = "../common/rosetta_core" }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { workspace = true, features = ["bundled"] }
 tokio-rusqlite = "0.7"
 serde = { workspace = true }
 serde_bytes = { workspace = true }
@@ -73,7 +73,7 @@ ic-management-canister-types = { workspace = true }
 ic-rosetta-test-utils = { path = "../icp/test_utils" }
 ic-test-utilities-load-wasm = { path = "../../test_utilities/load_wasm" }
 ic-utils = { workspace = true }
-once_cell = "1.8.0"
+once_cell = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 prometheus-parse = { workspace = true }
 url = { workspace = true }

--- a/rs/rust_canisters/canister_profiler/Cargo.toml
+++ b/rs/rust_canisters/canister_profiler/Cargo.toml
@@ -7,5 +7,5 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-ic-metrics-encoder = "1.1.0"
+ic-metrics-encoder = { workspace = true }
 ic0 = { workspace = true }

--- a/rs/rust_canisters/canister_serve/Cargo.toml
+++ b/rs/rust_canisters/canister_serve/Cargo.toml
@@ -12,11 +12,11 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-by_address = "1.1.0"
+by_address = { workspace = true }
 ic-canister-log = { path = "../canister_log", version = "0.2.0" }
 ic-cdk = { workspace = true }
-ic-metrics-encoder = "1.1.0"
-maplit = "1.0.2"
-priority-queue = "1.3.1"
+ic-metrics-encoder = { workspace = true }
+maplit = { workspace = true }
+priority-queue = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/rust_canisters/canister_test/Cargo.toml
+++ b/rs/rust_canisters/canister_test/Cargo.toml
@@ -9,9 +9,9 @@ documentation.workspace = true
 [dependencies]
 backoff = { workspace = true }
 candid = { workspace = true }
-cargo_metadata = "0.14.2"
+cargo_metadata = { workspace = true }
 dfn_candid = { path = "../dfn_candid" }
-escargot = "0.5.2"
+escargot = { workspace = true }
 ic-canister-client = { path = "../../canister_client" }
 ic-config = { path = "../../config" }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }

--- a/rs/rust_canisters/dfn_http_metrics/Cargo.toml
+++ b/rs/rust_canisters/dfn_http_metrics/Cargo.toml
@@ -11,5 +11,5 @@ dfn_candid = { path = "../dfn_candid" }
 dfn_core = { path = "../dfn_core" }
 dfn_http = { path = "../dfn_http" }
 ic-http-types = { path = "../../../packages/ic-http-types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 serde_bytes = { workspace = true }

--- a/rs/rust_canisters/memory_test/Cargo.toml
+++ b/rs/rust_canisters/memory_test/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 dfn_core = { path = "../dfn_core" }
 rand = { workspace = true }
-rand_pcg = "0.3"
+rand_pcg = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/rs/rust_canisters/stable_reader/Cargo.toml
+++ b/rs/rust_canisters/stable_reader/Cargo.toml
@@ -7,4 +7,4 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-byteorder = "1.3.4"
+byteorder = { workspace = true }

--- a/rs/rust_canisters/tests/Cargo.toml
+++ b/rs/rust_canisters/tests/Cargo.toml
@@ -13,7 +13,7 @@ dfn_json = { path = "../dfn_json" }
 ic-cdk = { workspace = true }
 on_wire = { path = "../on_wire" }
 rand = { workspace = true }
-rand_pcg = "0.3.1"
+rand_pcg = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/rs/rust_canisters/xnet_test/Cargo.toml
+++ b/rs/rust_canisters/xnet_test/Cargo.toml
@@ -17,6 +17,6 @@ ic-cdk = { workspace = true }
 ic-dummy-getrandom-for-wasm = { path = "../../../packages/ic-dummy-getrandom-for-wasm" }
 ic-management-canister-types = { workspace = true }
 rand = { workspace = true }
-rand_pcg = "0.3"
+rand_pcg = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/rs/sns/audit/Cargo.toml
+++ b/rs/sns/audit/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 candid = { workspace = true }
-colored = "2.0.0"
+colored = { workspace = true }
 csv = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
@@ -28,10 +28,10 @@ ic-nns-common = { path = "../../nns/common" }
 ic-nns-governance-api = { path = "../../nns/governance/api" }
 ic-sns-governance = { path = "../governance" }
 ic-sns-swap = { path = "../swap" }
-rgb = "0.8.37"
-rust_decimal = "1.36.0"
+rgb = { workspace = true }
+rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-textplots = { version = "0.8" }
+textplots = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rs/sns/cli/Cargo.toml
+++ b/rs/sns/cli/Cargo.toml
@@ -43,7 +43,7 @@ ic-sns-wasm = { path = "../../nns/sns-wasm" }
 ic-wasm = { workspace = true }
 itertools = { workspace = true }
 json-patch = "0.2.6"
-maplit = "1.0.2"
+maplit = { workspace = true }
 pretty_assertions = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -46,7 +46,7 @@ ic-management-canister-types-private = { path = "../../types/management_canister
 icrc-ledger-client = { path = "../../../packages/icrc-ledger-client" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-icrc1-ledger = { path = "../../ledger_suite/icrc1/ledger" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-collections-union-multi-map = { path = "../../nervous_system/collections/union_multi_map" }
@@ -74,13 +74,13 @@ lazy_static = { workspace = true }
 icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 itertools = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/sns/governance/api_helpers/Cargo.toml
+++ b/rs/sns/governance/api_helpers/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/lib.rs"
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 ic-nervous-system-common = { path = "../../../nervous_system/common" }
 ic-sns-governance-api = { path = "../api" }
-maplit = "1.0.2"
+maplit = { workspace = true }

--- a/rs/sns/governance/proposals_amount_total_limit/Cargo.toml
+++ b/rs/sns/governance/proposals_amount_total_limit/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 [dependencies]
 ic-sns-governance-token-valuation = { path = "../token_valuation" }
 num-traits = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 
 [dev-dependencies]
 candid = { workspace = true }

--- a/rs/sns/governance/token_valuation/Cargo.toml
+++ b/rs/sns/governance/token_valuation/Cargo.toml
@@ -18,9 +18,9 @@ ic-sns-swap-proto-library = { path = "../../../sns/swap/proto_library" }
 icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
 mockall = { workspace = true }
 num-traits = { workspace = true }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 tokio = { workspace = true }

--- a/rs/sns/init/Cargo.toml
+++ b/rs/sns/init/Cargo.toml
@@ -27,7 +27,7 @@ ic-sns-swap = { path = "../swap" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 isocountry = "0.3.2"
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/rs/sns/integration_tests/Cargo.toml
+++ b/rs/sns/integration_tests/Cargo.toml
@@ -48,7 +48,7 @@ ic-sns-root = { path = "../root" }
 ic-nns-test-utils-golden-nns-state = { path = "../../nns/test_utils/golden_nns_state" }
 ic-universal-canister = { path = "../../universal_canister/lib" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 pretty-bytes = "0.2.2"
 proptest = { workspace = true }
 prost = { workspace = true }
@@ -85,7 +85,7 @@ lazy_static = { workspace = true }
 num-traits = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 pretty_assertions = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 tokio = { workspace = true }
 wat = { workspace = true }

--- a/rs/sns/root/Cargo.toml
+++ b/rs/sns/root/Cargo.toml
@@ -24,7 +24,7 @@ ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
@@ -40,7 +40,7 @@ serde = { workspace = true }
 candid_parser = { workspace = true }
 ic-sns-root-protobuf-generator = { path = "./protobuf_generator" }
 ic-test-utilities-compare-dirs = { path = "../../test_utilities/compare_dirs" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/rs/sns/swap/Cargo.toml
+++ b/rs/sns/swap/Cargo.toml
@@ -30,7 +30,7 @@ ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
-ic-metrics-encoder = "1"
+ic-metrics-encoder = { workspace = true }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
@@ -46,10 +46,10 @@ icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 prost = { workspace = true }
-rust_decimal = "1.36.0"
-rust_decimal_macros = "1.36.0"
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 

--- a/rs/sns/test_utils/Cargo.toml
+++ b/rs/sns/test_utils/Cargo.toml
@@ -42,7 +42,7 @@ icp-ledger = { path = "../../ledger_suite/icp" }
 icrc-ledger-client = { path = "../../../packages/icrc-ledger-client" }
 icrc-ledger-types = { path = "../../../packages/icrc-ledger-types" }
 lazy_static = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
 on_wire = { path = "../../rust_canisters/on_wire" }
 prost = { workspace = true }

--- a/rs/sns/testing/Cargo.toml
+++ b/rs/sns/testing/Cargo.toml
@@ -59,7 +59,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 slog ={ workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/rs/sns/treasury_manager/mock/Cargo.toml
+++ b/rs/sns/treasury_manager/mock/Cargo.toml
@@ -13,7 +13,7 @@ candid = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers.workspace = true
 sns-treasury-manager = { path = "../../treasury_manager" }
-ic-canister-log = "0.2.0"
+ic-canister-log = { workspace = true }
 
 [dev-dependencies]
 candid_parser = { workspace = true }

--- a/rs/state_layout/Cargo.toml
+++ b/rs/state_layout/Cargo.toml
@@ -24,7 +24,7 @@ ic-wasm-types = { path = "../types/wasm_types" }
 libc = { workspace = true }
 prometheus = { workspace = true }
 prost = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 slog = { workspace = true }
 
 [dev-dependencies]

--- a/rs/state_machine_tests/Cargo.toml
+++ b/rs/state_machine_tests/Cargo.toml
@@ -67,7 +67,7 @@ ic-test-utilities-types = { path = "../test_utilities/types" }
 ic-types = { path = "../types/types" }
 ic-types-cycles = { path = "../types/cycles" }
 ic-xnet-payload-builder = { path = "../xnet/payload_builder" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
 serde = { workspace = true }

--- a/rs/state_manager/Cargo.toml
+++ b/rs/state_manager/Cargo.toml
@@ -38,7 +38,7 @@ prometheus = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 slog = { workspace = true }
@@ -70,7 +70,7 @@ ic-test-utilities-privileges = { path = "../test_utilities/privileges" }
 ic-test-utilities-state = { path = "../test_utilities/state" }
 ic-test-utilities-tmpdir = { path = "../test_utilities/tmpdir" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 proptest = { workspace = true }
 strum = { workspace = true }
 test-strategy = "0.4.0"

--- a/rs/sys/Cargo.toml
+++ b/rs/sys/Cargo.toml
@@ -21,7 +21,7 @@ wsl = { workspace = true }
 rand = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-cvt = "0.1.1"
+cvt = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/rs/test_utilities/Cargo.toml
+++ b/rs/test_utilities/Cargo.toml
@@ -7,7 +7,7 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }
 ic-btc-replica-types = { path = "../bitcoin/replica_types" }
 ic-canonical-state = { path = "../canonical_state" }
 ic-canonical-state-tree-hash = { path = "../canonical_state/tree_hash" }
@@ -38,5 +38,5 @@ wat = { workspace = true }
 [dev-dependencies]
 ic-artifact-pool = { path = "../artifact_pool" }
 ic-test-utilities-logger = { path = "./logger" }
-rusty-fork = "0.3.0"
+rusty-fork = { workspace = true }
 wasmprinter = { workspace = true }

--- a/rs/test_utilities/execution_environment/Cargo.toml
+++ b/rs/test_utilities/execution_environment/Cargo.toml
@@ -34,7 +34,7 @@ ic-types-cycles = { path = "../../types/cycles" }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 ic-universal-canister = { path = "../../universal_canister/lib" }
 ic-wasm-types = { path = "../../types/wasm_types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 num-traits = { workspace = true }
 prometheus = { workspace = true }
 slog = { workspace = true }

--- a/rs/test_utilities/load_wasm/Cargo.toml
+++ b/rs/test_utilities/load_wasm/Cargo.toml
@@ -7,5 +7,5 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-cargo_metadata = "0.14.2"
-escargot = { version = "0.5.7", features = ["print"] }
+cargo_metadata = { workspace = true }
+escargot = { workspace = true, features = ["print"] }

--- a/rs/tests/cross_chain/Cargo.toml
+++ b/rs/tests/cross_chain/Cargo.toml
@@ -13,7 +13,7 @@ candid = { workspace = true }
 canister-test = { path = "../../rust_canisters/canister_test" }
 dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 futures = { workspace = true }
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-btc-adapter-test-utils = { path = "../../bitcoin/adapter/test_utils" }
 ic_consensus_system_test_utils = { path = "../consensus/utils" }

--- a/rs/tests/httpbin-rs/Cargo.toml
+++ b/rs/tests/httpbin-rs/Cargo.toml
@@ -15,7 +15,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 rand = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = "2.1.2"
+rustls-pemfile = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -49,7 +49,7 @@ ic-types = { path = "../../types/types" }
 ic-utils = { workspace = true }
 itertools = { workspace = true }
 leb128 = { workspace = true }
-maplit = "1.0.2"
+maplit = { workspace = true }
 proxy_canister = { path = "../../rust_canisters/proxy_canister" }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/rs/tests/nns/sns/Cargo.toml
+++ b/rs/tests/nns/sns/Cargo.toml
@@ -12,7 +12,7 @@ ic-nervous-system-common = { path = "../../../nervous_system/common" }
 ic-nervous-system-proto = { path = "../../../nervous_system/proto" }
 ic-sns-swap = { path = "../../../sns/swap" }
 ic-system-test-driver = { path = "../../driver" }
-rust_decimal = "1.36.0"
+rust_decimal = { workspace = true }
 slog = { workspace = true }
 sns_system_test_lib = { path = "./lib" }
 

--- a/rs/tests/test_canisters/http_counter/Cargo.toml
+++ b/rs/tests/test_canisters/http_counter/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 [target.wasm32-unknown-unknown.dependencies]
 candid = { workspace = true }
 ic-cdk = { workspace = true }
-ic-certified-map = "0.3.1"
+ic-certified-map = { workspace = true }
 serde = { workspace = true }

--- a/rs/tests/test_canisters/kv_store/Cargo.toml
+++ b/rs/tests/test_canisters/kv_store/Cargo.toml
@@ -15,7 +15,7 @@ base64 = { workspace = true }
 candid = { workspace = true }
 flate2 = { workspace = true }
 ic-cdk = { workspace = true }
-ic-certified-map = "0.3"
+ic-certified-map = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 sha2 = { workspace = true }

--- a/rs/tests/testnets/mainnet_nns/Cargo.toml
+++ b/rs/tests/testnets/mainnet_nns/Cargo.toml
@@ -27,7 +27,7 @@ ic-system-test-driver = { path = "../../driver" }
 ic-types = { path = "../../../types/types" }
 ic_consensus_system_test_utils = { path = "../../consensus/utils" }
 nix = { workspace = true }
-once_cell = "1.21"
+once_cell = { workspace = true }
 rand = { workspace = true }
 registry-canister = { path = "../../../registry/canister" }
 reqwest = { workspace = true }

--- a/rs/tla_instrumentation/local_key/Cargo.toml
+++ b/rs/tla_instrumentation/local_key/Cargo.toml
@@ -9,4 +9,4 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pin-project-lite = "0.2"
+pin-project-lite = { workspace = true }

--- a/rs/tree_deserializer/Cargo.toml
+++ b/rs/tree_deserializer/Cargo.toml
@@ -12,7 +12,7 @@ leb128 = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-maplit = "1.0.2"
+maplit = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 test-strategy = "0.4.0"

--- a/rs/types/cycles/Cargo.toml
+++ b/rs/types/cycles/Cargo.toml
@@ -13,4 +13,4 @@ candid = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-thousands = "0.2.0"
+thousands = { workspace = true }

--- a/rs/types/management_canister_types/fuzz/Cargo.toml
+++ b/rs/types/management_canister_types/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 [dependencies]
 candid = { workspace = true }
 ic-management-canister-types-private = { path = ".." }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { workspace = true }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/rs/types/types/Cargo.toml
+++ b/rs/types/types/Cargo.toml
@@ -25,9 +25,9 @@ ic-types-cycles = { path = "../cycles" }
 ic-utils = { path = "../../utils" }
 ic-validate-eq = { path = "../../utils/validate_eq" }
 ic-validate-eq-derive = { path = "../../utils/validate_eq_derive" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 more-asserts = { workspace = true }
-once_cell = "1.8"
+once_cell = { workspace = true }
 phantom_newtype = { path = "../../phantom_newtype" }
 prost = { workspace = true }
 rand = { workspace = true }
@@ -39,14 +39,14 @@ serde_with = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
-thousands = "0.2.0"
+thousands = { workspace = true }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 chrono = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-hex-literal = "0.4.1"
+hex-literal = { workspace = true }
 ic-crypto-test-utils-canister-threshold-sigs = { path = "../../crypto/test_utils/canister_threshold_sigs" }
 ic-crypto-test-utils-ni-dkg = { path = "../../crypto/test_utils/ni-dkg" }
 ic-crypto-test-utils-reproducible-rng = { path = "../../crypto/test_utils/reproducible_rng" }
@@ -55,7 +55,7 @@ ic-types-test-utils = { path = "../types_test_utils" }
 pretty_assertions = { workspace = true }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }
-rusty-fork = "0.3.0"
+rusty-fork = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = { workspace = true }

--- a/rs/utils/Cargo.toml
+++ b/rs/utils/Cargo.toml
@@ -8,7 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 hex = { workspace = true }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 

--- a/rs/validator/fuzz/Cargo.toml
+++ b/rs/validator/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ cargo-fuzz = true
 ic-types = { path = "../../types/types" }
 ic-validator-http-request-arbitrary = { path = "../http_request_arbitrary" }
 ic-validator-ingress-message = { path = "../ingress_message" }
-libfuzzer-sys = "0.4"
+libfuzzer-sys = { workspace = true }
 
 [dependencies.ic-validator]
 path = ".."

--- a/rs/xnet/payload_builder/Cargo.toml
+++ b/rs/xnet/payload_builder/Cargo.toml
@@ -54,7 +54,7 @@ ic-test-utilities-registry = { path = "../../test_utilities/registry" }
 ic-test-utilities-state = { path = "../../test_utilities/state" }
 ic-test-utilities-time = { path = "../../test_utilities/time" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
-maplit = "1.0.2"
+maplit = { workspace = true }
 mockall = { workspace = true }
 nix = { workspace = true }
 proptest = { workspace = true }


### PR DESCRIPTION
This edits all our Cargo.tomls to use crates from the workspace definition, which helps prevent version drifts between dependencies in our crates.

This is a follow-up to https://github.com/dfinity/ic/pull/10809