### PR TITLE
test(btc-adapter): remove requires-network tag from adapter_test

### DIFF
--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -104,7 +104,6 @@ rust_test(
         "test_data/first_2500_testnet_headers.json",
     ],
     crate = ":adapter",
-    tags = ["requires-network"],
     deps = [
         # Keep sorted.
         "//rs/bitcoin/adapter/test_utils",

--- a/rs/bitcoin/adapter/src/stream.rs
+++ b/rs/bitcoin/adapter/src/stream.rs
@@ -383,8 +383,6 @@ pub fn handle_stream<
 #[cfg(test)]
 pub mod test {
 
-    use std::net::{IpAddr, Ipv4Addr};
-
     use crate::common::DEFAULT_CHANNEL_BUFFER_SIZE;
 
     use super::*;
@@ -456,11 +454,62 @@ pub mod test {
         let (_adapter_tx, adapter_rx) = tokio::sync::mpsc::unbounded_channel();
         let (stream_tx, _) = tokio::sync::mpsc::channel(DEFAULT_CHANNEL_BUFFER_SIZE);
 
-        // Try to connect to a non routable IP address to force a timeout to happen. If a routable IP is used,
-        // then the connection either succeeds or other errors are generated.
-        // https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error
-        // The chosen ephemeral port is random and should not affect the test.
-        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)), 55535);
+        // Bind a loopback listener with a minimal backlog and never accept from
+        // it. Once its accept queue is full the kernel silently drops further
+        // SYNs (see `tcp_conn_request`/`sk_acceptq_is_full`), so a fresh TCP
+        // connect neither completes nor is refused: it hangs until the stream's
+        // connect timeout fires. This exercises the connect-timeout path using
+        // only loopback, so the test does not require network egress. (A
+        // non-routable address like 192.168.2.0 only times out when a default
+        // route exists to black-hole the packets; without one the OS returns an
+        // immediate "network unreachable" error instead.)
+        let socket = tokio::net::TcpSocket::new_v4().unwrap();
+        socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener = socket.listen(1).unwrap();
+        let address = listener.local_addr().unwrap();
+
+        // Fill the accept queue with connections that are never accepted. We
+        // keep the successful ones alive so the queue stays full; the queue is
+        // saturated once a fresh connect no longer completes but hangs.
+        //
+        // The loop is self-terminating (it stops as soon as a connect hangs),
+        // so the bound is just a safety cap to avoid running away. With
+        // `listen(1)` the queue saturates after `backlog + 1 = 2` connects on
+        // Linux (`sk_acceptq_is_full`), so the 3rd connect already hangs; 16
+        // leaves a generous margin and is far above any real accept-queue
+        // capacity for this backlog.
+        let mut blockers = Vec::new();
+        let mut saturated = false;
+        for _ in 0..16 {
+            match timeout(
+                Duration::from_millis(200),
+                tokio::net::TcpStream::connect(address),
+            )
+            .await
+            {
+                // Connect succeeded quickly: still room in the queue, keep it
+                // alive and keep filling.
+                Ok(Ok(stream)) => blockers.push(stream),
+                // Connect hung past the probe timeout: the queue is saturated
+                // and further SYNs are being dropped, which is exactly the
+                // state we need for the stream's connect to time out.
+                Err(_elapsed) => {
+                    saturated = true;
+                    break;
+                }
+                // An immediate connect error means the queue is *not*
+                // saturated (e.g. the connection was refused). Failing here
+                // rather than proceeding keeps the test deterministic and
+                // surfaces the real cause instead of a confusing downstream
+                // failure.
+                Ok(Err(e)) => panic!("unexpected error while filling accept queue: {e}"),
+            }
+        }
+        assert!(
+            saturated,
+            "accept queue never saturated after {} connects; cannot exercise the connect timeout",
+            blockers.len()
+        );
 
         let stream_config = StreamConfig {
             address,


### PR DESCRIPTION
## What

Removes the `requires-network` bazel tag from `//rs/bitcoin/adapter:adapter_test` to make it hermetic.

## Why

The `initialization_times_out_after_five_seconds` test connected to the non-routable address `192.168.2.0` and expected a `StreamError::Timeout`. That only works when a default route exists to black-hole the packets; in a network-less sandbox the OS returns an immediate "network unreachable" error instead, so the assertion panics:

```
thread 'stream::test::initialization_times_out_after_five_seconds' panicked at rs/bitcoin/adapter/src/stream.rs:477:9:
assertion failed: matches!(err, StreamError::Timeout)
```

This is why the target carried the `requires-network` tag.

## How

Rewrite the test to trigger the connect timeout over loopback only, using the same trick as #10803:

- Bind a loopback listener with a minimal backlog (`listen(1)`) and never accept from it.
- Fill the kernel accept queue with never-accepted connections. Once saturated, the kernel silently drops further SYNs, so a fresh connect neither completes nor is refused — it hangs.
- The stream's connect to the saturated listener then hangs until its 5s `CONNECTION_TIMEOUT_SECS` fires, yielding `StreamError::Timeout` without any network egress.

The fill loop is self-terminating (stops as soon as a probe connect hangs) with a safety cap, and asserts saturation was reached to stay deterministic.

## Verification

- `bazel test //rs/bitcoin/adapter:adapter_test` passes in the network-less sandbox that previously required the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)