### PR TITLE
chore(Core): Limit wasm locals #2

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -67,6 +67,7 @@ const WASM_FUNCTION_COMPLEXITY_LIMIT: Complexity = Complexity(1_000_000);
 pub const WASM_FUNCTION_SIZE_LIMIT: usize = 1_000_000;
 pub const MAX_CODE_SECTION_SIZE_IN_BYTES: u32 = 12 * 1024 * 1024;
 pub const MAX_WASM_FUNCTION_NAME_LENGTH: usize = 1024 * 1024;
+pub const MAX_WASM_FUNCTION_NUM_LOCALS: usize = 2000;
 
 // Represents the expected function signature for any System APIs the Internet
 // Computer provides or any special exported user functions.
@@ -1336,6 +1337,13 @@ fn validate_function_section(
             .unwrap()
             .body
             .num_locals;
+        if num_locals > MAX_WASM_FUNCTION_NUM_LOCALS as u32 {
+            return Err(WasmValidationError::TooManyLocals {
+                index: *id as usize,
+                defined: num_locals as usize,
+                allowed: MAX_WASM_FUNCTION_NUM_LOCALS,
+            });
+        }
         max_num_locals = max_num_locals.max(num_locals);
     }
 

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -67,7 +67,7 @@ const WASM_FUNCTION_COMPLEXITY_LIMIT: Complexity = Complexity(1_000_000);
 pub const WASM_FUNCTION_SIZE_LIMIT: usize = 1_000_000;
 pub const MAX_CODE_SECTION_SIZE_IN_BYTES: u32 = 12 * 1024 * 1024;
 pub const MAX_WASM_FUNCTION_NAME_LENGTH: usize = 1024 * 1024;
-pub const MAX_WASM_FUNCTION_NUM_LOCALS: usize = 2000;
+pub const MAX_WASM_FUNCTION_NUM_LOCALS: usize = 10_000;
 
 // Represents the expected function signature for any System APIs the Internet
 // Computer provides or any special exported user functions.

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -7,7 +7,8 @@ use ic_embedders::{
     wasm_utils::{
         Complexity, WasmImportsDetails, WasmValidationDetails, validate_and_instrument_for_testing,
         validation::{
-            MAX_WASM_FUNCTION_NAME_LENGTH, RESERVED_SYMBOLS, extract_custom_section_name,
+            MAX_WASM_FUNCTION_NAME_LENGTH, MAX_WASM_FUNCTION_NUM_LOCALS, RESERVED_SYMBOLS,
+            extract_custom_section_name,
         },
     },
 };
@@ -1475,6 +1476,29 @@ fn wasm_with_long_func_name_is_invalid() {
             size: MAX_WASM_FUNCTION_NAME_LENGTH + 10,
             allowed: MAX_WASM_FUNCTION_NAME_LENGTH,
             name: format!("{}...", "A".repeat(100)),
+        })
+    );
+}
+
+#[test]
+fn wasm_with_many_locals_is_invalid() {
+    let wat = format!(
+        r#"
+          (module
+            (func $f (export "canister_update f") 
+              (local {})
+            )
+          )"#,
+        "i32 ".repeat(MAX_WASM_FUNCTION_NUM_LOCALS + 1)
+    );
+
+    let wasm = wat2wasm(&wat).unwrap();
+    assert_eq!(
+        validate_wasm_binary(&wasm, &EmbeddersConfig::default()),
+        Err(WasmValidationError::TooManyLocals {
+            index: 0,
+            defined: MAX_WASM_FUNCTION_NUM_LOCALS + 1,
+            allowed: MAX_WASM_FUNCTION_NUM_LOCALS,
         })
     );
 }

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -140,6 +140,12 @@ pub enum WasmValidationError {
         allowed: usize,
         name: String,
     },
+    /// A function contains too many locals.
+    TooManyLocals {
+        index: usize,
+        defined: usize,
+        allowed: usize,
+    },
     /// The code section is too large.
     CodeSectionTooLarge {
         size: u32,
@@ -263,6 +269,15 @@ impl std::fmt::Display for WasmValidationError {
                 "Wasm module contains a function at index {index} \
                     with name '{name}' of size {size} bytes that exceeds the maximum allowed size of {allowed} bytes.",
             ),
+            Self::TooManyLocals {
+                index,
+                defined,
+                allowed,
+            } => write!(
+                f,
+                "Wasm module contains a function at index {index} \
+                    with {defined} locals that exceeds the maximum allowed number of locals {allowed}"
+            ),
             Self::CodeSectionTooLarge { size, allowed } => write!(
                 f,
                 "Wasm module code section size of {size} \
@@ -339,6 +354,10 @@ impl AsErrorHelp for WasmValidationError {
             WasmValidationError::FunctionNameTooLarge { .. } => ErrorHelp::UserError {
                 suggestion: "Try using shorter function names.".to_string(),
                 doc_link: doc_ref("wasm-module-function-name-too-large"),
+            },
+            WasmValidationError::TooManyLocals { .. } => ErrorHelp::UserError {
+                suggestion: "Try different optimizer settings.".to_string(),
+                doc_link: doc_ref("wasm-module-too-many-locals"),
             },
             WasmValidationError::CodeSectionTooLarge { .. } => ErrorHelp::UserError {
                 suggestion: "Try shrinking the module code section using tools like \


### PR DESCRIPTION
Essentially reverts this revert: https://github.com/dfinity/ic/pull/10475
Metrics show that this is almost twice the max of existing canisters over all subnets. 