### PR TITLE
feat(icp-rosetta): DEFI-2950: Migrate block store to async tokio-rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10758,6 +10758,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "tokio",
+ "tokio-rusqlite",
  "tracing",
  "url",
 ]

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/BUILD.bazel
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/BUILD.bazel
@@ -32,6 +32,7 @@ rust_library(
         "@crate_index//:rusqlite",
         "@crate_index//:serde",
         "@crate_index//:tokio",
+        "@crate_index//:tokio-rusqlite",
         "@crate_index//:tracing",
         "@crate_index//:url",
     ],

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/BUILD.bazel
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/BUILD.bazel
@@ -49,9 +49,32 @@ rust_test(
     ],
 )
 
+_RUNTIME_RESPONSIVENESS_TEST = "tests/runtime_responsiveness_test.rs"
+
+# This test builds a fixed 2-worker tokio runtime plus a canary/block_on thread
+# and asserts a wall-clock tick ratio, so it needs dedicated CPUs to avoid
+# flaking under oversubscription. It therefore lives in its own `rust_test`
+# target (with a cpu reservation tag) rather than in the tests/** suite below,
+# whose tags would otherwise apply to every file in the suite.
+rust_test(
+    name = "runtime_responsiveness_test",
+    srcs = [_RUNTIME_RESPONSIVENESS_TEST],
+    crate_root = _RUNTIME_RESPONSIVENESS_TEST,
+    tags = ["cpu:4"],
+    deps = [
+        # Keep sorted.
+        ":ledger_canister_blocks_synchronizer_lib",
+        "//rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/test_utils",
+        "@crate_index//:tokio",
+    ],
+)
+
 rust_test_suite(
     name = "ledger_canister_blocks_synchronizer_test_suite",
-    srcs = glob(["tests/**"]),
+    srcs = glob(
+        ["tests/**"],
+        exclude = [_RUNTIME_RESPONSIVENESS_TEST],
+    ),
     deps = [
         # Keep sorted.
         ":ledger_canister_blocks_synchronizer_lib",

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/Cargo.toml
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/Cargo.toml
@@ -26,6 +26,7 @@ rosetta-core = { path = "../../common/rosetta_core" }
 rusqlite = { version = "0.37", features = ["bundled", "hooks"] }
 serde = { workspace = true }
 tokio = { workspace = true }
+tokio-rusqlite = "0.7"
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -1400,7 +1400,7 @@ impl Blocks {
             .connection
             .call::<_, _, BlockStoreError>(move |connection| {
         if range.end > range.start
-            && database_access::contains_block(connection, &range.start).unwrap_or(false)
+            && database_access::contains_block(connection, &range.start)?
         {
             let mut stmt = connection.prepare_cached(r#"SELECT block_hash, encoded_block, parent_hash, block_idx, timestamp FROM blocks WHERE block_idx >= :start AND block_idx < :end"#).map_err(|e| BlockStoreError::Other(e.to_string()))?;
             database_access::read_hashed_blocks(

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -1273,7 +1273,7 @@ impl Blocks {
                         }
                         if *item > other_indices[idx_b] {
                             /* Vector a is representative of the block_idxes in the blocks table and since other tables refer to the blocks
-                            table with a forein key constraint it should not be possible for other tables to have a block idx that is
+                            table with a foreign key constraint it should not be possible for other tables to have a block idx that is
                             not present in the blocks table. */
                             while idx_b < other_indices.len() {
                                 if *item == other_indices[idx_b] {

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -11,7 +11,6 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
 use std::path::Path;
-use std::sync::Mutex;
 use tracing::info;
 
 mod database_access {
@@ -691,6 +690,27 @@ impl From<String> for BlockStoreError {
     }
 }
 
+impl std::fmt::Display for BlockStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockStoreError::NotFound(idx) => write!(f, "Block not found: {idx}"),
+            BlockStoreError::NotAvailable(idx) => write!(f, "Block not available: {idx}"),
+            BlockStoreError::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BlockStoreError {}
+
+impl From<tokio_rusqlite::Error<BlockStoreError>> for BlockStoreError {
+    fn from(error: tokio_rusqlite::Error<BlockStoreError>) -> Self {
+        match error {
+            tokio_rusqlite::Error::Error(e) => e,
+            other => BlockStoreError::Other(other.to_string()),
+        }
+    }
+}
+
 fn vec_into_array(v: Vec<u8>) -> [u8; 32] {
     let ba: Box<[u8; 32]> = match v.into_boxed_slice().try_into() {
         Ok(ba) => ba,
@@ -749,61 +769,65 @@ impl RosettaDbConfig {
 }
 
 pub struct Blocks {
-    connection: Mutex<rusqlite::Connection>,
+    connection: tokio_rusqlite::Connection,
     pub rosetta_blocks_mode: RosettaBlocksMode,
 }
 
 impl Blocks {
-    pub fn new_persistent(
+    pub async fn new_persistent(
         location: &Path,
         config: RosettaDbConfig,
     ) -> Result<Self, BlockStoreError> {
         std::fs::create_dir_all(location)
             .expect("Unable to create directory for SQLite on-disk store.");
         let path = location.join("db.sqlite");
-        let connection =
-            rusqlite::Connection::open(path).map_err(|e| BlockStoreError::Other(e.to_string()))?;
-        Self::new(connection, config)
+        let connection = tokio_rusqlite::Connection::open(path)
+            .await
+            .map_err(|e| BlockStoreError::Other(e.to_string()))?;
+        Self::new(connection, config).await
     }
 
-    pub fn new_in_memory(config: RosettaDbConfig) -> Result<Self, BlockStoreError> {
-        // Use a unique in-memory database for each instance to avoid locks in parallel tests.
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        static COUNTER: AtomicUsize = AtomicUsize::new(0);
-        let counter = COUNTER.fetch_add(1, Ordering::SeqCst);
-        let connection =
-            rusqlite::Connection::open(format!("file:memdb{counter}?mode=memory&cache=private"))
-                .map_err(|e| BlockStoreError::Other(e.to_string()))?;
-        Self::new(connection, config)
+    pub async fn new_in_memory(config: RosettaDbConfig) -> Result<Self, BlockStoreError> {
+        // A tokio-rusqlite in-memory connection owns a dedicated background thread
+        // holding a single long-lived `:memory:` database, so each `Blocks` instance
+        // gets its own isolated in-memory store (no cross-test locking).
+        let connection = tokio_rusqlite::Connection::open_in_memory()
+            .await
+            .map_err(|e| BlockStoreError::Other(e.to_string()))?;
+        Self::new(connection, config).await
     }
 
-    fn new(
-        connection: rusqlite::Connection,
+    async fn new(
+        connection: tokio_rusqlite::Connection,
         config: RosettaDbConfig,
     ) -> Result<Self, BlockStoreError> {
         let mut store = Self {
-            connection: Mutex::new(connection),
+            connection,
             rosetta_blocks_mode: RosettaBlocksMode::Disabled,
         };
         store
             .connection
-            .lock()
-            .unwrap()
-            .execute("PRAGMA foreign_keys = 1", [])
-            .map_err(|e| BlockStoreError::Other(e.to_string()))?;
-        store.create_tables(config).map_err(|e| {
+            .call::<_, (), BlockStoreError>(|connection| {
+                connection
+                    .execute("PRAGMA foreign_keys = 1", [])
+                    .map_err(|e| BlockStoreError::Other(e.to_string()))?;
+                Ok(())
+            })
+            .await?;
+        store.create_tables(config).await.map_err(|e| {
             BlockStoreError::Other(format!("Failed to initialize SQLite database: {e}"))
         })?;
-        store.cache_rosetta_blocks_mode().map_err(|e| {
+        store.cache_rosetta_blocks_mode().await.map_err(|e| {
             BlockStoreError::Other(format!("Failed to determine the Rosetta Blocks Mode: {e}"))
         })?;
 
-        store.check_table_coherence()?;
+        store.check_table_coherence().await?;
         Ok(store)
     }
 
-    fn create_tables(&self, config: RosettaDbConfig) -> Result<(), rusqlite::Error> {
-        let mut connection = self.connection.lock().unwrap();
+    async fn create_tables(&self, config: RosettaDbConfig) -> Result<(), BlockStoreError> {
+        self.connection
+            .call::<_, (), rusqlite::Error>(move |connection| {
         let tx = connection.transaction()?;
         tx.execute(
             r#"
@@ -966,7 +990,7 @@ impl Blocks {
 
             // From account index
             create_index_if_not_exists(
-                &mut connection,
+                connection,
                 "from_account_index",
                 r#"
             CREATE INDEX from_account_index 
@@ -977,7 +1001,7 @@ impl Blocks {
 
             // To account index
             create_index_if_not_exists(
-                &mut connection,
+                connection,
                 "to_account_index",
                 r#"
             CREATE INDEX to_account_index 
@@ -988,7 +1012,7 @@ impl Blocks {
 
             // Spender account index
             create_index_if_not_exists(
-                &mut connection,
+                connection,
                 "spender_account_index",
                 r#"
             CREATE INDEX spender_account_index 
@@ -999,7 +1023,7 @@ impl Blocks {
 
             // Operation type index for searching by transaction type
             create_index_if_not_exists(
-                &mut connection,
+                connection,
                 "operation_type_index",
                 r#"
             CREATE INDEX operation_type_index 
@@ -1010,270 +1034,359 @@ impl Blocks {
         }
 
         Ok(())
+            })
+            .await
+            .map_err(|e| BlockStoreError::Other(e.to_string()))
     }
 
-    fn cache_rosetta_blocks_mode(&mut self) -> Result<(), rusqlite::Error> {
+    async fn cache_rosetta_blocks_mode(&mut self) -> Result<(), BlockStoreError> {
         // The Rosetta Blocks Mode is enabled if the rosetta_blocks table
         // exists.
         // See https://www.sqlite.org/fileformat2.html#storage_of_the_sql_database_schema/
-        let connection = self.connection.lock().unwrap();
-
-        // The query returns a single row if the table exists, no rows otherwise.
-        // .optional() converts Err(QueryReturnedNoRows) to Ok(None)
-        let is_rosetta_blocks_mode_enabled = connection
-            .query_row(
-                r#"SELECT 1
+        let mode = self
+            .connection
+            .call::<_, RosettaBlocksMode, rusqlite::Error>(|connection| {
+                // The query returns a single row if the table exists, no rows otherwise.
+                // .optional() converts Err(QueryReturnedNoRows) to Ok(None)
+                let is_rosetta_blocks_mode_enabled = connection
+                    .query_row(
+                        r#"SELECT 1
                    FROM sqlite_master
                    WHERE type='table'
                      AND name='rosetta_blocks'"#,
-                [],
-                |_| Ok(()),
-            )
-            .optional()
-            .map(|opt| opt.is_some())?;
-        if !is_rosetta_blocks_mode_enabled {
-            self.rosetta_blocks_mode = RosettaBlocksMode::Disabled;
-            return Ok(());
-        }
+                        [],
+                        |_| Ok(()),
+                    )
+                    .optional()
+                    .map(|opt| opt.is_some())?;
+                if !is_rosetta_blocks_mode_enabled {
+                    return Ok(RosettaBlocksMode::Disabled);
+                }
 
-        // From this point we know the table rosetta_blocks exists.
-        // There are three potential states:
-        //  1. if the table rosetta_blocks has at least one row then
-        //     the first rosetta block index is the smallest index
-        //     in that table
-        //  2. else if the table blocks has at least one row then
-        //     the first rosetta block index will be the highest index
-        //     in the blocks table + 1, i.e. the next incoming block.
-        //  3. else the first rosetta block index will be
-        //     the lowest possible block index, i.e. 0.
-        let first_rosetta_block_index = connection.query_row(
-            "SELECT min(rosetta_block_idx) FROM rosetta_blocks",
-            [],
-            |row| row.get::<_, Option<u64>>(0),
-        )?;
-        let first_rosetta_block_index = match first_rosetta_block_index {
-            Some(first_rosetta_block_index) => first_rosetta_block_index,
-            None => connection
-                .query_row("SELECT max(block_idx) + 1 FROM blocks", [], |row| {
-                    row.get::<_, Option<u64>>(0)
-                })?
-                .unwrap_or(0),
-        };
-        info!(
-            "Rosetta blocks mode enabled, first rosetta block index is {first_rosetta_block_index}"
-        );
-        self.rosetta_blocks_mode = RosettaBlocksMode::Enabled {
-            first_rosetta_block_index,
-        };
-        Ok(())
-    }
-
-    pub fn prune(&mut self, hb: &HashedBlock) -> Result<(), BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        connection
-            .execute_batch("BEGIN TRANSACTION;")
-            .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
-
-        database_access::prune_account_balances(&mut connection, &hb.index)?;
-        connection
-            .execute(
-                "DELETE FROM blocks WHERE block_idx > 0 AND block_idx < ?",
-                params![hb.index],
-            )
+                // From this point we know the table rosetta_blocks exists.
+                // There are three potential states:
+                //  1. if the table rosetta_blocks has at least one row then
+                //     the first rosetta block index is the smallest index
+                //     in that table
+                //  2. else if the table blocks has at least one row then
+                //     the first rosetta block index will be the highest index
+                //     in the blocks table + 1, i.e. the next incoming block.
+                //  3. else the first rosetta block index will be
+                //     the lowest possible block index, i.e. 0.
+                let first_rosetta_block_index = connection.query_row(
+                    "SELECT min(rosetta_block_idx) FROM rosetta_blocks",
+                    [],
+                    |row| row.get::<_, Option<u64>>(0),
+                )?;
+                let first_rosetta_block_index = match first_rosetta_block_index {
+                    Some(first_rosetta_block_index) => first_rosetta_block_index,
+                    None => connection
+                        .query_row("SELECT max(block_idx) + 1 FROM blocks", [], |row| {
+                            row.get::<_, Option<u64>>(0)
+                        })?
+                        .unwrap_or(0),
+                };
+                Ok(RosettaBlocksMode::Enabled {
+                    first_rosetta_block_index,
+                })
+            })
+            .await
             .map_err(|e| BlockStoreError::Other(e.to_string()))?;
-
-        connection
-            .execute_batch("COMMIT TRANSACTION;")
-            .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
-
+        if let RosettaBlocksMode::Enabled {
+            first_rosetta_block_index,
+        } = mode
+        {
+            info!(
+                "Rosetta blocks mode enabled, first rosetta block index is {first_rosetta_block_index}"
+            );
+        }
+        self.rosetta_blocks_mode = mode;
         Ok(())
     }
-    pub fn get_block_idx_by_block_hash(
+
+    pub async fn prune(&mut self, hb: &HashedBlock) -> Result<(), BlockStoreError> {
+        let index = hb.index;
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                connection
+                    .execute_batch("BEGIN TRANSACTION;")
+                    .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+
+                database_access::prune_account_balances(connection, &index)?;
+                connection
+                    .execute(
+                        "DELETE FROM blocks WHERE block_idx > 0 AND block_idx < ?",
+                        params![index],
+                    )
+                    .map_err(|e| BlockStoreError::Other(e.to_string()))?;
+
+                connection
+                    .execute_batch("COMMIT TRANSACTION;")
+                    .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+
+                Ok(())
+            })
+            .await?;
+        Ok(())
+    }
+    pub async fn get_block_idx_by_block_hash(
         &self,
         hash: &HashOf<EncodedBlock>,
     ) -> Result<u64, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-
-        database_access::get_block_idx_by_block_hash(&mut connection, hash)
+        let hash = *hash;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_block_idx_by_block_hash(connection, &hash)
+            })
+            .await?)
     }
 
-    pub fn get_block_idxs_by_transaction_hash(
+    pub async fn get_block_idxs_by_transaction_hash(
         &self,
         hash: &HashOf<icp_ledger::Transaction>,
     ) -> Result<Vec<u64>, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_block_idx_by_transaction_hash(&mut connection, hash)
+        let hash = *hash;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_block_idx_by_transaction_hash(connection, &hash)
+            })
+            .await?)
     }
-    pub fn get_account_balance_history(
+    pub async fn get_account_balance_history(
         &self,
         acc: &AccountIdentifier,
         limit_num_blocks: Option<u64>,
     ) -> Result<Vec<(u64, Tokens)>, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_account_balance_history(&mut connection, acc, limit_num_blocks)
+        let acc = *acc;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_account_balance_history(connection, &acc, limit_num_blocks)
+            })
+            .await?)
     }
 
     /// Sanity check (sum of tokens equal pool size).
-    fn sanity_check(&self, latest_hb: &HashedBlock) -> Result<(), BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        let accounts = database_access::get_all_accounts(&mut connection)?;
-        let mut total = Tokens::ZERO;
-        for account in accounts {
-            let amount = database_access::get_account_balance(
-                &mut connection,
-                &latest_hb.index.clone(),
-                &account,
-            )?;
-            total = total
-                .checked_add(&Tokens::from_e8s(amount.unwrap()))
-                .unwrap();
-        }
-        assert!(total <= Tokens::MAX);
+    async fn sanity_check(&self, latest_hb: &HashedBlock) -> Result<(), BlockStoreError> {
+        let index = latest_hb.index;
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                let accounts = database_access::get_all_accounts(connection)?;
+                let mut total = Tokens::ZERO;
+                for account in accounts {
+                    let amount =
+                        database_access::get_account_balance(connection, &index, &account)?;
+                    total = total
+                        .checked_add(&Tokens::from_e8s(amount.unwrap()))
+                        .unwrap();
+                }
+                assert!(total <= Tokens::MAX);
+                Ok(())
+            })
+            .await?;
         Ok(())
     }
 
-    pub fn get_transaction_hash(
+    pub async fn get_transaction_hash(
         &self,
         block_idx: &u64,
     ) -> Result<Option<HashOf<icp_ledger::Transaction>>, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-
-        if database_access::contains_block(&mut connection, block_idx)? {
-            database_access::get_transaction_hash(&mut connection, block_idx)
-        } else {
-            Err(BlockStoreError::NotAvailable(*block_idx))
-        }
+        let block_idx = *block_idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                if database_access::contains_block(connection, &block_idx)? {
+                    database_access::get_transaction_hash(connection, &block_idx)
+                } else {
+                    Err(BlockStoreError::NotAvailable(block_idx))
+                }
+            })
+            .await?)
     }
 
-    pub fn get_first_verified_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_first_hashed_block(&mut connection, Some(true))
+    pub async fn get_first_verified_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_first_hashed_block(connection, Some(true))
+            })
+            .await?)
     }
-    pub fn get_hashed_block(&self, block_idx: &u64) -> Result<HashedBlock, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_hashed_block(&mut connection, block_idx)
+    pub async fn get_hashed_block(&self, block_idx: &u64) -> Result<HashedBlock, BlockStoreError> {
+        let block_idx = *block_idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_hashed_block(connection, &block_idx)
+            })
+            .await?)
     }
 
-    pub fn get_transaction(
+    pub async fn get_transaction(
         &self,
         block_idx: &u64,
     ) -> Result<icp_ledger::Transaction, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_transaction(&mut connection, block_idx)
+        let block_idx = *block_idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_transaction(connection, &block_idx)
+            })
+            .await?)
     }
-    fn check_table_coherence(&self) -> Result<(), BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        let mut block_indices =
-            database_access::get_all_block_indices_from_blocks_table(&mut connection)?;
-        let mut account_balances_block_indices =
-            database_access::get_all_block_indices_from_account_balances_table(&mut connection)?;
-        let vec_sorted_diff = |blocks_indices: &mut [u64],
-                               other_indices: &mut [u64]|
-         -> Result<Vec<u64>, BlockStoreError> {
-            let mut result: Vec<u64> = Vec::new();
-            let mut idx_b = 0;
-            for item in blocks_indices {
-                if idx_b >= other_indices.len() || *item < other_indices[idx_b] {
-                    result.push(*item);
-                    continue;
-                }
-                if *item == other_indices[idx_b] {
-                    idx_b += 1;
-                    continue;
-                }
-                if *item > other_indices[idx_b] {
-                    /* Vector a is representative of the block_idxes in the blocks table and since other tables refer to the blocks
-                    table with a forein key constraint it should not be possible for other tables to have a block idx that is
-                    not present in the blocks table. */
-                    while idx_b < other_indices.len() {
+    async fn check_table_coherence(&self) -> Result<(), BlockStoreError> {
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                let mut block_indices =
+                    database_access::get_all_block_indices_from_blocks_table(connection)?;
+                let mut account_balances_block_indices =
+                    database_access::get_all_block_indices_from_account_balances_table(connection)?;
+                let vec_sorted_diff = |blocks_indices: &mut [u64],
+                                       other_indices: &mut [u64]|
+                 -> Result<Vec<u64>, BlockStoreError> {
+                    let mut result: Vec<u64> = Vec::new();
+                    let mut idx_b = 0;
+                    for item in blocks_indices {
+                        if idx_b >= other_indices.len() || *item < other_indices[idx_b] {
+                            result.push(*item);
+                            continue;
+                        }
                         if *item == other_indices[idx_b] {
                             idx_b += 1;
-                            break;
+                            continue;
                         }
-                        idx_b += 1;
+                        if *item > other_indices[idx_b] {
+                            /* Vector a is representative of the block_idxes in the blocks table and since other tables refer to the blocks
+                            table with a forein key constraint it should not be possible for other tables to have a block idx that is
+                            not present in the blocks table. */
+                            while idx_b < other_indices.len() {
+                                if *item == other_indices[idx_b] {
+                                    idx_b += 1;
+                                    break;
+                                }
+                                idx_b += 1;
+                            }
+                        }
+                    }
+                    Ok(result)
+                };
+
+                block_indices.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                block_indices.dedup();
+
+                account_balances_block_indices.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                account_balances_block_indices.dedup();
+                if !block_indices.is_empty() {
+                    let difference_account_balances_indices: Vec<u64> = vec_sorted_diff(
+                        block_indices.as_mut_slice(),
+                        account_balances_block_indices.as_mut_slice(),
+                    )?;
+                    for missing_index in difference_account_balances_indices {
+                        let missing_block =
+                            database_access::get_hashed_block(connection, &missing_index)?;
+                        database_access::update_balance_book(connection, &missing_block)?;
                     }
                 }
-            }
-            Ok(result)
-        };
-
-        block_indices.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        block_indices.dedup();
-
-        account_balances_block_indices.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        account_balances_block_indices.dedup();
-        if !block_indices.is_empty() {
-            let difference_account_balances_indices: Vec<u64> = vec_sorted_diff(
-                block_indices.as_mut_slice(),
-                account_balances_block_indices.as_mut_slice(),
-            )?;
-            for missing_index in difference_account_balances_indices {
-                let missing_block =
-                    database_access::get_hashed_block(&mut connection, &missing_index)?;
-                database_access::update_balance_book(&mut connection, &missing_block)?;
-            }
-        }
+                Ok(())
+            })
+            .await?;
         Ok(())
     }
-    pub fn is_verified_by_hash(
+    pub async fn is_verified_by_hash(
         &self,
         hash: &HashOf<EncodedBlock>,
     ) -> Result<bool, BlockStoreError> {
-        let block_idx = self.get_block_idx_by_block_hash(hash)?;
-        let mut con = self.connection.lock().unwrap();
-        match database_access::contains_block(&mut con, &block_idx)? {
-            true => database_access::is_verified(&mut con, &block_idx),
-            false => Err(BlockStoreError::NotFound(block_idx)),
-        }
+        let hash = *hash;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                let block_idx = database_access::get_block_idx_by_block_hash(connection, &hash)?;
+                match database_access::contains_block(connection, &block_idx)? {
+                    true => database_access::is_verified(connection, &block_idx),
+                    false => Err(BlockStoreError::NotFound(block_idx)),
+                }
+            })
+            .await?)
     }
 
-    pub fn is_verified_by_idx(&self, idx: &u64) -> Result<bool, BlockStoreError> {
-        let mut con = self.connection.lock().unwrap();
-        match database_access::contains_block(&mut con, idx)? {
-            true => database_access::is_verified(&mut con, idx),
-            false => Err(BlockStoreError::NotFound(*idx)),
-        }
+    pub async fn is_verified_by_idx(&self, idx: &u64) -> Result<bool, BlockStoreError> {
+        let idx = *idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| match database_access::contains_block(
+                connection, &idx,
+            )? {
+                true => database_access::is_verified(connection, &idx),
+                false => Err(BlockStoreError::NotFound(idx)),
+            })
+            .await?)
     }
 
-    pub fn get_first_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_first_hashed_block(&mut connection, None)
+    pub async fn get_first_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_first_hashed_block(connection, None)
+            })
+            .await?)
     }
 
-    pub fn get_latest_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_latest_hashed_block(&mut connection, None)
+    pub async fn get_latest_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_latest_hashed_block(connection, None)
+            })
+            .await?)
     }
 
-    pub fn get_latest_verified_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_latest_hashed_block(&mut connection, Some(true))
+    pub async fn get_latest_verified_hashed_block(&self) -> Result<HashedBlock, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_latest_hashed_block(connection, Some(true))
+            })
+            .await?)
     }
 
-    pub fn get_account_balance(
+    pub async fn get_account_balance(
         &self,
         account: &AccountIdentifier,
         block_idx: &u64,
     ) -> Result<Tokens, BlockStoreError> {
-        if self.is_verified_by_idx(block_idx)? {
-            let mut connection = self.connection.lock().unwrap();
-            let amount = database_access::get_account_balance(&mut connection, block_idx, account)?;
-            match amount {
-                Some(a) => Ok(Tokens::from_e8s(a)),
-                None => Ok(Tokens::ZERO),
-            }
-        } else {
-            Err(BlockStoreError::NotAvailable(*block_idx))
-        }
+        let account = *account;
+        let block_idx = *block_idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                let is_verified = match database_access::contains_block(connection, &block_idx)? {
+                    true => database_access::is_verified(connection, &block_idx)?,
+                    false => return Err(BlockStoreError::NotFound(block_idx)),
+                };
+                if !is_verified {
+                    return Err(BlockStoreError::NotAvailable(block_idx));
+                }
+                let amount =
+                    database_access::get_account_balance(connection, &block_idx, &account)?;
+                match amount {
+                    Some(a) => Ok(Tokens::from_e8s(a)),
+                    None => Ok(Tokens::ZERO),
+                }
+            })
+            .await?)
     }
 
-    pub fn get_hashed_block_range(
+    pub async fn get_hashed_block_range(
         &self,
         range: std::ops::Range<BlockIndex>,
     ) -> Result<Vec<HashedBlock>, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
         if range.end > range.start
-            && database_access::contains_block(&mut connection, &range.start).unwrap_or(false)
+            && database_access::contains_block(connection, &range.start).unwrap_or(false)
         {
             let mut stmt = connection.prepare_cached(r#"SELECT block_hash, encoded_block, parent_hash, block_idx, timestamp FROM blocks WHERE block_idx >= :start AND block_idx < :end"#).map_err(|e| BlockStoreError::Other(e.to_string()))?;
             database_access::read_hashed_blocks(
@@ -1289,31 +1402,43 @@ impl Blocks {
                 range.start, range.end
             )))
         }
+            })
+            .await?)
     }
 
-    pub fn push(&mut self, hb: &HashedBlock) -> Result<(), BlockStoreError> {
-        let mut con = self.connection.lock().unwrap();
-        con.execute_batch("BEGIN TRANSACTION;")
-            .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
-        database_access::push_hashed_block(&mut con, hb)?;
-        database_access::update_balance_book(&mut con, hb)?;
-        con.execute_batch("COMMIT TRANSACTION;")
-            .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
-        drop(con);
-        self.sanity_check(hb)?;
+    pub async fn push(&mut self, hb: &HashedBlock) -> Result<(), BlockStoreError> {
+        let hb_owned = hb.clone();
+        self.connection
+            .call::<_, (), BlockStoreError>(move |con| {
+                con.execute_batch("BEGIN TRANSACTION;")
+                    .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+                database_access::push_hashed_block(con, &hb_owned)?;
+                database_access::update_balance_book(con, &hb_owned)?;
+                con.execute_batch("COMMIT TRANSACTION;")
+                    .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+                Ok(())
+            })
+            .await?;
+        self.sanity_check(hb).await?;
         Ok(())
     }
-    pub fn get_all_accounts(&self) -> Result<Vec<AccountIdentifier>, BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
-        database_access::get_all_accounts(&mut connection)
+    pub async fn get_all_accounts(&self) -> Result<Vec<AccountIdentifier>, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::get_all_accounts(connection)
+            })
+            .await?)
     }
 
-    pub fn push_batch(
+    pub async fn push_batch(
         &mut self,
         batch: Vec<HashedBlock>,
         progress_bar: Option<&indicatif::ProgressBar>,
     ) -> Result<(), BlockStoreError> {
-        let connection = self.connection.lock().unwrap();
+        let progress_bar = progress_bar.cloned();
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
         connection
             .execute_batch("BEGIN TRANSACTION;")
             .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
@@ -1352,7 +1477,7 @@ impl Blocks {
                     return Err(e);
                 }
             }
-            if let Some(bar) = progress_bar {
+            if let Some(bar) = &progress_bar {
                 bar.inc(1);
             }
         }
@@ -1360,9 +1485,12 @@ impl Blocks {
             .execute_batch("COMMIT TRANSACTION;")
             .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
         Ok(())
+            })
+            .await?;
+        Ok(())
     }
 
-    pub fn try_prune(
+    pub async fn try_prune(
         &mut self,
         max_blocks: &Option<u64>,
         prune_delay: u64,
@@ -1370,19 +1498,21 @@ impl Blocks {
         if let Some(block_limit) = max_blocks {
             let first_idx = self
                 .get_first_hashed_block()
+                .await
                 .ok()
                 .map(|hb| hb.index)
                 .unwrap_or(0);
             let last_idx = self
                 .get_latest_hashed_block()
+                .await
                 .ok()
                 .map(|hb| hb.index)
                 .unwrap_or(0);
             if first_idx + block_limit + prune_delay < last_idx {
                 let new_first_idx = last_idx - block_limit;
-                let hb = self.get_hashed_block(&new_first_idx).ok();
+                let hb = self.get_hashed_block(&new_first_idx).await.ok();
                 match hb {
-                    Some(b) => self.prune(&b)?,
+                    Some(b) => self.prune(&b).await?,
                     None => return Err(BlockStoreError::NotFound(new_first_idx)),
                 }
             }
@@ -1390,14 +1520,17 @@ impl Blocks {
         Ok(())
     }
 
-    pub fn set_hashed_block_to_verified(
+    pub async fn set_hashed_block_to_verified(
         &self,
         block_height: &BlockIndex,
     ) -> Result<(), BlockStoreError> {
-        let mut connection = self.connection.lock().unwrap();
+        let block_height = *block_height;
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
         let last_verified =
-            database_access::get_latest_hashed_block(&mut connection, Some(true)).ok();
-        let last_block = database_access::get_latest_hashed_block(&mut connection, None)?;
+            database_access::get_latest_hashed_block(connection, Some(true)).ok();
+        let last_block = database_access::get_latest_hashed_block(connection, None)?;
+        let block_height = &block_height;
         match last_verified {
             Some(verified) => {
                 assert!(verified.index <= *block_height);
@@ -1427,6 +1560,9 @@ impl Blocks {
                 Ok(())
             }
         }
+            })
+            .await?;
+        Ok(())
     }
 
     // Returns the index of the next Rosetta Block and of the first block
@@ -1434,13 +1570,12 @@ impl Blocks {
     //
     // Note: this method requires that the rosetta blocks table exist but
     // it doesn't need them to be populated.
-    fn get_next_rosetta_block_indices(
+    async fn get_next_rosetta_block_indices(
         &self,
     ) -> Result<Option<RosettaBlockIndices>, BlockStoreError> {
-        let connection: std::sync::MutexGuard<rusqlite::Connection> = self
+        Ok(self
             .connection
-            .lock()
-            .map_err(|e| format!("Unable to acquire the connection mutex: {e:?}"))?;
+            .call::<_, Option<RosettaBlockIndices>, BlockStoreError>(move |connection| {
         let last_rosetta_block_index: Option<BlockIndex> = connection
             .query_row(
                 "SELECT max(rosetta_block_idx) FROM rosetta_blocks",
@@ -1461,9 +1596,11 @@ impl Blocks {
             rosetta_block_index: last_rosetta_block_index + 1,
             first_block_index: last_block_index_in_rosetta_block + 1,
         }))
+            })
+            .await?)
     }
 
-    pub fn make_rosetta_blocks_if_enabled(
+    pub async fn make_rosetta_blocks_if_enabled(
         &self,
         certified_tip_index: BlockIndex,
     ) -> Result<(), BlockStoreError> {
@@ -1472,13 +1609,27 @@ impl Blocks {
             RosettaBlocksMode::Enabled {
                 first_rosetta_block_index,
             } => self
-                .get_next_rosetta_block_indices()?
+                .get_next_rosetta_block_indices()
+                .await?
                 .unwrap_or(RosettaBlockIndices {
                     rosetta_block_index: first_rosetta_block_index,
                     first_block_index: first_rosetta_block_index,
                 }),
         };
 
+        // We fetch the first icp block to extract the timestamp, the first icp transaction and the first parent_hash of the first rosetta block created
+        let Block {
+            parent_hash,
+            timestamp,
+            ..
+        } = Block::decode(
+            self.get_hashed_block(&next_block_indices.first_block_index)
+                .await?
+                .block,
+        )?;
+
+        self.connection
+            .call::<_, (), BlockStoreError>(move |connection| {
         // Keep track of how many rosetta blocks are being created
         let num_rosetta_blocks_created = RefCell::new(0);
 
@@ -1489,23 +1640,9 @@ impl Blocks {
         // A list of all icp block indices that we need to convert to rosetta blocks
         let block_indices = next_block_indices.first_block_index..=certified_tip_index;
 
-        // We fetch the first icp block to extract the timestamp, the first icp transaction and the first parent_hash of the first rosetta block created
         let current_rosetta_block_index = RefCell::new(next_block_indices.rosetta_block_index);
-        let Block {
-            parent_hash,
-            timestamp,
-            ..
-        } = Block::decode(
-            self.get_hashed_block(&next_block_indices.first_block_index)?
-                .block,
-        )?;
-
         let current_rosetta_block_parent_hash = RefCell::new(parent_hash);
         let current_rosetta_block_timestamp = RefCell::new(timestamp);
-        let mut connection = self
-            .connection
-            .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
 
         let sql_tx = connection
             .transaction()
@@ -1569,7 +1706,7 @@ impl Blocks {
                 current_rosetta_block_timestamp.replace(current_icp_block_timestamp);
                 icp_transactions_per_rosetta_block.replace(HashMap::new());
 
-                self.store_rosetta_block(
+                Self::store_rosetta_block(
                     rosetta_block,
                     &mut insert_rosetta_block_stmt,
                     &mut insert_rosetta_block_transaction_stmt,
@@ -1635,10 +1772,12 @@ impl Blocks {
         );
 
         Ok(())
+            })
+            .await?;
+        Ok(())
     }
 
     pub(crate) fn store_rosetta_block(
-        &self,
         rosetta_block: RosettaBlock,
         insert_rosetta_block_stmt: &mut CachedStatement,
         insert_rosetta_block_transaction_stmt: &mut CachedStatement,
@@ -1671,14 +1810,16 @@ impl Blocks {
         Ok(())
     }
 
-    pub fn get_rosetta_block(
+    pub async fn get_rosetta_block(
         &self,
         rosetta_block_index: BlockIndex,
     ) -> Result<RosettaBlock, BlockStoreError> {
-        let (parent_hash, timestamp) =
-            self.get_rosetta_block_phash_timestamp(rosetta_block_index)?;
-        let transactions: BTreeMap<u64, Transaction> =
-            self.get_rosetta_block_transactions(rosetta_block_index)?;
+        let (parent_hash, timestamp) = self
+            .get_rosetta_block_phash_timestamp(rosetta_block_index)
+            .await?;
+        let transactions: BTreeMap<u64, Transaction> = self
+            .get_rosetta_block_transactions(rosetta_block_index)
+            .await?;
         Ok(RosettaBlock {
             index: rosetta_block_index,
             parent_hash,
@@ -1687,105 +1828,124 @@ impl Blocks {
         })
     }
 
-    pub fn get_highest_rosetta_block_index(&self) -> Result<Option<u64>, BlockStoreError> {
-        let connection = self
+    pub async fn get_highest_rosetta_block_index(&self) -> Result<Option<u64>, BlockStoreError> {
+        Ok(self
             .connection
-            .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
-        let block_idx = match connection
-            .prepare_cached("SELECT MAX(rosetta_block_idx) FROM rosetta_blocks")
-            .map_err(|e| format!("Unable to prepare query: {e:?}"))?
-            .query_map(params![], |row| row.get(0))
-            .map_err(|e| {
-                BlockStoreError::Other(format!("Unable to select from rosetta_blocks: {e:?}"))
-            })?
-            .next()
-        {
-            Some(Ok(block_idx)) => block_idx,
-            Some(Err(e)) => return Err(BlockStoreError::Other(e.to_string())),
-            None => None,
-        };
-        Ok(block_idx)
+            .call::<_, Option<u64>, BlockStoreError>(move |connection| {
+                let block_idx = match connection
+                    .prepare_cached("SELECT MAX(rosetta_block_idx) FROM rosetta_blocks")
+                    .map_err(|e| format!("Unable to prepare query: {e:?}"))?
+                    .query_map(params![], |row| row.get(0))
+                    .map_err(|e| {
+                        BlockStoreError::Other(format!(
+                            "Unable to select from rosetta_blocks: {e:?}"
+                        ))
+                    })?
+                    .next()
+                {
+                    Some(Ok(block_idx)) => block_idx,
+                    Some(Err(e)) => return Err(BlockStoreError::Other(e.to_string())),
+                    None => None,
+                };
+                Ok(block_idx)
+            })
+            .await?)
     }
 
-    fn get_rosetta_block_phash_timestamp(
+    async fn get_rosetta_block_phash_timestamp(
         &self,
         rosetta_block_index: BlockIndex,
     ) -> Result<(Option<[u8; 32]>, TimeStamp), BlockStoreError> {
-        let connection = self
+        Ok(self
             .connection
-            .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
-        let mut statement = connection
+            .call::<_, (Option<[u8; 32]>, TimeStamp), BlockStoreError>(move |connection| {
+                let mut statement = connection
             .prepare_cached(
                 "SELECT parent_hash, timestamp FROM rosetta_blocks WHERE rosetta_block_idx=:idx",
             )
             .map_err(|e| format!("Unable to prepare query: {e:?}"))?;
-        let mut blocks = statement
-            .query_map(named_params! { ":idx": rosetta_block_index }, |row| {
-                let parent_hash = row.get(0)?;
-                let timestamp = row.get(1).map(iso8601_to_timestamp)?;
-                Ok((parent_hash, timestamp))
+                let mut blocks = statement
+                    .query_map(named_params! { ":idx": rosetta_block_index }, |row| {
+                        let parent_hash = row.get(0)?;
+                        let timestamp = row.get(1).map(iso8601_to_timestamp)?;
+                        Ok((parent_hash, timestamp))
+                    })
+                    .map_err(|e| {
+                        BlockStoreError::from(format!(
+                            "Unable to select from rosetta_blocks: {e:?}"
+                        ))
+                    })?;
+                match blocks.next() {
+                    Some(block) => block.map_err(|e| BlockStoreError::Other(e.to_string())),
+                    None => Err(BlockStoreError::NotFound(rosetta_block_index)),
+                }
             })
-            .map_err(|e| {
-                BlockStoreError::from(format!("Unable to select from rosetta_blocks: {e:?}"))
-            })?;
-        match blocks.next() {
-            Some(block) => block.map_err(|e| BlockStoreError::Other(e.to_string())),
-            None => Err(BlockStoreError::NotFound(rosetta_block_index)),
-        }
+            .await?)
     }
 
-    fn get_rosetta_block_transactions(
+    async fn get_rosetta_block_transactions(
         &self,
         rosetta_block_index: BlockIndex,
     ) -> Result<BTreeMap<BlockIndex, Transaction>, BlockStoreError> {
-        let connection = self
+        Ok(self
             .connection
-            .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
-        let mut statement = connection
-            .prepare_cached(
-                r#"SELECT blocks.block_idx, encoded_block
+            .call::<_, BTreeMap<BlockIndex, Transaction>, BlockStoreError>(move |connection| {
+                let mut statement = connection
+                    .prepare_cached(
+                        r#"SELECT blocks.block_idx, encoded_block
                    FROM rosetta_blocks_transactions JOIN blocks
                    ON rosetta_blocks_transactions.block_idx = blocks.block_idx
                    WHERE rosetta_blocks_transactions.rosetta_block_idx=:idx"#,
-            )
-            .map_err(|e| format!("Unable to select block: {e:?}"))?;
-        let blocks = statement
-            .query_map(named_params! { ":idx": rosetta_block_index }, |row| {
-                let block_index: BlockIndex = row.get(0)?;
-                let block = row.get(1).and_then(sql_bytes_to_block)?;
-                Ok((block_index, block))
+                    )
+                    .map_err(|e| format!("Unable to select block: {e:?}"))?;
+                let blocks = statement
+                    .query_map(named_params! { ":idx": rosetta_block_index }, |row| {
+                        let block_index: BlockIndex = row.get(0)?;
+                        let block = row.get(1).and_then(sql_bytes_to_block)?;
+                        Ok((block_index, block))
+                    })
+                    .map_err(|e| format!("Unable to select block: {e:?}"))?;
+                let mut transactions = BTreeMap::new();
+                for index_and_block in blocks {
+                    let (block_index, block) =
+                        index_and_block.map_err(|e| format!("Unable to select block: {e:?}"))?;
+                    let transaction = block.transaction;
+                    transactions.insert(block_index, transaction);
+                }
+                Ok(transactions)
             })
-            .map_err(|e| format!("Unable to select block: {e:?}"))?;
-        let mut transactions = BTreeMap::new();
-        for index_and_block in blocks {
-            let (block_index, block) =
-                index_and_block.map_err(|e| format!("Unable to select block: {e:?}"))?;
-            let transaction = block.transaction;
-            transactions.insert(block_index, transaction);
-        }
-        Ok(transactions)
+            .await?)
     }
 
-    pub fn contains_block(&self, block_idx: &BlockIndex) -> Result<bool, BlockStoreError> {
-        let mut connection = self.connection.lock().map_err(|e| {
-            BlockStoreError::Other(format!("Unable to acquire the connection mutex: {e:?}"))
-        })?;
-        database_access::contains_block(&mut connection, block_idx)
+    pub async fn contains_block(&self, block_idx: &BlockIndex) -> Result<bool, BlockStoreError> {
+        let block_idx = *block_idx;
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                database_access::contains_block(connection, &block_idx)
+            })
+            .await?)
     }
 
-    pub fn get_blocks_by_custom_query<P>(
+    pub async fn get_blocks_by_custom_query(
         &self,
         sql_query: String,
-        params: P,
-    ) -> Result<Vec<HashedBlock>, BlockStoreError>
-    where
-        P: rusqlite::Params,
-    {
-        let open_connection = self.connection.lock().unwrap();
-        database_access::get_blocks_by_custom_query(&open_connection, sql_query, params)
+        params: Vec<(String, rusqlite::types::Value)>,
+    ) -> Result<Vec<HashedBlock>, BlockStoreError> {
+        Ok(self
+            .connection
+            .call::<_, _, BlockStoreError>(move |connection| {
+                let params_refs: Vec<(&str, &dyn rusqlite::ToSql)> = params
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v as &dyn rusqlite::ToSql))
+                    .collect();
+                database_access::get_blocks_by_custom_query(
+                    connection,
+                    sql_query,
+                    params_refs.as_slice(),
+                )
+            })
+            .await?)
     }
 }
 
@@ -1807,14 +1967,14 @@ struct RosettaBlockIndices {
 
 #[cfg(test)]
 mod tests {
-    use super::{Blocks, IndexOptimization, RosettaDbConfig};
+    use super::{BlockStoreError, Blocks, IndexOptimization, RosettaDbConfig};
     use crate::rosetta_block::RosettaBlock;
     use candid::Principal;
     use ic_ledger_core::block::BlockType;
     use icp_ledger::{AccountIdentifier, Block, Memo, Operation, TimeStamp, Tokens, Transaction};
 
-    #[test]
-    fn test_store_load_rosetta_block() {
+    #[tokio::test]
+    async fn test_store_load_rosetta_block() {
         let to = AccountIdentifier::new(ic_types::PrincipalId(Principal::anonymous()), None);
         let transaction0 = Transaction {
             operation: Operation::Mint {
@@ -1865,44 +2025,53 @@ mod tests {
             transactions: [(0, transaction0), (1, transaction1)].into_iter().collect(),
         };
 
-        let mut blocks = Blocks::new_in_memory(RosettaDbConfig::default_enabled()).unwrap();
-        blocks.push(&hashed_block0).unwrap();
-        blocks.push(&hashed_block1).unwrap();
-        let mut connection = blocks.connection.lock().unwrap();
-        let transaction = connection.transaction().unwrap();
-
-        let mut insert_rosetta_block_stmt = transaction
-            .prepare_cached(
-                r#"INSERT INTO rosetta_blocks (rosetta_block_idx, hash, timestamp)
-                VALUES (:idx, :hash, :timestamp)"#,
-            )
+        let mut blocks = Blocks::new_in_memory(RosettaDbConfig::default_enabled())
+            .await
             .unwrap();
-        let mut insert_rosetta_block_transaction_stmt = transaction
-            .prepare_cached(
-                r#"INSERT INTO rosetta_blocks_transactions (rosetta_block_idx, block_idx)
-VALUES (:idx, :block_idx)"#,
-            )
-            .unwrap();
-
+        blocks.push(&hashed_block0).await.unwrap();
+        blocks.push(&hashed_block1).await.unwrap();
+        let rosetta_block_to_store = rosetta_block.clone();
         blocks
-            .store_rosetta_block(
-                rosetta_block.clone(),
-                &mut insert_rosetta_block_stmt,
-                &mut insert_rosetta_block_transaction_stmt,
-            )
-            .unwrap();
+            .connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                let transaction = connection.transaction().unwrap();
 
-        drop(insert_rosetta_block_stmt);
-        drop(insert_rosetta_block_transaction_stmt);
-        transaction.commit().unwrap();
-        drop(connection);
-        let actual_rosetta_block = blocks.get_rosetta_block(0).unwrap();
+                let mut insert_rosetta_block_stmt = transaction
+                    .prepare_cached(
+                        r#"INSERT INTO rosetta_blocks (rosetta_block_idx, hash, timestamp)
+                VALUES (:idx, :hash, :timestamp)"#,
+                    )
+                    .unwrap();
+                let mut insert_rosetta_block_transaction_stmt = transaction
+                    .prepare_cached(
+                        r#"INSERT INTO rosetta_blocks_transactions (rosetta_block_idx, block_idx)
+VALUES (:idx, :block_idx)"#,
+                    )
+                    .unwrap();
+
+                Blocks::store_rosetta_block(
+                    rosetta_block_to_store,
+                    &mut insert_rosetta_block_stmt,
+                    &mut insert_rosetta_block_transaction_stmt,
+                )
+                .unwrap();
+
+                drop(insert_rosetta_block_stmt);
+                drop(insert_rosetta_block_transaction_stmt);
+                transaction.commit().unwrap();
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let actual_rosetta_block = blocks.get_rosetta_block(0).await.unwrap();
         assert_eq!(rosetta_block, actual_rosetta_block);
     }
 
-    #[test]
-    fn test_update_balance_book_with_large_values() {
-        let mut blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled()).unwrap();
+    #[tokio::test]
+    async fn test_update_balance_book_with_large_values() {
+        let mut blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled())
+            .await
+            .unwrap();
 
         let account = AccountIdentifier::new(ic_types::PrincipalId(Principal::anonymous()), None);
 
@@ -1928,28 +2097,32 @@ VALUES (:idx, :block_idx)"#,
         let hashed_block = super::HashedBlock::hash_block(encoded_block, None, 0, block.timestamp);
 
         // Push the block (this should handle the large value correctly with TEXT storage)
-        blocks.push(&hashed_block).unwrap();
+        blocks.push(&hashed_block).await.unwrap();
 
         // Set the block as verified so we can query the balance
-        blocks.set_hashed_block_to_verified(&0).unwrap();
+        blocks.set_hashed_block_to_verified(&0).await.unwrap();
 
         // Verify the balance was stored and can be retrieved with full precision
-        let balance = blocks.get_account_balance(&account, &0).unwrap();
+        let balance = blocks.get_account_balance(&account, &0).await.unwrap();
         assert_eq!(balance, Tokens::from_e8s(large_amount));
 
         // Verify the balance history
-        let history = blocks.get_account_balance_history(&account, None).unwrap();
+        let history = blocks
+            .get_account_balance_history(&account, None)
+            .await
+            .unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0], (0_u64, Tokens::from_e8s(large_amount)));
     }
 
-    #[test]
-    fn test_comprehensive_backwards_compatibility() {
+    #[tokio::test]
+    async fn test_comprehensive_backwards_compatibility() {
         use super::database_access;
         use rusqlite::params;
 
-        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled()).unwrap();
-        let mut connection = blocks.connection.lock().unwrap();
+        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled())
+            .await
+            .unwrap();
 
         let account1 = AccountIdentifier::new(ic_types::PrincipalId(Principal::anonymous()), None);
         let account2 = AccountIdentifier::new(
@@ -1957,144 +2130,171 @@ VALUES (:idx, :block_idx)"#,
             None,
         );
 
-        // Scenario 1: Existing database with small INTEGER values (backwards compatible)
-        let small_value1 = 1000000_u64; // 0.01 ICP
-        let small_value2 = 5000000000_u64; // 50 ICP
-        connection
+        blocks
+            .connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                // Scenario 1: Existing database with small INTEGER values (backwards compatible)
+                let small_value1 = 1000000_u64; // 0.01 ICP
+                let small_value2 = 5000000000_u64; // 50 ICP
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![1_u64, account1.to_hex(), small_value1 as i64],
             )
             .unwrap();
-        connection
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![2_u64, account2.to_hex(), small_value2 as i64],
             )
             .unwrap();
 
-        // Scenario 2: New large values using bit-reinterpretation
-        let large_value1 = 10000000000000000000_u64; // The problematic value from the original error
-        let large_value2 = 18446744073709551615_u64; // u64::MAX
-        connection
+                // Scenario 2: New large values using bit-reinterpretation
+                let large_value1 = 10000000000000000000_u64; // The problematic value from the original error
+                let large_value2 = 18446744073709551615_u64; // u64::MAX
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![3_u64, account1.to_hex(), large_value1 as i64], // Stored as negative i64
             )
             .unwrap();
-        connection
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![4_u64, account2.to_hex(), large_value2 as i64], // Stored as -1
             )
             .unwrap();
 
-        // Test reading all values - should work seamlessly with bit-reinterpretation
-        let balance1 =
-            database_access::get_account_balance(&mut connection, &1_u64, &account1).unwrap();
-        let balance2 =
-            database_access::get_account_balance(&mut connection, &2_u64, &account2).unwrap();
-        let balance3 =
-            database_access::get_account_balance(&mut connection, &3_u64, &account1).unwrap();
-        let balance4 =
-            database_access::get_account_balance(&mut connection, &4_u64, &account2).unwrap();
+                // Test reading all values - should work seamlessly with bit-reinterpretation
+                let balance1 =
+                    database_access::get_account_balance(connection, &1_u64, &account1).unwrap();
+                let balance2 =
+                    database_access::get_account_balance(connection, &2_u64, &account2).unwrap();
+                let balance3 =
+                    database_access::get_account_balance(connection, &3_u64, &account1).unwrap();
+                let balance4 =
+                    database_access::get_account_balance(connection, &4_u64, &account2).unwrap();
 
-        // All values should be read correctly regardless of magnitude
-        assert_eq!(balance1, Some(small_value1));
-        assert_eq!(balance2, Some(small_value2));
-        assert_eq!(balance3, Some(large_value1));
-        assert_eq!(balance4, Some(large_value2));
+                // All values should be read correctly regardless of magnitude
+                assert_eq!(balance1, Some(small_value1));
+                assert_eq!(balance2, Some(small_value2));
+                assert_eq!(balance3, Some(large_value1));
+                assert_eq!(balance4, Some(large_value2));
 
-        // Test that the latest balance query works correctly (should return the large values)
-        let latest_balance1 =
-            database_access::get_account_balance(&mut connection, &10_u64, &account1).unwrap();
-        let latest_balance2 =
-            database_access::get_account_balance(&mut connection, &10_u64, &account2).unwrap();
+                // Test that the latest balance query works correctly (should return the large values)
+                let latest_balance1 =
+                    database_access::get_account_balance(connection, &10_u64, &account1).unwrap();
+                let latest_balance2 =
+                    database_access::get_account_balance(connection, &10_u64, &account2).unwrap();
 
-        assert_eq!(latest_balance1, Some(large_value1));
-        assert_eq!(latest_balance2, Some(large_value2));
+                assert_eq!(latest_balance1, Some(large_value1));
+                assert_eq!(latest_balance2, Some(large_value2));
+                Ok(())
+            })
+            .await
+            .unwrap();
     }
 
-    #[test]
-    fn test_account_balance_bit_reinterpretation() {
+    #[tokio::test]
+    async fn test_account_balance_bit_reinterpretation() {
         use super::database_access;
         use rusqlite::params;
 
-        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled()).unwrap();
-        let mut connection = blocks.connection.lock().unwrap();
+        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_disabled())
+            .await
+            .unwrap();
 
         let account = AccountIdentifier::new(ic_types::PrincipalId(Principal::anonymous()), None);
 
-        // Test 1: Small value (fits in i64) - stored as positive
-        let small_value = 1000000_u64; // 0.01 ICP in e8s
-        connection
+        blocks
+            .connection
+            .call::<_, (), BlockStoreError>(move |connection| {
+                // Test 1: Small value (fits in i64) - stored as positive
+                let small_value = 1000000_u64; // 0.01 ICP in e8s
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![1_u64, account.to_hex(), small_value as i64],
             )
             .unwrap();
 
-        let balance =
-            database_access::get_account_balance(&mut connection, &1_u64, &account).unwrap();
-        assert_eq!(balance, Some(small_value));
+                let balance =
+                    database_access::get_account_balance(connection, &1_u64, &account).unwrap();
+                assert_eq!(balance, Some(small_value));
 
-        // Test 2: Large value (exceeds i64::MAX) - stored as negative i64, reinterpreted as u64
-        let large_value = 10000000000000000000_u64; // Exceeds i64::MAX
-        let large_value_as_i64 = large_value as i64; // This becomes negative
-        connection
+                // Test 2: Large value (exceeds i64::MAX) - stored as negative i64, reinterpreted as u64
+                let large_value = 10000000000000000000_u64; // Exceeds i64::MAX
+                let large_value_as_i64 = large_value as i64; // This becomes negative
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![2_u64, account.to_hex(), large_value_as_i64],
             )
             .unwrap();
 
-        let balance =
-            database_access::get_account_balance(&mut connection, &2_u64, &account).unwrap();
-        assert_eq!(balance, Some(large_value)); // Should recover the original value
+                let balance =
+                    database_access::get_account_balance(connection, &2_u64, &account).unwrap();
+                assert_eq!(balance, Some(large_value)); // Should recover the original value
 
-        // Test 3: u64::MAX value
-        let max_value = u64::MAX;
-        let max_value_as_i64 = max_value as i64; // This becomes -1
-        connection
+                // Test 3: u64::MAX value
+                let max_value = u64::MAX;
+                let max_value_as_i64 = max_value as i64; // This becomes -1
+                connection
             .execute(
                 "INSERT INTO account_balances (block_idx, account, tokens) VALUES (?1, ?2, ?3)",
                 params![3_u64, account.to_hex(), max_value_as_i64],
             )
             .unwrap();
 
-        let balance =
-            database_access::get_account_balance(&mut connection, &3_u64, &account).unwrap();
-        assert_eq!(balance, Some(max_value)); // Should recover u64::MAX
+                let balance =
+                    database_access::get_account_balance(connection, &3_u64, &account).unwrap();
+                assert_eq!(balance, Some(max_value)); // Should recover u64::MAX
 
-        // Verify that bit reinterpretation works correctly
-        assert_eq!(large_value_as_i64, -8446744073709551616_i64);
-        assert_eq!(max_value_as_i64, -1_i64);
-        assert_eq!((-8446744073709551616_i64) as u64, 10000000000000000000_u64);
-        assert_eq!((-1_i64) as u64, u64::MAX);
+                // Verify that bit reinterpretation works correctly
+                assert_eq!(large_value_as_i64, -8446744073709551616_i64);
+                assert_eq!(max_value_as_i64, -1_i64);
+                assert_eq!((-8446744073709551616_i64) as u64, 10000000000000000000_u64);
+                assert_eq!((-1_i64) as u64, u64::MAX);
+                Ok(())
+            })
+            .await
+            .unwrap();
     }
 
-    #[test]
-    fn test_search_indexes_creation_when_enabled() {
-        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_enabled()).unwrap();
-        let connection = blocks.connection.lock().unwrap();
+    async fn read_search_index_names(blocks: &Blocks) -> Vec<String> {
+        blocks
+            .connection
+            .call::<_, Vec<String>, BlockStoreError>(move |connection| {
+                let index_query =
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name IN (?, ?, ?, ?)";
+                let mut stmt = connection.prepare(index_query).unwrap();
+                let index_names: Vec<String> = stmt
+                    .query_map(
+                        [
+                            "from_account_index",
+                            "to_account_index",
+                            "spender_account_index",
+                            "operation_type_index",
+                        ],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                Ok(index_names)
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_search_indexes_creation_when_enabled() {
+        let blocks = Blocks::new_in_memory(RosettaDbConfig::default_enabled())
+            .await
+            .unwrap();
 
         // Check that indexes exist when optimization is enabled
-        let index_query =
-            "SELECT name FROM sqlite_master WHERE type='index' AND name IN (?, ?, ?, ?)";
-        let mut stmt = connection.prepare(index_query).unwrap();
-        let index_names: Vec<String> = stmt
-            .query_map(
-                [
-                    "from_account_index",
-                    "to_account_index",
-                    "spender_account_index",
-                    "operation_type_index",
-                ],
-                |row| row.get::<_, String>(0),
-            )
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+        let index_names = read_search_index_names(&blocks).await;
 
         assert!(index_names.contains(&"from_account_index".to_string()));
         assert!(index_names.contains(&"to_account_index".to_string()));
@@ -2102,31 +2302,16 @@ VALUES (:idx, :block_idx)"#,
         assert!(index_names.contains(&"operation_type_index".to_string()));
     }
 
-    #[test]
-    fn test_search_indexes_not_created_when_disabled() {
+    #[tokio::test]
+    async fn test_search_indexes_not_created_when_disabled() {
         let blocks = Blocks::new_in_memory(RosettaDbConfig::with_rosetta_blocks_enabled(
             IndexOptimization::Disabled,
         ))
+        .await
         .unwrap();
-        let connection = blocks.connection.lock().unwrap();
 
         // Check that indexes don't exist when optimization is disabled
-        let index_query =
-            "SELECT name FROM sqlite_master WHERE type='index' AND name IN (?, ?, ?, ?)";
-        let mut stmt = connection.prepare(index_query).unwrap();
-        let index_names: Vec<String> = stmt
-            .query_map(
-                [
-                    "from_account_index",
-                    "to_account_index",
-                    "spender_account_index",
-                    "operation_type_index",
-                ],
-                |row| row.get::<_, String>(0),
-            )
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+        let index_names = read_search_index_names(&blocks).await;
 
         // These specific indexes should not exist
         assert!(!index_names.contains(&"from_account_index".to_string()));
@@ -2135,13 +2320,15 @@ VALUES (:idx, :block_idx)"#,
         assert!(!index_names.contains(&"operation_type_index".to_string()));
     }
 
-    #[test]
-    fn test_search_indexes_creation_existing_db() {
+    #[tokio::test]
+    async fn test_search_indexes_creation_existing_db() {
         let tmp_dir = ic_ledger_canister_blocks_synchronizer_test_utils::create_tmp_dir();
         let config_disabled = RosettaDbConfig::default_disabled();
 
         {
-            let mut blocks = Blocks::new_persistent(tmp_dir.path(), config_disabled).unwrap();
+            let mut blocks = Blocks::new_persistent(tmp_dir.path(), config_disabled)
+                .await
+                .unwrap();
 
             let to = AccountIdentifier::new(ic_types::PrincipalId(Principal::anonymous()), None);
             let transaction0 = Transaction {
@@ -2165,31 +2352,17 @@ VALUES (:idx, :block_idx)"#,
                 0,
                 block0.timestamp,
             );
-            blocks.push(&hashed_block0).unwrap();
+            blocks.push(&hashed_block0).await.unwrap();
         }
 
         // Re-open with optimization enabled
         let config_enabled = RosettaDbConfig::default_enabled();
-        let blocks = Blocks::new_persistent(tmp_dir.path(), config_enabled).unwrap();
-        let connection = blocks.connection.lock().unwrap();
+        let blocks = Blocks::new_persistent(tmp_dir.path(), config_enabled)
+            .await
+            .unwrap();
 
         // Check indexes
-        let index_query =
-            "SELECT name FROM sqlite_master WHERE type='index' AND name IN (?, ?, ?, ?)";
-        let mut stmt = connection.prepare(index_query).unwrap();
-        let index_names: Vec<String> = stmt
-            .query_map(
-                [
-                    "from_account_index",
-                    "to_account_index",
-                    "spender_account_index",
-                    "operation_type_index",
-                ],
-                |row| row.get::<_, String>(0),
-            )
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+        let index_names = read_search_index_names(&blocks).await;
 
         assert!(index_names.contains(&"from_account_index".to_string()));
         assert!(index_names.contains(&"to_account_index".to_string()));

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -1108,17 +1108,31 @@ impl Blocks {
         let index = hb.index;
         self.connection
             .call::<_, (), BlockStoreError>(move |connection| {
+                // The connection is long-lived and reused, so any error path that
+                // returns without closing the transaction would leave it open and
+                // cause every subsequent write to fail with "cannot start a
+                // transaction within a transaction". Explicitly roll back on every
+                // error path (mirroring `push_batch`).
                 connection
                     .execute_batch("BEGIN TRANSACTION;")
                     .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
 
-                database_access::prune_account_balances(connection, &index)?;
-                connection
-                    .execute(
-                        "DELETE FROM blocks WHERE block_idx > 0 AND block_idx < ?",
-                        params![index],
-                    )
-                    .map_err(|e| BlockStoreError::Other(e.to_string()))?;
+                if let Err(e) = database_access::prune_account_balances(connection, &index)
+                    .and_then(|_| {
+                        connection
+                            .execute(
+                                "DELETE FROM blocks WHERE block_idx > 0 AND block_idx < ?",
+                                params![index],
+                            )
+                            .map(|_| ())
+                            .map_err(|e| BlockStoreError::Other(e.to_string()))
+                    })
+                {
+                    connection
+                        .execute_batch("ROLLBACK TRANSACTION;")
+                        .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+                    return Err(e);
+                }
 
                 connection
                     .execute_batch("COMMIT TRANSACTION;")
@@ -1410,10 +1424,20 @@ impl Blocks {
         let hb_owned = hb.clone();
         self.connection
             .call::<_, (), BlockStoreError>(move |con| {
+                // The connection is long-lived and reused, so any error path that
+                // returns without closing the transaction would leave it open and
+                // cause every subsequent write to fail with "cannot start a
+                // transaction within a transaction". Explicitly roll back on every
+                // error path (mirroring `push_batch`).
                 con.execute_batch("BEGIN TRANSACTION;")
                     .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
-                database_access::push_hashed_block(con, &hb_owned)?;
-                database_access::update_balance_book(con, &hb_owned)?;
+                if let Err(e) = database_access::push_hashed_block(con, &hb_owned)
+                    .and_then(|_| database_access::update_balance_book(con, &hb_owned))
+                {
+                    con.execute_batch("ROLLBACK TRANSACTION;")
+                        .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
+                    return Err(e);
+                }
                 con.execute_batch("COMMIT TRANSACTION;")
                     .map_err(|e| BlockStoreError::Other(format!("{e}")))?;
                 Ok(())

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
@@ -64,8 +64,8 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         let rosetta_metrics =
             RosettaMetrics::new("ICP".to_string(), "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string());
         let mut blocks = match store_location {
-            Some(loc) => Blocks::new_persistent(loc, config)?,
-            None => Blocks::new_in_memory(config)?,
+            Some(loc) => Blocks::new_persistent(loc, config).await?,
+            None => Blocks::new_in_memory(config).await?,
         };
 
         if let Some(blocks_access) = &blocks_access {
@@ -78,8 +78,8 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         }
 
         info!("Loading blocks from store");
-        let first_block = blocks.get_first_hashed_block();
-        let last_block = blocks.get_latest_hashed_block();
+        let first_block = blocks.get_first_hashed_block().await;
+        let last_block = blocks.get_latest_hashed_block().await;
         if let (Ok(first), Ok(last)) = (&first_block, &last_block) {
             info!(
                 "Ledger client is up. Loaded {} blocks from store. First block at {}, last at {}",
@@ -97,11 +97,11 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         if let Ok(x) = last_block {
             rosetta_metrics.set_synced_height(x.index);
         }
-        if let Ok(x) = blocks.get_latest_verified_hashed_block() {
+        if let Ok(x) = blocks.get_latest_verified_hashed_block().await {
             rosetta_metrics.set_verified_height(x.index);
         }
 
-        blocks.try_prune(&store_max_blocks, PRUNE_DELAY)?;
+        blocks.try_prune(&store_max_blocks, PRUNE_DELAY).await?;
 
         Ok(Self {
             blockchain: RwLock::new(blocks),
@@ -114,8 +114,8 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
 
     async fn verify_store(blocks: &Blocks, canister_access: &B) -> Result<(), Error> {
         debug!("Verifying store...");
-        let first_block = blocks.get_first_hashed_block().ok();
-        match blocks.get_hashed_block(&0) {
+        let first_block = blocks.get_first_hashed_block().await.ok();
+        match blocks.get_hashed_block(&0).await {
             Ok(store_genesis) => {
                 let genesis = canister_access
                     .query_raw_block(0)
@@ -208,7 +208,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         Ok(())
     }
 
-    pub async fn read_blocks(&self) -> Box<dyn Deref<Target = Blocks> + '_> {
+    pub async fn read_blocks(&self) -> Box<dyn Deref<Target = Blocks> + Send + '_> {
         Box::new(self.blockchain.read().await)
     }
 
@@ -274,7 +274,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
 
         let mut blockchain = self.blockchain.write().await;
 
-        let latest_hb_opt = blockchain.get_latest_hashed_block();
+        let latest_hb_opt = blockchain.get_latest_hashed_block().await;
         let (last_block_hash, next_block_index) = match latest_hb_opt {
             Ok(hb) => (Some(hb.hash), hb.index + 1),
             Err(_) => (None, 0),
@@ -320,15 +320,16 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         )
         .await?;
 
-        blockchain.make_rosetta_blocks_if_enabled(tip_index)?;
+        blockchain.make_rosetta_blocks_if_enabled(tip_index).await?;
 
         info!(
             "You are all caught up to block {}",
-            blockchain.get_latest_hashed_block()?.index
+            blockchain.get_latest_hashed_block().await?.index
         );
 
         blockchain
             .try_prune(&self.store_max_blocks, PRUNE_DELAY)
+            .await
             .map_err(|_| Error::InternalError("Failed to prune store".to_string()))
     }
 
@@ -445,16 +446,22 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                     bar.set_message("store blocks");
                     bar.set_position(bar.position() - block_batch.len() as u64)
                 };
-                blockchain.push_batch(block_batch, progress_bar.as_ref())?;
+                blockchain
+                    .push_batch(block_batch, progress_bar.as_ref())
+                    .await?;
                 block_batch = Vec::new();
             }
         }
-        blockchain.push_batch(block_batch, progress_bar.as_ref())?;
+        blockchain
+            .push_batch(block_batch, progress_bar.as_ref())
+            .await?;
         if let Some(bar) = &progress_bar {
             bar.finish();
         }
         info!("Synced took {} seconds", t_total.elapsed().as_secs_f64());
-        blockchain.set_hashed_block_to_verified(&(range.end - 1))?;
+        blockchain
+            .set_hashed_block_to_verified(&(range.end - 1))
+            .await?;
         self.rosetta_metrics.set_verified_height(range.end - 1);
         Ok(())
     }
@@ -589,6 +596,7 @@ mod test {
                 .read_blocks()
                 .await
                 .get_first_hashed_block()
+                .await
                 .ok()
         );
     }
@@ -604,8 +612,13 @@ mod test {
         let actual_blocks = blocks_sync.read_blocks().await;
         // there isn't a blocks.len() to use, so we check that the last index + 1 gives error and then we check the blocks
         for (idx, eb) in blocks.iter().enumerate() {
-            let hb = actual_blocks.get_hashed_block(&(idx as u64)).unwrap();
-            assert!(actual_blocks.is_verified_by_idx(&(idx as u64)).unwrap());
+            let hb = actual_blocks.get_hashed_block(&(idx as u64)).await.unwrap();
+            assert!(
+                actual_blocks
+                    .is_verified_by_idx(&(idx as u64))
+                    .await
+                    .unwrap()
+            );
             assert_eq!(Block::block_hash(eb), Block::block_hash(&hb.block));
         }
     }
@@ -622,8 +635,8 @@ mod test {
             .unwrap();
         {
             let actual_blocks = blocks_sync.read_blocks().await;
-            let hashed_blocks = actual_blocks.get_hashed_block(&0).unwrap();
-            assert!(actual_blocks.is_verified_by_idx(&0).unwrap());
+            let hashed_blocks = actual_blocks.get_hashed_block(&0).await.unwrap();
+            assert!(actual_blocks.is_verified_by_idx(&0).await.unwrap());
             assert_eq!(
                 Block::block_hash(&blocks[0]),
                 Block::block_hash(&hashed_blocks.block)
@@ -637,8 +650,8 @@ mod test {
             .unwrap();
         {
             let actual_blocks = blocks_sync.read_blocks().await;
-            let hashed_blocks = actual_blocks.get_hashed_block(&1).unwrap();
-            assert!(actual_blocks.is_verified_by_idx(&1).unwrap());
+            let hashed_blocks = actual_blocks.get_hashed_block(&1).await.unwrap();
+            assert!(actual_blocks.is_verified_by_idx(&1).await.unwrap());
             assert_eq!(
                 Block::block_hash(&blocks[1]),
                 Block::block_hash(&hashed_blocks.block)

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/runtime_responsiveness_test.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/runtime_responsiveness_test.rs
@@ -1,0 +1,135 @@
+//! Regression test for DEFI-2950 / DEFI-2491: the ICP Rosetta block store must
+//! not starve the async runtime.
+//!
+//! ICP Rosetta serves its endpoints from `async` handlers running on a `tokio`
+//! multi-threaded runtime, but the block store's query methods are **blocking**
+//! (synchronous `rusqlite` behind a `std::sync::Mutex<Connection>`, with no
+//! `.await` points). When several such calls run concurrently they occupy all
+//! `tokio` worker threads for the whole duration of the work, and no other async
+//! task — a `/health` request, `/metrics`, the watchdog heartbeat — can make
+//! progress. This is the runtime-starvation bottleneck analysed in DEFI-2491.
+//!
+//! This test reproduces that scenario deterministically: it runs a small, fixed
+//! number of worker threads, hammers the block store from several concurrent
+//! tasks, and concurrently runs a lightweight "canary" task that only sleeps and
+//! counts ticks (it never touches the database). If the store blocks the worker
+//! threads, the canary is starved and makes almost no progress.
+//!
+//! * On `master` (blocking store) the canary is starved -> this test FAILS.
+//! * After migrating the store to async SQLite (`tokio-rusqlite`) the worker
+//!   threads stay free -> the canary keeps ticking -> this test PASSES.
+//!
+//! The test is intentionally independent of absolute query latency: the hammer
+//! loop contains no `.await`, so on `master` a single scheduled hammer monopol-
+//! ises a worker thread for the entire load window regardless of how fast an
+//! individual query is. What changes after the migration is that each store call
+//! becomes an `.await` point that yields the worker while the query runs on the
+//! store's dedicated background thread.
+
+use ic_ledger_canister_blocks_synchronizer::blocks::{Blocks, RosettaDbConfig};
+use ic_ledger_canister_blocks_synchronizer_test_utils::sample_data::Scribe;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Deliberately small so the starvation is deterministic regardless of the host
+/// core count (production integrators are recommended to run with ~4 CPUs).
+const WORKER_THREADS: usize = 2;
+/// More concurrent DB tasks than worker threads, so every worker is kept busy.
+const NUM_HAMMER_TASKS: usize = 8;
+/// How long the concurrent database load runs.
+const LOAD_WINDOW: Duration = Duration::from_secs(2);
+/// The canary tries to wake up this often.
+const CANARY_TICK: Duration = Duration::from_millis(10);
+
+#[test]
+fn block_store_does_not_starve_async_runtime() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(WORKER_THREADS)
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    runtime.block_on(async {
+        // Build and populate an in-memory store.
+        let mut store = Blocks::new_in_memory(RosettaDbConfig::default_disabled())
+            .await
+            .expect("failed to create in-memory block store");
+        let scribe = Scribe::new_with_sample_data(10, 100);
+        for hb in &scribe.blockchain {
+            store.push(hb).await.expect("failed to push block");
+        }
+        let num_blocks = scribe.blockchain.len() as u64;
+        assert!(num_blocks > 0, "expected a non-empty test blockchain");
+        let store = Arc::new(store);
+
+        // Canary: only sleeps and counts ticks; never touches the database.
+        let canary_ticks = Arc::new(AtomicU64::new(0));
+        let canary = {
+            let canary_ticks = canary_ticks.clone();
+            tokio::spawn(async move {
+                let start = Instant::now();
+                while start.elapsed() < LOAD_WINDOW {
+                    tokio::time::sleep(CANARY_TICK).await;
+                    canary_ticks.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        };
+
+        // Hammer tasks: continuously read from the store for the whole window.
+        let db_ops = Arc::new(AtomicU64::new(0));
+        let hammers: Vec<_> = (0..NUM_HAMMER_TASKS)
+            .map(|task_idx| {
+                let store = store.clone();
+                let db_ops = db_ops.clone();
+                tokio::spawn(async move {
+                    let start = Instant::now();
+                    let mut block_idx = (task_idx as u64) % num_blocks;
+                    while start.elapsed() < LOAD_WINDOW {
+                        // NOTE: on `master` this is a blocking, synchronous call
+                        // with no `.await`, so it monopolises the worker thread.
+                        // After the async-SQLite migration this becomes
+                        // `store.get_hashed_block(&block_idx).await`.
+                        let _ = store.get_hashed_block(&block_idx).await;
+                        db_ops.fetch_add(1, Ordering::Relaxed);
+                        block_idx = (block_idx + 1) % num_blocks;
+                    }
+                })
+            })
+            .collect();
+
+        canary.await.expect("canary task panicked");
+        for hammer in hammers {
+            hammer.await.expect("hammer task panicked");
+        }
+
+        let ticks = canary_ticks.load(Ordering::Relaxed);
+        let ops = db_ops.load(Ordering::Relaxed);
+        // Ideal number of ticks if the canary were never starved.
+        let ideal_ticks = (LOAD_WINDOW.as_millis() / CANARY_TICK.as_millis()) as u64;
+        // Require the canary to have made at least a quarter of its ideal
+        // progress. Under starvation it manages ~0; with a non-blocking store it
+        // manages close to `ideal_ticks`.
+        let min_expected_ticks = ideal_ticks / 4;
+
+        println!(
+            "canary ticks: {ticks}/{ideal_ticks} (min expected {min_expected_ticks}), \
+             db ops completed: {ops}, worker threads: {WORKER_THREADS}, \
+             hammer tasks: {NUM_HAMMER_TASKS}"
+        );
+
+        assert!(
+            ops > 0,
+            "sanity check failed: hammer tasks did not perform any DB operations"
+        );
+        assert!(
+            ticks >= min_expected_ticks,
+            "async runtime was starved by the block store: the canary only ticked \
+             {ticks} times out of an ideal {ideal_ticks} (required at least \
+             {min_expected_ticks}) while {ops} blocking DB operations ran on \
+             {WORKER_THREADS} worker threads. This means the block store's query \
+             methods block the tokio worker threads instead of yielding (see \
+             DEFI-2491)."
+        );
+    });
+}

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/runtime_responsiveness_test.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/runtime_responsiveness_test.rs
@@ -34,6 +34,12 @@ use std::time::{Duration, Instant};
 
 /// Deliberately small so the starvation is deterministic regardless of the host
 /// core count (production integrators are recommended to run with ~4 CPUs).
+///
+/// The assertion is wall-clock based (it compares canary ticks against an ideal
+/// tick count), so it assumes the test can actually run its threads in parallel:
+/// the two tokio worker threads plus the `block_on`/canary thread. The bazel
+/// target reserves CPUs accordingly (`tags = ["cpu:4"]`) to keep it from
+/// under-ticking and flaking on an oversubscribed CI runner.
 const WORKER_THREADS: usize = 2;
 /// More concurrent DB tasks than worker threads, so every worker is kept busy.
 const NUM_HAMMER_TASKS: usize = 8;

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/store_tests.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/store_tests.rs
@@ -85,6 +85,34 @@ async fn store_smoke_test() {
 }
 
 #[actix_rt::test]
+async fn store_push_rolls_back_on_error() {
+    let tmpdir = create_tmp_dir();
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
+    let scribe = Scribe::new_with_sample_data(10, 100);
+
+    let blocks: Vec<_> = scribe.blockchain.iter().cloned().collect();
+
+    // Push the first two blocks successfully.
+    store.push(&blocks[0]).await.unwrap();
+    store.push(&blocks[1]).await.unwrap();
+
+    // Pushing an already-present block violates the PRIMARY KEY constraint on
+    // `block_idx` and must return an error.
+    let err = store.push(&blocks[0]).await;
+    assert!(err.is_err(), "expected duplicate push to fail, got {err:?}");
+
+    // The failed push must have rolled back its transaction. If the transaction
+    // had been left open, this subsequent valid push would fail with "cannot
+    // start a transaction within a transaction".
+    store.push(&blocks[2]).await.unwrap();
+
+    assert_eq!(
+        store.get_hashed_block(&blocks[2].index).await.unwrap(),
+        blocks[2]
+    );
+}
+
+#[actix_rt::test]
 async fn store_coherence_test() {
     let tmpdir = create_tmp_dir();
 

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/store_tests.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/tests/store_tests.rs
@@ -13,8 +13,10 @@ use icp_ledger::{AccountIdentifier, Block, Operation, apply_operation};
 use rusqlite::params;
 use std::path::Path;
 
-pub(crate) fn sqlite_on_disk_store(path: &Path) -> Blocks {
-    Blocks::new_persistent(path, RosettaDbConfig::default_disabled()).unwrap()
+pub(crate) async fn sqlite_on_disk_store(path: &Path) -> Blocks {
+    Blocks::new_persistent(path, RosettaDbConfig::default_disabled())
+        .await
+        .unwrap()
 }
 
 #[derive(Default)]
@@ -53,31 +55,31 @@ impl LedgerContext for TestContext {
 #[actix_rt::test]
 async fn store_smoke_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
 
     for hb in &scribe.blockchain {
-        store.push(hb).unwrap();
+        store.push(hb).await.unwrap();
     }
 
     for hb in &scribe.blockchain {
-        assert_eq!(store.get_hashed_block(&hb.index).unwrap(), *hb);
+        assert_eq!(store.get_hashed_block(&hb.index).await.unwrap(), *hb);
         assert_eq!(
-            store.get_transaction(&hb.index).unwrap(),
+            store.get_transaction(&hb.index).await.unwrap(),
             Block::decode((*hb).clone().block).unwrap().transaction
         );
     }
     assert_eq!(
-        store.get_first_hashed_block().unwrap(),
+        store.get_first_hashed_block().await.unwrap(),
         *scribe.blockchain.front().unwrap()
     );
     assert_eq!(
-        store.get_latest_hashed_block().unwrap(),
+        store.get_latest_hashed_block().await.unwrap(),
         *scribe.blockchain.get(109).unwrap()
     );
     let last_idx = scribe.blockchain.back().unwrap().index;
     assert_eq!(
-        store.get_hashed_block(&(last_idx + 1)).unwrap_err(),
+        store.get_hashed_block(&(last_idx + 1)).await.unwrap_err(),
         BlockStoreError::NotFound(last_idx + 1)
     );
 }
@@ -88,7 +90,7 @@ async fn store_coherence_test() {
 
     let location = tmpdir.path();
 
-    let store = sqlite_on_disk_store(location);
+    let store = sqlite_on_disk_store(location).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
     let path = location.join("db.sqlite");
     let con = rusqlite::Connection::open(path).unwrap();
@@ -113,24 +115,24 @@ async fn store_coherence_test() {
     }
     drop(con);
     for hb in &scribe.blockchain {
-        assert_eq!(store.get_hashed_block(&hb.index).unwrap(), *hb);
-        assert!(store.get_all_accounts().unwrap().is_empty());
+        assert_eq!(store.get_hashed_block(&hb.index).await.unwrap(), *hb);
+        assert!(store.get_all_accounts().await.unwrap().is_empty());
     }
-    let store = sqlite_on_disk_store(location);
+    let store = sqlite_on_disk_store(location).await;
     for hb in &scribe.blockchain {
-        assert_eq!(store.get_hashed_block(&hb.index).unwrap(), *hb);
+        assert_eq!(store.get_hashed_block(&hb.index).await.unwrap(), *hb);
         assert_eq!(
-            store.get_transaction_hash(&hb.index).unwrap(),
+            store.get_transaction_hash(&hb.index).await.unwrap(),
             Some(Block::decode(hb.block.clone()).unwrap().transaction.hash())
         );
     }
-    assert_eq!(store.get_all_accounts().unwrap().len(), 10);
+    assert_eq!(store.get_all_accounts().await.unwrap().len(), 10);
 }
 
 #[actix_rt::test]
 async fn store_account_balances_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
     let mut context = TestContext::default();
     let now = TimeStamp::from_nanos_since_unix_epoch(12345678);
@@ -140,8 +142,8 @@ async fn store_account_balances_test() {
         context.balance_book.store.transaction_context = Some(hb.index);
         apply_operation(&mut context, &operation, now).unwrap();
         context.balance_book.store.transaction_context = None;
-        store.push(hb).unwrap();
-        store.set_hashed_block_to_verified(&hb.index).unwrap();
+        store.push(hb).await.unwrap();
+        store.set_hashed_block_to_verified(&hb.index).await.unwrap();
         let to_account: Option<String>;
         let from_account: Option<String>;
         match operation {
@@ -164,20 +166,20 @@ async fn store_account_balances_test() {
         }
         if let Some(acc_str) = from_account {
             let id = AccountIdentifier::from_hex(acc_str.as_str()).unwrap();
-            let amount_from = store.get_account_balance(&id, &hb.index).unwrap();
+            let amount_from = store.get_account_balance(&id, &hb.index).await.unwrap();
             let amount_local = context.balance_book.store.get_balance(&id).unwrap();
             assert_eq!(amount_from, amount_local);
         }
         if let Some(acc_str) = to_account {
             let id = AccountIdentifier::from_hex(acc_str.as_str()).unwrap();
-            let amount_to = store.get_account_balance(&id, &hb.index).unwrap();
+            let amount_to = store.get_account_balance(&id, &hb.index).await.unwrap();
             let amount_local = context.balance_book.store.get_balance(&id).unwrap();
             assert_eq!(amount_to, amount_local);
         }
     }
     for (acc, history) in context.balance_book.store.acc_to_hist.iter() {
         for (block_index, tokens) in history.get_history(None) {
-            let amount = store.get_account_balance(acc, block_index).unwrap();
+            let amount = store.get_account_balance(acc, block_index).await.unwrap();
             assert_eq!(*tokens, amount);
         }
     }
@@ -186,139 +188,139 @@ async fn store_account_balances_test() {
 #[actix_rt::test]
 async fn store_prune_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
 
     for hb in &scribe.blockchain {
-        store.push(hb).unwrap();
-        store.set_hashed_block_to_verified(&hb.index).unwrap();
+        store.push(hb).await.unwrap();
+        store.set_hashed_block_to_verified(&hb.index).await.unwrap();
     }
 
-    prune(&scribe, &mut store, 10);
-    verify_pruned(&scribe, &mut store, 10);
+    prune(&scribe, &mut store, 10).await;
+    verify_pruned(&scribe, &mut store, 10).await;
 
-    prune(&scribe, &mut store, 20);
-    verify_pruned(&scribe, &mut store, 20);
+    prune(&scribe, &mut store, 20).await;
+    verify_pruned(&scribe, &mut store, 20).await;
 }
 
 #[actix_rt::test]
 async fn store_prune_corner_cases_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
 
     for hb in &scribe.blockchain {
-        store.push(hb).unwrap();
+        store.push(hb).await.unwrap();
     }
 
-    prune(&scribe, &mut store, 0);
-    verify_pruned(&scribe, &mut store, 0);
+    prune(&scribe, &mut store, 0).await;
+    verify_pruned(&scribe, &mut store, 0).await;
 
-    prune(&scribe, &mut store, 1);
-    verify_pruned(&scribe, &mut store, 0);
+    prune(&scribe, &mut store, 1).await;
+    verify_pruned(&scribe, &mut store, 0).await;
 
     let last_idx = scribe.blockchain.back().unwrap().index;
 
-    prune(&scribe, &mut store, last_idx);
-    verify_pruned(&scribe, &mut store, last_idx);
+    prune(&scribe, &mut store, last_idx).await;
+    verify_pruned(&scribe, &mut store, last_idx).await;
 }
 
 #[actix_rt::test]
 async fn store_prune_first_balance_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
     let scribe = Scribe::new_with_sample_data(10, 100);
 
     for hb in &scribe.blockchain {
-        store.push(hb).unwrap();
-        store.set_hashed_block_to_verified(&hb.index).unwrap();
+        store.push(hb).await.unwrap();
+        store.set_hashed_block_to_verified(&hb.index).await.unwrap();
     }
 
-    prune(&scribe, &mut store, 10);
-    verify_pruned(&scribe, &mut store, 10);
-    verify_balance_snapshot(&scribe, &mut store, 10);
+    prune(&scribe, &mut store, 10).await;
+    verify_pruned(&scribe, &mut store, 10).await;
+    verify_balance_snapshot(&scribe, &mut store, 10).await;
 
-    prune(&scribe, &mut store, 20);
-    verify_pruned(&scribe, &mut store, 20);
-    verify_balance_snapshot(&scribe, &mut store, 20);
+    prune(&scribe, &mut store, 20).await;
+    verify_pruned(&scribe, &mut store, 20).await;
+    verify_balance_snapshot(&scribe, &mut store, 20).await;
 }
 
 #[actix_rt::test]
 async fn store_prune_and_load_test() {
     let tmpdir = create_tmp_dir();
-    let mut store = sqlite_on_disk_store(tmpdir.path());
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
 
     let scribe = Scribe::new_with_sample_data(10, 100);
 
     for hb in &scribe.blockchain {
-        store.push(hb).unwrap();
-        store.set_hashed_block_to_verified(&hb.index).unwrap();
+        store.push(hb).await.unwrap();
+        store.set_hashed_block_to_verified(&hb.index).await.unwrap();
     }
 
-    prune(&scribe, &mut store, 10);
-    verify_pruned(&scribe, &mut store, 10);
-    verify_balance_snapshot(&scribe, &mut store, 10);
+    prune(&scribe, &mut store, 10).await;
+    verify_pruned(&scribe, &mut store, 10).await;
+    verify_balance_snapshot(&scribe, &mut store, 10).await;
 
-    prune(&scribe, &mut store, 20);
-    verify_pruned(&scribe, &mut store, 20);
-    verify_balance_snapshot(&scribe, &mut store, 20);
+    prune(&scribe, &mut store, 20).await;
+    verify_pruned(&scribe, &mut store, 20).await;
+    verify_balance_snapshot(&scribe, &mut store, 20).await;
 
     drop(store);
     // Now reload from disk
-    let mut store = sqlite_on_disk_store(tmpdir.path());
-    verify_pruned(&scribe, &mut store, 20);
-    verify_balance_snapshot(&scribe, &mut store, 20);
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
+    verify_pruned(&scribe, &mut store, 20).await;
+    verify_balance_snapshot(&scribe, &mut store, 20).await;
 
-    prune(&scribe, &mut store, 30);
-    verify_pruned(&scribe, &mut store, 30);
-    verify_balance_snapshot(&scribe, &mut store, 30);
+    prune(&scribe, &mut store, 30).await;
+    verify_pruned(&scribe, &mut store, 30).await;
+    verify_balance_snapshot(&scribe, &mut store, 30).await;
 
     drop(store);
     // Reload once again
-    let mut store = sqlite_on_disk_store(tmpdir.path());
-    verify_pruned(&scribe, &mut store, 30);
-    verify_balance_snapshot(&scribe, &mut store, 30);
+    let mut store = sqlite_on_disk_store(tmpdir.path()).await;
+    verify_pruned(&scribe, &mut store, 30).await;
+    verify_balance_snapshot(&scribe, &mut store, 30).await;
 }
 
-fn prune(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
+async fn prune(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
     let oldest_idx = prune_at;
     let oldest_block = scribe.blockchain.get(oldest_idx as usize).unwrap();
-    store.prune(oldest_block).unwrap();
+    store.prune(oldest_block).await.unwrap();
 }
 
-fn verify_pruned(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
+async fn verify_pruned(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
     let after_last_idx = scribe.blockchain.len() as u64;
     let oldest_idx = prune_at.min(after_last_idx);
 
     if after_last_idx > 1 {
         // Genesis block (at idx 0) should still be accessible
         assert_eq!(
-            store.get_hashed_block(&0).unwrap(),
+            store.get_hashed_block(&0).await.unwrap(),
             *scribe.blockchain.front().unwrap()
         );
     }
 
     for i in 1..oldest_idx {
         assert_eq!(
-            store.get_hashed_block(&i).unwrap_err(),
+            store.get_hashed_block(&i).await.unwrap_err(),
             BlockStoreError::NotFound(i)
         );
         assert_eq!(
-            store.get_transaction(&i).unwrap_err(),
+            store.get_transaction(&i).await.unwrap_err(),
             BlockStoreError::NotFound(i)
         );
     }
 
     if oldest_idx < after_last_idx {
         assert_eq!(
-            store.get_first_hashed_block().ok().map(|x| x.index),
+            store.get_first_hashed_block().await.ok().map(|x| x.index),
             Some(oldest_idx)
         );
     }
 
     for i in oldest_idx..after_last_idx {
         assert_eq!(
-            store.get_hashed_block(&i).unwrap(),
+            store.get_hashed_block(&i).await.unwrap(),
             *scribe.blockchain.get(i as usize).unwrap()
         );
     }
@@ -326,28 +328,29 @@ fn verify_pruned(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
     for i in oldest_idx..after_last_idx {
         let block = (*scribe.blockchain.get(i as usize).unwrap()).clone().block;
         assert_eq!(
-            store.get_transaction(&i).unwrap(),
+            store.get_transaction(&i).await.unwrap(),
             Block::decode(block).unwrap().transaction
         );
     }
 
     for i in after_last_idx..=scribe.blockchain.len() as u64 {
         assert_eq!(
-            store.get_hashed_block(&i).unwrap_err(),
+            store.get_hashed_block(&i).await.unwrap_err(),
             BlockStoreError::NotFound(i)
         );
     }
 }
 
-fn verify_balance_snapshot(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
+async fn verify_balance_snapshot(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
     let oldest_idx = prune_at as usize;
-    let oldest_block = store.get_first_hashed_block().unwrap();
+    let oldest_block = store.get_first_hashed_block().await.unwrap();
     assert_eq!(oldest_block, *scribe.blockchain.get(oldest_idx).unwrap());
 
     let scribe_balances = scribe.balance_history.get(oldest_idx).unwrap().clone();
     for (acc, tokens) in scribe_balances {
         let balance = store
             .get_account_balance(&acc, &(oldest_idx as u64))
+            .await
             .unwrap();
         assert_eq!(balance, tokens);
     }
@@ -355,11 +358,12 @@ fn verify_balance_snapshot(scribe: &Scribe, store: &mut Blocks, prune_at: u64) {
     for amount in scribe.balance_history.get(oldest_idx).unwrap().values() {
         sum_icpt = sum_icpt.checked_add(amount).unwrap();
     }
-    let accounts = store.get_all_accounts().unwrap();
+    let accounts = store.get_all_accounts().await.unwrap();
     let mut total = Tokens::ZERO;
     for account in accounts {
         let amount = store
             .get_account_balance(&account, &(oldest_idx as u64))
+            .await
             .unwrap();
         total = total.checked_add(&amount).unwrap();
     }

--- a/rs/rosetta-api/icp/src/ledger_client.rs
+++ b/rs/rosetta-api/icp/src/ledger_client.rs
@@ -85,7 +85,7 @@ use self::{
 #[async_trait]
 pub trait LedgerAccess {
     // Maybe we should just return RwLockReadGuard explicitly and drop the Box
-    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + 'a>;
+    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + Send + 'a>;
     async fn sync_blocks(&self, stopped: Arc<AtomicBool>) -> Result<(), ApiError>;
     fn ledger_canister_id(&self) -> &CanisterId;
     fn governance_canister_id(&self) -> &CanisterId;
@@ -263,7 +263,7 @@ impl LedgerClient {
 
 #[async_trait]
 impl LedgerAccess for LedgerClient {
-    async fn read_blocks(&self) -> Box<dyn Deref<Target = Blocks> + '_> {
+    async fn read_blocks(&self) -> Box<dyn Deref<Target = Blocks> + Send + '_> {
         self.ledger_blocks_synchronizer.read_blocks().await
     }
 

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -816,8 +816,9 @@ impl RosettaRequestHandler {
         let mut parameters: Vec<(String, rusqlite::types::Value)> = Vec::new();
 
         parameters.push((
-            // `as i64` bit-reinterprets the u64; block indices are well within
-            // the i64 range, so this is lossless in practice.
+            // `start_idx` derives from the request's `i64` `max_block` field via
+            // `try_into()`, which rejects negatives, so the value is non-negative
+            // and fits in `i64`; the cast back to `i64` is lossless.
             ":max_block_idx".to_string(),
             rusqlite::types::Value::from(start_idx as i64),
         ));
@@ -858,8 +859,9 @@ impl RosettaRequestHandler {
 
         command.push_str("LIMIT :limit ");
         parameters.push((
-            // `as i64` bit-reinterprets the u64; the limit is well within the
-            // i64 range, so this is lossless in practice.
+            // `limit` derives from the request's `i64` `limit` field via
+            // `try_into()`, which rejects negatives, so the value is non-negative
+            // and fits in `i64`; the cast back to `i64` is lossless.
             ":limit".to_string(),
             rusqlite::types::Value::from(limit as i64),
         ));

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -816,6 +816,8 @@ impl RosettaRequestHandler {
         let mut parameters: Vec<(String, rusqlite::types::Value)> = Vec::new();
 
         parameters.push((
+            // `as i64` bit-reinterprets the u64; block indices are well within
+            // the i64 range, so this is lossless in practice.
             ":max_block_idx".to_string(),
             rusqlite::types::Value::from(start_idx as i64),
         ));
@@ -856,6 +858,8 @@ impl RosettaRequestHandler {
 
         command.push_str("LIMIT :limit ");
         parameters.push((
+            // `as i64` bit-reinterprets the u64; the limit is well within the
+            // i64 range, so this is lossless in practice.
             ":limit".to_string(),
             rusqlite::types::Value::from(limit as i64),
         ));

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -187,7 +187,9 @@ impl RosettaRequestHandler {
         })?;
         let block = self.get_block(msg.block_identifier).await?;
         let blocks = self.ledger.read_blocks().await;
-        let tokens = blocks.get_account_balance(&account_id, &block.block_identifier.index)?;
+        let tokens = blocks
+            .get_account_balance(&account_id, &block.block_identifier.index)
+            .await?;
         let amount = tokens_to_amount(tokens, self.ledger.token_symbol())?;
         Ok(AccountBalanceResponse {
             block_identifier: block.block_identifier,
@@ -254,6 +256,7 @@ impl RosettaRequestHandler {
                     );
                     if storage
                         .contains_block(&lowest_index)
+                        .await
                         .map_err(|err| ApiError::InvalidBlockId(false, format!("{err:?}").into()))?
                     {
                         // TODO: Use block range with rosetta blocks
@@ -262,6 +265,7 @@ impl RosettaRequestHandler {
                                 lowest_index
                                     ..query_block_range.highest_block_index.saturating_add(1),
                             )
+                            .await
                             .map_err(ApiError::from)?
                             .into_iter()
                         {
@@ -371,6 +375,7 @@ impl RosettaRequestHandler {
                         .read_blocks()
                         .await
                         .get_highest_rosetta_block_index()
+                        .await
                         .map_err(ApiError::from)?
                         .ok_or_else(|| ApiError::BlockchainEmpty(false, Default::default()))?;
                     self.get_rosetta_block_by_index(highest_block_index).await
@@ -389,13 +394,13 @@ impl RosettaRequestHandler {
         let parent_block_index = block_index.saturating_sub(1);
         let blocks = self.ledger.read_blocks().await;
         if self.is_a_rosetta_block_index(parent_block_index).await {
-            let parent_block = blocks.get_rosetta_block(parent_block_index)?;
+            let parent_block = blocks.get_rosetta_block(parent_block_index).await?;
             Ok(BlockIdentifier {
                 index: parent_block_index,
                 hash: hex::encode(parent_block.hash()),
             })
-        } else if blocks.is_verified_by_idx(&parent_block_index)? {
-            let parent_block = &blocks.get_hashed_block(&parent_block_index)?;
+        } else if blocks.is_verified_by_idx(&parent_block_index).await? {
+            let parent_block = &blocks.get_hashed_block(&parent_block_index).await?;
             convert::block_id(parent_block)
         } else {
             Err(ApiError::InvalidBlockId(true, Default::default()))
@@ -417,6 +422,7 @@ impl RosettaRequestHandler {
             let blocks = self.ledger.read_blocks().await;
             blocks
                 .get_latest_verified_hashed_block()
+                .await
                 .map_err(ApiError::from)
         }?;
         self.hashed_block_to_rosetta_core_block(block).await
@@ -428,10 +434,10 @@ impl RosettaRequestHandler {
     ) -> Result<rosetta_core::objects::Block, ApiError> {
         let block = {
             let blocks = self.ledger.read_blocks().await;
-            if !blocks.is_verified_by_idx(&block_index)? {
+            if !blocks.is_verified_by_idx(&block_index).await? {
                 return Err(ApiError::InvalidBlockId(false, Default::default()));
             }
-            blocks.get_hashed_block(&block_index)
+            blocks.get_hashed_block(&block_index).await
         }?;
         self.hashed_block_to_rosetta_core_block(block).await
     }
@@ -455,11 +461,11 @@ impl RosettaRequestHandler {
         let hash = convert::to_hash::<ic_ledger_core::block::EncodedBlock>(block_hash)?;
         let block = {
             let blocks = self.ledger.read_blocks().await;
-            if !blocks.is_verified_by_hash(&hash)? {
+            if !blocks.is_verified_by_hash(&hash).await? {
                 return Err(ApiError::InvalidBlockId(true, Default::default()));
             }
-            let block_index = blocks.get_block_idx_by_block_hash(&hash)?;
-            blocks.get_hashed_block(&block_index)
+            let block_index = blocks.get_block_idx_by_block_hash(&hash).await?;
+            blocks.get_hashed_block(&block_index).await
         }?;
         self.hashed_block_to_rosetta_core_block(block).await
     }
@@ -470,7 +476,7 @@ impl RosettaRequestHandler {
     ) -> Result<rosetta_core::objects::Block, ApiError> {
         let rosetta_block = {
             let blocks = self.ledger.read_blocks().await;
-            blocks.get_rosetta_block(block_index)
+            blocks.get_rosetta_block(block_index).await
         }?;
         let parent_block_id = self.create_parent_block_id(block_index).await?;
         let token_symbol = self.ledger.token_symbol();
@@ -614,9 +620,9 @@ impl RosettaRequestHandler {
             // If rosetta mode is not enabled we simply fetched the latest verified block
             RosettaBlocksMode::Disabled => {
                 let blocks = self.ledger.read_blocks().await;
-                let tip_verified_block = blocks.get_latest_verified_hashed_block()?;
-                let genesis_block = blocks.get_hashed_block(&0)?;
-                let first_verified_block = blocks.get_first_verified_hashed_block()?;
+                let tip_verified_block = blocks.get_latest_verified_hashed_block().await?;
+                let genesis_block = blocks.get_hashed_block(&0).await?;
+                let first_verified_block = blocks.get_first_verified_hashed_block().await?;
                 let oldest_block_id = if first_verified_block.index != 0 {
                     Some(convert::block_id(&first_verified_block)?)
                 } else {
@@ -651,7 +657,8 @@ impl RosettaRequestHandler {
                     .ledger
                     .read_blocks()
                     .await
-                    .get_highest_rosetta_block_index()?;
+                    .get_highest_rosetta_block_index()
+                    .await?;
                 // If rosetta blocks mode is enabled we have to check whether the rosetta blocks table has been populated
                 match highest_rosetta_block_index {
                     // If it has been populated we can return the highest rosetta block
@@ -662,7 +669,7 @@ impl RosettaRequestHandler {
                         // If Rosetta Blocks started only after a certain index then the genesis block as well as the first verified block will be the first icp block
                         let genesis_block_id = if first_rosetta_block_index > 0 {
                             let hashed_block =
-                                self.ledger.read_blocks().await.get_hashed_block(&0)?;
+                                self.ledger.read_blocks().await.get_hashed_block(&0).await?;
                             self.hashed_block_to_rosetta_core_block(hashed_block)
                                 .await?
                                 .block_identifier
@@ -749,6 +756,7 @@ impl RosettaRequestHandler {
 
         let block_with_highest_block_index = block_storage
             .get_latest_verified_hashed_block()
+            .await
             .map_err(|e| ApiError::InvalidBlockId(false, format!("{e:?}").into()))?;
 
         let max_block: u64 = request
@@ -805,9 +813,12 @@ impl RosettaRequestHandler {
             "SELECT block_hash, encoded_block, parent_hash, block_idx, timestamp
                    FROM blocks WHERE block_idx <= :max_block_idx ",
         );
-        let mut parameters: Vec<(&str, Box<dyn rusqlite::ToSql>)> = Vec::new();
+        let mut parameters: Vec<(String, rusqlite::types::Value)> = Vec::new();
 
-        parameters.push((":max_block_idx", Box::new(start_idx)));
+        parameters.push((
+            ":max_block_idx".to_string(),
+            rusqlite::types::Value::from(start_idx as i64),
+        ));
 
         if let Some(transaction_identifier) = request.transaction_identifier.clone() {
             command.push_str("AND tx_hash = :tx_hash ");
@@ -819,36 +830,39 @@ impl RosettaRequestHandler {
                 })?
                 .as_slice()
                 .to_vec();
-            parameters.push((":tx_hash", Box::new(tx_hash)));
+            parameters.push((
+                ":tx_hash".to_string(),
+                rusqlite::types::Value::from(tx_hash),
+            ));
         }
 
         if let Some(operation_type) = operation_type {
             command.push_str("AND operation_type = :operation_type ");
-            parameters.push((":operation_type", Box::new(operation_type)));
+            parameters.push((
+                ":operation_type".to_string(),
+                rusqlite::types::Value::from(operation_type),
+            ));
         }
 
         if let Some(account) = account_id {
             command.push_str("AND (from_account = :account_id OR to_account = :account_id OR spender_account = :account_id) ");
-            parameters.push((":account_id", Box::new(account.to_hex())));
+            parameters.push((
+                ":account_id".to_string(),
+                rusqlite::types::Value::from(account.to_hex()),
+            ));
         }
 
         command.push_str("ORDER BY block_idx DESC ");
 
         command.push_str("LIMIT :limit ");
-        parameters.push((":limit", Box::new(limit)));
+        parameters.push((
+            ":limit".to_string(),
+            rusqlite::types::Value::from(limit as i64),
+        ));
 
         let blocks = block_storage
-            .get_blocks_by_custom_query(
-                command,
-                parameters
-                    .iter()
-                    .map(|(key, param)| {
-                        let param_ref: &dyn rusqlite::ToSql = param.as_ref();
-                        (key.to_owned(), param_ref)
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
+            .get_blocks_by_custom_query(command, parameters)
+            .await
             .map_err(|e| ApiError::invalid_block_id(format!("Error fetching blocks: {e:?}")))?;
 
         let mut transactions = vec![];

--- a/rs/rosetta-api/icp/src/request_handler/tests.rs
+++ b/rs/rosetta-api/icp/src/request_handler/tests.rs
@@ -38,7 +38,7 @@ impl MockLedger {
 
 #[async_trait]
 impl LedgerAccess for MockLedger {
-    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + 'a> {
+    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + Send + 'a> {
         unimplemented!("Not needed for this test")
     }
 

--- a/rs/rosetta-api/icp/tests/rosetta_cli_tests.rs
+++ b/rs/rosetta-api/icp/tests/rosetta_cli_tests.rs
@@ -40,7 +40,7 @@ async fn rosetta_cli_data_test() {
         scribe.gen_transaction();
     }
 
-    let ledger = Arc::new(TestLedger::new());
+    let ledger = Arc::new(TestLedger::new().await);
     let initial_sync_complete = Arc::new(AtomicBool::new(true));
     let req_handler = RosettaRequestHandler::new_with_default_blockchain(
         ledger.clone(),
@@ -116,7 +116,7 @@ async fn rosetta_cli_construction_create_account_test() {
         scribe.gen_transaction();
     }
 
-    let ledger = Arc::new(TestLedger::new());
+    let ledger = Arc::new(TestLedger::new().await);
     let initial_sync_complete = Arc::new(AtomicBool::new(true));
     let req_handler = RosettaRequestHandler::new_with_default_blockchain(
         ledger.clone(),
@@ -211,7 +211,7 @@ async fn rosetta_cli_construction_test() {
         100_000_000_007,
     );
 
-    let ledger = Arc::new(TestLedger::new());
+    let ledger = Arc::new(TestLedger::new().await);
     let initial_sync_complete = Arc::new(AtomicBool::new(true));
     let req_handler = RosettaRequestHandler::new_with_default_blockchain(
         ledger.clone(),

--- a/rs/rosetta-api/icp/tests/test_utils/mod.rs
+++ b/rs/rosetta-api/icp/tests/test_utils/mod.rs
@@ -51,7 +51,6 @@ impl TestLedger {
         )
     }
 
-    #[allow(dead_code)]
     pub(crate) fn from_blockchain(blocks: Blocks) -> Self {
         Self {
             blockchain: RwLock::new(blocks),

--- a/rs/rosetta-api/icp/tests/test_utils/mod.rs
+++ b/rs/rosetta-api/icp/tests/test_utils/mod.rs
@@ -43,11 +43,18 @@ pub struct TestLedger {
 }
 
 impl TestLedger {
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
+        Self::from_blockchain(
+            Blocks::new_in_memory(RosettaDbConfig::default_disabled())
+                .await
+                .unwrap(),
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn from_blockchain(blocks: Blocks) -> Self {
         Self {
-            blockchain: RwLock::new(
-                Blocks::new_in_memory(RosettaDbConfig::default_disabled()).unwrap(),
-            ),
+            blockchain: RwLock::new(blocks),
             canister_id: CanisterId::unchecked_from_principal(
                 PrincipalId::from_str("5v3p4-iyaaa-aaaaa-qaaaa-cai").unwrap(),
             ),
@@ -60,14 +67,6 @@ impl TestLedger {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn from_blockchain(blocks: Blocks) -> Self {
-        Self {
-            blockchain: RwLock::new(blocks),
-            ..Default::default()
-        }
-    }
-
     async fn last_submitted(&self) -> Result<HashedBlock, ApiError> {
         match self.submit_queue.read().await.last() {
             Some(b) => Ok(b.clone()),
@@ -75,6 +74,7 @@ impl TestLedger {
                 .read_blocks()
                 .await
                 .get_latest_verified_hashed_block()
+                .await
                 .map_err(ApiError::from),
         }
     }
@@ -82,9 +82,10 @@ impl TestLedger {
     #[allow(dead_code)]
     pub async fn add_block(&self, hb: HashedBlock) -> Result<(), ApiError> {
         let mut blockchain = self.blockchain.write().await;
-        blockchain.push(&hb).map_err(ApiError::from)?;
+        blockchain.push(&hb).await.map_err(ApiError::from)?;
         blockchain
             .set_hashed_block_to_verified(&hb.index)
+            .await
             .map_err(ApiError::from)
     }
 
@@ -101,15 +102,9 @@ fn next_millisecond(t: TimeStamp) -> TimeStamp {
     TimeStamp::from_nanos_since_unix_epoch(t.as_nanos_since_unix_epoch() + 1_000_000)
 }
 
-impl Default for TestLedger {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl LedgerAccess for TestLedger {
-    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + 'a> {
+    async fn read_blocks<'a>(&'a self) -> Box<dyn Deref<Target = Blocks> + Send + 'a> {
         Box::new(self.blockchain.read().await)
     }
 
@@ -141,8 +136,8 @@ impl LedgerAccess for TestLedger {
         {
             let mut blockchain = self.blockchain.write().await;
             for hb in queue.iter() {
-                blockchain.push(hb)?;
-                blockchain.set_hashed_block_to_verified(&hb.index)?;
+                blockchain.push(hb).await?;
+                blockchain.set_hashed_block_to_verified(&hb.index).await?;
             }
         }
 


### PR DESCRIPTION
## Purpose

ICP Rosetta serves its endpoints from `async` handlers on a multi-threaded
tokio runtime, but its block store's query methods were **blocking**
(synchronous SQLite behind a mutex). Under concurrent load these calls occupied
all tokio worker threads for the duration of each query, starving every other
async task — health checks, metrics, the block-sync watchdog — which is the
runtime-starvation bottleneck analysed under DEFI-2491.

This PR removes that starvation by moving the ICP block store to async
**`tokio-rusqlite`** (queries run on a dedicated background DB thread), mirroring
what ICRC Rosetta already does. The block store's API becomes `async` and its
callers await it, so a slow query no longer blocks the runtime.

A new deterministic regression test demonstrates the fix: it hammers the store
from several concurrent tasks on a 2-worker runtime while a lightweight canary
task only sleeps and counts ticks. On `master` the blocking store starved the
canary (~1/200 ticks); with this change it ticks ~180/200. Red on master, green
here.

## PR stack — 3 ICP Rosetta PRs, in merge order

1. **[DEFI-2950] async `tokio-rusqlite` block store ← this PR**
2. [DEFI-2951] async-store hardening (panic-safety + shorten lock hold) — lands before the axum migration
3. [DEFI-2952] actix → axum migration

[DEFI-2950]: https://dfinity.atlassian.net/browse/DEFI-2950
[DEFI-2951]: https://dfinity.atlassian.net/browse/DEFI-2951
[DEFI-2952]: https://dfinity.atlassian.net/browse/DEFI-2952
