### PR TITLE
fix(devcontainer): auto-install pinned rust toolchain in rust-analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -78,6 +78,18 @@
           "bazel-ic/": true,
           "bazel-out/": true,
           "targets/": true
+        },
+        // rust-analyzer runs `cargo` with RUSTUP_AUTO_INSTALL=0, so a freshly
+        // (re)built dev container that lacks the toolchain pinned in
+        // rust-toolchain.toml fails to load the workspace until it's installed
+        // by hand. Overriding it back to 1 lets rust-analyzer's own cargo
+        // invocation install the pinned toolchain on demand. extraEnv is
+        // applied after rust-analyzer sets the =0 default, so this wins.
+        "rust-analyzer.cargo.extraEnv": {
+          "RUSTUP_AUTO_INSTALL": "1"
+        },
+        "rust-analyzer.check.extraEnv": {
+          "RUSTUP_AUTO_INSTALL": "1"
         }
       }
     }


### PR DESCRIPTION
## Problem

Every time the dev container is rebuilt, the rust-analyzer VS Code extension fails to load the workspace:

```
FetchWorkspaceError: rust-analyzer failed to load workspace: Failed to load the project at /ic/Cargo.toml:
Failed to read Cargo metadata from Cargo.toml file /ic/Cargo.toml, None:
Failed to run `cd "/ic" && RUSTUP_AUTO_INSTALL="0" "/opt/cargo/bin/cargo" "metadata" ...`:
`cargo metadata` exited with an error: error: toolchain '1.97.1-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install` to install it
```

The freshly built image does not contain the toolchain pinned in `rust-toolchain.toml` (`1.97.1`), and rust-analyzer runs `cargo` with `RUSTUP_AUTO_INSTALL=0`, so rustup refuses to install it on demand. The workspace stays broken until the toolchain is installed by hand (`rustup toolchain install`).

## Fix

Override `RUSTUP_AUTO_INSTALL` back to `1` for rust-analyzer's `cargo` and `check` invocations via the dev container's `customizations.vscode.settings`:

```json
"rust-analyzer.cargo.extraEnv": { "RUSTUP_AUTO_INSTALL": "1" },
"rust-analyzer.check.extraEnv": { "RUSTUP_AUTO_INSTALL": "1" }
```

rust-analyzer sets the `=0` default *before* applying `extraEnv` (see [`crates/toolchain/src/lib.rs`](https://github.com/rust-lang/rust-analyzer/blob/master/crates/toolchain/src/lib.rs)), so this override wins. rust-analyzer's own `cargo metadata` call then installs the pinned toolchain on demand, and the workspace loads without any manual step.

## Why a setting rather than a `postCreateCommand` / `postStartCommand` hook

A lifecycle hook that runs `rustup toolchain install` was tried first but is fragile: if the install command exits non-zero (e.g. it runs before the container's network is ready) it **aborts the entire container rebuild**. A pure editor setting cannot break the rebuild, has no lifecycle-hook timing/`cwd`/`PATH` dependencies, and introduces no race with extension startup.

## Notes

- This intentionally lets rust-analyzer trigger toolchain installs (upstream disables this by default to avoid surprise installs); that is exactly the desired behavior here, and it is scoped to this dev container rather than global user settings.
- First workspace load after a rebuild takes slightly longer while the toolchain downloads; afterwards `rustup toolchain list` shows it too, since the install is global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)