### PR TITLE
fix: //packages/pocket-ic:canister_snapshots on RBE @ Namespace

### DIFF
--- a/packages/pocket-ic/tests/canister_snapshots.rs
+++ b/packages/pocket-ic/tests/canister_snapshots.rs
@@ -103,10 +103,11 @@ fn test_canister_snapshot_download_upload(pic: &mut PocketIc, canister_id: Princ
 
     // We need to make the PocketIC instance live for dfx to work.
     let mut url = pic.make_live(None);
-// Rewrite the URL host from `localhost` to `127.0.0.1` since some
-// sandboxed environments (e.g. Namespace RBE) cannot resolve `localhost`
-// (the HTTP gateway binds to `127.0.0.1` and accepts it as a host).
-url.set_host(Some("127.0.0.1")).expect("Failed to rewrite PocketIC URL host to 127.0.0.1");
+    // Rewrite the URL host from `localhost` to `127.0.0.1` since some
+    // sandboxed environments (e.g. Namespace RBE) cannot resolve `localhost`
+    // (the HTTP gateway binds to `127.0.0.1` and accepts it as a host).
+    url.set_host(Some("127.0.0.1"))
+        .expect("Failed to rewrite PocketIC URL host to 127.0.0.1");
 
     // Create a home directory for dfx (that contains a configuration file)
     // and a snapshot directory for the snapshot downloaded using dfx.

--- a/packages/pocket-ic/tests/canister_snapshots.rs
+++ b/packages/pocket-ic/tests/canister_snapshots.rs
@@ -102,7 +102,11 @@ fn test_canister_snapshot_download_upload(pic: &mut PocketIc, canister_id: Princ
     }
 
     // We need to make the PocketIC instance live for dfx to work.
-    let url = pic.make_live(None);
+    let mut url = pic.make_live(None);
+    // Rewrite the URL host from `localhost` to `127.0.0.1` since some
+    // sandboxed environments (e.g. Namespace RBE) cannot resolve `localhost`
+    // (the HTTP gateway binds to `127.0.0.1` and accepts it as a host).
+    url.set_host(Some("127.0.0.1")).unwrap();
 
     // Create a home directory for dfx (that contains a configuration file)
     // and a snapshot directory for the snapshot downloaded using dfx.
@@ -125,7 +129,7 @@ fn test_canister_snapshot_download_upload(pic: &mut PocketIc, canister_id: Princ
     // Download canister snapshot using dfx.
     let relative_dfx_path = std::env::var_os("DFX").expect("Missing dfx binary");
     let absolute_dfx_path = std::env::current_dir().unwrap().join(relative_dfx_path);
-    Command::new(absolute_dfx_path)
+    let dfx_output = Command::new(absolute_dfx_path)
         .arg("canister")
         .arg("snapshot")
         .arg("download")
@@ -140,7 +144,15 @@ fn test_canister_snapshot_download_upload(pic: &mut PocketIc, canister_id: Princ
         .current_dir(dfx_home_dir.clone())
         .env("HOME", dfx_home_dir.clone())
         .output()
-        .unwrap();
+        .expect("Failed to execute dfx");
+    if !dfx_output.status.success() {
+        panic!(
+            "dfx canister snapshot download failed ({}): stdout: {}; stderr: {}",
+            dfx_output.status,
+            String::from_utf8_lossy(&dfx_output.stdout),
+            String::from_utf8_lossy(&dfx_output.stderr),
+        );
+    }
 
     // Check that the snapshots downloaded using PocketIC and dfx are equal.
     let diff = Command::new("diff")

--- a/packages/pocket-ic/tests/canister_snapshots.rs
+++ b/packages/pocket-ic/tests/canister_snapshots.rs
@@ -103,10 +103,10 @@ fn test_canister_snapshot_download_upload(pic: &mut PocketIc, canister_id: Princ
 
     // We need to make the PocketIC instance live for dfx to work.
     let mut url = pic.make_live(None);
-    // Rewrite the URL host from `localhost` to `127.0.0.1` since some
-    // sandboxed environments (e.g. Namespace RBE) cannot resolve `localhost`
-    // (the HTTP gateway binds to `127.0.0.1` and accepts it as a host).
-    url.set_host(Some("127.0.0.1")).unwrap();
+// Rewrite the URL host from `localhost` to `127.0.0.1` since some
+// sandboxed environments (e.g. Namespace RBE) cannot resolve `localhost`
+// (the HTTP gateway binds to `127.0.0.1` and accepts it as a host).
+url.set_host(Some("127.0.0.1")).expect("Failed to rewrite PocketIC URL host to 127.0.0.1");
 
     // Create a home directory for dfx (that contains a configuration file)
     // and a snapshot directory for the snapshot downloaded using dfx.


### PR DESCRIPTION
`//packages/pocket-ic:canister_snapshots` fails deterministically on Namespace RBE (e.g. [this job](https://github.com/dfinity/ic/actions/runs/29578412371/job/87878083484) on #10579) with a confusing panic:

```
Snapshots differ (dfx snapshot: ...): Only in ...: metadata.json ...
```

**Root cause:** Namespace's sandboxed action environment has no usable `localhost` resolution (no populated `/etc/hosts`, and glibc has no built-in fallback for `localhost`). The test is the only pocket-ic test that performs a hostname lookup: it hands dfx the `make_live` URL, whose host is `localhost`, while everything else talks to `127.0.0.1` directly. `dfx canister snapshot download` therefore fails instantly, but the test ignored dfx's exit status, so the failure only surfaced later as a diff against an empty snapshot directory.

**Changes** (test-only):

1. Check `dfx`'s exit status and panic with its stdout/stderr, so any dfx failure reports the actual error instead of masquerading as "Snapshots differ".
2. Rewrite the `make_live` URL host from `localhost` to `127.0.0.1` before passing it to dfx. This is safe because the HTTP gateway binds to `127.0.0.1` and the pocket-ic server always accepts it as a host authority, and dfx only uses the plain `/api` routes (no subdomain-based canister routing).

Note this only works around the missing `localhost` resolution for this test. The underlying sandbox gap is worth fixing separately (e.g. baking `127.0.0.1 localhost` into the `ic-build-worker` image's `/etc/hosts`), since anything else that resolves `localhost` in a sandboxed RBE action will hit the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
