### PR TITLE
fix: avoid Too many open files

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -659,6 +659,10 @@ jobs:
           startsWith(env.BRANCH_NAME, 'hotfix-') ||
           startsWith(env.BRANCH_NAME, 'public-hotfix-')
         shell: bash
+        env:
+          # on dind_small cargo sometimes runs out of files (when building and linting). This trades
+          # some performance for reliability.
+          CARGO_BUILD_JOBS: 8
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors


### PR DESCRIPTION
Every now and then cargo (build and clippy) fails with:

>  Too many open files (os error 24)

This appears to be due to the concurrency being to high for `ulimit`. For now (and because this job is fast compared to other jobs) we limit the concurrency.

The issue can be reproduced by setting eg `ulimit -n 1024` and `CARGO_BUILD_JOBS=256`.