### PR TITLE
feat: Enable flexible HTTP outcalls on free and system subnets

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1253,9 +1253,8 @@ impl ExecutionEnvironment {
                 // paying subnets flexible outcalls remain unavailable until the
                 // flag is enabled, since legacy pricing would overcharge them
                 // (it charges the maximum response size up front).
-                let http_outcalls_are_free = state.get_own_cost_schedule()
-                    == CanisterCyclesCostSchedule::Free
-                    || self.own_subnet_type == SubnetType::System;
+                let http_outcalls_are_free =
+                    self.http_outcalls_are_free(state.get_own_cost_schedule());
                 let pricing_version = match self.config.flexible_http_requests {
                     FlagStatus::Enabled => Some(PricingVersion::PayAsYouGo),
                     FlagStatus::Disabled if http_outcalls_are_free => Some(PricingVersion::Legacy),
@@ -2159,6 +2158,14 @@ impl ExecutionEnvironment {
         }
     }
 
+    /// Returns whether HTTP outcalls are free on this subnet, i.e. the subnet
+    /// charges nothing for them. This is true on a free cost schedule, and on
+    /// system subnets.
+    fn http_outcalls_are_free(&self, cost_schedule: CanisterCyclesCostSchedule) -> bool {
+        cost_schedule == CanisterCyclesCostSchedule::Free
+            || self.own_subnet_type == SubnetType::System
+    }
+
     fn try_add_http_context_to_replicated_state(
         &self,
         mut canister_http_request_context: CanisterHttpRequestContext,
@@ -2228,12 +2235,17 @@ impl ExecutionEnvironment {
             ));
         }
 
+        let http_outcalls_are_free = self.http_outcalls_are_free(cost_schedule);
+
         // The refundable cycles are everything the payment covers beyond the
-        // base fee; on a free cost schedule nothing is charged, so nothing is
+        // base fee; when the outcall is free nothing is charged, so nothing is
         // refundable. We set the refund status even for legacy pricing in order
-        // to enable observability during the dark launch. However, nothing will
-        // actually be refunded for legacy pricing.
-        let refundable_cycles = if cost_schedule == CanisterCyclesCostSchedule::Free {
+        // to enable observability during the dark launch. However, nothing is
+        // refunded via the `refund_status` mechanism under legacy pricing; the
+        // caller is instead refunded the unspent `request.payment` (the full
+        // payment on free/system subnets, where the legacy fee is zero) when the
+        // response is delivered.
+        let refundable_cycles = if http_outcalls_are_free {
             Cycles::new(0)
         } else {
             canister_http_request_context.request.payment - base_fee.real()
@@ -2259,9 +2271,9 @@ impl ExecutionEnvironment {
             }
             PricingVersion::PayAsYouGo => {
                 // Take out the entire payment upfront; the refundable portion is
-                // returned later via the refund mechanism. On a free cost
-                // schedule there is nothing to charge.
-                if cost_schedule != CanisterCyclesCostSchedule::Free {
+                // returned later via the refund mechanism. When the outcall is
+                // free there is nothing to charge.
+                if !http_outcalls_are_free {
                     canister_http_request_context.request.payment.take();
                 }
             }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1240,56 +1240,74 @@ impl ExecutionEnvironment {
                 }
             },
 
-            Ok(Ic00Method::FlexibleHttpRequest) => match self.config.flexible_http_requests {
-                FlagStatus::Disabled => ExecuteSubnetMessageResult::Finished {
-                    response: Err(UserError::new(
-                        ErrorCode::CanisterContractViolation,
-                        "This API is not enabled on this subnet".to_string(),
-                    )),
-                    refund: msg.take_cycles(),
-                },
-                FlagStatus::Enabled => match &msg {
-                    CanisterCall::Request(request) => {
-                        match FlexibleCanisterHttpRequestArgs::decode(payload) {
-                            Err(err) => ExecuteSubnetMessageResult::Finished {
-                                response: Err(err),
-                                refund: msg.take_cycles(),
-                            },
-                            Ok(args) => {
-                                match CanisterHttpRequestContext::generate_from_flexible_args(
-                                    state.time(),
-                                    request.as_ref(),
-                                    args,
-                                    &registry_settings.node_ids,
-                                    registry_settings.registry_version,
-                                    rng,
-                                ) {
-                                    Err(err) => ExecuteSubnetMessageResult::Finished {
-                                        response: Err(err.into()),
-                                        refund: msg.take_cycles(),
-                                    },
-                                    Ok(canister_http_request_context) => match self
-                                        .try_add_http_context_to_replicated_state(
-                                            canister_http_request_context,
-                                            &mut state,
-                                            request.as_ref(),
-                                            since,
-                                        ) {
+            Ok(Ic00Method::FlexibleHttpRequest) => {
+                // Flexible HTTP outcalls are priced with the pay-as-you-go
+                // pricing model. That model is gated behind the
+                // `flexible_http_requests` feature flag and, once enabled,
+                // applies to every subnet. Until then, flexible outcalls are
+                // still offered on free subnets, where pricing is moot, by
+                // falling back to the legacy (charge-everything-up-front)
+                // pricing. On paying subnets they remain unavailable until the
+                // flag is enabled.
+                let pricing_version = match self.config.flexible_http_requests {
+                    FlagStatus::Enabled => Some(PricingVersion::PayAsYouGo),
+                    FlagStatus::Disabled => match state.get_own_cost_schedule() {
+                        CanisterCyclesCostSchedule::Free => Some(PricingVersion::Legacy),
+                        CanisterCyclesCostSchedule::Normal => None,
+                    },
+                };
+                match pricing_version {
+                    None => ExecuteSubnetMessageResult::Finished {
+                        response: Err(UserError::new(
+                            ErrorCode::CanisterContractViolation,
+                            "This API is not enabled on this subnet".to_string(),
+                        )),
+                        refund: msg.take_cycles(),
+                    },
+                    Some(pricing_version) => match &msg {
+                        CanisterCall::Request(request) => {
+                            match FlexibleCanisterHttpRequestArgs::decode(payload) {
+                                Err(err) => ExecuteSubnetMessageResult::Finished {
+                                    response: Err(err),
+                                    refund: msg.take_cycles(),
+                                },
+                                Ok(args) => {
+                                    match CanisterHttpRequestContext::generate_from_flexible_args(
+                                        state.time(),
+                                        request.as_ref(),
+                                        args,
+                                        &registry_settings.node_ids,
+                                        registry_settings.registry_version,
+                                        rng,
+                                        pricing_version,
+                                    ) {
                                         Err(err) => ExecuteSubnetMessageResult::Finished {
-                                            response: Err(err),
+                                            response: Err(err.into()),
                                             refund: msg.take_cycles(),
                                         },
-                                        Ok(()) => ExecuteSubnetMessageResult::Processing,
-                                    },
+                                        Ok(canister_http_request_context) => match self
+                                            .try_add_http_context_to_replicated_state(
+                                                canister_http_request_context,
+                                                &mut state,
+                                                request.as_ref(),
+                                                since,
+                                            ) {
+                                            Err(err) => ExecuteSubnetMessageResult::Finished {
+                                                response: Err(err),
+                                                refund: msg.take_cycles(),
+                                            },
+                                            Ok(()) => ExecuteSubnetMessageResult::Processing,
+                                        },
+                                    }
                                 }
                             }
                         }
-                    }
-                    CanisterCall::Ingress(_) => {
-                        self.reject_unexpected_ingress(Ic00Method::FlexibleHttpRequest)
-                    }
-                },
-            },
+                        CanisterCall::Ingress(_) => {
+                            self.reject_unexpected_ingress(Ic00Method::FlexibleHttpRequest)
+                        }
+                    },
+                }
+            }
 
             Ok(Ic00Method::HttpRequest) => match state.subnet_features().http_requests {
                 true => match &msg {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -1245,16 +1245,21 @@ impl ExecutionEnvironment {
                 // pricing model. That model is gated behind the
                 // `flexible_http_requests` feature flag and, once enabled,
                 // applies to every subnet. Until then, flexible outcalls are
-                // still offered on free subnets, where pricing is moot, by
-                // falling back to the legacy (charge-everything-up-front)
-                // pricing. On paying subnets they remain unavailable until the
-                // flag is enabled.
+                // still offered on subnets where HTTP outcalls are free (pricing
+                // is moot), by falling back to the legacy
+                // (charge-everything-up-front) pricing. That covers subnets on a
+                // free cost schedule as well as system subnets, which charge
+                // zero for HTTP outcalls despite a normal cost schedule. On
+                // paying subnets flexible outcalls remain unavailable until the
+                // flag is enabled, since legacy pricing would overcharge them
+                // (it charges the maximum response size up front).
+                let http_outcalls_are_free = state.get_own_cost_schedule()
+                    == CanisterCyclesCostSchedule::Free
+                    || self.own_subnet_type == SubnetType::System;
                 let pricing_version = match self.config.flexible_http_requests {
                     FlagStatus::Enabled => Some(PricingVersion::PayAsYouGo),
-                    FlagStatus::Disabled => match state.get_own_cost_schedule() {
-                        CanisterCyclesCostSchedule::Free => Some(PricingVersion::Legacy),
-                        CanisterCyclesCostSchedule::Normal => None,
-                    },
+                    FlagStatus::Disabled if http_outcalls_are_free => Some(PricingVersion::Legacy),
+                    FlagStatus::Disabled => None,
                 };
                 match pricing_version {
                     None => ExecuteSubnetMessageResult::Finished {

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -3673,6 +3673,49 @@ fn execute_flexible_canister_http_request_free_subnet_uses_legacy() {
 }
 
 #[test]
+fn execute_flexible_canister_http_request_system_subnet_uses_legacy() {
+    // System subnets charge nothing for HTTP outcalls despite a normal cost
+    // schedule, so flexible outcalls are available there by default (without the
+    // feature flag) and fall back to legacy pricing.
+    let own_subnet = subnet_test_id(1);
+    let caller_canister = canister_test_id(10);
+    let mut test = ExecutionTestBuilder::new()
+        .with_own_subnet_id(own_subnet)
+        .with_caller(own_subnet, caller_canister)
+        // A system subnet keeps the default (normal) cost schedule but charges
+        // zero for HTTP outcalls; the feature flag is left disabled.
+        .with_subnet_type(SubnetType::System)
+        .build();
+
+    let args = flexible_http_request_args(caller_canister);
+    let payment = Cycles::new(1_000_000_000);
+    test.inject_call_to_ic00(Method::FlexibleHttpRequest, args.encode(), payment);
+    test.execute_all();
+
+    let canister_http_request_contexts = &test
+        .state()
+        .metadata
+        .subnet_call_context_manager
+        .canister_http_request_contexts;
+    assert_eq!(canister_http_request_contexts.len(), 1);
+
+    let http_request_context = canister_http_request_contexts
+        .get(&CallbackId::from(0))
+        .unwrap();
+    // Routed through legacy pricing with flexible replication, just like a
+    // free-cost-schedule subnet.
+    assert_eq!(http_request_context.pricing_version, PricingVersion::Legacy);
+    assert!(
+        matches!(
+            http_request_context.replication,
+            Replication::Flexible { .. }
+        ),
+        "expected flexible replication, got {:?}",
+        http_request_context.replication
+    );
+}
+
+#[test]
 fn execute_flexible_canister_http_request_explicit_replication() {
     // An explicit replication request with total_requests < subnet_size yields a
     // committee smaller than the subnet, so the per-replica allowance is split

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -3572,8 +3572,9 @@ fn execute_flexible_canister_http_request() {
         let http_request_context = canister_http_request_contexts
             .get(&CallbackId::from(0))
             .unwrap();
-        // The flexible endpoint always uses pay-as-you-go pricing and flexible
-        // replication.
+        // With the `flexible_http_requests` feature flag enabled, the flexible
+        // endpoint uses pay-as-you-go pricing on every subnet (free or paying)
+        // and flexible replication.
         assert_eq!(
             http_request_context.pricing_version,
             PricingVersion::PayAsYouGo
@@ -3614,6 +3615,61 @@ fn execute_flexible_canister_http_request() {
                 .is_empty()
         );
     }
+}
+
+#[test]
+fn execute_flexible_canister_http_request_free_subnet_uses_legacy() {
+    // On a free subnet, flexible outcalls are available by default (without the
+    // `flexible_http_requests` feature flag) and fall back to legacy pricing,
+    // where pricing is moot because a free subnet charges nothing.
+    let own_subnet = subnet_test_id(1);
+    let caller_canister = canister_test_id(10);
+    let mut test = ExecutionTestBuilder::new()
+        .with_own_subnet_id(own_subnet)
+        .with_caller(own_subnet, caller_canister)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        // The feature flag is deliberately left disabled: the free-subnet path
+        // does not depend on it.
+        .build();
+
+    let args = flexible_http_request_args(caller_canister);
+    let payment = Cycles::new(1_000_000_000);
+    test.inject_call_to_ic00(Method::FlexibleHttpRequest, args.encode(), payment);
+    test.execute_all();
+
+    let canister_http_request_contexts = &test
+        .state()
+        .metadata
+        .subnet_call_context_manager
+        .canister_http_request_contexts;
+    assert_eq!(canister_http_request_contexts.len(), 1);
+
+    let http_request_context = canister_http_request_contexts
+        .get(&CallbackId::from(0))
+        .unwrap();
+    // The request is routed through legacy pricing with flexible replication.
+    assert_eq!(http_request_context.pricing_version, PricingVersion::Legacy);
+    assert!(
+        matches!(
+            http_request_context.replication,
+            Replication::Flexible { .. }
+        ),
+        "expected flexible replication, got {:?}",
+        http_request_context.replication
+    );
+
+    // Legacy pricing on a free subnet charges nothing: the full payment is
+    // retained (to be refunded when the response is delivered) and nothing is
+    // marked refundable through the pay-as-you-go mechanism.
+    assert_eq!(http_request_context.request.payment, payment);
+    assert_eq!(
+        http_request_context.refund_status.refundable_cycles,
+        Cycles::new(0)
+    );
+    assert_eq!(
+        http_request_context.refund_status.per_replica_allowance,
+        Cycles::new(0)
+    );
 }
 
 #[test]
@@ -3707,8 +3763,9 @@ fn execute_flexible_canister_http_request_insufficient_payment() {
 
 #[test]
 fn execute_flexible_canister_http_request_disabled() {
-    // The flexible HTTP outcalls feature is gated behind a feature flag that is
-    // disabled by default.
+    // On a paying subnet, flexible outcalls under pay-as-you-go pricing are
+    // gated behind the `flexible_http_requests` feature flag, which is disabled
+    // by default.
     let own_subnet = subnet_test_id(1);
     let caller_canister = canister_test_id(10);
     let mut test = ExecutionTestBuilder::new()
@@ -3725,7 +3782,8 @@ fn execute_flexible_canister_http_request_disabled() {
     test.execute_all();
 
     // No context is added and the request is rejected specifically because the
-    // feature flag is disabled (as opposed to any other rejection reason).
+    // feature is not available on this subnet (as opposed to any other
+    // rejection reason).
     let canister_http_request_contexts = &test
         .state()
         .metadata

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -3714,6 +3714,21 @@ fn execute_flexible_canister_http_request_system_subnet_uses_legacy() {
         "expected flexible replication, got {:?}",
         http_request_context.replication
     );
+
+    // A system subnet charges nothing for HTTP outcalls despite its normal cost
+    // schedule, so `try_add_http_context_to_replicated_state` treats it as free
+    // just like a free-cost-schedule subnet: the full payment is retained (to be
+    // refunded when the response is delivered) and nothing is marked refundable
+    // through the pay-as-you-go mechanism.
+    assert_eq!(http_request_context.request.payment, payment);
+    assert_eq!(
+        http_request_context.refund_status.refundable_cycles,
+        Cycles::new(0)
+    );
+    assert_eq!(
+        http_request_context.refund_status.per_replica_allowance,
+        Cycles::new(0)
+    );
 }
 
 #[test]

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -65,6 +65,9 @@ system_test_nns(
 system_test_nns(
     name = "canister_http_flexible_test",
     cpus = MIN_LOCAL_CPUS + 5 * DEFAULT_VCPUS_PER_VM + 1 * DEFAULT_VCPUS_PER_VM,  # 5 IC Node VMs (1 system + 4 app) + 1 UVM (httpbin), 6 vCPUs each.
+    tags = [
+        "long_test",  # since it exercises many outcall scenarios.
+    ],
     runtime_deps = CANISTER_HTTP_RUNTIME_DEPS | {
         "PROXY_WASM_PATH": "//rs/rust_canisters/proxy_canister:proxy_canister",
     },

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -26,6 +26,7 @@ pub const BACKOFF_DELAY: Duration = Duration::from_secs(5);
 const APP_SUBNET_SIZES: [usize; 3] = [13, 28, 40];
 pub const CONCURRENCY_LEVELS: [u64; 3] = [200, 500, 1000];
 const PROXY_CANISTER_ID_PATH: &str = "proxy_canister_id";
+const SYSTEM_PROXY_CANISTER_ID_PATH: &str = "system_proxy_canister_id";
 
 pub enum PemType {
     PemCert,
@@ -63,22 +64,42 @@ pub fn install_nns_canisters(env: &TestEnv) {
 }
 
 pub fn setup(env: TestEnv) {
-    setup_with_cost_schedule(env, CanisterCyclesCostSchedule::Normal);
+    setup_with_cost_schedule(
+        env,
+        CanisterCyclesCostSchedule::Normal,
+        /*system_subnet_outcalls=*/ false,
+    );
 }
 
-/// Like [`setup`], but the application subnet uses a free cost schedule. This
-/// enables flexible HTTP outcalls (which otherwise require the pay-as-you-go
-/// pricing model) via the legacy pricing fallback.
+/// Like [`setup`], but the application subnet uses a free cost schedule (enabling
+/// flexible HTTP outcalls via the legacy pricing fallback) and the system subnet
+/// also runs HTTP outcalls with its own proxy canister — system subnets are free
+/// for outcalls too, despite a normal cost schedule.
 pub fn setup_with_free_cost_schedule(env: TestEnv) {
-    setup_with_cost_schedule(env, CanisterCyclesCostSchedule::Free);
+    setup_with_cost_schedule(
+        env,
+        CanisterCyclesCostSchedule::Free,
+        /*system_subnet_outcalls=*/ true,
+    );
 }
 
-fn setup_with_cost_schedule(env: TestEnv, cost_schedule: CanisterCyclesCostSchedule) {
+fn setup_with_cost_schedule(
+    env: TestEnv,
+    cost_schedule: CanisterCyclesCostSchedule,
+    system_subnet_outcalls: bool,
+) {
     std::thread::scope(|s| {
         // Set up IC with 1 system subnet with one node, and one application subnet with 4 nodes.
         s.spawn(|| {
+            let mut system_subnet = Subnet::new(SubnetType::System).add_nodes(1);
+            if system_subnet_outcalls {
+                system_subnet = system_subnet.with_features(SubnetFeatures {
+                    http_requests: true,
+                    ..SubnetFeatures::default()
+                });
+            }
             InternetComputer::new()
-                .add_subnet(Subnet::new(SubnetType::System).add_nodes(1))
+                .add_subnet(system_subnet)
                 .add_subnet(
                     Subnet::new(SubnetType::Application)
                         .with_features(SubnetFeatures {
@@ -95,6 +116,18 @@ fn setup_with_cost_schedule(env: TestEnv, cost_schedule: CanisterCyclesCostSched
 
             s.spawn(|| {
                 install_nns_canisters(&env);
+                if system_subnet_outcalls {
+                    let node = get_system_subnet_node_snapshots(&env)
+                        .next()
+                        .expect("there is no system-subnet node");
+                    let runtime = get_runtime_from_node(&node);
+                    let _ = create_proxy_canister_with_name(
+                        &env,
+                        &runtime,
+                        &node,
+                        SYSTEM_PROXY_CANISTER_ID_PATH,
+                    );
+                }
             });
             s.spawn(|| {
                 // Get application subnet node to deploy canister to.
@@ -439,4 +472,10 @@ pub fn get_proxy_canister_id_with_name(env: &TestEnv, name: &str) -> PrincipalId
 
 pub fn get_proxy_canister_id(env: &TestEnv) -> PrincipalId {
     get_proxy_canister_id_with_name(env, PROXY_CANISTER_ID_PATH)
+}
+
+/// The proxy canister installed on the system subnet (available only with a
+/// setup that enables HTTP outcalls there, e.g. [`setup_with_free_cost_schedule`]).
+pub fn get_system_proxy_canister_id(env: &TestEnv) -> PrincipalId {
+    get_proxy_canister_id_with_name(env, SYSTEM_PROXY_CANISTER_ID_PATH)
 }

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -467,7 +467,7 @@ pub fn create_proxy_canister_with_cycles<'a>(
 
 pub fn get_proxy_canister_id_with_name(env: &TestEnv, name: &str) -> PrincipalId {
     env.read_json_object(name)
-        .expect("Proxy canister should should .")
+        .unwrap_or_else(|e| panic!("proxy canister id '{name}' not found in TestEnv: {e}"))
 }
 
 pub fn get_proxy_canister_id(env: &TestEnv) -> PrincipalId {

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -13,7 +13,7 @@ use ic_system_test_driver::driver::universal_vm::*;
 use ic_system_test_driver::driver::{test_env::TestEnv, test_env_api::*};
 use ic_system_test_driver::util::{self, create_and_install, create_and_install_with_cycles};
 pub use ic_types::{CanisterId, PrincipalId};
-use ic_types_cycles::Cycles;
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use slog::info;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -63,6 +63,17 @@ pub fn install_nns_canisters(env: &TestEnv) {
 }
 
 pub fn setup(env: TestEnv) {
+    setup_with_cost_schedule(env, CanisterCyclesCostSchedule::Normal);
+}
+
+/// Like [`setup`], but the application subnet uses a free cost schedule. This
+/// enables flexible HTTP outcalls (which otherwise require the pay-as-you-go
+/// pricing model) via the legacy pricing fallback.
+pub fn setup_with_free_cost_schedule(env: TestEnv) {
+    setup_with_cost_schedule(env, CanisterCyclesCostSchedule::Free);
+}
+
+fn setup_with_cost_schedule(env: TestEnv, cost_schedule: CanisterCyclesCostSchedule) {
     std::thread::scope(|s| {
         // Set up IC with 1 system subnet with one node, and one application subnet with 4 nodes.
         s.spawn(|| {
@@ -74,6 +85,7 @@ pub fn setup(env: TestEnv) {
                             http_requests: true,
                             ..SubnetFeatures::default()
                         })
+                        .with_cost_schedule(cost_schedule)
                         .add_nodes(4),
                 )
                 .setup_and_start(&env)

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -2781,10 +2781,14 @@ fn test_flexible_http_request_not_enabled_on_normal_subnet(env: TestEnv) {
     let result = block_on(submit_flexible_outcall(&handlers, request));
 
     match result {
-        Err((_reject_code, message)) => assert!(
-            message.contains("This API is not enabled on this subnet"),
-            "unexpected rejection message: '{message}'"
-        ),
+        Err((reject_code, message)) => {
+            // A `CanisterContractViolation` (5xx) surfaces as `CanisterError`.
+            assert_matches!(reject_code, RejectionCode::CanisterError);
+            assert!(
+                message.contains("This API is not enabled on this subnet"),
+                "unexpected rejection message: '{message}'"
+            );
+        }
         Ok(bytes) => panic!(
             "expected the flexible outcall to be rejected on a normal subnet, \
              got a {}-byte reply",

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -2769,6 +2769,7 @@ fn test_flexible_http_request_not_enabled_on_normal_subnet(env: TestEnv) {
     let request = FlexibleRemoteHttpRequest {
         request: FlexibleCanisterHttpRequestArgs {
             url: format!("https://[{webserver_ipv6}]/ascii/hello"),
+            max_response_bytes: None,
             headers: BoundedHttpHeaders::new(vec![]),
             body: None,
             method: HttpMethod::GET,

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -30,7 +30,8 @@ use ic_cdk::api::call::RejectionCode;
 use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_management_canister_types_private::{
-    HttpHeader, HttpMethod, TransformContext, TransformFunc,
+    BoundedHttpHeaders, FlexibleCanisterHttpRequestArgs, HttpHeader, HttpMethod, TransformContext,
+    TransformFunc,
 };
 use ic_system_test_driver::{
     canister_agent::HasCanisterAgentCapability,
@@ -51,7 +52,7 @@ use ic_types::{
 };
 use ic_types_cycles::CanisterCyclesCostSchedule;
 use proxy_canister::{
-    RemoteHttpRequest, RemoteHttpResponse, ResponseWithRefundedCycles,
+    FlexibleRemoteHttpRequest, RemoteHttpRequest, RemoteHttpResponse, ResponseWithRefundedCycles,
     UnvalidatedCanisterHttpRequestArgs,
 };
 use serde_json::Value;
@@ -201,7 +202,11 @@ fn main() -> Result<()> {
                     test_only_headers_with_custom_max_response_bytes_exceeded
                 ))
                 .add_test(systest!(test_max_response_bytes_too_large))
-                .add_test(systest!(test_max_response_bytes_2_mb_returns_ok)),
+                .add_test(systest!(test_max_response_bytes_2_mb_returns_ok))
+                // Flexible outcalls are not available on a normal (paying) subnet.
+                .add_test(systest!(
+                    test_flexible_http_request_not_enabled_on_normal_subnet
+                )),
         )
         .execute_from_args()?;
 
@@ -2708,6 +2713,83 @@ where
                 });
             (result, RefundedCycles::Cycles(refunded_cycles))
         }
+    }
+}
+
+/// Submits a flexible HTTP outcall through the proxy canister and returns the
+/// proxy's raw reply: `Ok(bytes)` (the Candid-encoded `FlexibleHttpRequestResult`)
+/// on a handled outcall, or `Err((code, message))` when `flexible_http_request`
+/// is rejected synchronously (e.g. because it is not enabled on this subnet).
+async fn submit_flexible_outcall(
+    handlers: &Handlers<'_>,
+    request: FlexibleRemoteHttpRequest,
+) -> Result<Vec<u8>, (RejectionCode, String)> {
+    let args = Encode!(&request).unwrap();
+    let agent = handlers.agent().await;
+
+    let principal_id: PrincipalId = handlers.proxy_canister().effective_canister_id();
+    let principal: Principal = principal_id.into();
+
+    let log = handlers.env.logger();
+    let canister_response = match retry_agent_on_transport_errors!(
+        "submit_flexible_outcall: call",
+        &log,
+        agent
+            .update(&principal, "send_flexible_request")
+            .with_arg(args.clone())
+            .call()
+    )
+    .await
+    .expect("submit_flexible_outcall retries exhausted")
+    {
+        Ok(CallResponse::Response(response)) => Ok(response),
+        Ok(CallResponse::Poll(request_id)) => retry_agent_on_transport_errors!(
+            "submit_flexible_outcall: wait",
+            &log,
+            agent.wait(&request_id, principal)
+        )
+        .await
+        .expect("submit_flexible_outcall retries exhausted"),
+        Err(err) => Err(err),
+    };
+
+    let serialized_bytes = canister_response.expect("send_flexible_request should reply");
+    decode_one::<Result<Vec<u8>, (RejectionCode, String)>>(&serialized_bytes.0)
+        .expect("Decoding the send_flexible_request reply should succeed.")
+}
+
+/// Flexible HTTP outcalls are priced with the (not-yet-enabled) pay-as-you-go
+/// pricing model, so they are rejected on a normal (paying) subnet. (On a free
+/// subnet they are available via the legacy pricing fallback; that path is
+/// covered by `canister_http_flexible_test`.)
+fn test_flexible_http_request_not_enabled_on_normal_subnet(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let request = FlexibleRemoteHttpRequest {
+        request: FlexibleCanisterHttpRequestArgs {
+            url: format!("https://[{webserver_ipv6}]/ascii/hello"),
+            headers: BoundedHttpHeaders::new(vec![]),
+            body: None,
+            method: HttpMethod::GET,
+            transform: None,
+            replication: None,
+        },
+        cycles: HTTP_REQUEST_CYCLE_PAYMENT,
+    };
+
+    let result = block_on(submit_flexible_outcall(&handlers, request));
+
+    match result {
+        Err((_reject_code, message)) => assert!(
+            message.contains("This API is not enabled on this subnet"),
+            "unexpected rejection message: '{message}'"
+        ),
+        Ok(bytes) => panic!(
+            "expected the flexible outcall to be rejected on a normal subnet, \
+             got a {}-byte reply",
+            bytes.len()
+        ),
     }
 }
 

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -84,6 +84,8 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_min_responses_fit_max_would_exceed))
                 .add_test(systest!(test_single_large_response_ok))
                 .add_test(systest!(test_fire_and_forget))
+                // System subnet (free for outcalls despite a normal cost schedule).
+                .add_test(systest!(test_system_subnet_outcall))
                 // Transform behavior.
                 .add_test(systest!(test_transform_appends_context))
                 .add_test(systest!(test_transform_sets_status_and_headers))
@@ -132,6 +134,20 @@ fn app_runtime(env: &TestEnv) -> Runtime {
 /// Returns the proxy canister installed during setup.
 fn proxy_canister<'a>(env: &TestEnv, runtime: &'a Runtime) -> Canister<'a> {
     let principal_id = get_proxy_canister_id(env);
+    Canister::new(runtime, CanisterId::unchecked_from_principal(principal_id))
+}
+
+/// Returns a runtime for the (single) system-subnet node.
+fn system_runtime(env: &TestEnv) -> Runtime {
+    let node = get_system_subnet_node_snapshots(env)
+        .next()
+        .expect("there is no system-subnet node");
+    get_runtime_from_node(&node)
+}
+
+/// Returns the proxy canister installed on the system subnet during setup.
+fn system_proxy_canister<'a>(env: &TestEnv, runtime: &'a Runtime) -> Canister<'a> {
+    let principal_id = get_system_proxy_canister_id(env);
     Canister::new(runtime, CanisterId::unchecked_from_principal(principal_id))
 }
 
@@ -1323,6 +1339,40 @@ fn test_too_many_rejects_composite_transform(env: TestEnv) {
             Ok(())
         },
     );
+}
+
+// ---------------------------------------------------------------------------
+// System subnet
+// ---------------------------------------------------------------------------
+
+/// Flexible outcalls work on a system subnet too: system subnets are free for
+/// HTTP outcalls (despite a normal cost schedule), so the request is routed
+/// through legacy pricing. The system subnet has a single node, so exactly one
+/// response comes back.
+fn test_system_subnet_outcall(env: TestEnv) {
+    let logger = env.logger();
+    let runtime = system_runtime(&env);
+    let proxy = system_proxy_canister(&env, &runtime);
+
+    block_on(async {
+        ic_system_test_driver::retry_with_msg_async!(
+            "flexible outcall on a system subnet succeeds".to_string(),
+            &logger,
+            READY_WAIT_TIMEOUT,
+            RETRY_BACKOFF,
+            || async {
+                let args = get_args(format!("{}/ascii/system", webserver_base(&env)));
+                let result = send_flexible(&proxy, args, CYCLES).await?;
+                // A single-node subnet returns exactly one response.
+                let payloads = expect_ok(result, 1, 1)?;
+                expect_all_status(&payloads, 200)?;
+                expect_all_bodies(&payloads, b"system")?;
+                Ok(())
+            }
+        )
+        .await
+        .expect("flexible outcall on the system subnet did not succeed");
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -158,14 +158,17 @@ fn get_args(url: String) -> FlexibleCanisterHttpRequestArgs {
     }
 }
 
-/// Sends a flexible outcall through the proxy canister and returns either the
-/// decoded [`FlexibleHttpRequestResult`] (on a handled outcall) or the
-/// synchronous rejection (on a validation failure).
+/// Sends a flexible outcall through the proxy canister. The outer `Result` is
+/// `Err` on a (retryable) transport failure of the proxy call itself; the inner
+/// `Result` is the outcall outcome — the decoded [`FlexibleHttpRequestResult`]
+/// on a handled outcall, or the synchronous rejection on a validation failure.
 async fn send_flexible(
     proxy: &Canister<'_>,
     args: FlexibleCanisterHttpRequestArgs,
     cycles: u64,
-) -> Result<FlexibleHttpRequestResult, (RejectionCode, String)> {
+) -> Result<Result<FlexibleHttpRequestResult, (RejectionCode, String)>> {
+    // A failure here is a transport-level error talking to the proxy canister,
+    // not an outcall outcome; return it so the retry loop can absorb blips.
     let res = proxy
         .update_(
             "send_flexible_request",
@@ -176,12 +179,12 @@ async fn send_flexible(
             },
         )
         .await
-        .expect("Update call to proxy canister failed");
+        .map_err(|err| anyhow::anyhow!("update call to proxy canister failed: {err}"))?;
 
-    res.map(|bytes| {
+    Ok(res.map(|bytes| {
         Decode!(&bytes, FlexibleHttpRequestResult)
             .expect("Failed to decode FlexibleHttpRequestResult")
-    })
+    }))
 }
 
 /// Runs `assert_result` against the outcome of the flexible outcall built by
@@ -204,7 +207,7 @@ where
             RETRY_BACKOFF,
             || async {
                 let args = make_args(&env);
-                let result = send_flexible(&proxy, args, CYCLES).await;
+                let result = send_flexible(&proxy, args, CYCLES).await?;
                 assert_result(result)
             }
         )
@@ -1368,7 +1371,7 @@ fn test_fault_tolerance(env: TestEnv) {
                     max_responses: SUBNET_NODES,
                 });
                 // Attaching cycles should be possible, even of free subnets
-                let result = send_flexible(&proxy, args, 1000).await;
+                let result = send_flexible(&proxy, args, 1000).await?;
                 // At most the surviving nodes (n - 1) can respond.
                 let payloads = expect_ok(result, 2, (SUBNET_NODES - 1) as usize)?;
                 expect_all_status(&payloads, 200)?;

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -2,19 +2,24 @@
 Title:: Flexible HTTP outcalls.
 
 Goal:: Exhaustively exercise the `flexible_http_request` management canister
-endpoint on a free subnet (where flexible outcalls fall back to legacy pricing).
+endpoint on subnets where HTTP outcalls are free (a free-cost-schedule
+application subnet and a system subnet), where flexible outcalls fall back to
+legacy pricing.
 
 Runbook::
 0. Instantiate a universal VM with a webserver (httpbin).
-1. Instantiate an IC with one application subnet (4 nodes, free cost schedule)
-   with the HTTP feature enabled.
+1. Instantiate an IC with the HTTP feature enabled on both a 4-node application
+   subnet (free cost schedule) and the 1-node system subnet (free for outcalls
+   despite a normal cost schedule).
 2. Install NNS canisters.
-3. Install the proxy canister.
-4. Make flexible HTTP outcalls through the proxy canister covering:
+3. Install a proxy canister on each of the two subnets.
+4. Make flexible HTTP outcalls through the proxy canisters covering:
    - success across replication parameters and HTTP methods,
    - synchronous validation rejections,
    - runtime errors (too many rejects, responses too large),
-   - adapter-level per-node failures.
+   - adapter-level per-node failures,
+   - an outcall on the system subnet,
+   - fault tolerance: an outcall still succeeds with a subnet node killed.
 
 Success::
 1. Each scenario returns the expected `FlexibleHttpRequestResult` (or rejection).
@@ -527,8 +532,7 @@ fn test_put_with_deterministic_replication(env: TestEnv) {
                 min_responses: SUBNET_NODES,
                 max_responses: SUBNET_NODES,
             });
-            // Strip the (non-deterministic) echoed request headers so every node
-            // agrees on the response.
+            // Strip the echoed request headers.
             args.transform = Some(TransformContext {
                 function: TransformFunc(candid::Func {
                     principal: proxy_principal(env),
@@ -647,8 +651,8 @@ fn test_single_request_nondeterministic(env: TestEnv) {
 /// `max_responses` of them would exceed it, so the outcall succeeds with exactly
 /// `min_responses` responses.
 fn test_min_responses_fit_max_would_exceed(env: TestEnv) {
-    // Each node returns a 1 MB body: 2 just fit within the ~2 MiB
-    // (2_097_152 B) payload limit (2.0 MB), but 3 would exceed it (3.0 MB).
+    // Each node returns a 1 MB body: 2 bodies (2.0 MB) fit within the ~2 MiB
+    // (2_097_152 B) payload limit, but 3 (3.0 MB) exceed it.
     const BODY_SIZE: usize = 1_000_000;
     run_flexible_test(
         env,
@@ -768,7 +772,7 @@ fn test_head_method(env: TestEnv) {
         |env| {
             let mut args = get_args(format!("{}/anything", webserver_base(env)));
             args.method = HttpMethod::HEAD;
-            // Strip the echoed request headers for cross-node agreement.
+            // Strip the echoed request headers.
             args.transform = Some(TransformContext {
                 function: TransformFunc(candid::Func {
                     principal: proxy_principal(env),
@@ -1229,9 +1233,9 @@ fn test_too_many_rejects_non_https(env: TestEnv) {
 }
 
 /// When the aggregated responses are too large to fit in a block, the outcall
-/// reports `responses_too_large`. Each node returns a ~1 MiB body (below the
-/// per-response 2 MiB limit), but `min_responses` (3) of them exceed the 2 MiB
-/// payload limit.
+/// reports `responses_too_large`. Each node returns a ~1 MB body (below the
+/// per-node 2 MB limit), but `min_responses` (3) of them exceed the ~2 MiB
+/// block payload limit.
 fn test_responses_too_large(env: TestEnv) {
     run_flexible_test(
         env,
@@ -1449,8 +1453,9 @@ fn test_system_subnet_outcall(env: TestEnv) {
 
 /// A flexible outcall with `min_responses < total_requests` still succeeds when
 /// one of the committee's nodes is down — the defining reliability property of
-/// flexible outcalls. This test kills (and later restarts) a node, so it is
-/// registered as a trailing sequential test rather than in the parallel suite.
+/// flexible outcalls. This test kills a node and leaves it down, so it is
+/// registered as a trailing sequential test rather than in the parallel suite
+/// (nothing must run on the crippled subnet afterwards).
 fn test_fault_tolerance(env: TestEnv) {
     let logger = env.logger();
 
@@ -1488,7 +1493,7 @@ fn test_fault_tolerance(env: TestEnv) {
                     min_responses: 2,
                     max_responses: SUBNET_NODES,
                 });
-                // Attaching cycles should be possible, even of free subnets
+                // Attaching cycles should be possible, even on free subnets.
                 let result = send_flexible(&proxy, args, 1000).await?;
                 // At most the surviving nodes (n - 1) can respond.
                 let payloads = expect_ok(result, 2, (SUBNET_NODES - 1) as usize)?;

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -36,7 +36,7 @@ use ic_management_canister_types_private::{
 use ic_system_test_driver::driver::group::{SystemTestGroup, SystemTestSubGroup};
 use ic_system_test_driver::driver::{
     test_env::TestEnv,
-    test_env_api::{READY_WAIT_TIMEOUT, RETRY_BACKOFF},
+    test_env_api::{HasPublicApiUrl, HasVm, READY_WAIT_TIMEOUT, RETRY_BACKOFF},
 };
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::block_on;
@@ -44,8 +44,8 @@ use proxy_canister::FlexibleRemoteHttpRequest;
 use slog::info;
 
 /// The cycles attached to each flexible outcall. On a free subnet nothing is
-/// charged, but the caller must still be able to attach the payment.
-const CYCLES: u64 = 500_000_000_000;
+/// charged.
+const CYCLES: u64 = 0;
 
 /// The application subnet has 4 nodes (see `setup`). With the default
 /// replication (`replication: None`) the committee is all `n` nodes,
@@ -76,6 +76,10 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_redirects_are_not_followed))
                 .add_test(systest!(test_redirect_zero_no_content))
                 .add_test(systest!(test_nondeterministic_responses))
+                .add_test(systest!(test_single_request_nondeterministic))
+                .add_test(systest!(test_min_responses_fit_max_would_exceed))
+                .add_test(systest!(test_single_large_response_ok))
+                .add_test(systest!(test_fire_and_forget))
                 // Transform behavior.
                 .add_test(systest!(test_transform_appends_context))
                 .add_test(systest!(test_transform_sets_status_and_headers))
@@ -91,14 +95,19 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_reject_invalid_transform_principal))
                 .add_test(systest!(test_reject_header_name_too_long))
                 .add_test(systest!(test_reject_header_value_too_long))
+                .add_test(systest!(test_reject_request_too_large))
                 // Runtime errors and adapter-level per-node failures.
                 .add_test(systest!(test_too_many_rejects_connection_refused))
                 .add_test(systest!(test_too_many_rejects_invalid_domain))
+                .add_test(systest!(test_too_many_rejects_non_https))
                 .add_test(systest!(test_too_many_rejects_response_over_node_limit))
                 .add_test(systest!(test_too_many_rejects_transform_over_node_limit))
                 .add_test(systest!(test_too_many_rejects_composite_transform))
                 .add_test(systest!(test_responses_too_large)),
         )
+        // Fault tolerance kills a node, so it must run sequentially AFTER the
+        // parallel suite.
+        .add_test(systest!(test_fault_tolerance))
         .execute_from_args()?;
 
     Ok(())
@@ -120,6 +129,16 @@ fn app_runtime(env: &TestEnv) -> Runtime {
 fn proxy_canister<'a>(env: &TestEnv, runtime: &'a Runtime) -> Canister<'a> {
     let principal_id = get_proxy_canister_id(env);
     Canister::new(runtime, CanisterId::unchecked_from_principal(principal_id))
+}
+
+/// The principal of the proxy canister (the sender of the outcalls), used as the
+/// valid transform principal.
+fn proxy_principal(env: &TestEnv) -> Principal {
+    get_proxy_canister_id(env).0
+}
+
+fn webserver_base(env: &TestEnv) -> String {
+    format!("https://[{}]", get_universal_vm_address(env))
 }
 
 /// Base flexible request arguments: a `GET` with no headers, body, transform, or
@@ -156,7 +175,7 @@ async fn send_flexible(
         .expect("Update call to proxy canister failed");
 
     res.map(|bytes| {
-        candid::Decode!(&bytes, FlexibleHttpRequestResult)
+        Decode!(&bytes, FlexibleHttpRequestResult)
             .expect("Failed to decode FlexibleHttpRequestResult")
     })
 }
@@ -190,10 +209,13 @@ where
     });
 }
 
-/// The principal of the proxy canister (the sender of the outcalls), used as the
-/// valid transform principal.
-fn proxy_principal(env: &TestEnv) -> Principal {
-    get_proxy_canister_id(env).0
+/// Returns the value of the (case-insensitive) response header `name`, if present.
+fn header_value<'a>(payload: &'a CanisterHttpResponsePayload, name: &str) -> Option<&'a str> {
+    payload
+        .headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case(name))
+        .map(|header| header.value.as_str())
 }
 
 /// Asserts the result is `Ok` with a payload count in `[min, max]` and returns
@@ -225,6 +247,42 @@ fn expect_all_status(payloads: &[CanisterHttpResponsePayload], status: u128) -> 
                 "expected status {status} for every payload, got {}",
                 payload.status
             );
+        }
+    }
+    Ok(())
+}
+
+/// Asserts every payload body equals `expected`.
+fn expect_all_bodies(payloads: &[CanisterHttpResponsePayload], expected: &[u8]) -> Result<()> {
+    for payload in payloads {
+        if payload.body.as_slice() != expected {
+            bail!(
+                "expected body {:?}, got {:?}",
+                String::from_utf8_lossy(expected),
+                String::from_utf8_lossy(&payload.body)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Asserts every payload body (interpreted as UTF-8) contains `needle`.
+fn expect_all_bodies_contain(payloads: &[CanisterHttpResponsePayload], needle: &str) -> Result<()> {
+    for payload in payloads {
+        let body = String::from_utf8_lossy(&payload.body);
+        if !body.contains(needle) {
+            bail!("expected body to contain '{needle}', got {body:?}");
+        }
+    }
+    Ok(())
+}
+
+/// Asserts every payload has no response headers (e.g. after a header-stripping
+/// transform).
+fn expect_all_headers_empty(payloads: &[CanisterHttpResponsePayload]) -> Result<()> {
+    for payload in payloads {
+        if !payload.headers.is_empty() {
+            bail!("expected no headers, got {:?}", payload.headers);
         }
     }
     Ok(())
@@ -279,26 +337,26 @@ fn expect_global_error(
     }
 }
 
-/// Asserts every node in a runtime error carries an error whose message contains
-/// `expected_substring`.
-fn expect_all_node_errors_contain(
+/// Asserts every node in a runtime error carries an error with the given `code`
+/// and a message containing `message_substring`.
+fn expect_all_node_errors(
     err: &FlexibleHttpRequestErr,
-    expected_substring: &str,
+    code: &str,
+    message_substring: &str,
 ) -> Result<()> {
     if err.node_details.is_empty() {
         bail!("expected per-node error details");
     }
     for detail in &err.node_details {
         match &detail.error {
-            Some(node_error) if node_error.message.contains(expected_substring) => {}
-            other => bail!("node error {other:?} does not contain '{expected_substring}'"),
+            Some(node_error)
+                if node_error.code == code && node_error.message.contains(message_substring) => {}
+            other => bail!(
+                "node error {other:?} does not match code '{code}' / message '{message_substring}'"
+            ),
         }
     }
     Ok(())
-}
-
-fn webserver_base(env: &TestEnv) -> String {
-    format!("https://[{}]", get_universal_vm_address(env))
 }
 
 // ---------------------------------------------------------------------------
@@ -316,14 +374,7 @@ fn test_default_replication(env: TestEnv) {
         move |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 200)?;
-            for payload in &payloads {
-                if payload.body != b"hello_world".to_vec() {
-                    bail!(
-                        "unexpected body: {:?}",
-                        String::from_utf8_lossy(&payload.body)
-                    );
-                }
-            }
+            expect_all_bodies(&payloads, b"hello_world")?;
             info!(
                 logger,
                 "default replication returned {} payloads",
@@ -351,9 +402,7 @@ fn test_single_request(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 1, 1)?;
             expect_all_status(&payloads, 200)?;
-            if payloads[0].body != b"single".to_vec() {
-                bail!("unexpected body");
-            }
+            expect_all_bodies(&payloads, b"single")?;
             Ok(())
         },
     );
@@ -376,6 +425,7 @@ fn test_all_nodes(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies(&payloads, b"all")?;
             Ok(())
         },
     );
@@ -398,6 +448,7 @@ fn test_partial_responses(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, 3)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies(&payloads, b"partial")?;
             Ok(())
         },
     );
@@ -417,6 +468,9 @@ fn test_post_with_body(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 200)?;
+            // The endpoint echoes the request method and body as JSON.
+            expect_all_bodies_contain(&payloads, "\"method\":\"POST\"")?;
+            expect_all_bodies_contain(&payloads, "flexible-body")?;
             Ok(())
         },
     );
@@ -442,17 +496,9 @@ fn test_transform_appends_context(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 200)?;
-            for payload in &payloads {
-                if payload.body != b"base-ctx".to_vec() {
-                    bail!(
-                        "expected transformed body 'base-ctx', got {:?}",
-                        String::from_utf8_lossy(&payload.body)
-                    );
-                }
-                if !payload.headers.is_empty() {
-                    bail!("expected transform to strip headers");
-                }
-            }
+            // The transform appends the context to the body and strips headers.
+            expect_all_bodies(&payloads, b"base-ctx")?;
+            expect_all_headers_empty(&payloads)?;
             Ok(())
         },
     );
@@ -486,6 +532,7 @@ fn test_put_with_deterministic_replication(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies_contain(&payloads, "\"method\":\"PUT\"")?;
             Ok(())
         },
     );
@@ -500,6 +547,13 @@ fn test_redirects_are_not_followed(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 303)?;
+            // The redirect target is returned in the location header, not followed.
+            for payload in &payloads {
+                match header_value(payload, "location") {
+                    Some(location) if location.contains("relative-redirect") => {}
+                    other => bail!("expected a redirect location header, got {other:?}"),
+                }
+            }
             Ok(())
         },
     );
@@ -523,6 +577,138 @@ fn test_nondeterministic_responses(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, SUBNET_NODES as usize)?;
             expect_all_status(&payloads, 200)?;
+            // Bodies may differ across payloads, but each is a numeric string.
+            for payload in &payloads {
+                if payload.body.is_empty() || !payload.body.iter().all(|b| b.is_ascii_digit()) {
+                    bail!(
+                        "expected a numeric random body, got {:?}",
+                        String::from_utf8_lossy(&payload.body)
+                    );
+                }
+            }
+            Ok(())
+        },
+    );
+}
+
+/// A single-node request to a non-deterministic endpoint succeeds: with one
+/// response there is nothing to reconcile. (The flexible replacement for the
+/// legacy non-replicated mode.)
+fn test_single_request_nondeterministic(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a single-node request to a non-deterministic endpoint succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/random", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 1,
+                min_responses: 1,
+                max_responses: 1,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 1, 1)?;
+            expect_all_status(&payloads, 200)?;
+            if payloads[0].body.is_empty() || !payloads[0].body.iter().all(|b| b.is_ascii_digit()) {
+                bail!(
+                    "expected a numeric random body, got {:?}",
+                    String::from_utf8_lossy(&payloads[0].body)
+                );
+            }
+            Ok(())
+        },
+    );
+}
+
+/// The response count is capped by the block payload limit: `min_responses`
+/// responses fit within the ~2 MiB `MAX_CANISTER_HTTP_PAYLOAD_SIZE`, but
+/// `max_responses` of them would exceed it, so the outcall succeeds with exactly
+/// `min_responses` responses.
+fn test_min_responses_fit_max_would_exceed(env: TestEnv) {
+    // Each node returns a 1 MB body: 2 just fit within the ~2 MiB
+    // (2_097_152 B) payload limit (2.0 MB), but 3 would exceed it (3.0 MB).
+    const BODY_SIZE: usize = 1_000_000;
+    run_flexible_test(
+        env,
+        "response count is capped at min_responses by the payload limit",
+        |env| {
+            let mut args = get_args(format!("{}/bytes/{BODY_SIZE}", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES,
+                min_responses: 2,
+                max_responses: SUBNET_NODES,
+            });
+            args
+        },
+        |result| {
+            // Exactly min_responses (2) come back, even though max_responses (4)
+            // was requested.
+            let payloads = expect_ok(result, 2, 2)?;
+            expect_all_status(&payloads, 200)?;
+            for payload in &payloads {
+                if payload.body.len() != BODY_SIZE {
+                    bail!(
+                        "expected a {BODY_SIZE}-byte body, got {} bytes",
+                        payload.body.len()
+                    );
+                }
+            }
+            Ok(())
+        },
+    );
+}
+
+/// A "fire-and-forget" outcall (`min_responses = max_responses = 0`) dispatches
+/// the request but requires no responses, so it succeeds immediately with an
+/// empty result.
+fn test_fire_and_forget(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "min = max = 0 fire-and-forget returns an empty result",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/ignored", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 1,
+                min_responses: 0,
+                max_responses: 0,
+            });
+            args
+        },
+        |result| {
+            // No responses are collected or returned.
+            expect_ok(result, 0, 0)?;
+            Ok(())
+        },
+    );
+}
+
+/// A single response just under the 2 MB per-node limit succeeds. This is the
+/// positive counterpart to `test_too_many_rejects_response_over_node_limit`,
+/// where a response over the limit is rejected.
+fn test_single_large_response_ok(env: TestEnv) {
+    const BODY_SIZE: usize = 1_900_000;
+    run_flexible_test(
+        env,
+        "a single response just under the 2 MB per-node limit succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/bytes/{BODY_SIZE}", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 1,
+                min_responses: 1,
+                max_responses: 1,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 1, 1)?;
+            expect_all_status(&payloads, 200)?;
+            if payloads[0].body.len() != BODY_SIZE {
+                bail!(
+                    "expected a {BODY_SIZE}-byte body, got {} bytes",
+                    payloads[0].body.len()
+                );
+            }
             Ok(())
         },
     );
@@ -546,6 +732,7 @@ fn test_intermediate_range(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, 4)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies(&payloads, b"range")?;
             Ok(())
         },
     );
@@ -573,6 +760,8 @@ fn test_head_method(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 200)?;
+            // A HEAD response carries no body.
+            expect_all_bodies(&payloads, b"")?;
             Ok(())
         },
     );
@@ -603,6 +792,7 @@ fn test_delete_with_deterministic_replication(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, 2)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies_contain(&payloads, "\"method\":\"DELETE\"")?;
             Ok(())
         },
     );
@@ -633,6 +823,7 @@ fn test_patch_with_deterministic_replication(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, 2)?;
             expect_all_status(&payloads, 200)?;
+            expect_all_bodies_contain(&payloads, "\"method\":\"PATCH\"")?;
             Ok(())
         },
     );
@@ -647,6 +838,8 @@ fn test_redirect_zero_no_content(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 204)?;
+            // 204 No Content carries no body.
+            expect_all_bodies(&payloads, b"")?;
             Ok(())
         },
     );
@@ -671,11 +864,20 @@ fn test_transform_sets_status_and_headers(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
             expect_all_status(&payloads, 202)?;
+            // The transform replaces the body with the context and sets a fixed
+            // pair of headers (the caller is the management canister).
+            expect_all_bodies(&payloads, b"transform_context")?;
             for payload in &payloads {
-                if payload.body != b"transform_context".to_vec() {
+                if header_value(payload, "hello") != Some("bonjour") {
                     bail!(
-                        "expected transformed body 'transform_context', got {:?}",
-                        String::from_utf8_lossy(&payload.body)
+                        "expected header hello=bonjour, got {:?}",
+                        header_value(payload, "hello")
+                    );
+                }
+                if header_value(payload, "caller") != Some("aaaaa-aa") {
+                    bail!(
+                        "expected header caller=aaaaa-aa, got {:?}",
+                        header_value(payload, "caller")
                     );
                 }
             }
@@ -709,14 +911,9 @@ fn test_deterministic_transform_normalizes(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
             expect_all_status(&payloads, 200)?;
-            for payload in &payloads {
-                if payload.body != b"deterministic".to_vec() {
-                    bail!(
-                        "expected normalized body 'deterministic', got {:?}",
-                        String::from_utf8_lossy(&payload.body)
-                    );
-                }
-            }
+            // Every node is normalized to the same body with no headers.
+            expect_all_bodies(&payloads, b"deterministic")?;
+            expect_all_headers_empty(&payloads)?;
             Ok(())
         },
     );
@@ -916,6 +1113,22 @@ fn test_reject_header_value_too_long(env: TestEnv) {
     );
 }
 
+/// A request whose headers plus body exceed the 2 MB request-size limit
+/// (`MAX_CANISTER_HTTP_REQUEST_BYTES`) is rejected.
+fn test_reject_request_too_large(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a request exceeding the 2 MB size limit is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            // One byte over the 2_000_000-byte limit (no headers).
+            args.body = Some(vec![0u8; 2_000_001]);
+            args
+        },
+        |result| expect_rejection(result, "exceeds 2000000"),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Runtime errors and adapter-level per-node failures
 // ---------------------------------------------------------------------------
@@ -937,13 +1150,9 @@ fn test_too_many_rejects_connection_refused(env: TestEnv) {
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
-            // Every reject carries per-node details with an error.
-            if err.node_details.is_empty() {
-                bail!("expected per-node reject details");
-            }
-            if err.node_details.iter().any(|d| d.error.is_none()) {
-                bail!("expected an error for every rejecting node");
-            }
+            // Every node reports a transient connection failure whose message
+            // carries the refused connection.
+            expect_all_node_errors(&err, "SysTransient", "Connection refused")?;
             Ok(())
         },
     );
@@ -957,11 +1166,32 @@ fn test_too_many_rejects_invalid_domain(env: TestEnv) {
         "an invalid domain yields too_many_rejects",
         |_env| get_args("https://xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.com".to_string()),
         |result| {
-            expect_global_error(
+            let err = expect_global_error(
                 result,
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
+            // DNS resolution fails on every node during connection setup.
+            expect_all_node_errors(&err, "SysTransient", "Connecting to")?;
+            Ok(())
+        },
+    );
+}
+
+/// The adapter enforces HTTPS: a non-`https` url is rejected on every node, so
+/// the outcall reports `too_many_rejects`.
+fn test_too_many_rejects_non_https(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a non-https url is rejected on every node",
+        |env| get_args(format!("http://[{}]", get_universal_vm_address(env))),
+        |result| {
+            let err = expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            expect_all_node_errors(&err, "SysFatal", "Url need to specify https scheme")?;
             Ok(())
         },
     );
@@ -977,11 +1207,13 @@ fn test_responses_too_large(env: TestEnv) {
         "oversized aggregated responses yield responses_too_large",
         |env| get_args(format!("{}/bytes/1000000", webserver_base(env))),
         |result| {
-            expect_global_error(
+            let err = expect_global_error(
                 result,
                 &FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved),
                 "Responses too large",
             )?;
+            // Each node returned an OK response; the details report their sizes.
+            expect_all_node_errors(&err, "ok", "bytes")?;
             Ok(())
         },
     );
@@ -1001,7 +1233,11 @@ fn test_too_many_rejects_response_over_node_limit(env: TestEnv) {
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
-            expect_all_node_errors_contain(&err, "exceeds size limit")?;
+            expect_all_node_errors(
+                &err,
+                "SysFatal",
+                "Http body exceeds size limit of 2000000 bytes",
+            )?;
             Ok(())
         },
     );
@@ -1031,7 +1267,11 @@ fn test_too_many_rejects_transform_over_node_limit(env: TestEnv) {
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
-            expect_all_node_errors_contain(&err, "Transformed http response exceeds limit")?;
+            expect_all_node_errors(
+                &err,
+                "SysFatal",
+                "Transformed http response exceeds limit: 2000000",
+            )?;
             Ok(())
         },
     );
@@ -1055,12 +1295,77 @@ fn test_too_many_rejects_composite_transform(env: TestEnv) {
             args
         },
         |result| {
-            expect_global_error(
+            let err = expect_global_error(
                 result,
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
+            // The transform query is rejected on every node.
+            expect_all_node_errors(
+                &err,
+                "CanisterError",
+                "Composite query cannot be used as transform",
+            )?;
             Ok(())
         },
     );
+}
+
+// ---------------------------------------------------------------------------
+// Fault tolerance (destructive: runs sequentially after the parallel suite)
+// ---------------------------------------------------------------------------
+
+/// A flexible outcall with `min_responses < total_requests` still succeeds when
+/// one of the committee's nodes is down — the defining reliability property of
+/// flexible outcalls. This test kills (and later restarts) a node, so it is
+/// registered as a trailing sequential test rather than in the parallel suite.
+fn test_fault_tolerance(env: TestEnv) {
+    let logger = env.logger();
+
+    let mut nodes = get_node_snapshots(&env);
+    let killed_node = nodes.next().expect("no application nodes");
+    let healthy_node = nodes.next().expect("need at least two application nodes");
+
+    // The proxy canister lives on the subnet, so reach it through a node that
+    // stays up.
+    let runtime = get_runtime_from_node(&healthy_node);
+    let proxy = proxy_canister(&env, &runtime);
+
+    info!(logger, "Killing one application node.");
+    killed_node.vm().kill();
+    killed_node
+        .await_status_is_unavailable()
+        .expect("the killed node did not become unavailable");
+    info!(
+        logger,
+        "Node is down; a flexible outcall requiring fewer responses than nodes must still succeed."
+    );
+
+    block_on(async {
+        ic_system_test_driver::retry_with_msg_async!(
+            "flexible outcall succeeds with a node down".to_string(),
+            &logger,
+            READY_WAIT_TIMEOUT,
+            RETRY_BACKOFF,
+            || async {
+                let mut args = get_args(format!("{}/ascii/tolerate", webserver_base(&env)));
+                // Target all nodes but require only 2 responses: the surviving
+                // nodes are enough to meet min_responses.
+                args.replication = Some(ReplicationCounts {
+                    total_requests: SUBNET_NODES,
+                    min_responses: 2,
+                    max_responses: SUBNET_NODES,
+                });
+                // Attaching cycles should be possible, even of free subnets
+                let result = send_flexible(&proxy, args, 1000).await;
+                // At most the surviving nodes (n - 1) can respond.
+                let payloads = expect_ok(result, 2, (SUBNET_NODES - 1) as usize)?;
+                expect_all_status(&payloads, 200)?;
+                expect_all_bodies(&payloads, b"tolerate")?;
+                Ok(())
+            }
+        )
+        .await
+        .expect("the flexible outcall did not succeed while a node was down");
+    });
 }

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -54,6 +54,11 @@ const SUBNET_NODES: u32 = 4;
 const DEFAULT_MIN_RESPONSES: usize = 3; // floor(2*4/3) + 1
 const DEFAULT_MAX_RESPONSES: usize = SUBNET_NODES as usize;
 
+/// The minimum number of per-node reject details in a `TooManyRejects` error
+/// under default replication: the error fires only once more nodes reject than
+/// the slack (`total_requests - min_responses`) allows, i.e. at least this many.
+const MIN_REJECT_DETAILS: usize = SUBNET_NODES as usize - DEFAULT_MIN_RESPONSES + 1;
+
 fn main() -> Result<()> {
     SystemTestGroup::new()
         // Flexible outcalls require the pay-as-you-go pricing model, which is
@@ -64,7 +69,6 @@ fn main() -> Result<()> {
             SystemTestSubGroup::new()
                 // Success across replication parameters and HTTP methods.
                 .add_test(systest!(test_default_replication))
-                .add_test(systest!(test_single_request))
                 .add_test(systest!(test_all_nodes))
                 .add_test(systest!(test_partial_responses))
                 .add_test(systest!(test_intermediate_range))
@@ -288,21 +292,22 @@ fn expect_all_headers_empty(payloads: &[CanisterHttpResponsePayload]) -> Result<
     Ok(())
 }
 
-/// Asserts the result is a synchronous rejection whose message contains
-/// `expected_substring`.
+/// Asserts the result is a synchronous rejection with reject code
+/// `CanisterReject` (argument validation fails with `CanisterRejectedMessage`,
+/// a 4xx error code) and a message containing `expected_substring`.
 fn expect_rejection(
     result: Result<FlexibleHttpRequestResult, (RejectionCode, String)>,
     expected_substring: &str,
 ) -> Result<()> {
     match result {
         Err((code, message)) => {
-            if message.contains(expected_substring) {
-                Ok(())
-            } else {
-                bail!(
-                    "rejection message '{message}' (code {code:?}) does not contain '{expected_substring}'"
-                )
+            if !matches!(code, RejectionCode::CanisterReject) {
+                bail!("expected reject code CanisterReject, got {code:?} (message: '{message}')");
             }
+            if !message.contains(expected_substring) {
+                bail!("rejection message '{message}' does not contain '{expected_substring}'");
+            }
+            Ok(())
         }
         other => bail!("expected a synchronous rejection, got: {other:?}"),
     }
@@ -337,15 +342,19 @@ fn expect_global_error(
     }
 }
 
-/// Asserts every node in a runtime error carries an error with the given `code`
-/// and a message containing `message_substring`.
+/// Asserts a runtime error carries at least `min_details` per-node details, each
+/// with the given `code` and a message containing `message_substring`.
 fn expect_all_node_errors(
     err: &FlexibleHttpRequestErr,
+    min_details: usize,
     code: &str,
     message_substring: &str,
 ) -> Result<()> {
-    if err.node_details.is_empty() {
-        bail!("expected per-node error details");
+    if err.node_details.len() < min_details {
+        bail!(
+            "expected at least {min_details} per-node error details, got {}",
+            err.node_details.len()
+        );
     }
     for detail in &err.node_details {
         match &detail.error {
@@ -380,29 +389,6 @@ fn test_default_replication(env: TestEnv) {
                 "default replication returned {} payloads",
                 payloads.len()
             );
-            Ok(())
-        },
-    );
-}
-
-/// A committee of a single node returns exactly one payload.
-fn test_single_request(env: TestEnv) {
-    run_flexible_test(
-        env,
-        "single-node replication returns exactly one payload",
-        |env| {
-            let mut args = get_args(format!("{}/ascii/single", webserver_base(env)));
-            args.replication = Some(ReplicationCounts {
-                total_requests: 1,
-                min_responses: 1,
-                max_responses: 1,
-            });
-            args
-        },
-        |result| {
-            let payloads = expect_ok(result, 1, 1)?;
-            expect_all_status(&payloads, 200)?;
-            expect_all_bodies(&payloads, b"single")?;
             Ok(())
         },
     );
@@ -577,7 +563,7 @@ fn test_nondeterministic_responses(env: TestEnv) {
         |result| {
             let payloads = expect_ok(result, 2, SUBNET_NODES as usize)?;
             expect_all_status(&payloads, 200)?;
-            // Bodies may differ across payloads, but each is a numeric string.
+            // Each body is a numeric string.
             for payload in &payloads {
                 if payload.body.is_empty() || !payload.body.iter().all(|b| b.is_ascii_digit()) {
                     bail!(
@@ -585,6 +571,18 @@ fn test_nondeterministic_responses(env: TestEnv) {
                         String::from_utf8_lossy(&payload.body)
                     );
                 }
+            }
+            // Flexible outcalls keep the differing per-node responses rather than
+            // reconciling them into a single agreed value: collect the bodies
+            // into a set and confirm they are all distinct.
+            let unique_bodies: std::collections::HashSet<_> =
+                payloads.iter().map(|p| &p.body).collect();
+            if unique_bodies.len() != payloads.len() {
+                bail!(
+                    "expected all {} random bodies to be distinct, got {} distinct",
+                    payloads.len(),
+                    unique_bodies.len()
+                );
             }
             Ok(())
         },
@@ -1122,7 +1120,7 @@ fn test_reject_request_too_large(env: TestEnv) {
         |env| {
             let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
             // One byte over the 2_000_000-byte limit (no headers).
-            args.body = Some(vec![0u8; 2_000_001]);
+            args.body = Some(vec![0_u8; 2_000_001]);
             args
         },
         |result| expect_rejection(result, "exceeds 2000000"),
@@ -1152,7 +1150,12 @@ fn test_too_many_rejects_connection_refused(env: TestEnv) {
             )?;
             // Every node reports a transient connection failure whose message
             // carries the refused connection.
-            expect_all_node_errors(&err, "SysTransient", "Connection refused")?;
+            expect_all_node_errors(
+                &err,
+                MIN_REJECT_DETAILS,
+                "SysTransient",
+                "Connection refused",
+            )?;
             Ok(())
         },
     );
@@ -1164,7 +1167,7 @@ fn test_too_many_rejects_invalid_domain(env: TestEnv) {
     run_flexible_test(
         env,
         "an invalid domain yields too_many_rejects",
-        |_env| get_args("https://xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.com".to_string()),
+        |_env| get_args("https://xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.invalid".to_string()),
         |result| {
             let err = expect_global_error(
                 result,
@@ -1172,7 +1175,7 @@ fn test_too_many_rejects_invalid_domain(env: TestEnv) {
                 "Too many rejects",
             )?;
             // DNS resolution fails on every node during connection setup.
-            expect_all_node_errors(&err, "SysTransient", "Connecting to")?;
+            expect_all_node_errors(&err, MIN_REJECT_DETAILS, "SysTransient", "Connecting to")?;
             Ok(())
         },
     );
@@ -1191,7 +1194,12 @@ fn test_too_many_rejects_non_https(env: TestEnv) {
                 &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
                 "Too many rejects",
             )?;
-            expect_all_node_errors(&err, "SysFatal", "Url need to specify https scheme")?;
+            expect_all_node_errors(
+                &err,
+                MIN_REJECT_DETAILS,
+                "SysFatal",
+                "Url need to specify https scheme",
+            )?;
             Ok(())
         },
     );
@@ -1213,7 +1221,7 @@ fn test_responses_too_large(env: TestEnv) {
                 "Responses too large",
             )?;
             // Each node returned an OK response; the details report their sizes.
-            expect_all_node_errors(&err, "ok", "bytes")?;
+            expect_all_node_errors(&err, DEFAULT_MIN_RESPONSES, "ok", "bytes")?;
             Ok(())
         },
     );
@@ -1235,6 +1243,7 @@ fn test_too_many_rejects_response_over_node_limit(env: TestEnv) {
             )?;
             expect_all_node_errors(
                 &err,
+                MIN_REJECT_DETAILS,
                 "SysFatal",
                 "Http body exceeds size limit of 2000000 bytes",
             )?;
@@ -1269,6 +1278,7 @@ fn test_too_many_rejects_transform_over_node_limit(env: TestEnv) {
             )?;
             expect_all_node_errors(
                 &err,
+                MIN_REJECT_DETAILS,
                 "SysFatal",
                 "Transformed http response exceeds limit: 2000000",
             )?;
@@ -1303,6 +1313,7 @@ fn test_too_many_rejects_composite_transform(env: TestEnv) {
             // The transform query is rejected on every node.
             expect_all_node_errors(
                 &err,
+                MIN_REJECT_DETAILS,
                 "CanisterError",
                 "Composite query cannot be used as transform",
             )?;

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -18,13 +18,15 @@ end::catalog[] */
 
 use anyhow::Result;
 use anyhow::bail;
+use candid::Decode;
 use canister_http::*;
 use canister_test::Canister;
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
+use ic_management_canister_types_private::ReplicationCounts;
 use ic_management_canister_types_private::{
-    BoundedHttpHeaders, FlexibleCanisterHttpRequestArgs, HttpMethod, TransformContext,
-    TransformFunc,
+    BoundedHttpHeaders, FlexibleCanisterHttpRequestArgs, FlexibleHttpRequestResult, HttpMethod,
+    TransformContext, TransformFunc,
 };
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::{
@@ -38,7 +40,10 @@ use slog::{Logger, info};
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(canister_http::setup)
+        // Flexible outcalls require the pay-as-you-go pricing model, which is
+        // still gated. On a free subnet they are available via the legacy
+        // pricing fallback, so the test runs on a free-cost-schedule subnet.
+        .with_setup(canister_http::setup_with_free_cost_schedule)
         .add_test(systest!(test))
         .execute_from_args()?;
 
@@ -75,58 +80,84 @@ async fn test_proxy_canister(proxy_canister: &Canister<'_>, url: String, logger:
         RETRY_BACKOFF,
         || async {
             let context = "There is context to be appended in body";
-            let res = proxy_canister
-                .update_(
-                    "send_flexible_request",
-                    candid_one::<
-                        Result<Vec<u8>, (RejectionCode, String)>,
-                        FlexibleRemoteHttpRequest,
-                    >,
-                    FlexibleRemoteHttpRequest {
-                        request: FlexibleCanisterHttpRequestArgs {
-                            url: url.clone(),
-                            headers: BoundedHttpHeaders::new(vec![]),
-                            body: None,
-                            transform: Some(TransformContext {
-                                function: TransformFunc(candid::Func {
-                                    principal: proxy_canister.canister_id().get().0,
-                                    method: "transform_with_context".to_string(),
+            let res =
+                proxy_canister
+                    .update_(
+                        "send_flexible_request",
+                        candid_one::<
+                            Result<Vec<u8>, (RejectionCode, String)>,
+                            FlexibleRemoteHttpRequest,
+                        >,
+                        FlexibleRemoteHttpRequest {
+                            request: FlexibleCanisterHttpRequestArgs {
+                                url: url.clone(),
+                                headers: BoundedHttpHeaders::new(vec![]),
+                                body: None,
+                                transform: Some(TransformContext {
+                                    function: TransformFunc(candid::Func {
+                                        principal: proxy_canister.canister_id().get().0,
+                                        method: "transform_with_context".to_string(),
+                                    }),
+                                    context: context.as_bytes().to_vec(),
                                 }),
-                                context: context.as_bytes().to_vec(),
-                            }),
-                            method: HttpMethod::GET,
-                            replication: None,
+                                method: HttpMethod::GET,
+                                replication: None,
+                            },
+                            cycles: 500_000_000_000,
                         },
-                        cycles: 500_000_000_000,
-                    },
-                )
-                .await
-                .expect("Update call to proxy canister failed");
+                    )
+                    .await
+                    .expect("Update call to proxy canister failed");
 
-            let expected_error_msg = "This API is not enabled on this subnet";
-
-            match res {
-                Ok(_) => {
-                    bail!("Update call succeeded unexpectedly.");
-                }
+            // On a free subnet the flexible outcall succeeds (via legacy
+            // pricing). The reply is the Candid-encoded `FlexibleHttpRequestResult`.
+            let response_bytes = match res {
+                Ok(response_bytes) => response_bytes,
                 Err((code, message)) => {
-                    if message == expected_error_msg {
-                        info!(
-                            &logger,
-                            "Http request failed with expected error. Code: {:?}, Message: {}",
-                            code, message
-                        );
-                        Ok(())
-                    } else {
-                        bail!(
-                            "Http request failed with unexpected error. Code: {:?}, Message: '{}'. Expected: '{}'",
-                            code, message, expected_error_msg
-                        );
+                    bail!(
+                        "Flexible http request failed unexpectedly. Code: {:?}, Message: '{}'",
+                        code,
+                        message
+                    );
+                }
+            };
+
+            let result =
+                candid::Decode!(&response_bytes, FlexibleHttpRequestResult).map_err(|err| {
+                    anyhow::anyhow!("Failed to decode FlexibleHttpRequestResult: {err}")
+                })?;
+
+            match result {
+                FlexibleHttpRequestResult::Ok(payloads) => {
+                    if payloads.is_empty() {
+                        bail!("Flexible http request returned no response payloads.");
                     }
+                    for payload in &payloads {
+                        if payload.status != 200 {
+                            bail!(
+                                "Flexible http request returned unexpected status {}.",
+                                payload.status
+                            );
+                        }
+                    }
+                    info!(
+                        &logger,
+                        "Flexible http request succeeded: {} response(s), status {}, {}-byte body.",
+                        payloads.len(),
+                        payloads[0].status,
+                        payloads[0].body.len(),
+                    );
+                    Ok(())
+                }
+                FlexibleHttpRequestResult::Err(err) => {
+                    bail!(
+                        "Flexible http request returned an error: '{}'.",
+                        err.message
+                    )
                 }
             }
         }
     )
     .await
-    .expect("Timeout waiting for http call to fail with the correct error");
+    .expect("Timeout waiting for the flexible http call to succeed");
 }

--- a/rs/tests/networking/canister_http_flexible_test.rs
+++ b/rs/tests/networking/canister_http_flexible_test.rs
@@ -1,34 +1,39 @@
 /* tag::catalog[]
-Title:: Basic HTTP requests from canisters
+Title:: Flexible HTTP outcalls.
 
-Goal:: Ensure simple HTTP requests can be made from canisters.
+Goal:: Exhaustively exercise the `flexible_http_request` management canister
+endpoint on a free subnet (where flexible outcalls fall back to legacy pricing).
 
 Runbook::
-0. Instantiate a universal VM with a webserver
-1. Instantiate an IC with one application subnet with the HTTP feature enabled.
-2. Install NNS canisters
-3. Install the proxy canister
-4. Make an update call to the proxy canister.
+0. Instantiate a universal VM with a webserver (httpbin).
+1. Instantiate an IC with one application subnet (4 nodes, free cost schedule)
+   with the HTTP feature enabled.
+2. Install NNS canisters.
+3. Install the proxy canister.
+4. Make flexible HTTP outcalls through the proxy canister covering:
+   - success across replication parameters and HTTP methods,
+   - synchronous validation rejections,
+   - runtime errors (too many rejects, responses too large),
+   - adapter-level per-node failures.
 
 Success::
-1. Received http response with status 200.
+1. Each scenario returns the expected `FlexibleHttpRequestResult` (or rejection).
 
 end::catalog[] */
 #![allow(deprecated)]
 
-use anyhow::Result;
-use anyhow::bail;
-use candid::Decode;
+use anyhow::{Result, bail};
+use candid::{Decode, Principal};
 use canister_http::*;
-use canister_test::Canister;
+use canister_test::{Canister, Runtime};
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
-use ic_management_canister_types_private::ReplicationCounts;
 use ic_management_canister_types_private::{
-    BoundedHttpHeaders, FlexibleCanisterHttpRequestArgs, FlexibleHttpRequestResult, HttpMethod,
-    TransformContext, TransformFunc,
+    BoundedHttpHeaders, CanisterHttpResponsePayload, FlexibleCanisterHttpRequestArgs,
+    FlexibleHttpGlobalError, FlexibleHttpRequestErr, FlexibleHttpRequestResult, HttpHeader,
+    HttpMethod, ReplicationCounts, TransformContext, TransformFunc,
 };
-use ic_system_test_driver::driver::group::SystemTestGroup;
+use ic_system_test_driver::driver::group::{SystemTestGroup, SystemTestSubGroup};
 use ic_system_test_driver::driver::{
     test_env::TestEnv,
     test_env_api::{READY_WAIT_TIMEOUT, RETRY_BACKOFF},
@@ -36,7 +41,18 @@ use ic_system_test_driver::driver::{
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::block_on;
 use proxy_canister::FlexibleRemoteHttpRequest;
-use slog::{Logger, info};
+use slog::info;
+
+/// The cycles attached to each flexible outcall. On a free subnet nothing is
+/// charged, but the caller must still be able to attach the payment.
+const CYCLES: u64 = 500_000_000_000;
+
+/// The application subnet has 4 nodes (see `setup`). With the default
+/// replication (`replication: None`) the committee is all `n` nodes,
+/// `max_responses = n` and `min_responses = floor(2n/3) + 1`.
+const SUBNET_NODES: u32 = 4;
+const DEFAULT_MIN_RESPONSES: usize = 3; // floor(2*4/3) + 1
+const DEFAULT_MAX_RESPONSES: usize = SUBNET_NODES as usize;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
@@ -44,120 +60,1007 @@ fn main() -> Result<()> {
         // still gated. On a free subnet they are available via the legacy
         // pricing fallback, so the test runs on a free-cost-schedule subnet.
         .with_setup(canister_http::setup_with_free_cost_schedule)
-        .add_test(systest!(test))
+        .add_parallel(
+            SystemTestSubGroup::new()
+                // Success across replication parameters and HTTP methods.
+                .add_test(systest!(test_default_replication))
+                .add_test(systest!(test_single_request))
+                .add_test(systest!(test_all_nodes))
+                .add_test(systest!(test_partial_responses))
+                .add_test(systest!(test_intermediate_range))
+                .add_test(systest!(test_post_with_body))
+                .add_test(systest!(test_head_method))
+                .add_test(systest!(test_put_with_deterministic_replication))
+                .add_test(systest!(test_delete_with_deterministic_replication))
+                .add_test(systest!(test_patch_with_deterministic_replication))
+                .add_test(systest!(test_redirects_are_not_followed))
+                .add_test(systest!(test_redirect_zero_no_content))
+                .add_test(systest!(test_nondeterministic_responses))
+                // Transform behavior.
+                .add_test(systest!(test_transform_appends_context))
+                .add_test(systest!(test_transform_sets_status_and_headers))
+                .add_test(systest!(test_deterministic_transform_normalizes))
+                // Synchronous validation rejections.
+                .add_test(systest!(test_reject_total_requests_zero))
+                .add_test(systest!(test_reject_total_requests_exceed_nodes))
+                .add_test(systest!(test_reject_min_exceeds_max))
+                .add_test(systest!(test_reject_max_exceeds_total))
+                .add_test(systest!(test_reject_put_requires_deterministic))
+                .add_test(systest!(test_reject_delete_non_deterministic))
+                .add_test(systest!(test_reject_url_too_long))
+                .add_test(systest!(test_reject_invalid_transform_principal))
+                .add_test(systest!(test_reject_header_name_too_long))
+                .add_test(systest!(test_reject_header_value_too_long))
+                // Runtime errors and adapter-level per-node failures.
+                .add_test(systest!(test_too_many_rejects_connection_refused))
+                .add_test(systest!(test_too_many_rejects_invalid_domain))
+                .add_test(systest!(test_too_many_rejects_response_over_node_limit))
+                .add_test(systest!(test_too_many_rejects_transform_over_node_limit))
+                .add_test(systest!(test_too_many_rejects_composite_transform))
+                .add_test(systest!(test_responses_too_large)),
+        )
         .execute_from_args()?;
 
     Ok(())
 }
 
-pub fn test(env: TestEnv) {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns a runtime for one of the application-subnet nodes.
+fn app_runtime(env: &TestEnv) -> Runtime {
+    let node = get_node_snapshots(env)
+        .next()
+        .expect("there is no application node");
+    get_runtime_from_node(&node)
+}
+
+/// Returns the proxy canister installed during setup.
+fn proxy_canister<'a>(env: &TestEnv, runtime: &'a Runtime) -> Canister<'a> {
+    let principal_id = get_proxy_canister_id(env);
+    Canister::new(runtime, CanisterId::unchecked_from_principal(principal_id))
+}
+
+/// Base flexible request arguments: a `GET` with no headers, body, transform, or
+/// explicit replication.
+fn get_args(url: String) -> FlexibleCanisterHttpRequestArgs {
+    FlexibleCanisterHttpRequestArgs {
+        url,
+        headers: BoundedHttpHeaders::new(vec![]),
+        body: None,
+        method: HttpMethod::GET,
+        transform: None,
+        replication: None,
+    }
+}
+
+/// Sends a flexible outcall through the proxy canister and returns either the
+/// decoded [`FlexibleHttpRequestResult`] (on a handled outcall) or the
+/// synchronous rejection (on a validation failure).
+async fn send_flexible(
+    proxy: &Canister<'_>,
+    args: FlexibleCanisterHttpRequestArgs,
+    cycles: u64,
+) -> Result<FlexibleHttpRequestResult, (RejectionCode, String)> {
+    let res = proxy
+        .update_(
+            "send_flexible_request",
+            candid_one::<Result<Vec<u8>, (RejectionCode, String)>, FlexibleRemoteHttpRequest>,
+            FlexibleRemoteHttpRequest {
+                request: args,
+                cycles,
+            },
+        )
+        .await
+        .expect("Update call to proxy canister failed");
+
+    res.map(|bytes| {
+        candid::Decode!(&bytes, FlexibleHttpRequestResult)
+            .expect("Failed to decode FlexibleHttpRequestResult")
+    })
+}
+
+/// Runs `assert_result` against the outcome of the flexible outcall built by
+/// `make_args`, retrying (to absorb transient startup/network flakiness) until
+/// the expected outcome is observed or the retry budget is exhausted.
+fn run_flexible_test<M, A>(env: TestEnv, description: &str, make_args: M, assert_result: A)
+where
+    M: Fn(&TestEnv) -> FlexibleCanisterHttpRequestArgs,
+    A: Fn(Result<FlexibleHttpRequestResult, (RejectionCode, String)>) -> Result<()>,
+{
     let logger = env.logger();
-    let mut nodes = get_node_snapshots(&env);
-    let node = nodes.next().expect("there is no application node");
-    let runtime = get_runtime_from_node(&node);
-    let proxy_canister = create_proxy_canister(&env, &runtime, &node);
-    let webserver_ipv6 = get_universal_vm_address(&env);
+    let runtime = app_runtime(&env);
+    let proxy = proxy_canister(&env, &runtime);
 
     block_on(async {
-        test_proxy_canister(
-            &proxy_canister,
-            format!("https://[{webserver_ipv6}]"),
-            logger,
+        ic_system_test_driver::retry_with_msg_async!(
+            description.to_string(),
+            &logger,
+            READY_WAIT_TIMEOUT,
+            RETRY_BACKOFF,
+            || async {
+                let args = make_args(&env);
+                let result = send_flexible(&proxy, args, CYCLES).await;
+                assert_result(result)
+            }
         )
-        .await;
+        .await
+        .unwrap_or_else(|err| panic!("'{description}' did not reach the expected outcome: {err}"));
     });
 }
 
-async fn test_proxy_canister(proxy_canister: &Canister<'_>, url: String, logger: Logger) {
-    ic_system_test_driver::retry_with_msg_async!(
-        format!(
-            "calling send_request of proxy canister {} with URL {}",
-            proxy_canister.canister_id(),
-            url
-        ),
-        &logger,
-        READY_WAIT_TIMEOUT,
-        RETRY_BACKOFF,
-        || async {
-            let context = "There is context to be appended in body";
-            let res =
-                proxy_canister
-                    .update_(
-                        "send_flexible_request",
-                        candid_one::<
-                            Result<Vec<u8>, (RejectionCode, String)>,
-                            FlexibleRemoteHttpRequest,
-                        >,
-                        FlexibleRemoteHttpRequest {
-                            request: FlexibleCanisterHttpRequestArgs {
-                                url: url.clone(),
-                                headers: BoundedHttpHeaders::new(vec![]),
-                                body: None,
-                                transform: Some(TransformContext {
-                                    function: TransformFunc(candid::Func {
-                                        principal: proxy_canister.canister_id().get().0,
-                                        method: "transform_with_context".to_string(),
-                                    }),
-                                    context: context.as_bytes().to_vec(),
-                                }),
-                                method: HttpMethod::GET,
-                                replication: None,
-                            },
-                            cycles: 500_000_000_000,
-                        },
-                    )
-                    .await
-                    .expect("Update call to proxy canister failed");
+/// The principal of the proxy canister (the sender of the outcalls), used as the
+/// valid transform principal.
+fn proxy_principal(env: &TestEnv) -> Principal {
+    get_proxy_canister_id(env).0
+}
 
-            // On a free subnet the flexible outcall succeeds (via legacy
-            // pricing). The reply is the Candid-encoded `FlexibleHttpRequestResult`.
-            let response_bytes = match res {
-                Ok(response_bytes) => response_bytes,
-                Err((code, message)) => {
-                    bail!(
-                        "Flexible http request failed unexpectedly. Code: {:?}, Message: '{}'",
-                        code,
-                        message
-                    );
-                }
-            };
+/// Asserts the result is `Ok` with a payload count in `[min, max]` and returns
+/// the payloads for further inspection.
+fn expect_ok(
+    result: Result<FlexibleHttpRequestResult, (RejectionCode, String)>,
+    min: usize,
+    max: usize,
+) -> Result<Vec<CanisterHttpResponsePayload>> {
+    match result {
+        Ok(FlexibleHttpRequestResult::Ok(payloads)) => {
+            if payloads.len() < min || payloads.len() > max {
+                bail!(
+                    "expected between {min} and {max} response payloads, got {}",
+                    payloads.len()
+                );
+            }
+            Ok(payloads)
+        }
+        other => bail!("expected Ok response payloads, got: {other:?}"),
+    }
+}
 
-            let result =
-                candid::Decode!(&response_bytes, FlexibleHttpRequestResult).map_err(|err| {
-                    anyhow::anyhow!("Failed to decode FlexibleHttpRequestResult: {err}")
-                })?;
+/// Asserts every payload has the given HTTP status.
+fn expect_all_status(payloads: &[CanisterHttpResponsePayload], status: u128) -> Result<()> {
+    for payload in payloads {
+        if payload.status != status {
+            bail!(
+                "expected status {status} for every payload, got {}",
+                payload.status
+            );
+        }
+    }
+    Ok(())
+}
 
-            match result {
-                FlexibleHttpRequestResult::Ok(payloads) => {
-                    if payloads.is_empty() {
-                        bail!("Flexible http request returned no response payloads.");
-                    }
-                    for payload in &payloads {
-                        if payload.status != 200 {
-                            bail!(
-                                "Flexible http request returned unexpected status {}.",
-                                payload.status
-                            );
-                        }
-                    }
-                    info!(
-                        &logger,
-                        "Flexible http request succeeded: {} response(s), status {}, {}-byte body.",
-                        payloads.len(),
-                        payloads[0].status,
-                        payloads[0].body.len(),
-                    );
-                    Ok(())
-                }
-                FlexibleHttpRequestResult::Err(err) => {
-                    bail!(
-                        "Flexible http request returned an error: '{}'.",
-                        err.message
-                    )
-                }
+/// Asserts the result is a synchronous rejection whose message contains
+/// `expected_substring`.
+fn expect_rejection(
+    result: Result<FlexibleHttpRequestResult, (RejectionCode, String)>,
+    expected_substring: &str,
+) -> Result<()> {
+    match result {
+        Err((code, message)) => {
+            if message.contains(expected_substring) {
+                Ok(())
+            } else {
+                bail!(
+                    "rejection message '{message}' (code {code:?}) does not contain '{expected_substring}'"
+                )
             }
         }
-    )
-    .await
-    .expect("Timeout waiting for the flexible http call to succeed");
+        other => bail!("expected a synchronous rejection, got: {other:?}"),
+    }
+}
+
+/// Asserts the result is a runtime `FlexibleHttpRequestResult::Err` with the
+/// given global error and a message containing `expected_substring`, and returns
+/// the error for further inspection.
+fn expect_global_error(
+    result: Result<FlexibleHttpRequestResult, (RejectionCode, String)>,
+    expected: &FlexibleHttpGlobalError,
+    expected_substring: &str,
+) -> Result<FlexibleHttpRequestErr> {
+    match result {
+        Ok(FlexibleHttpRequestResult::Err(err)) => {
+            if err.global_error.as_ref() != Some(expected) {
+                bail!(
+                    "expected global error {expected:?}, got {:?} (message: '{}')",
+                    err.global_error,
+                    err.message
+                );
+            }
+            if !err.message.contains(expected_substring) {
+                bail!(
+                    "error message '{}' does not contain '{expected_substring}'",
+                    err.message
+                );
+            }
+            Ok(err)
+        }
+        other => bail!("expected a FlexibleHttpRequestResult::Err, got: {other:?}"),
+    }
+}
+
+/// Asserts every node in a runtime error carries an error whose message contains
+/// `expected_substring`.
+fn expect_all_node_errors_contain(
+    err: &FlexibleHttpRequestErr,
+    expected_substring: &str,
+) -> Result<()> {
+    if err.node_details.is_empty() {
+        bail!("expected per-node error details");
+    }
+    for detail in &err.node_details {
+        match &detail.error {
+            Some(node_error) if node_error.message.contains(expected_substring) => {}
+            other => bail!("node error {other:?} does not contain '{expected_substring}'"),
+        }
+    }
+    Ok(())
+}
+
+fn webserver_base(env: &TestEnv) -> String {
+    format!("https://[{}]", get_universal_vm_address(env))
+}
+
+// ---------------------------------------------------------------------------
+// Success: replication parameters and HTTP methods
+// ---------------------------------------------------------------------------
+
+/// Default replication (`None`) returns between `min_responses` and
+/// `max_responses` identical payloads for a deterministic endpoint.
+fn test_default_replication(env: TestEnv) {
+    let logger = env.logger();
+    run_flexible_test(
+        env,
+        "default replication returns min..=max identical payloads",
+        |env| get_args(format!("{}/ascii/hello_world", webserver_base(env))),
+        move |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 200)?;
+            for payload in &payloads {
+                if payload.body != b"hello_world".to_vec() {
+                    bail!(
+                        "unexpected body: {:?}",
+                        String::from_utf8_lossy(&payload.body)
+                    );
+                }
+            }
+            info!(
+                logger,
+                "default replication returned {} payloads",
+                payloads.len()
+            );
+            Ok(())
+        },
+    );
+}
+
+/// A committee of a single node returns exactly one payload.
+fn test_single_request(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "single-node replication returns exactly one payload",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/single", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 1,
+                min_responses: 1,
+                max_responses: 1,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 1, 1)?;
+            expect_all_status(&payloads, 200)?;
+            if payloads[0].body != b"single".to_vec() {
+                bail!("unexpected body");
+            }
+            Ok(())
+        },
+    );
+}
+
+/// Requiring all nodes (`min == max == total == n`) returns exactly `n` payloads.
+fn test_all_nodes(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "all-nodes replication returns exactly n payloads",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/all", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES,
+                min_responses: SUBNET_NODES,
+                max_responses: SUBNET_NODES,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// A partial range (`min < max < total`) returns between `min` and `max` payloads.
+fn test_partial_responses(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "partial replication returns min..=max payloads",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/partial", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 4,
+                min_responses: 2,
+                max_responses: 3,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 2, 3)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// A `POST` with a body succeeds.
+fn test_post_with_body(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "POST with a body succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/post", webserver_base(env)));
+            args.method = HttpMethod::POST;
+            args.body = Some(b"flexible-body".to_vec());
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// The transform function is applied to each response (here it appends the
+/// context to the body and strips headers).
+fn test_transform_appends_context(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "transform is applied to each response",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/base", webserver_base(env)));
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "transform_with_context".to_string(),
+                }),
+                context: b"-ctx".to_vec(),
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 200)?;
+            for payload in &payloads {
+                if payload.body != b"base-ctx".to_vec() {
+                    bail!(
+                        "expected transformed body 'base-ctx', got {:?}",
+                        String::from_utf8_lossy(&payload.body)
+                    );
+                }
+                if !payload.headers.is_empty() {
+                    bail!("expected transform to strip headers");
+                }
+            }
+            Ok(())
+        },
+    );
+}
+
+/// `PUT` (like `DELETE`/`PATCH`) is only allowed with deterministic replication
+/// (`min == max == total`); this exercises the allowed case.
+fn test_put_with_deterministic_replication(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "PUT with deterministic replication succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::PUT;
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES,
+                min_responses: SUBNET_NODES,
+                max_responses: SUBNET_NODES,
+            });
+            // Strip the (non-deterministic) echoed request headers so every node
+            // agrees on the response.
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// The adapter does not follow redirects: a redirecting endpoint yields a 303.
+fn test_redirects_are_not_followed(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "redirects are not followed (status 303)",
+        |env| get_args(format!("{}/redirect/10", webserver_base(env))),
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 303)?;
+            Ok(())
+        },
+    );
+}
+
+/// Flexible outcalls can aggregate differing responses: a non-deterministic
+/// endpoint returns several (possibly different) payloads without diverging.
+fn test_nondeterministic_responses(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "non-deterministic responses are aggregated",
+        |env| {
+            let mut args = get_args(format!("{}/random", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES,
+                min_responses: 2,
+                max_responses: SUBNET_NODES,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 2, SUBNET_NODES as usize)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// An intermediate range (`min < max == total`) returns between `min` and `max`
+/// payloads.
+fn test_intermediate_range(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "intermediate replication returns min..=max payloads",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/range", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 4,
+                min_responses: 2,
+                max_responses: 4,
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 2, 4)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// A `HEAD` request succeeds. `HEAD` is not restricted to deterministic
+/// replication (unlike `PUT`/`DELETE`/`PATCH`).
+fn test_head_method(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "HEAD request succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::HEAD;
+            // Strip the echoed request headers for cross-node agreement.
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// `DELETE` with deterministic replication (`min == max == total`) succeeds.
+fn test_delete_with_deterministic_replication(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "DELETE with deterministic replication succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::DELETE;
+            args.replication = Some(ReplicationCounts {
+                total_requests: 2,
+                min_responses: 2,
+                max_responses: 2,
+            });
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 2, 2)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// `PATCH` with deterministic replication over a sub-committee succeeds.
+fn test_patch_with_deterministic_replication(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "PATCH with deterministic replication succeeds",
+        |env| {
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::PATCH;
+            args.replication = Some(ReplicationCounts {
+                total_requests: 2,
+                min_responses: 2,
+                max_responses: 2,
+            });
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, 2, 2)?;
+            expect_all_status(&payloads, 200)?;
+            Ok(())
+        },
+    );
+}
+
+/// A `redirect/0` endpoint returns a 204 (No Content) that is not followed.
+fn test_redirect_zero_no_content(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "redirect/0 returns 204",
+        |env| get_args(format!("{}/redirect/0", webserver_base(env))),
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 204)?;
+            Ok(())
+        },
+    );
+}
+
+/// A transform can set the status, headers, and body of every response.
+fn test_transform_sets_status_and_headers(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "transform can set status, headers and body",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/ignored", webserver_base(env)));
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "test_transform".to_string(),
+                }),
+                context: b"transform_context".to_vec(),
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, DEFAULT_MIN_RESPONSES, DEFAULT_MAX_RESPONSES)?;
+            expect_all_status(&payloads, 202)?;
+            for payload in &payloads {
+                if payload.body != b"transform_context".to_vec() {
+                    bail!(
+                        "expected transformed body 'transform_context', got {:?}",
+                        String::from_utf8_lossy(&payload.body)
+                    );
+                }
+            }
+            Ok(())
+        },
+    );
+}
+
+/// A deterministic transform normalizes a non-deterministic endpoint so every
+/// node agrees on an identical response.
+fn test_deterministic_transform_normalizes(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a deterministic transform normalizes a non-deterministic endpoint",
+        |env| {
+            let mut args = get_args(format!("{}/random", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES,
+                min_responses: SUBNET_NODES,
+                max_responses: SUBNET_NODES,
+            });
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "deterministic_transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let payloads = expect_ok(result, SUBNET_NODES as usize, SUBNET_NODES as usize)?;
+            expect_all_status(&payloads, 200)?;
+            for payload in &payloads {
+                if payload.body != b"deterministic".to_vec() {
+                    bail!(
+                        "expected normalized body 'deterministic', got {:?}",
+                        String::from_utf8_lossy(&payload.body)
+                    );
+                }
+            }
+            Ok(())
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous validation rejections
+// ---------------------------------------------------------------------------
+
+fn test_reject_total_requests_zero(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "total_requests = 0 is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 0,
+                min_responses: 0,
+                max_responses: 0,
+            });
+            args
+        },
+        |result| expect_rejection(result, "total_requests (0) must be at least 1"),
+    );
+}
+
+fn test_reject_total_requests_exceed_nodes(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "total_requests > number of nodes is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: SUBNET_NODES + 1,
+                min_responses: 1,
+                max_responses: 1,
+            });
+            args
+        },
+        |result| expect_rejection(result, "must not exceed the number of available nodes (4)"),
+    );
+}
+
+fn test_reject_min_exceeds_max(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "min_responses > max_responses is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 4,
+                min_responses: 3,
+                max_responses: 2,
+            });
+            args
+        },
+        |result| {
+            expect_rejection(
+                result,
+                "min_responses (3) must not exceed max_responses (2)",
+            )
+        },
+    );
+}
+
+fn test_reject_max_exceeds_total(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "max_responses > total_requests is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.replication = Some(ReplicationCounts {
+                total_requests: 2,
+                min_responses: 1,
+                max_responses: 3,
+            });
+            args
+        },
+        |result| {
+            expect_rejection(
+                result,
+                "max_responses (3) must not exceed total_requests (2)",
+            )
+        },
+    );
+}
+
+fn test_reject_put_requires_deterministic(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "PUT with non-deterministic replication is rejected",
+        |env| {
+            // Default replication has min < total, which is not allowed for PUT.
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::PUT;
+            args
+        },
+        |result| expect_rejection(result, "min_responses = max_responses = total_requests"),
+    );
+}
+
+fn test_reject_url_too_long(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "an over-long url is rejected",
+        |env| {
+            // MAX_CANISTER_HTTP_URL_SIZE is 8192.
+            let long_path = "a".repeat(8200);
+            get_args(format!("{}/ascii/{long_path}", webserver_base(env)))
+        },
+        |result| expect_rejection(result, "exceeds 8192"),
+    );
+}
+
+fn test_reject_invalid_transform_principal(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a transform referencing another principal is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            // The transform must reference the calling (proxy) canister; the
+            // management canister principal does not.
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: Principal::management_canister(),
+                    method: "transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| expect_rejection(result, "transform principal id expected to be"),
+    );
+}
+
+/// `DELETE` (like `PUT`/`PATCH`) with explicit but non-equal replication counts
+/// is rejected (distinct from the default-replication case).
+fn test_reject_delete_non_deterministic(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "DELETE with non-equal replication counts is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/anything", webserver_base(env)));
+            args.method = HttpMethod::DELETE;
+            args.replication = Some(ReplicationCounts {
+                total_requests: 4,
+                min_responses: 3,
+                max_responses: 4,
+            });
+            args
+        },
+        |result| expect_rejection(result, "min_responses = max_responses = total_requests"),
+    );
+}
+
+fn test_reject_header_name_too_long(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "an over-long header name is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            // Name of 8193 bytes: the element (8193) is within the candid bound
+            // (16384) so it decodes, but exceeds the 8192 header name/value limit.
+            args.headers = BoundedHttpHeaders::new(vec![HttpHeader {
+                name: "a".repeat(8193),
+                value: String::new(),
+            }]);
+            args
+        },
+        |result| {
+            expect_rejection(
+                result,
+                "number of bytes to represent some http header name 8193 exceeds 8192",
+            )
+        },
+    );
+}
+
+fn test_reject_header_value_too_long(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "an over-long header value is rejected",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.headers = BoundedHttpHeaders::new(vec![HttpHeader {
+                name: "name".to_string(),
+                value: "b".repeat(8193),
+            }]);
+            args
+        },
+        |result| {
+            expect_rejection(
+                result,
+                "number of bytes to represent some http header value 8193 exceeds 8192",
+            )
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime errors and adapter-level per-node failures
+// ---------------------------------------------------------------------------
+
+/// When enough nodes fail to reach the endpoint (here: connection refused on a
+/// closed port) `min_responses` cannot be met and the outcall reports
+/// `too_many_rejects` with per-node details.
+fn test_too_many_rejects_connection_refused(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "connection refused on all nodes yields too_many_rejects",
+        |env| {
+            // Port 9090 on the webserver is closed => connection refused.
+            get_args(format!("https://[{}]:9090", get_universal_vm_address(env)))
+        },
+        |result| {
+            let err = expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            // Every reject carries per-node details with an error.
+            if err.node_details.is_empty() {
+                bail!("expected per-node reject details");
+            }
+            if err.node_details.iter().any(|d| d.error.is_none()) {
+                bail!("expected an error for every rejecting node");
+            }
+            Ok(())
+        },
+    );
+}
+
+/// An unresolvable domain fails at the adapter on every node, again yielding
+/// `too_many_rejects`.
+fn test_too_many_rejects_invalid_domain(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "an invalid domain yields too_many_rejects",
+        |_env| get_args("https://xwWPqqbNqxxHmLXdguF4DN9xGq22nczV.com".to_string()),
+        |result| {
+            expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            Ok(())
+        },
+    );
+}
+
+/// When the aggregated responses are too large to fit in a block, the outcall
+/// reports `responses_too_large`. Each node returns a ~1 MiB body (below the
+/// per-response 2 MiB limit), but `min_responses` (3) of them exceed the 2 MiB
+/// payload limit.
+fn test_responses_too_large(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "oversized aggregated responses yield responses_too_large",
+        |env| get_args(format!("{}/bytes/1000000", webserver_base(env))),
+        |result| {
+            expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved),
+                "Responses too large",
+            )?;
+            Ok(())
+        },
+    );
+}
+
+/// A single per-node response that exceeds the 2 MB per-node limit is rejected
+/// by the adapter (download limit), so every node rejects and the outcall
+/// reports `too_many_rejects`.
+fn test_too_many_rejects_response_over_node_limit(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a per-node response over the 2 MB limit yields too_many_rejects",
+        |env| get_args(format!("{}/bytes/2100000", webserver_base(env))),
+        |result| {
+            let err = expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            expect_all_node_errors_contain(&err, "exceeds size limit")?;
+            Ok(())
+        },
+    );
+}
+
+/// A transform whose output exceeds the 2 MB per-node limit is rejected by the
+/// adapter (transform-output limit) on every node, again yielding
+/// `too_many_rejects`.
+fn test_too_many_rejects_transform_over_node_limit(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a transform output over the 2 MB limit yields too_many_rejects",
+        |env| {
+            let mut args = get_args(format!("{}/bytes/16", webserver_base(env)));
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "bloat_transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            let err = expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            expect_all_node_errors_contain(&err, "Transformed http response exceeds limit")?;
+            Ok(())
+        },
+    );
+}
+
+/// A composite query cannot be used as a transform: it fails per node, so every
+/// node rejects and the outcall reports `too_many_rejects`.
+fn test_too_many_rejects_composite_transform(env: TestEnv) {
+    run_flexible_test(
+        env,
+        "a composite-query transform yields too_many_rejects",
+        |env| {
+            let mut args = get_args(format!("{}/ascii/x", webserver_base(env)));
+            args.transform = Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: proxy_principal(env),
+                    method: "test_composite_transform".to_string(),
+                }),
+                context: vec![],
+            });
+            args
+        },
+        |result| {
+            expect_global_error(
+                result,
+                &FlexibleHttpGlobalError::TooManyRejects(candid::Reserved),
+                "Too many rejects",
+            )?;
+            Ok(())
+        },
+    );
 }

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -647,6 +647,7 @@ impl CanisterHttpRequestContext {
         node_ids: &BTreeSet<NodeId>,
         registry_version: RegistryVersion,
         rng: &mut dyn RngCore,
+        pricing_version: PricingVersion,
     ) -> Result<Self, CanisterHttpRequestContextError> {
         validate_transform_principal(&args.transform, request.sender.get())?;
         validate_url_length(&args.url)?;
@@ -737,7 +738,7 @@ impl CanisterHttpRequestContext {
                 min_responses,
                 max_responses,
             },
-            pricing_version: PricingVersion::PayAsYouGo,
+            pricing_version,
             // The refund status is populated in `try_add_http_context_to_replicated_state`
             // based on the request's payment and the base fee.
             refund_status: RefundStatus::default(),
@@ -1439,46 +1440,48 @@ mod tests {
         ];
 
         for replication in replications {
-            let initial = CanisterHttpRequestContext {
-                url: "https://example.com".to_string(),
-                headers: vec![CanisterHttpHeader {
-                    name: "Content-Type".to_string(),
-                    value: "application/json".to_string(),
-                }],
-                body: Some(b"{\"hello\":\"world\"}".to_vec()),
-                max_response_bytes: Some(NumBytes::from(1234)),
-                http_method: CanisterHttpMethod::POST,
-                transform: Some(Transform {
-                    method_name: "transform_response".to_string(),
-                    context: vec![1, 2, 3],
-                }),
-                request: Request {
-                    receiver: CanisterId::ic_00(),
-                    sender: CanisterId::ic_00(),
-                    sender_reply_callback: CallbackId::from(3),
-                    payment: Cycles::new(10),
-                    method_name: "transform".to_string(),
-                    method_payload: Vec::new(),
-                    metadata: Default::default(),
-                    deadline: NO_DEADLINE,
-                },
-                time: UNIX_EPOCH,
-                replication,
-                pricing_version: PricingVersion::PayAsYouGo,
-                refund_status: RefundStatus {
-                    refundable_cycles: Cycles::new(13_000_000),
-                    per_replica_allowance: Cycles::new(1_000_000),
-                    refunded_cycles: Cycles::new(123),
-                    refunding_nodes: BTreeSet::from([node_test_id(1), node_test_id(2)]),
-                },
-                registry_version: RegistryVersion::from(7),
-                subnet_size: NumberOfNodes::from(13),
-                cost_schedule: Some(CanisterCyclesCostSchedule::Free),
-            };
+            for pricing_version in [PricingVersion::Legacy, PricingVersion::PayAsYouGo] {
+                let initial = CanisterHttpRequestContext {
+                    url: "https://example.com".to_string(),
+                    headers: vec![CanisterHttpHeader {
+                        name: "Content-Type".to_string(),
+                        value: "application/json".to_string(),
+                    }],
+                    body: Some(b"{\"hello\":\"world\"}".to_vec()),
+                    max_response_bytes: Some(NumBytes::from(1234)),
+                    http_method: CanisterHttpMethod::POST,
+                    transform: Some(Transform {
+                        method_name: "transform_response".to_string(),
+                        context: vec![1, 2, 3],
+                    }),
+                    request: Request {
+                        receiver: CanisterId::ic_00(),
+                        sender: CanisterId::ic_00(),
+                        sender_reply_callback: CallbackId::from(3),
+                        payment: Cycles::new(10),
+                        method_name: "transform".to_string(),
+                        method_payload: Vec::new(),
+                        metadata: Default::default(),
+                        deadline: NO_DEADLINE,
+                    },
+                    time: UNIX_EPOCH,
+                    replication: replication.clone(),
+                    pricing_version,
+                    refund_status: RefundStatus {
+                        refundable_cycles: Cycles::new(13_000_000),
+                        per_replica_allowance: Cycles::new(1_000_000),
+                        refunded_cycles: Cycles::new(123),
+                        refunding_nodes: BTreeSet::from([node_test_id(1), node_test_id(2)]),
+                    },
+                    registry_version: RegistryVersion::from(7),
+                    subnet_size: NumberOfNodes::from(13),
+                    cost_schedule: Some(CanisterCyclesCostSchedule::Free),
+                };
 
-            let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
-            let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
-            assert_eq!(initial, round_trip);
+                let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
+                let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
+                assert_eq!(initial, round_trip);
+            }
         }
     }
 
@@ -2022,6 +2025,7 @@ mod tests {
             node_ids,
             RegistryVersion::from(1),
             &mut ReproducibleRng::new(),
+            PricingVersion::PayAsYouGo,
         )
     }
 }


### PR DESCRIPTION
This PR enables the `flexible_http_request` management canister endpoint on **free cost schedule subnets** by falling back to **legacy pricing**. Legacy pricing charges the full cost of the outcall up front (which is zero on free subnets).

On normal subnets, flexible outcalls are still disabled (gated by a feature flag), as they depend on the new pay-as-you-go pricing implementation. 

**Changes:**
- Route `FlexibleHttpRequest` execution to **legacy pricing on free subnets** even when the `flexible_http_requests` feature flag is disabled; keep it gated on paying subnets.
- Extend `CanisterHttpRequestContext::generate_from_flexible_args` to accept an explicit `PricingVersion`, and update tests accordingly.
- Add/expand networking system tests to exhaustively cover flexible outcall scenarios on a free-cost-schedule subnet, plus a correctness test asserting the API remains disabled on normal subnets.