### PR TITLE
feat: migrate hpke 0.12 -> 0.13

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1f1282b2d826a19f5348514e87e1bde8f79b2482a6d7e56dcfd31dbaa38ab8f0",
+  "checksum": "22446b7b142461d94c2d08c9fe4db5d2d9047c00777054093d2d528ed771a456",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -21329,7 +21329,7 @@
               "target": "hmac"
             },
             {
-              "id": "hpke 0.12.0",
+              "id": "hpke 0.13.0",
               "target": "hpke"
             },
             {
@@ -21861,8 +21861,18 @@
               "target": "rand"
             },
             {
+              "id": "rand 0.9.4",
+              "target": "rand",
+              "alias": "rand_0_9"
+            },
+            {
               "id": "rand_chacha 0.3.1",
               "target": "rand_chacha"
+            },
+            {
+              "id": "rand_chacha 0.9.0",
+              "target": "rand_chacha",
+              "alias": "rand_chacha_0_9"
             },
             {
               "id": "rand_distr 0.4.3",
@@ -32271,14 +32281,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "hpke 0.12.0": {
+    "hpke 0.13.0": {
       "name": "hpke",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "package_url": "https://github.com/rozbb/rust-hpke",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hpke/0.12.0/download",
-          "sha256": "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+          "url": "https://static.crates.io/crates/hpke/0.13.0/download",
+          "sha256": "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
         }
       },
       "targets": [
@@ -32342,7 +32352,7 @@
               "target": "p384"
             },
             {
-              "id": "rand_core 0.6.4",
+              "id": "rand_core 0.9.3",
               "target": "rand_core"
             },
             {
@@ -32361,7 +32371,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.12.0"
+        "version": "0.13.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -50417,8 +50427,6 @@
             "default",
             "ioctl",
             "memoffset",
-            "process",
-            "signal",
             "socket"
           ],
           "selects": {}
@@ -58426,7 +58434,7 @@
               "target": "log"
             },
             {
-              "id": "nix 0.27.1",
+              "id": "nix 0.30.1",
               "target": "nix"
             },
             {
@@ -98576,7 +98584,7 @@
     "hickory-resolver 0.26.1",
     "hkdf 0.12.4",
     "hmac 0.12.1",
-    "hpke 0.12.0",
+    "hpke 0.13.0",
     "http 1.3.1",
     "http-body 1.0.1",
     "http-body-util 0.1.3",
@@ -98712,7 +98720,9 @@
     "quinn-udp 0.5.5",
     "quote 1.0.42",
     "rand 0.8.6",
+    "rand 0.9.4",
     "rand_chacha 0.3.1",
+    "rand_chacha 0.9.0",
     "rand_distr 0.4.3",
     "rand_pcg 0.3.1",
     "ratatui 0.29.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3749,7 +3749,9 @@ dependencies = [
  "quinn-udp",
  "quote",
  "rand 0.8.6",
+ "rand 0.9.4",
  "rand_chacha 0.3.1",
+ "rand_chacha 0.9.0",
  "rand_distr",
  "rand_pcg",
  "ratatui",
@@ -5513,9 +5515,9 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -5525,7 +5527,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p384",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "sha2 0.10.9",
  "subtle",
  "zeroize",
@@ -9931,7 +9933,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix 0.30.1",
  "once_cell",
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2362,7 +2362,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4315,7 +4315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5806,9 +5806,9 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -5818,7 +5818,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p384",
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
  "sha2 0.10.9",
  "subtle",
  "zeroize",
@@ -9736,8 +9736,8 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "hpke",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
+ "rand 0.9.3",
+ "rand_chacha 0.9.0",
 ]
 
 [[package]]
@@ -16855,7 +16855,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18719,7 +18719,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20166,7 +20166,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix 0.30.1",
  "once_cell",
  "prost",
  "prost-build",
@@ -21920,7 +21920,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -22029,7 +22029,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -22050,7 +22050,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -22962,7 +22962,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -23314,7 +23314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -23875,10 +23875,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -23909,7 +23909,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -25934,7 +25934,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -626,7 +626,7 @@ crate.spec(
         "alloc",
     ],
     package = "hpke",
-    version = "^0.12",
+    version = "^0.13",
 )
 crate.spec(
     package = "humantime",
@@ -1307,8 +1307,23 @@ crate.spec(
     version = "^0.8.6",
 )
 crate.spec(
+    default_features = False,
+    features = [
+        "os_rng",
+    ],
+    package = "rand",
+    package_alias = "rand_0_9",
+    version = "^0.9.3",
+)
+crate.spec(
     package = "rand_chacha",
     version = "^0.3.1",
+)
+crate.spec(
+    default_features = False,
+    package = "rand_chacha",
+    package_alias = "rand_chacha_0_9",
+    version = "^0.9.0",
 )
 crate.spec(
     package = "rand_distr",

--- a/packages/ic-hpke/BUILD.bazel
+++ b/packages/ic-hpke/BUILD.bazel
@@ -26,8 +26,8 @@ rust_doc_test(
         ":ic-hpke",
         "@crate_index//:hex",
         "@crate_index//:hpke",
-        "@crate_index//:rand",
-        "@crate_index//:rand_chacha",
+        "@crate_index//:rand_0_9",
+        "@crate_index//:rand_chacha_0_9",
     ],
 )
 
@@ -38,8 +38,8 @@ rust_test(
         # Keep sorted.
         "@crate_index//:hex",
         "@crate_index//:hpke",
-        "@crate_index//:rand",
-        "@crate_index//:rand_chacha",
+        "@crate_index//:rand_0_9",
+        "@crate_index//:rand_chacha_0_9",
     ],
 )
 
@@ -51,7 +51,7 @@ rust_test_suite(
         ":ic-hpke",
         "@crate_index//:hex",
         "@crate_index//:hpke",
-        "@crate_index//:rand",
-        "@crate_index//:rand_chacha",
+        "@crate_index//:rand_0_9",
+        "@crate_index//:rand_chacha_0_9",
     ],
 )

--- a/packages/ic-hpke/Cargo.toml
+++ b/packages/ic-hpke/Cargo.toml
@@ -11,9 +11,9 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
-hpke = { version = "0.12", default-features = false, features = [ "p384", "alloc" ] }
+hpke = { version = "0.13", default-features = false, features = [ "p384", "alloc" ] }
 
 [dev-dependencies]
 hex = { workspace = true }
-rand = { version = "0.8", default-features = false, features = ["getrandom"] }
-rand_chacha = { version = "0.3", default-features = false }
+rand = { version = "0.9", default-features = false, features = ["os_rng"] }
+rand_chacha = { version = "0.9", default-features = false }

--- a/packages/ic-hpke/src/lib.rs
+++ b/packages/ic-hpke/src/lib.rs
@@ -36,7 +36,8 @@
 //! # Example (Authenticated Encryption)
 //!
 //! ```
-//! let mut rng = rand::rngs::OsRng;
+//! use rand::TryRngCore;
+//! let mut rng = rand::rngs::OsRng.unwrap_err();
 //!
 //! let a_sk = ic_hpke::PrivateKey::generate(&mut rng);
 //! let a_pk = a_sk.public_key();
@@ -65,7 +66,8 @@
 //! # Example (Non-Authenticated Encryption)
 //!
 //! ```
-//! let mut rng = rand::rngs::OsRng;
+//! use rand::TryRngCore;
+//! let mut rng = rand::rngs::OsRng.unwrap_err();
 //!
 //! // perform key generation:
 //! let sk = ic_hpke::PrivateKey::generate(&mut rng);

--- a/packages/ic-hpke/tests/tests.rs
+++ b/packages/ic-hpke/tests/tests.rs
@@ -1,5 +1,5 @@
 use ic_hpke::*;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, RngCore, SeedableRng, TryRngCore};
 
 #[test]
 fn key_generation_and_noauth_encrypt_is_stable() {
@@ -76,14 +76,14 @@ fn key_generation_and_authticated_encrypt_is_stable() {
 
 #[test]
 fn smoke_test_noauth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
     let sk = PrivateKey::generate(&mut rng);
     let pk = sk.public_key();
 
     for ptext_len in 0..128 {
         let mut ptext = vec![0_u8; ptext_len];
         rng.fill_bytes(&mut ptext);
-        let aad = rng.r#gen::<[u8; 32]>();
+        let aad = rng.random::<[u8; 32]>();
         let ctext = pk.encrypt_noauth(&ptext, &aad, &mut rng).unwrap();
         let rec = sk.decrypt_noauth(&ctext, &aad).unwrap();
         assert_eq!(rec, ptext);
@@ -92,7 +92,7 @@ fn smoke_test_noauth() {
 
 #[test]
 fn smoke_test_auth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
 
     let a_sk = PrivateKey::generate(&mut rng);
     let a_pk = a_sk.public_key();
@@ -100,7 +100,7 @@ fn smoke_test_auth() {
     let b_sk = PrivateKey::generate(&mut rng);
     let b_pk = b_sk.public_key();
 
-    let aad = rng.r#gen::<[u8; 32]>();
+    let aad = rng.random::<[u8; 32]>();
 
     for ptext_len in 0..128 {
         let mut ptext = vec![0_u8; ptext_len];
@@ -115,13 +115,13 @@ fn smoke_test_auth() {
 
 #[test]
 fn any_bit_flip_causes_rejection_noauth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
 
     let a_sk = PrivateKey::generate(&mut rng);
     let a_pk = a_sk.public_key();
 
-    let ptext = rng.r#gen::<[u8; 16]>().to_vec();
-    let aad = rng.r#gen::<[u8; 32]>();
+    let ptext = rng.random::<[u8; 16]>().to_vec();
+    let aad = rng.random::<[u8; 32]>();
 
     let mut ctext = a_pk.encrypt_noauth(&ptext, &aad, &mut rng).unwrap();
 
@@ -140,7 +140,7 @@ fn any_bit_flip_causes_rejection_noauth() {
 
 #[test]
 fn any_bit_flip_causes_rejection_auth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
 
     let a_sk = PrivateKey::generate(&mut rng);
     let a_pk = a_sk.public_key();
@@ -148,8 +148,8 @@ fn any_bit_flip_causes_rejection_auth() {
     let b_sk = PrivateKey::generate(&mut rng);
     let b_pk = b_sk.public_key();
 
-    let ptext = rng.r#gen::<[u8; 16]>().to_vec();
-    let aad = rng.r#gen::<[u8; 32]>();
+    let ptext = rng.random::<[u8; 16]>().to_vec();
+    let aad = rng.random::<[u8; 32]>();
 
     let mut ctext = a_pk.encrypt(&ptext, &aad, &b_sk, &mut rng).unwrap();
 
@@ -168,13 +168,13 @@ fn any_bit_flip_causes_rejection_auth() {
 
 #[test]
 fn any_truncation_causes_rejection_noauth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
 
     let a_sk = PrivateKey::generate(&mut rng);
     let a_pk = a_sk.public_key();
 
-    let ptext = rng.r#gen::<[u8; 16]>().to_vec();
-    let aad = rng.r#gen::<[u8; 32]>();
+    let ptext = rng.random::<[u8; 16]>().to_vec();
+    let aad = rng.random::<[u8; 32]>();
 
     let mut ctext = a_pk.encrypt_noauth(&ptext, &aad, &mut rng).unwrap();
 
@@ -193,7 +193,7 @@ fn any_truncation_causes_rejection_noauth() {
 
 #[test]
 fn any_truncation_causes_rejection_auth() {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rngs::OsRng.unwrap_err();
 
     let a_sk = PrivateKey::generate(&mut rng);
     let a_pk = a_sk.public_key();
@@ -201,8 +201,8 @@ fn any_truncation_causes_rejection_auth() {
     let b_sk = PrivateKey::generate(&mut rng);
     let b_pk = b_sk.public_key();
 
-    let ptext = rng.r#gen::<[u8; 16]>().to_vec();
-    let aad = rng.r#gen::<[u8; 32]>();
+    let ptext = rng.random::<[u8; 16]>().to_vec();
+    let aad = rng.random::<[u8; 32]>();
 
     let mut ctext = a_pk.encrypt(&ptext, &aad, &b_sk, &mut rng).unwrap();
 


### PR DESCRIPTION
This takes us one step closer to the latest hpke version (0.14) and allows us to move more crates off of rand 0.6.