### PR TITLE
feat: increase cargo build concurrency on CI

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -649,6 +649,7 @@ jobs:
               - "**/*.lock"
               - "ci/scripts/rust-lint.sh"
               - "ci/container/TAG"
+              - ".github/**"
       - name: Run Cargo ${{ matrix.name }} Linux
         if: |
           steps.filter.outputs.cargo == 'true' ||
@@ -662,7 +663,8 @@ jobs:
         env:
           # on dind_small cargo sometimes runs out of files (when building and linting). This trades
           # some performance for reliability.
-          CARGO_BUILD_JOBS: 8
+          # (at the time of writing, nproc returns 64 on dind_small where this job runs)
+          CARGO_BUILD_JOBS: 32
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors


### PR DESCRIPTION
To work around failures on CI (fd exhaustion) we limited the concurrency on cargo jobs: https://github.com/dfinity/ic/pull/10827

This brought the number of concurrent jobs from 64 down to 8, which started causing timeouts. This increases the concurrency back up to something that should fit comfortably within the time limits but also prevents resource exhaustion.

The timeout issue was not caught because the cargo jobs only run when rust files are modified; this updates the filter to also include any changes to the CI workflows.