### PR TITLE
chore(deps): bump ansible-core to 2.20.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,6 @@
 ansible>=12.2.0
+# Pinned explicitly (resolved transitively via ansible)
+ansible-core>=2.20.7
 cbor>=1.0.0
 cbor2>=5.9.0
 configargparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,12 @@ ansible==13.2.0 \
     --hash=sha256:8a7f536542d4b18118200b8eaba40aa62ed990bd0e7b7622368b656b67db056f \
     --hash=sha256:fac46e202d1020027341659918b39e588dd7c43cef26537d7ca7fe51c324fe31
     # via -r requirements.in
-ansible-core==2.20.1 \
-    --hash=sha256:2a66825b4a53f130b62515e7e2a3d811d544b19b6e8a22d9ef88c55896384cb3 \
-    --hash=sha256:a891e5f90cd46626778f0f3d545ec1115840c9b50e8adf25944c5e1748452106
-    # via ansible
+ansible-core==2.20.7 \
+    --hash=sha256:84d4097a28e816e8bf8066307088f833837db9efdc9dc6716b43253de3b14106 \
+    --hash=sha256:f4be63a9a8b6bb5f4fc68d41f8582f5b289b1ee1db0600caab8b3a660b9d7ddc
+    # via
+    #   -r requirements.in
+    #   ansible
 bcrypt==4.3.0 \
     --hash=sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f \
     --hash=sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d \


### PR DESCRIPTION
Superseded by a fresh PR from branch @tmu0/bump-ansible-core (opened after a branch rename).