### PR TITLE
fix: avoid double counting deleted canisters in SubnetMetrics::consumed_cycles_total

### DIFF
--- a/rs/canonical_state/src/encoding/types.rs
+++ b/rs/canonical_state/src/encoding/types.rs
@@ -733,7 +733,12 @@ impl
             CertificationVersion,
         ),
     ) -> Self {
-        let (high, low) = metrics.consumed_cycles_total().into_parts();
+        // All currently supported certification versions (up to and including
+        // `V27`) use the legacy total, which double counts the cycles consumed
+        // by deleted canisters. Switching to the fixed `consumed_cycles_total`
+        // changes the certified value, so it must be gated behind a new
+        // certification version once one is introduced.
+        let (high, low) = metrics.consumed_cycles_total_v27().into_parts();
         Self {
             num_canisters: metrics.num_canisters,
             canister_state_bytes: metrics.canister_state_bytes.get(),

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -2139,6 +2139,8 @@ impl SystemState {
         // The use cases below are not valid on the canister
         // level, they should only appear on the subnet level.
         debug_assert_ne!(use_case, CyclesUseCase::ECDSAOutcalls);
+        debug_assert_ne!(use_case, CyclesUseCase::SchnorrOutcalls);
+        debug_assert_ne!(use_case, CyclesUseCase::VetKd);
         debug_assert_ne!(use_case, CyclesUseCase::HTTPOutcalls);
         debug_assert_ne!(use_case, CyclesUseCase::DeletedCanisters);
         debug_assert_ne!(use_case, CyclesUseCase::DroppedMessages);

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -505,7 +505,78 @@ impl SubnetMetrics {
         &self.consumed_cycles_by_use_case_as_counters
     }
 
+    /// Computes the total consumed cycles on the subnet.
+    ///
+    /// This is the current computation, which avoids double counting the cycles
+    /// consumed by deleted canisters. It is not yet reflected in the certified
+    /// state: the canonical state consumer still uses
+    /// [`Self::consumed_cycles_total_v27`] for all certification versions up to
+    /// and including `V27`. A future certification version should switch the
+    /// consumer over to this function.
     pub fn consumed_cycles_total(&self) -> NominalCycles {
+        let mut total = NominalCycles::zero();
+
+        total += self.consumed_cycles_by_deleted_canisters;
+        total += self.consumed_cycles_http_outcalls;
+        total += self.consumed_cycles_ecdsa_outcalls;
+
+        for (use_case, cycles) in self.consumed_cycles_by_use_case.iter() {
+            match use_case {
+                // Skip the use cases that are already fully accounted for by the
+                // scalar metrics added above:
+                //
+                // - `ECDSAOutcalls` and `HTTPOutcalls` are supersets of the
+                //   corresponding use case entries (see
+                //   `consumed_cycles_ecdsa_outcalls` and
+                //   `consumed_cycles_http_outcalls`).
+                // - `DeletedCanisters` holds the leftover cycles of deleted
+                //   canisters, which are already included in
+                //   `consumed_cycles_by_deleted_canisters`.
+                // - The remaining canister-level use cases below
+                //   (`Memory`, `ComputeAllocation`, `IngressInduction`,
+                //   `Instructions`, `RequestAndResponseTransmission`,
+                //   `Uninstall`, `CanisterCreation`, `BurnedCycles`) only ever
+                //   end up in this map when a canister is deleted, at which point
+                //   the deleted canister's total consumption (the sum of these
+                //   use cases) is also added to
+                //   `consumed_cycles_by_deleted_canisters`. Summing them here as
+                //   well would double count the cycles consumed by deleted
+                //   canisters.
+                CyclesUseCase::ECDSAOutcalls
+                | CyclesUseCase::HTTPOutcalls
+                | CyclesUseCase::DeletedCanisters
+                | CyclesUseCase::Memory
+                | CyclesUseCase::ComputeAllocation
+                | CyclesUseCase::IngressInduction
+                | CyclesUseCase::Instructions
+                | CyclesUseCase::RequestAndResponseTransmission
+                | CyclesUseCase::Uninstall
+                | CyclesUseCase::CanisterCreation
+                | CyclesUseCase::BurnedCycles => {}
+                // The remaining use cases are only ever recorded at the subnet
+                // level (never charged to a canister's balance), so they are not
+                // covered by any of the scalar metrics above and must be added to
+                // the total.
+                CyclesUseCase::SchnorrOutcalls
+                | CyclesUseCase::VetKd
+                | CyclesUseCase::DroppedMessages => total += *cycles,
+            }
+        }
+
+        total
+    }
+
+    /// Legacy computation of the total consumed cycles, used by the canonical
+    /// state consumer for certification versions up to and including `V27`.
+    ///
+    /// This version double counts the cycles consumed by deleted canisters: at
+    /// deletion, a canister's per-use-case consumption is added both to
+    /// `consumed_cycles_by_deleted_canisters` and to the
+    /// `consumed_cycles_by_use_case` map, and both are summed here. It is kept
+    /// unchanged to preserve the certified state for existing certification
+    /// versions; [`Self::consumed_cycles_total`] fixes the double counting for
+    /// future certification versions.
+    pub fn consumed_cycles_total_v27(&self) -> NominalCycles {
         let mut total = NominalCycles::zero();
 
         total += self.consumed_cycles_by_deleted_canisters;

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2386,44 +2386,72 @@ fn stream_responses_tracking() {
 
 #[test]
 fn consumed_cycles_total_calculates_the_right_amount() {
+    // Each entry gets a distinct power of two so that the resulting total is a
+    // bitmask: any use case that is miscategorized (added when it should be
+    // skipped, or vice versa) changes the total by a unique amount that cannot
+    // be masked by other entries cancelling out.
     let mut consumed_cycles_by_use_case = BTreeMap::new();
-    // Use cases already covered by the scalar metrics below; these must not be
+    // Use cases covered by a dedicated scalar metric below; these must not be
     // added to the total again (otherwise the cycles consumed by deleted
-    // canisters would be double counted).
-    consumed_cycles_by_use_case.insert(CyclesUseCase::DeletedCanisters, NominalCycles::new(5));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::HTTPOutcalls, NominalCycles::new(12));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::ECDSAOutcalls, NominalCycles::new(30));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::Instructions, NominalCycles::new(100));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::Memory, NominalCycles::new(50));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::CanisterCreation, NominalCycles::new(40));
+    // canisters / outcalls would be double counted).
+    consumed_cycles_by_use_case.insert(CyclesUseCase::DeletedCanisters, NominalCycles::new(1));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::HTTPOutcalls, NominalCycles::new(2));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::ECDSAOutcalls, NominalCycles::new(4));
+    // Canister-level use cases that only ever enter the map when a canister is
+    // deleted; already covered by the deleted canisters scalar, so not added to
+    // the total.
+    consumed_cycles_by_use_case.insert(CyclesUseCase::Memory, NominalCycles::new(8));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::ComputeAllocation, NominalCycles::new(16));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::IngressInduction, NominalCycles::new(32));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::Instructions, NominalCycles::new(64));
+    consumed_cycles_by_use_case.insert(
+        CyclesUseCase::RequestAndResponseTransmission,
+        NominalCycles::new(128),
+    );
+    consumed_cycles_by_use_case.insert(CyclesUseCase::Uninstall, NominalCycles::new(256));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::CanisterCreation, NominalCycles::new(512));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::BurnedCycles, NominalCycles::new(1024));
     // Subnet-level use cases not covered by any scalar metric; these are added
     // to the total.
-    consumed_cycles_by_use_case.insert(CyclesUseCase::SchnorrOutcalls, NominalCycles::new(7));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::VetKd, NominalCycles::new(8));
-    consumed_cycles_by_use_case.insert(CyclesUseCase::DroppedMessages, NominalCycles::new(9));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::SchnorrOutcalls, NominalCycles::new(2048));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::VetKd, NominalCycles::new(4096));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::DroppedMessages, NominalCycles::new(8192));
+
+    // Every use case must be exercised above, so that adding a new variant
+    // forces this test (and the categorization in `consumed_cycles_total`) to
+    // be revisited.
+    for use_case in CyclesUseCase::iter() {
+        assert!(
+            consumed_cycles_by_use_case.contains_key(&use_case),
+            "use case {use_case:?} is not covered by this test"
+        );
+    }
 
     let subnet_metrics = SubnetMetrics {
-        consumed_cycles_by_deleted_canisters: NominalCycles::new(10),
-        consumed_cycles_http_outcalls: NominalCycles::new(20),
-        consumed_cycles_ecdsa_outcalls: NominalCycles::new(30),
+        consumed_cycles_by_deleted_canisters: NominalCycles::new(16384),
+        consumed_cycles_http_outcalls: NominalCycles::new(32768),
+        consumed_cycles_ecdsa_outcalls: NominalCycles::new(65536),
         consumed_cycles_by_use_case,
         ..Default::default()
     };
 
-    // 10 (deleted canisters) + 20 (HTTP outcalls) + 30 (ECDSA outcalls)
-    // + 7 (Schnorr outcalls) + 8 (VetKd) + 9 (dropped messages).
+    // 16384 (deleted canisters) + 32768 (HTTP outcalls) + 65536 (ECDSA outcalls)
+    // + 2048 (Schnorr outcalls) + 4096 (VetKd) + 8192 (dropped messages).
     assert_eq!(
         subnet_metrics.consumed_cycles_total(),
-        NominalCycles::new(84)
+        NominalCycles::new(129024)
     );
 
     // The legacy computation additionally sums the per-use-case entries that a
     // deleted canister contributes to the map (already covered by the deleted
-    // canisters scalar), hence the double counting:
-    // 84 + 100 (instructions) + 50 (memory) + 40 (canister creation).
+    // canisters scalar), hence the double counting. On top of the 129024 from
+    // the fixed `consumed_cycles_total` above:
+    // 129024 + 8 (memory) + 16 (compute allocation) + 32 (ingress induction)
+    // + 64 (instructions) + 128 (request and response transmission)
+    // + 256 (uninstall) + 512 (canister creation) + 1024 (burned cycles).
     assert_eq!(
         subnet_metrics.consumed_cycles_total_v27(),
-        NominalCycles::new(274)
+        NominalCycles::new(131064)
     );
 }
 

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2387,12 +2387,20 @@ fn stream_responses_tracking() {
 #[test]
 fn consumed_cycles_total_calculates_the_right_amount() {
     let mut consumed_cycles_by_use_case = BTreeMap::new();
+    // Use cases already covered by the scalar metrics below; these must not be
+    // added to the total again (otherwise the cycles consumed by deleted
+    // canisters would be double counted).
     consumed_cycles_by_use_case.insert(CyclesUseCase::DeletedCanisters, NominalCycles::new(5));
     consumed_cycles_by_use_case.insert(CyclesUseCase::HTTPOutcalls, NominalCycles::new(12));
     consumed_cycles_by_use_case.insert(CyclesUseCase::ECDSAOutcalls, NominalCycles::new(30));
     consumed_cycles_by_use_case.insert(CyclesUseCase::Instructions, NominalCycles::new(100));
     consumed_cycles_by_use_case.insert(CyclesUseCase::Memory, NominalCycles::new(50));
     consumed_cycles_by_use_case.insert(CyclesUseCase::CanisterCreation, NominalCycles::new(40));
+    // Subnet-level use cases not covered by any scalar metric; these are added
+    // to the total.
+    consumed_cycles_by_use_case.insert(CyclesUseCase::SchnorrOutcalls, NominalCycles::new(7));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::VetKd, NominalCycles::new(8));
+    consumed_cycles_by_use_case.insert(CyclesUseCase::DroppedMessages, NominalCycles::new(9));
 
     let subnet_metrics = SubnetMetrics {
         consumed_cycles_by_deleted_canisters: NominalCycles::new(10),
@@ -2402,9 +2410,20 @@ fn consumed_cycles_total_calculates_the_right_amount() {
         ..Default::default()
     };
 
+    // 10 (deleted canisters) + 20 (HTTP outcalls) + 30 (ECDSA outcalls)
+    // + 7 (Schnorr outcalls) + 8 (VetKd) + 9 (dropped messages).
     assert_eq!(
         subnet_metrics.consumed_cycles_total(),
-        NominalCycles::new(250)
+        NominalCycles::new(84)
+    );
+
+    // The legacy computation additionally sums the per-use-case entries that a
+    // deleted canister contributes to the map (already covered by the deleted
+    // canisters scalar), hence the double counting:
+    // 84 + 100 (instructions) + 50 (memory) + 40 (canister creation).
+    assert_eq!(
+        subnet_metrics.consumed_cycles_total_v27(),
+        NominalCycles::new(274)
     );
 }
 


### PR DESCRIPTION
When a canister is deleted, its per-use-case consumption is added both to the `consumed_cycles_by_deleted_canisters` scalar and to the `consumed_cycles_by_use_case` map. `SubnetMetrics::consumed_cycles_total()` summed both, double counting the cycles consumed by deleted canisters.

Fix `consumed_cycles_total()` to skip the canister-level use cases (which only ever enter the map via deleted canisters and are already covered by the deleted canisters scalar), summing only the subnet-level use cases (SchnorrOutcalls, VetKd, DroppedMessages) that are not covered by any scalar.

Since this changes the certified state, the legacy behavior is preserved in `consumed_cycles_total_v27()`, which the canonical state consumer keeps using for all certification versions up to and including V27. A future certification version can switch the consumer over to the fixed `consumed_cycles_total()`.