### PR TITLE
feat: Migrate HTTP/ECDSA outcall cycles in SubnetMetrics from scaler to per-use-case map

### DIFF
--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -480,6 +480,7 @@ impl SubnetMetrics {
     }
 
     pub fn observe_consumed_cycles_http_outcalls(&mut self, cycles: NominalCycles) {
+        self.migrate_outcalls_cycles_to_use_cases();
         self.consumed_cycles_http_outcalls += cycles;
     }
 
@@ -488,7 +489,55 @@ impl SubnetMetrics {
     }
 
     pub fn observe_consumed_cycles_ecdsa_outcalls(&mut self, cycles: NominalCycles) {
+        self.migrate_outcalls_cycles_to_use_cases();
         self.consumed_cycles_ecdsa_outcalls += cycles;
+    }
+
+    /// Migrates the cycles consumed by HTTP and ECDSA outcalls that are tracked
+    /// in the legacy scalar fields (`consumed_cycles_http_outcalls` /
+    /// `consumed_cycles_ecdsa_outcalls`) into the corresponding entries of
+    /// `consumed_cycles_by_use_case` and `consumed_cycles_by_use_case_as_counters`.
+    ///
+    /// The scalar fields predate use-case tracking, so they are a superset of
+    /// the corresponding use-case entries. We therefore bring the use-case
+    /// entries up to the scalar value (via `max`), which backfills the history
+    /// that predates use-case tracking while avoiding double counting the
+    /// overlapping period.
+    ///
+    /// This runs whenever the scalar fields are observed, i.e. right before they
+    /// are incremented (the matching `observe_consumed_cycles_with_use_case`
+    /// call then bumps the use-case entry by the same amount). As a result the
+    /// use-case entries evolve in lockstep with the scalar fields.
+    ///
+    /// The scalar fields are intentionally kept (and kept up to date) rather
+    /// than zeroed, so that they remain the source of truth for readers such as
+    /// `consumed_cycles_total` (which still reads them for now) and so that
+    /// downgrading to an earlier replica version observes the correct totals.
+    fn migrate_outcalls_cycles_to_use_cases(&mut self) {
+        for (scalar, use_case) in [
+            (
+                self.consumed_cycles_http_outcalls,
+                CyclesUseCase::HTTPOutcalls,
+            ),
+            (
+                self.consumed_cycles_ecdsa_outcalls,
+                CyclesUseCase::ECDSAOutcalls,
+            ),
+        ] {
+            if scalar.get() == 0 {
+                continue;
+            }
+            let entry = self
+                .consumed_cycles_by_use_case
+                .entry(use_case)
+                .or_insert_with(NominalCycles::zero);
+            *entry = (*entry).max(scalar);
+            let counter = self
+                .consumed_cycles_by_use_case_as_counters
+                .entry(use_case)
+                .or_insert_with(NominalCycles::zero);
+            *counter = (*counter).max(scalar);
+        }
     }
 
     pub fn get_consumed_cycles_ecdsa_outcalls(&self) -> NominalCycles {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -469,6 +469,11 @@ impl SubnetMetrics {
             .consumed_cycles_by_use_case_as_counters
             .entry(use_case)
             .or_insert_with(NominalCycles::zero) += cycles;
+
+        // Migrate the legacy scalar outcall fields into the use-case map. This
+        // runs on every observed use case, independently of whether the scalar
+        // fields themselves are observed.
+        self.migrate_outcalls_cycles_to_use_cases();
     }
 
     pub fn observe_consumed_cycles_by_deleted_canisters(&mut self, cycles: NominalCycles) {
@@ -480,7 +485,6 @@ impl SubnetMetrics {
     }
 
     pub fn observe_consumed_cycles_http_outcalls(&mut self, cycles: NominalCycles) {
-        self.migrate_outcalls_cycles_to_use_cases();
         self.consumed_cycles_http_outcalls += cycles;
     }
 
@@ -489,14 +493,13 @@ impl SubnetMetrics {
     }
 
     pub fn observe_consumed_cycles_ecdsa_outcalls(&mut self, cycles: NominalCycles) {
-        self.migrate_outcalls_cycles_to_use_cases();
         self.consumed_cycles_ecdsa_outcalls += cycles;
     }
 
     /// Migrates the cycles consumed by HTTP and ECDSA outcalls that are tracked
     /// in the legacy scalar fields (`consumed_cycles_http_outcalls` /
     /// `consumed_cycles_ecdsa_outcalls`) into the corresponding entries of
-    /// `consumed_cycles_by_use_case` and `consumed_cycles_by_use_case_as_counters`.
+    /// `consumed_cycles_by_use_case`.
     ///
     /// The scalar fields predate use-case tracking, so they are a superset of
     /// the corresponding use-case entries. We therefore bring the use-case
@@ -504,10 +507,14 @@ impl SubnetMetrics {
     /// that predates use-case tracking while avoiding double counting the
     /// overlapping period.
     ///
-    /// This runs whenever the scalar fields are observed, i.e. right before they
-    /// are incremented (the matching `observe_consumed_cycles_with_use_case`
-    /// call then bumps the use-case entry by the same amount). As a result the
-    /// use-case entries evolve in lockstep with the scalar fields.
+    /// This runs whenever a use case is observed (see
+    /// `observe_consumed_cycles_with_use_case`), i.e. independently of whether
+    /// the scalar fields themselves are observed, so the use-case entries also
+    /// catch up on subnets that stop performing outcalls.
+    ///
+    /// Only the `consumed_cycles_by_use_case` map is migrated; the monotonic
+    /// `consumed_cycles_by_use_case_as_counters` map is intentionally left
+    /// untouched (backfilling it would introduce a spurious counter jump).
     ///
     /// The scalar fields are intentionally kept (and kept up to date) rather
     /// than zeroed, so that they remain the source of truth for readers such as
@@ -532,11 +539,6 @@ impl SubnetMetrics {
                 .entry(use_case)
                 .or_insert_with(NominalCycles::zero);
             *entry = (*entry).max(scalar);
-            let counter = self
-                .consumed_cycles_by_use_case_as_counters
-                .entry(use_case)
-                .or_insert_with(NominalCycles::zero);
-            *counter = (*counter).max(scalar);
         }
     }
 

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2408,6 +2408,67 @@ fn consumed_cycles_total_calculates_the_right_amount() {
     );
 }
 
+#[test]
+fn observe_outcalls_cycles_migrates_scalar_fields_into_use_cases() {
+    let mut subnet_metrics = SubnetMetrics {
+        // Simulate a state persisted before use-case tracking existed: the scalar
+        // fields hold the full history while the use-case entries only cover a
+        // more recent (smaller) subset.
+        consumed_cycles_http_outcalls: NominalCycles::new(100),
+        consumed_cycles_ecdsa_outcalls: NominalCycles::new(200),
+        consumed_cycles_by_use_case: BTreeMap::from([
+            (CyclesUseCase::HTTPOutcalls, NominalCycles::new(60)),
+            (CyclesUseCase::ECDSAOutcalls, NominalCycles::new(150)),
+        ]),
+        consumed_cycles_by_use_case_as_counters: BTreeMap::from([
+            (CyclesUseCase::HTTPOutcalls, NominalCycles::new(60)),
+            (CyclesUseCase::ECDSAOutcalls, NominalCycles::new(150)),
+        ]),
+        ..Default::default()
+    };
+
+    // Observing an HTTP outcall first migrates the (superset) scalar fields into
+    // the use-case entries (via `max`), then bumps the HTTP scalar. In
+    // production the matching `observe_consumed_cycles_with_use_case` call then
+    // bumps the use-case entry by the same amount, keeping them in lockstep.
+    subnet_metrics.observe_consumed_cycles_http_outcalls(NominalCycles::new(5));
+    subnet_metrics
+        .observe_consumed_cycles_with_use_case(CyclesUseCase::HTTPOutcalls, NominalCycles::new(5));
+
+    let by_use_case = subnet_metrics.get_consumed_cycles_by_use_case();
+    let by_use_case_as_counters = subnet_metrics.get_consumed_cycles_by_use_case_as_counters();
+
+    // HTTP: use-case entry caught up to the scalar (100) and then grew by 5.
+    assert_eq!(
+        by_use_case[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(105)
+    );
+    assert_eq!(
+        by_use_case_as_counters[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(105)
+    );
+    // ECDSA: the scalar (200) has been migrated into the use-case entries as well.
+    assert_eq!(
+        by_use_case[&CyclesUseCase::ECDSAOutcalls],
+        NominalCycles::new(200)
+    );
+    assert_eq!(
+        by_use_case_as_counters[&CyclesUseCase::ECDSAOutcalls],
+        NominalCycles::new(200)
+    );
+
+    // The scalar fields keep evolving in lockstep and are not zeroed (kept for
+    // downgrade compatibility).
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_http_outcalls(),
+        NominalCycles::new(105)
+    );
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_ecdsa_outcalls(),
+        NominalCycles::new(200)
+    );
+}
+
 impl From<(u64, u64)> for BlockmakerStats {
     fn from(item: (u64, u64)) -> Self {
         Self {

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2409,7 +2409,7 @@ fn consumed_cycles_total_calculates_the_right_amount() {
 }
 
 #[test]
-fn observe_outcalls_cycles_migrates_scalar_fields_into_use_cases() {
+fn observe_use_case_migrates_outcalls_scalar_fields_into_use_cases() {
     let mut subnet_metrics = SubnetMetrics {
         // Simulate a state persisted before use-case tracking existed: the scalar
         // fields hold the full history while the use-case entries only cover a
@@ -2427,45 +2427,97 @@ fn observe_outcalls_cycles_migrates_scalar_fields_into_use_cases() {
         ..Default::default()
     };
 
-    // Observing an HTTP outcall first migrates the (superset) scalar fields into
-    // the use-case entries (via `max`), then bumps the HTTP scalar. In
-    // production the matching `observe_consumed_cycles_with_use_case` call then
-    // bumps the use-case entry by the same amount, keeping them in lockstep.
-    subnet_metrics.observe_consumed_cycles_http_outcalls(NominalCycles::new(5));
+    // Observing an *unrelated* use case triggers the migration, i.e. it runs
+    // independently of whether the HTTP/ECDSA scalar fields are observed.
     subnet_metrics
-        .observe_consumed_cycles_with_use_case(CyclesUseCase::HTTPOutcalls, NominalCycles::new(5));
+        .observe_consumed_cycles_with_use_case(CyclesUseCase::Instructions, NominalCycles::new(5));
 
     let by_use_case = subnet_metrics.get_consumed_cycles_by_use_case();
-    let by_use_case_as_counters = subnet_metrics.get_consumed_cycles_by_use_case_as_counters();
 
-    // HTTP: use-case entry caught up to the scalar (100) and then grew by 5.
+    // The HTTP/ECDSA use-case entries have been brought up to the (superset)
+    // scalar values, even though no outcall was observed.
     assert_eq!(
         by_use_case[&CyclesUseCase::HTTPOutcalls],
-        NominalCycles::new(105)
+        NominalCycles::new(100)
     );
-    assert_eq!(
-        by_use_case_as_counters[&CyclesUseCase::HTTPOutcalls],
-        NominalCycles::new(105)
-    );
-    // ECDSA: the scalar (200) has been migrated into the use-case entries as well.
     assert_eq!(
         by_use_case[&CyclesUseCase::ECDSAOutcalls],
         NominalCycles::new(200)
     );
+    // The observed use case was recorded as usual.
     assert_eq!(
-        by_use_case_as_counters[&CyclesUseCase::ECDSAOutcalls],
-        NominalCycles::new(200)
+        by_use_case[&CyclesUseCase::Instructions],
+        NominalCycles::new(5)
     );
 
-    // The scalar fields keep evolving in lockstep and are not zeroed (kept for
+    // The migration must NOT touch the monotonic counters map: its HTTP/ECDSA
+    // entries stay at their original values (only the just-observed use case
+    // grew).
+    let counters = subnet_metrics.get_consumed_cycles_by_use_case_as_counters();
+    assert_eq!(
+        counters[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(60)
+    );
+    assert_eq!(
+        counters[&CyclesUseCase::ECDSAOutcalls],
+        NominalCycles::new(150)
+    );
+    assert_eq!(
+        counters[&CyclesUseCase::Instructions],
+        NominalCycles::new(5)
+    );
+
+    // The scalar fields are not zeroed (kept as the source of truth / for
     // downgrade compatibility).
     assert_eq!(
         subnet_metrics.get_consumed_cycles_http_outcalls(),
-        NominalCycles::new(105)
+        NominalCycles::new(100)
     );
     assert_eq!(
         subnet_metrics.get_consumed_cycles_ecdsa_outcalls(),
         NominalCycles::new(200)
+    );
+}
+
+#[test]
+fn observe_http_outcall_use_case_stays_in_lockstep_with_scalar() {
+    let mut subnet_metrics = SubnetMetrics {
+        // Pre-use-case-tracking history: the scalar (100) is a superset of the
+        // use-case entry (60).
+        consumed_cycles_http_outcalls: NominalCycles::new(100),
+        consumed_cycles_by_use_case: BTreeMap::from([(
+            CyclesUseCase::HTTPOutcalls,
+            NominalCycles::new(60),
+        )]),
+        consumed_cycles_by_use_case_as_counters: BTreeMap::from([(
+            CyclesUseCase::HTTPOutcalls,
+            NominalCycles::new(60),
+        )]),
+        ..Default::default()
+    };
+
+    // Production order for an HTTP outcall: the scalar is bumped first, then the
+    // matching use case is observed.
+    subnet_metrics.observe_consumed_cycles_http_outcalls(NominalCycles::new(5));
+    subnet_metrics
+        .observe_consumed_cycles_with_use_case(CyclesUseCase::HTTPOutcalls, NominalCycles::new(5));
+
+    // The use-case entry caught up to the (superset) scalar and grew by 5, with
+    // no double counting.
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_by_use_case()[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(105)
+    );
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_http_outcalls(),
+        NominalCycles::new(105)
+    );
+
+    // The counters map is not migrated: it only reflects its own increment (5),
+    // not the backfilled history.
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_by_use_case_as_counters()[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(65)
     );
 }
 


### PR DESCRIPTION
The cycles consumed by HTTP and ECDSA outcalls are tracked both in the legacy scalar fields consumed_cycles_http_outcalls / consumed_cycles_ecdsa_outcalls of SubnetMetrics and in the
  consumed_cycles_by_use_case map. The scalar fields predate use-case tracking, so they are a superset of the corresponding use-case entries.

  This adds a migration that brings the HTTPOutcalls / ECDSAOutcalls entries of consumed_cycles_by_use_case up to the scalar value (via max).

  The migration runs whenever any use case is observed (from observe_consumed_cycles_with_use_case), i.e. independently of whether the scalar fields themselves are observed, so the use-case
  entries also catch up on subnets that stop performing outcalls. It runs after the increments; since the scalar fields are bumped before the matching use-case observation at the call sites,
  the max reconciliation keeps the entries in lockstep with the scalar fields without double counting.
  
  Only the consumed_cycles_by_use_case map is migrated. The monotonic consumed_cycles_by_use_case_as_counters map is intentionally left untouched: backfilling it would introduce a spurious
  counter jump (the counters were introduced very recently, unlike the gauges).

  The scalar fields are intentionally kept (and kept up to date) rather than zeroed, so they remain the source of truth for the readers that still use them (e.g. consumed_cycles_total) and
  so that downgrading to an earlier replica version keeps observing the correct totals. Read paths are left unchanged for now.