### PR TITLE
fix(test-utils): make nobody temp base reachable under sandboxed RBE

### DIFF
--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -58,6 +58,10 @@ mod imp {
     /// * Temporary directories must be derived from `TMPDIR`/`TEST_TMPDIR` (as
     ///   `tempfile` and `ic_test_utilities_tmpdir::tmpdir` are); the child points
     ///   both at a `nobody`-owned base with mode `0700`, prepared by the parent.
+    ///   The parent also grants others-execute on the base's ancestor
+    ///   directories where missing, so `nobody` can traverse into it even when
+    ///   the temp root is not world-traversable (as under some sandboxed
+    ///   remote-execution setups); see `TmpDirRedirect::prepare`.
     /// * The parent test process may be multi-threaded, and after `fork` the
     ///   child must not wait on locks that another parent thread held at fork
     ///   time. The temp base and the `putenv(3)` strings are therefore prepared
@@ -103,6 +107,19 @@ mod imp {
             chown(&base, Some(NOBODY), Some(NOBODY)).expect("failed to chown the nobody temp base");
             std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700))
                 .expect("failed to chmod the nobody temp base");
+            // The child creates its temporary files under `base` as `nobody`,
+            // which requires *search* (execute) permission on every ancestor
+            // directory. Some sandboxed remote-execution setups leave the temp
+            // root not world-traversable: Namespace's
+            // `namespace_action_isolation=sandboxed` runs the action as uid 0
+            // with `TMPDIR` unset, so `std::env::temp_dir()` is a root-owned,
+            // non-traversable `/tmp` that `nobody` cannot descend into. As root
+            // (in the parent) grant others-execute on each ancestor that lacks
+            // it — the minimal relaxation permitting traversal, without exposing
+            // directory listings or write access (the base itself stays `0700`
+            // `nobody`). The sandbox is ephemeral and per-action, so this has no
+            // effect beyond the running test.
+            grant_ancestor_traversal(&base);
             let entry = |name: &str| {
                 CString::new(format!("{name}={}", base.display()))
                     .expect("temp base path contains an interior NUL byte")
@@ -130,6 +147,34 @@ mod imp {
                 }
             }
             Ok(())
+        }
+    }
+
+    /// Adds others-execute (search) permission to every ancestor directory of
+    /// `dir`, so the unprivileged `nobody` child can traverse the path down to
+    /// it. Only the execute bit is added, and only to directories that lack it,
+    /// so no directory becomes listable or writable by others. Runs as root in
+    /// the parent; see the call site in `TmpDirRedirect::prepare` for why this
+    /// is needed under sandboxed remote execution.
+    fn grant_ancestor_traversal(dir: &std::path::Path) {
+        // `ancestors()` yields `dir` first; skip it (it is already owned by
+        // `nobody`) and walk its parent, grandparent, ... up to the root.
+        for ancestor in dir.ancestors().skip(1) {
+            let Ok(metadata) = std::fs::metadata(ancestor) else {
+                // Unreadable ancestor (e.g. we walked above the mount root):
+                // nothing to relax here.
+                continue;
+            };
+            let mode = metadata.permissions().mode();
+            if mode & 0o001 == 0 {
+                std::fs::set_permissions(ancestor, std::fs::Permissions::from_mode(mode | 0o001))
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "failed to make {} traversable for nobody: {err}",
+                            ancestor.display()
+                        )
+                    });
+            }
         }
     }
 

--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -96,7 +96,8 @@ mod imp {
         fn prepare() -> Self {
             // Distinguishes concurrently prepared bases within one process.
             static SEQ: AtomicUsize = AtomicUsize::new(0);
-            let base = std::env::temp_dir().join(format!(
+            let temp_root = std::env::temp_dir();
+            let base = temp_root.join(format!(
                 "ic-nobody-{}-{}",
                 std::process::id(),
                 SEQ.fetch_add(1, Ordering::Relaxed)
@@ -119,7 +120,15 @@ mod imp {
             // directory listings or write access (the base itself stays `0700`
             // `nobody`). The sandbox is ephemeral and per-action, so this has no
             // effect beyond the running test.
-            grant_ancestor_traversal(&base);
+            //
+            // Confine this to the default temp root (`/tmp`, used precisely
+            // because `TMPDIR` is unset). An explicitly-configured `TMPDIR` is
+            // left untouched, so running tests as root *outside* the sandbox
+            // cannot be steered into world-traversing a sensitive directory
+            // (e.g. `TMPDIR=/root/tmp` must not relax `/root`).
+            if temp_root == std::path::Path::new("/tmp") {
+                grant_ancestor_traversal(&base);
+            }
             let entry = |name: &str| {
                 CString::new(format!("{name}={}", base.display()))
                     .expect("temp base path contains an interior NUL byte")


### PR DESCRIPTION
## Problem

`//rs/sns/cli:sns_test` fails on Remote Build Execution @ Namespace:

```
thread '...test_ensure_file_exists_and_is_writeable_fails_if_non_writeable' panicked at
rs/test_utilities/privileges/src/lib.rs:164:25:
Failed to create tmp file: Custom { kind: PermissionDenied, error: PathError {
  path: "/tmp/ic-nobody-16-0/.tmpwvvfUX", err: Os { code: 13, kind: PermissionDenied,
  message: "Permission denied" } } }
```

## Root cause

The affected tests are wrapped in `#[ic_test_utilities_privileges::as_nobody_when_root]`. When the action runs as root, `run_as_nobody_if_root` forks a child, redirects `TMPDIR`/`TEST_TMPDIR` to a `nobody`-owned `0700` base directory created under `std::env::temp_dir()`, drops to `nobody`, and runs the test body there.

Reaching a file under that base requires **search (execute) permission on every ancestor directory**. Under Namespace's `namespace_action_isolation=sandboxed`, the action runs as uid 0 in its own mount+user namespace with `TMPDIR` unset, so `env::temp_dir()` resolves to `/tmp` — which is **root-owned and not world-traversable**. The root parent creates and chowns the base fine, but the forked `nobody` child cannot descend through `/tmp` into it, so `NamedTempFile::new()` fails with `PermissionDenied`.

The `chown`/`setgid`/`setuid` to `65534` all succeeded (otherwise the panic would read "failed to chown"/"failed to drop privileges"), confirming `nobody` genuinely owns the `0700` base — so the blocker is an untraversable *ancestor*, not the base. The old RBE happened to have the usual world-traversable `1777 /tmp`, which hid this.

## Fix

In `TmpDirRedirect::prepare` (parent, pre-fork, as root), after creating the base, grant others-execute on the base's ancestor directories where missing. Only the **search** bit is added (never read/write), only to directories lacking it (a no-op on a normal `1777 /tmp`), and only when running as root — and the sandbox is ephemeral and per-action, so there is no effect beyond the running test.

The relaxation is **confined to the default `/tmp` temp root** — which is precisely the sandboxed-RBE case, since it leaves `TMPDIR` unset. An explicitly-configured `TMPDIR` is left untouched, so running tests as root *outside* the sandbox cannot be steered into world-traversing a sensitive directory (e.g. `TMPDIR=/root/tmp` must not relax `/root`).

## Verification

- `rustfmt`, `cargo check --all-targets --all-features`, and `cargo clippy` (with the mandated lint flags): clean.
- `bazel build //rs/test_utilities/privileges:privileges //rs/sns/cli:sns_test`: success.
- `bazel test //rs/sns/cli:sns_test`: passes (non-root, in-process path).
- **End-to-end**, in a user+mount namespace as fake-root reproducing the Namespace condition:
  - `TMPDIR` unset with `/tmp` remounted `0700` (non-traversable): both `nobody` tests pass, and `/tmp` ends up `drwx-----x` — confirming the fix path executed.
  - Explicit `TMPDIR=/tmp/sensitive-root` (`0700`, simulating `/root/tmp`): the directory is left `drwx------` before *and* after — confirming an explicit `TMPDIR` is never relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)