### PR TITLE
fix: use correct team name for governance

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -9,7 +9,7 @@
     "ic-owners-owners": "owners-owners",
     "InfraSec": "security",
     "languages": "eng-motoko",
-    "governance": "eng-nns-prs",
+    "governance-team": "eng-nns-prs",
     "node": "eng-node-prs",
     "Platform Operations": "eng-platform-ops",
     "pocket-ic": "pocket-ic",


### PR DESCRIPTION
It looks like the team was renamed in the last few months.