### PR TITLE
fix: drop unused  in slack-workflow-run

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -9,8 +9,6 @@ on:
       - rc--*
       - ic-mainnet-revisions
       - ic-nervous-system-wasms
-    tags:
-      - release-*
     workflows:
       - Schedule Daily
       - Schedule RC


### PR DESCRIPTION
The `workflow_run` trigger has not `tags`, this was silently ignored:

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_runbranchesbranches-ignore