### PR TITLE
fix: correctly mark GPG_PASSPHRASE as optional

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -23,7 +23,8 @@ inputs:
     default: ${{ github.job }}-${{ github.action }}-bep
     description: "The name of the Bazel Build Event Protocol (BEP) artifact."
   GPG_PASSPHRASE:
-    required: true
+    required: false
+    default: ""
     description: "GPG key to encrypt build events. Upload can be disabled by explicitly setting the input to an empty string."
 
 runs:


### PR DESCRIPTION
We expect caller to omit the `GPG_PASSPHRASE` when build events should _not_ be uploaded (see for instance "Run Build IC" step in `ci-main.yml`).