### PR TITLE
chore: Clean up guest_disk migrations

### DIFF
--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -9,8 +9,7 @@ use libcryptsetup_rs::{
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::File;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tracing::{info, warn};
@@ -274,100 +273,6 @@ pub fn check_encryption_key(
         .activate_by_passphrase(None, None, encryption_key, CryptActivate::empty())
         .context("Failed to activate device")?;
 
-    Ok(())
-}
-
-pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Result<()> {
-    let parent_dir = header_path
-        .parent()
-        .context("LUKS header path does not have a parent directory")?;
-    fs::create_dir_all(parent_dir).with_context(|| {
-        format!(
-            "Failed to create parent directory for LUKS header {}",
-            header_path.display()
-        )
-    })?;
-
-    // Export into a temporary sibling path and rename it into place so we only replace an existing
-    // detached header once cryptsetup has produced a complete backup.
-    let temp_dir = tempfile::tempdir_in(parent_dir)
-        .context("Failed to create temporary directory for LUKS header backup")?;
-    let temp_header_path = temp_dir.path().join("header");
-
-    let mut crypt_device = open_luks2_device(device_path, LuksHeaderLocation::Attached)
-        .context("Failed to open LUKS2 device for header backup")?;
-    crypt_device
-        .backup_handle()
-        .header_backup(Some(EncryptionFormat::Luks2), &temp_header_path)
-        .with_context(|| {
-            format!(
-                "Failed to back up LUKS header to {}",
-                temp_header_path.display()
-            )
-        })?;
-
-    // We allow every user to read the header. The replica (running as user ic-replica) needs
-    // access to this file so that it can share it during an upgrade.
-    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o644))
-        .context("Failed to set permissions on temporary detached LUKS header file")?;
-
-    fs::rename(&temp_header_path, header_path)
-        .with_context(|| format!("Failed to persist LUKS header to {}", header_path.display()))?;
-
-    Ok(())
-}
-
-/// Checks whether the device at `device_path` contains a valid LUKS2 header in the attached
-/// (on-device) position.
-pub fn has_attached_luks_header(device_path: &Path) -> Result<bool> {
-    const LUKS_MAGIC: &[u8; 4] = b"LUKS";
-
-    let mut start = vec![];
-    std::fs::File::open(device_path)
-        .context("Failed to open device for header check")?
-        .take(LUKS_MAGIC.len() as u64)
-        .read_to_end(&mut start)
-        .context("Failed to read first few bytes for header check")?;
-
-    Ok(start == LUKS_MAGIC)
-}
-
-/// Wipes (zeroizes) the header area of the device at `device_path`, removing any attached LUKS
-/// header.
-///
-/// This is used when the Store partition is opened with a detached header: if the data device still
-/// carries a legacy attached header (from an older GuestOS that wrote both), we wipe it so that
-/// only the detached header remains going forward.
-pub fn wipe_attached_luks_header(device_path: &Path) -> Result<()> {
-    let mut crypt_device = open_luks2_device(device_path, LuksHeaderLocation::Attached)
-        .context("Failed to open LUKS device to determine header size")?;
-    // `get_data_offset` returns the offset in 512-byte sectors; convert to bytes.
-    let data_offset_sectors = crypt_device.status_handle().get_data_offset();
-    let header_size_bytes = data_offset_sectors * 512;
-
-    let mut device = OpenOptions::new()
-        .write(true)
-        .open(device_path)
-        .with_context(|| {
-            format!(
-                "Failed to open device {} for writing",
-                device_path.display()
-            )
-        })?;
-    device
-        .write_all(&vec![0_u8; header_size_bytes as usize])
-        .with_context(|| {
-            format!(
-                "Failed to wipe LUKS header on device {}",
-                device_path.display()
-            )
-        })?;
-    device.flush().with_context(|| {
-        format!(
-            "Failed to flush LUKS header wipe on device {}",
-            device_path.display()
-        )
-    })?;
     Ok(())
 }
 

--- a/rs/ic_os/os_tools/guest_disk/src/metrics.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/metrics.rs
@@ -93,38 +93,6 @@ fn build_luks_metric_labels(
     ])
 }
 
-/// Registers the status of the attached LUKS2 header on the Store data device with the given
-/// registry. Call [`write_metrics`] at the end of the program to persist all registered metrics to
-/// disk.
-pub(crate) fn export_attached_luks2_header_status(
-    registry: &Registry,
-    device_path: &Path,
-    attached_header_present: Result<bool>,
-) -> Result<()> {
-    let opts = Opts::new(
-        "guest_disk_store_attached_luks2_header_status",
-        "Status of the attached (on-device) LUKS2 header on the Store partition data device",
-    );
-    let header_status = GaugeVec::new(opts, &["device_path", "status"])
-        .context("Failed to create attached LUKS2 header status gauge")?;
-
-    let device_path_str = device_path.to_string_lossy();
-    let status_str = match attached_header_present {
-        Ok(true) => "present",
-        Ok(false) => "absent",
-        Err(_) => "error",
-    };
-    let label_values: Vec<&str> = vec![&device_path_str, status_str];
-
-    header_status.with_label_values(&label_values).set(1.0);
-
-    registry
-        .register(Box::new(header_status))
-        .context("Failed to register attached LUKS2 header status metric")?;
-
-    Ok(())
-}
-
 /// Encodes all metrics registered in `registry` and writes them to `metrics_file`.
 pub fn write_metrics(registry: &Registry, metrics_file: &Path) {
     let mut buffer = vec![];

--- a/rs/ic_os/os_tools/guest_disk/src/sev.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/sev.rs
@@ -1,9 +1,7 @@
 use crate::crypt::{
     LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata, check_encryption_key,
-    destroy_keyslots_except, format_crypt_device, has_attached_luks_header, open_luks2_device,
-    wipe_attached_luks_header,
+    destroy_keyslots_except, format_crypt_device,
 };
-use crate::metrics::export_attached_luks2_header_status;
 use crate::{DiskEncryption, Partition, activate_flags};
 use anyhow::{Context, Result, bail};
 use attestation::attestation_report::AttestationReportExt;
@@ -25,74 +23,6 @@ pub struct SevDiskEncryption {
 }
 
 impl SevDiskEncryption {
-    /// Records the attached LUKS2 header status in the metrics registry. Failures are logged as
-    /// warnings and never propagated, because a metrics export failure must not prevent the
-    /// partition from being opened.
-    fn export_attached_header_status(
-        &self,
-        device_path: &Path,
-        attached_header_present: Result<bool>,
-    ) {
-        if let Err(e) = export_attached_luks2_header_status(
-            &self.metrics_registry,
-            device_path,
-            attached_header_present,
-        ) {
-            warn!("Failed to export attached LUKS2 header status metric: {e:#}");
-        }
-    }
-
-    /// Checks whether the device carries an attached (on-device) LUKS2 header. If a detached
-    /// header is available and an attached header is still present, the attached header is wiped
-    /// so that only the detached header is used going forward. Finally, the attached-header status
-    /// is recorded in the metrics registry.
-    ///
-    /// TODO: once no nodes with attached Store LUKS headers remain, remove this logic.
-    fn wipe_and_export_attached_luks2_header(&self, device_path: &Path) {
-        let attached_header_present = has_attached_luks_header(device_path).unwrap_or_else(|e| {
-            warn!(
-                "Failed to check for attached LUKS2 header on {}: {e:#}. \
-                Continuing without wiping.",
-                device_path.display()
-            );
-            false
-        });
-
-        if self.store_luks_header_path.exists() && attached_header_present {
-            if let Err(e) = open_luks2_device(
-                device_path,
-                LuksHeaderLocation::Detached(&self.store_luks_header_path),
-            ) {
-                warn!(
-                    "Refusing to wipe attached LUKS2 header on {}: detached header {} \
-                    cannot be read by libcryptsetup: {e:#}",
-                    device_path.display(),
-                    self.store_luks_header_path.display()
-                );
-            } else {
-                info!(
-                    "Detached Store LUKS header available and attached header still present \
-                    on {}. Wiping attached header.",
-                    device_path.display()
-                );
-                if let Err(e) = wipe_attached_luks_header(device_path) {
-                    warn!(
-                        "Failed to wipe attached LUKS2 header on {}: {e:#}. \
-                        Continuing with detached header.",
-                        device_path.display()
-                    );
-                }
-            }
-        }
-
-        self.export_attached_header_status(
-            device_path,
-            // Note that we don't use `attached_header_present` here, because the header may
-            // have been wiped above.
-            has_attached_luks_header(device_path),
-        );
-    }
-
     fn setup_store_with_previous_key(
         &self,
         device_path: &Path,
@@ -193,8 +123,6 @@ impl DiskEncryption for SevDiskEncryption {
             }
 
             Partition::Store => {
-                self.wipe_and_export_attached_luks2_header(device_path);
-
                 // Try to read the previous SEV key. This is the key that the previous version of the
                 // GuestOS used to unlock the store (data) partition. During the upgrade this key is
                 // written to `previous_key_path`. After the upgrade, when the GuestOS boots for the

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -29,7 +29,7 @@ use itertools::Either::Right;
 use libcryptsetup_rs::consts::flags::{CryptActivate, CryptVolumeKey};
 use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat, KeyslotInfo};
 use libcryptsetup_rs::{
-    CryptDevice, CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle, CryptTokenInfo, TokenInput,
+    CryptDevice, CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle, CryptTokenInfo,
 };
 use prometheus::Registry;
 use sev::Generation;
@@ -991,62 +991,6 @@ fn test_rollback_uses_frozen_header_without_key_exchange() {
     fixture.store_partition().open().unwrap();
     fixture.store_partition().assert_payload(b"rollback data");
     fixture.store_partition().deactivate();
-}
-
-#[test]
-fn test_sev_unlock_legacy_store_partition_without_tokens_backfills_token() {
-    let fixture = TestFixture::new_sev();
-
-    fixture.write_previous_key();
-
-    // Format with a detached header locked by the previous key.
-    let (mut device, previous_keyslot) = format_crypt_device(
-        fixture.store_device_path(),
-        LuksHeaderLocation::Detached(&fixture.store_header_path()),
-        PREVIOUS_KEY,
-    )
-    .expect("Failed to format Store device with previous key");
-
-    // Strip all tokens so the disk looks like a pre-token GuestOS.
-    {
-        let mut token_handle = device.token_handle();
-        for token_id in 0..LUKS2_N_TOKENS {
-            token_handle
-                .json_set(TokenInput::RemoveToken(token_id))
-                .expect("Failed to remove token");
-        }
-    }
-    drop(device);
-
-    // Ensure that the Store header has no metadata tokens.
-    let mut check_device = open_luks2_device(
-        fixture.store_device_path(),
-        LuksHeaderLocation::Detached(&fixture.store_header_path()),
-    )
-    .expect("Failed to open detached Store header before rotation");
-    assert!(
-        read_keyslot_metadata(&mut check_device)
-            .expect("Failed to read detached Store key-slot metadata")
-            .is_empty(),
-        "Store header should have no metadata tokens before rotation"
-    );
-    drop(check_device);
-
-    // Open the device with open() - in production, this would happen after an upgrade.
-    // This should rotate the passphrase and backfill the metadata for the new SEV keyslot.
-    fixture
-        .store_partition()
-        .open()
-        .expect("Failed to rotate Store disk from previous key to SEV key");
-
-    let metadata = fixture.store_partition().read_keyslot_metadata();
-    assert_eq!(metadata.len(), 1);
-    assert_ne!(
-        metadata[0].keyslot().unwrap(),
-        previous_keyslot,
-        "Store rotation should backfill metadata for a new keyslot"
-    );
-    assert_eq!(fixture.store_partition().active_keyslot_count(), 2);
 }
 
 #[test]

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -19,8 +19,8 @@ use config_types::{GuestOSConfig, GuestVMType, ICOSSettings};
 use guest_disk::DiskEncryption;
 use guest_disk::crypt::{
     KeyslotMetadata, LUKS2_N_KEYSLOTS, LUKS2_N_TOKENS, LuksHeaderLocation, activate_crypt_device,
-    backup_luks_header_to_file, check_encryption_key, deactivate_crypt_device, format_crypt_device,
-    open_luks2_device, read_keyslot_metadata,
+    check_encryption_key, deactivate_crypt_device, format_crypt_device, open_luks2_device,
+    read_keyslot_metadata,
 };
 use guest_disk::sev::{SevDiskEncryption, can_open_store};
 use ic_device::device_mapping::{Bytes, TempDevice};
@@ -457,38 +457,6 @@ impl TestFixture {
         )
     }
 
-    /// SEV upgrade path: writes the [`PREVIOUS_KEY`] file and formats the store device with
-    /// an *attached* LUKS header locked by that key. Simulates a legacy store partition as it
-    /// exists before the first SEV key rotation.
-    /// Returns the open crypt device handle and the keyslot of the previous key.
-    fn setup_legacy_store_with_previous_key(&self) -> (CryptDevice, u32) {
-        self.write_previous_key();
-        format_crypt_device(
-            self.store_device_path(),
-            LuksHeaderLocation::Attached,
-            PREVIOUS_KEY,
-        )
-        .expect("Failed to format legacy Store device with previous key")
-    }
-
-    /// As [`Self::setup_legacy_store_with_previous_key`], but also backs the attached
-    /// header up to the active slot's detached Store header file. Simulates a legacy device
-    /// that has both an attached and a detached header.
-    fn setup_legacy_store_with_attached_and_detached_headers(&self) -> u32 {
-        let (device, keyslot) = self.setup_legacy_store_with_previous_key();
-        drop(device);
-        self.backup_store_header();
-        keyslot
-    }
-
-    /// Backs the store device's attached LUKS header up to the active slot's detached
-    /// Store header file.
-    fn backup_store_header(&self) {
-        let store_header_path = self.store_header_path();
-        backup_luks_header_to_file(self.store_device_path(), &store_header_path)
-            .expect("Failed to back up Store LUKS header to detached file");
-    }
-
     /// Writes the [`PREVIOUS_KEY`] file on the active slot's var partition.
     fn write_previous_key(&self) {
         let previous_key_path = self.previous_key_path();
@@ -863,12 +831,10 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     // Let's assume the store partition is already encrypted with a previous key.
     let (mut device, _keyslot) = format_crypt_device(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         PREVIOUS_KEY,
     )
     .unwrap();
-
-    fixture.backup_store_header();
 
     // Let's also assume that an old deprecated key had been added to the device which will be
     // removed (only the previous key and the new SEV key should remain).
@@ -882,7 +848,7 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     // Write some data to the disk.
     activate_crypt_device(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         "store-crypt",
         PREVIOUS_KEY,
         CryptActivate::empty(),
@@ -893,18 +859,17 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     fixture.store_partition().write_payload(b"hello world");
 
     fixture.store_partition().deactivate();
-    fixture.backup_store_header();
 
     check_encryption_key(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         PREVIOUS_KEY,
     )
     .expect("previous key should unlock the store partition");
 
     check_encryption_key(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         DEPRECATED_KEY,
     )
     .expect("deprecated key should unlock the store partition");
@@ -930,14 +895,6 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     )
     .expect("previous key should unlock the store partition");
 
-    // The attached header is wiped during open() when a detached header is available.
-    check_encryption_key(
-        fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
-        PREVIOUS_KEY,
-    )
-    .expect_err("attached Store header should have been wiped during open()");
-
     let sev_key = fixture.derive_sev_key(Partition::Store);
 
     check_encryption_key(
@@ -946,14 +903,6 @@ fn test_sev_unlock_store_partition_with_previous_key() {
         &sev_key,
     )
     .expect("SEV key should unlock the store partition");
-
-    // The attached header has been wiped, so no key should unlock it.
-    check_encryption_key(
-        fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
-        &sev_key,
-    )
-    .expect_err("attached Store header should have been wiped during open()");
 
     check_encryption_key(
         fixture.store_device_path(),
@@ -1048,48 +997,54 @@ fn test_rollback_uses_frozen_header_without_key_exchange() {
 fn test_sev_unlock_legacy_store_partition_without_tokens_backfills_token() {
     let fixture = TestFixture::new_sev();
 
-    let (mut device, previous_keyslot) = fixture.setup_legacy_store_with_previous_key();
+    fixture.write_previous_key();
 
-    // Strip all legacy tokens so the disk looks like a pre-token GuestOS.
+    // Format with a detached header locked by the previous key.
+    let (mut device, previous_keyslot) = format_crypt_device(
+        fixture.store_device_path(),
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
+        PREVIOUS_KEY,
+    )
+    .expect("Failed to format Store device with previous key");
+
+    // Strip all tokens so the disk looks like a pre-token GuestOS.
     {
         let mut token_handle = device.token_handle();
         for token_id in 0..LUKS2_N_TOKENS {
             token_handle
                 .json_set(TokenInput::RemoveToken(token_id))
-                .expect("Failed to remove legacy token");
+                .expect("Failed to remove token");
         }
     }
-
-    fixture.backup_store_header();
     drop(device);
 
-    // Ensure that the legacy Store header has no metadata tokens.
-    let mut legacy_device = open_luks2_device(
+    // Ensure that the Store header has no metadata tokens.
+    let mut check_device = open_luks2_device(
         fixture.store_device_path(),
         LuksHeaderLocation::Detached(&fixture.store_header_path()),
     )
     .expect("Failed to open detached Store header before rotation");
     assert!(
-        read_keyslot_metadata(&mut legacy_device)
+        read_keyslot_metadata(&mut check_device)
             .expect("Failed to read detached Store key-slot metadata")
             .is_empty(),
-        "legacy detached Store header should have no metadata tokens"
+        "Store header should have no metadata tokens before rotation"
     );
-    drop(legacy_device);
+    drop(check_device);
 
     // Open the device with open() - in production, this would happen after an upgrade.
     // This should rotate the passphrase and backfill the metadata for the new SEV keyslot.
     fixture
         .store_partition()
         .open()
-        .expect("Failed to rotate legacy Store disk from previous key to SEV key");
+        .expect("Failed to rotate Store disk from previous key to SEV key");
 
     let metadata = fixture.store_partition().read_keyslot_metadata();
     assert_eq!(metadata.len(), 1);
     assert_ne!(
         metadata[0].keyslot().unwrap(),
         previous_keyslot,
-        "legacy Store rotation should backfill metadata for a new keyslot"
+        "Store rotation should backfill metadata for a new keyslot"
     );
     assert_eq!(fixture.store_partition().active_keyslot_count(), 2);
 }
@@ -1101,15 +1056,13 @@ fn test_sev_upgrade_vm_keeps_previous_key_file() {
 
     fixture.write_previous_key();
 
-    // Simulate a legacy store partition encrypted with the previous key (attached header).
+    // Simulate a store partition encrypted with the previous key.
     format_crypt_device(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         PREVIOUS_KEY,
     )
     .unwrap();
-
-    fixture.backup_store_header();
 
     fixture
         .store_partition()
@@ -1138,12 +1091,10 @@ fn test_sev_unlock_store_with_current_key_if_previous_key_does_not_work() {
     let sev_key = fixture.derive_sev_key(Partition::Store);
     format_crypt_device(
         fixture.store_device_path(),
-        LuksHeaderLocation::Attached,
+        LuksHeaderLocation::Detached(&fixture.store_header_path()),
         &sev_key,
     )
     .unwrap();
-
-    fixture.backup_store_header();
 
     // Opening it should succeed
     fixture
@@ -1419,81 +1370,6 @@ fn test_open_store_succeeds_with_detached_header_after_attached_header_is_corrup
     );
 }
 
-/// Test that the attached LUKS header is NOT wiped when the detached header cannot be read by
-/// libcryptsetup.
-#[test]
-fn test_open_store_keeps_attached_header_when_detached_header_is_corrupt() {
-    let fixture = TestFixture::new_sev();
-
-    // Simulate a legacy device that has an attached header (formatted via the legacy setup).
-    fixture.setup_legacy_store_with_previous_key();
-
-    assert!(fixture.store_partition().has_attached_luks2_header());
-
-    // Corrupt the detached header so libcryptsetup can no longer read it.
-    fs::write(fixture.store_header_path(), b"not a valid LUKS header")
-        .expect("Failed to corrupt detached header");
-
-    // Opening the store must fail because the detached header is unreadable.
-    fixture
-        .store_partition()
-        .open()
-        .expect_err("opening Store should fail when the detached header is corrupt");
-
-    // Crucially, the attached header must still be present: the wipe guard must have refused
-    // to wipe it because the detached header could not be verified.
-    assert!(
-        fixture.store_partition().has_attached_luks2_header(),
-        "attached LUKS header must not be wiped when the detached header is unreadable"
-    );
-}
-
-/// Test that opening the store partition wipes a legacy attached LUKS header when a detached
-/// header is available. This simulates upgrading from an older GuestOS that wrote both an
-/// attached and a detached header.
-#[test]
-fn test_open_store_wipes_attached_header_when_detached_header_is_available() {
-    let fixture = TestFixture::new_sev();
-
-    // Simulate a legacy device that has both an attached and a detached header.
-    fixture.setup_legacy_store_with_attached_and_detached_headers();
-
-    // Both headers should be present before opening.
-    assert!(fixture.store_partition().has_attached_luks2_header());
-    assert!(fixture.store_partition().has_detached_luks2_header());
-
-    // Opening the store should wipe the attached header.
-    fixture
-        .store_partition()
-        .open()
-        .expect("opening Store should succeed");
-
-    // The attached header should now be gone.
-    assert!(
-        !fixture.store_partition().has_attached_luks2_header(),
-        "attached LUKS header should have been wiped during open()"
-    );
-    // The detached header must still be present and valid.
-    assert!(
-        fixture.store_partition().has_detached_luks2_header(),
-        "detached LUKS header should still be present after open()"
-    );
-    assert!(fixture.store_header_path().exists());
-
-    fixture.store_partition().deactivate();
-
-    // Opening again should still succeed (using only the detached header).
-    fixture
-        .store_partition()
-        .open()
-        .expect("opening Store should succeed again after attached header wipe");
-
-    assert!(
-        fixture.store_partition().mapper_path().exists(),
-        "store mapper device should exist after reopen"
-    );
-}
-
 #[test]
 fn test_cannot_open_with_generated_key_if_sev_is_enabled() {
     for partition in [Partition::Store, Partition::Var] {
@@ -1690,79 +1566,6 @@ fn test_metrics_export() {
     assert!(
         metrics_content.contains("passes_verification=\"true\""),
         "Missing or incorrect passes_verification label: {metrics_content}"
-    );
-}
-
-#[test]
-fn test_store_attached_luks2_header_status_metric_absent() {
-    let fixture = TestFixture::new_sev();
-
-    // Format the store partition with a detached header only; there is no attached header on the
-    // data device.
-    fixture
-        .store_partition()
-        .format()
-        .expect("Failed to format store partition");
-
-    fixture
-        .store_partition()
-        .open()
-        .expect("Failed to open store partition");
-
-    let metrics_content = fs::read_to_string(fixture.metrics_file(Partition::Store))
-        .expect("Failed to read metrics file");
-
-    assert!(
-        metrics_content.contains("guest_disk_store_attached_luks2_header_status"),
-        "Missing attached LUKS2 header status metric: {metrics_content}"
-    );
-    assert!(
-        metrics_content.contains("status=\"absent\""),
-        "Expected status=\"absent\" label: {metrics_content}"
-    );
-    assert!(
-        !metrics_content.contains("status=\"present\""),
-        "Did not expect status=\"present\" label: {metrics_content}"
-    );
-}
-
-#[test]
-fn test_store_attached_luks2_header_status_metric_present() {
-    let fixture = TestFixture::new_sev();
-
-    // Simulate a legacy device that has both an attached and a detached header.
-    fixture.setup_legacy_store_with_attached_and_detached_headers();
-
-    assert!(fixture.store_partition().has_attached_luks2_header());
-
-    fixture
-        .store_partition()
-        .open()
-        .expect("opening Store should succeed");
-
-    // After opening, the attached header is wiped because a detached header is available.
-    // The metric reflects the end result, so it must report "absent".
-    assert!(
-        !fixture.store_partition().has_attached_luks2_header(),
-        "attached LUKS header should have been wiped during open()"
-    );
-
-    let metrics_content = fs::read_to_string(fixture.metrics_file(Partition::Store))
-        .expect("Failed to read metrics file");
-
-    assert!(
-        metrics_content.contains("guest_disk_store_attached_luks2_header_status"),
-        "Missing attached LUKS2 header status metric: {metrics_content}"
-    );
-    assert!(
-        metrics_content.contains("status=\"absent\""),
-        "Expected status=\"absent\" after wipe: {metrics_content}"
-    );
-    // The LUKS parameters metric must still be present (not overwritten by the header status
-    // metric).
-    assert!(
-        metrics_content.contains("guest_disk_encryption_info"),
-        "Missing encryption info metric: {metrics_content}"
     );
 }
 


### PR DESCRIPTION
All SEV nodes have migrated to detached-only Store partition LUKS headers, so we can remove the migration code.

In addition, all nodes now have LUKS tokens containing SEV passphrase-derivation metadata, we can also remove the corresponding test


<img width="300" alt="image" src="https://github.com/user-attachments/assets/b758701e-669a-43d6-8b61-943a66f7c299" />
