### PR TITLE
refactor: applying ingress induction debit after cleanup callback execution

### DIFF
--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -267,6 +267,7 @@ fn finish_err(
     canister.system_state.apply_ingress_induction_cycles_debit(
         canister.canister_id(),
         round.cost_schedule,
+        true, // strict
         round.log,
         round.counters.charging_from_balance_error,
     );
@@ -485,6 +486,7 @@ impl CallOrTaskHelper {
             .apply_ingress_induction_cycles_debit(
                 self.canister.canister_id(),
                 round.cost_schedule,
+                true, // strict
                 round.log,
                 round.counters.charging_from_balance_error,
             );

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -324,6 +324,7 @@ impl InstallCodeHelper {
             .apply_ingress_induction_cycles_debit(
                 self.canister.canister_id(),
                 round.cost_schedule,
+                true, // strict
                 round.log,
                 round.counters.charging_from_balance_error,
             );
@@ -869,6 +870,7 @@ pub(crate) fn finish_err(
         .apply_ingress_induction_cycles_debit(
             new_canister.canister_id(),
             round.cost_schedule,
+            true, // strict
             round.log,
             round.counters.charging_from_balance_error,
         );

--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -390,6 +390,7 @@ impl ResponseHelper {
             .apply_ingress_induction_cycles_debit(
                 self.canister.canister_id(),
                 round.cost_schedule,
+                true, // strict
                 round.log,
                 round.counters.charging_from_balance_error,
             );
@@ -472,37 +473,17 @@ impl ResponseHelper {
         round_limits: &mut RoundLimits,
         call_tree_metrics: &dyn CallTreeMetrics,
     ) -> ExecuteMessageResult {
-        // The ingress induction debit can interfere with cycles changes that happened concurrently
-        // during the cleanup callback execution. If the balance of the canister is not enough to
-        // cover the debit + the amount of removed cycles during execution, the canister might end
-        // up with an incorrect balance. To avoid this, we check if the balance is enough to cover
-        // the debit + the removed cycles to ensure that the cycles change can be performed.
+        // Apply the state changes of the cleanup callback first, and only then
+        // charge the ingress induction cycles debit.
         //
-        // This allows the cleanup callback to always succeed at the expense of some ingress
-        // messages being inducted for free in this edge case. This is acceptable because the cleanup
-        // callback is expected to always run and allow the canister to perform important cleanup tasks,
-        // like releasing locks or undoing other state changes.
-        let ingress_induction_cycles_debit =
-            self.canister.system_state.ingress_induction_cycles_debit();
-        let removed_cycles = canister_state_changes
-            .system_state_modifications
-            .removed_cycles();
-        if self.canister.system_state.balance() < ingress_induction_cycles_debit + removed_cycles {
-            self.canister
-                .system_state
-                .remove_charge_from_ingress_induction_cycles_debit(
-                    ingress_induction_cycles_debit - removed_cycles,
-                );
-        }
-        self.canister
-            .system_state
-            .apply_ingress_induction_cycles_debit(
-                self.canister.canister_id(),
-                round.cost_schedule,
-                round.log,
-                round.counters.charging_from_balance_error,
-            );
-
+        // The debit is charged using the saturating arithmetic of
+        // `apply_ingress_induction_cycles_debit`: if the remaining balance is
+        // smaller than the debit, only the available cycles are charged and the
+        // rest of the debit is dropped (some ingress messages end up inducted for
+        // free in this edge case). This allows the cleanup callback to always
+        // succeed, which is important because it is expected to always run and
+        // allow the canister to perform important cleanup tasks, like releasing
+        // locks or undoing other state changes.
         apply_canister_state_changes(
             canister_state_changes,
             self.canister.execution_state.as_mut().unwrap(),
@@ -520,6 +501,16 @@ impl ResponseHelper {
             is_composite_query(&original.call_origin),
             &|system_state| self.deallocation_sender.send(Box::new(system_state)),
         );
+
+        self.canister
+            .system_state
+            .apply_ingress_induction_cycles_debit(
+                self.canister.canister_id(),
+                round.cost_schedule,
+                false, // lenient: a cleanup callback may burn the balance below the debit
+                round.log,
+                round.counters.charging_from_balance_error,
+            );
 
         match output.wasm_result {
             Ok(_) => {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4517,6 +4517,7 @@ impl ExecutionEnvironment {
                 .apply_ingress_induction_cycles_debit(
                     canister_id,
                     cost_schedule,
+                    true, // strict
                     log,
                     &self.metrics.charging_from_balance_error,
                 );

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -1002,41 +1002,42 @@ impl SystemState {
         self.ingress_induction_cycles_debit += charge;
     }
 
-    /// Removes a previously postponed charge for ingress messages from the balance
-    /// of the canister.
-    ///
-    /// Note that this will saturate the balance to zero if the charge to remove is
-    /// larger than the current debit.
-    pub fn remove_charge_from_ingress_induction_cycles_debit(&mut self, charge: Cycles) {
-        self.ingress_induction_cycles_debit -= charge;
-    }
-
     /// Charges the pending 'ingress_induction_cycles_debit' from the balance.
     ///
-    /// Precondition:
-    /// - The balance is large enough to cover the debit.
+    /// If `strict` is `true`, the caller guarantees that the balance is large
+    /// enough to cover the debit and it is a bug if that is not the case.
+    ///
+    /// If `strict` is `false`, the balance is allowed to be smaller than the
+    /// debit: only the available cycles are charged and the rest of the debit is
+    /// silently dropped (making some of the postponed ingress induction charges
+    /// free). This is used after a cleanup callback, which can burn the canister's
+    /// cycles balance below the pending debit and must always be allowed to
+    /// succeed.
     pub fn apply_ingress_induction_cycles_debit(
         &mut self,
         canister_id: CanisterId,
         cost_schedule: CanisterCyclesCostSchedule,
+        strict: bool,
         log: &ReplicaLogger,
         charging_from_balance_error: &IntCounter,
     ) {
         // We rely on saturating operations of `Cycles` here.
         let remaining_debit = self.ingress_induction_cycles_debit - self.cycles_balance;
-        debug_assert_eq!(remaining_debit.get(), 0);
-        if remaining_debit.get() > 0 {
-            // This case is unreachable and may happen only due to a bug: if the
-            // caller has reduced the cycles balance below the cycles debit.
-            charging_from_balance_error.inc();
-            error!(
-                log,
-                "[EXC-BUG]: Debited cycles exceed the cycles balance of {} by {} in install_code",
-                canister_id,
-                remaining_debit,
-            );
-            // Continue the execution by dropping the remaining debit, which makes
-            // some of the postponed charges free.
+        if strict {
+            debug_assert_eq!(remaining_debit.get(), 0);
+            if remaining_debit.get() > 0 {
+                // This case is unreachable and may happen only due to a bug: if the
+                // caller has reduced the cycles balance below the cycles debit.
+                charging_from_balance_error.inc();
+                error!(
+                    log,
+                    "[EXC-BUG]: Debited cycles exceed the cycles balance of {} by {}",
+                    canister_id,
+                    remaining_debit,
+                );
+                // Continue the execution by dropping the remaining debit, which makes
+                // some of the postponed charges free.
+            }
         }
         self.consume_cycles(CompoundCycles::<IngressInduction>::new(
             self.ingress_induction_cycles_debit,

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -825,6 +825,7 @@ fn canister_state_ingress_induction_cycles_debit() {
     system_state.apply_ingress_induction_cycles_debit(
         system_state.canister_id(),
         cost_schedule,
+        true, // strict
         &no_op_logger(),
         &mock_metrics(),
     );


### PR DESCRIPTION
Charge the ingress induction cycles debit only after applying the state changes of a cleanup callback, using a new `strict` parameter of `SystemState::apply_ingress_induction_cycles_debit` that permits the balance to be smaller than the debit (relying on saturating arithmetic) for the cleanup path. This removes the previous logic (and the now-unused `remove_charge_from_ingress_induction_cycles_debit`) that trimmed the debit so it could be charged before applying the state changes.