### PR TITLE
fix(nns_delegation_manager): use custom DNS resolver in tests

### DIFF
--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -1,9 +1,4 @@
-use std::{
-    convert::TryFrom,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
+use std::{convert::TryFrom, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::body::Body;
 use futures::FutureExt;

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -1,4 +1,9 @@
-use std::{convert::TryFrom, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    convert::TryFrom,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::body::Body;
 use futures::FutureExt;
@@ -459,17 +464,26 @@ async fn connect(
             let (api_bn_id, domain) = get_random_api_boundary_node(registry_client)
                 .map_err(|err| format!("Could not find an API BN to talk to. Error: {err}"))?;
 
-            let mut dns_resolver = Resolver::builder_tokio()?;
-            dns_resolver.options_mut().ip_strategy = LookupIpStrategy::Ipv6Only;
-            let ip_addr = dns_resolver
-                .build()?
-                .lookup_ip(domain.as_str())
-                .await?
-                .iter()
-                .next()
-                .ok_or_else(|| {
-                    format!("API BN domain {domain} does not resolve to any IPv6 address.",)
-                })?;
+            // A literal IP address needs no DNS resolution. Short-circuit it so we don't build
+            // the DNS resolver, which reads the system config (`/etc/resolv.conf`) and fails
+            // with "no nameservers found in config" in environments without one (e.g. sandboxed
+            // remote execution).
+            let ip_addr = match domain.parse::<IpAddr>() {
+                Ok(ip_addr) => ip_addr,
+                Err(_) => {
+                    let mut dns_resolver = Resolver::builder_tokio()?;
+                    dns_resolver.options_mut().ip_strategy = LookupIpStrategy::Ipv6Only;
+                    dns_resolver
+                        .build()?
+                        .lookup_ip(domain.as_str())
+                        .await?
+                        .iter()
+                        .next()
+                        .ok_or_else(|| {
+                            format!("API BN domain {domain} does not resolve to any IPv6 address.")
+                        })?
+                }
+            };
 
             let addr = SocketAddr::new(ip_addr, 443);
 

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -7,7 +7,7 @@ use std::{
 
 use axum::body::Body;
 use futures::FutureExt;
-use hickory_resolver::{Resolver, config::LookupIpStrategy};
+use hickory_resolver::{Resolver, config::{LookupIpStrategy, NameServerConfig, ResolverConfig}, net::runtime::TokioRuntimeProvider};
 use http_body_util::{BodyExt, Full, LengthLimitError};
 use hyper::{Request, client::conn::http1::SendRequest};
 use hyper_util::rt::TokioIo;
@@ -464,26 +464,30 @@ async fn connect(
             let (api_bn_id, domain) = get_random_api_boundary_node(registry_client)
                 .map_err(|err| format!("Could not find an API BN to talk to. Error: {err}"))?;
 
-            // A literal IP address needs no DNS resolution. Short-circuit it so we don't build
-            // the DNS resolver, which reads the system config (`/etc/resolv.conf`) and fails
-            // with "no nameservers found in config" in environments without one (e.g. sandboxed
-            // remote execution).
-            let ip_addr = match domain.parse::<IpAddr>() {
-                Ok(ip_addr) => ip_addr,
-                Err(_) => {
-                    let mut dns_resolver = Resolver::builder_tokio()?;
-                    dns_resolver.options_mut().ip_strategy = LookupIpStrategy::Ipv6Only;
-                    dns_resolver
-                        .build()?
-                        .lookup_ip(domain.as_str())
-                        .await?
-                        .iter()
-                        .next()
-                        .ok_or_else(|| {
-                            format!("API BN domain {domain} does not resolve to any IPv6 address.")
-                        })?
-                }
+            // To test the DNS resolution in a hermetic environment which does not have any external
+            // network access, we use a placeholder nameserver which is never contacted, because the
+            // domain used in the test is an IP literal. In production, the resolver will use the
+            // system's default nameservers to resolve the domain.
+            let mut dns_resolver = if !cfg!(test) {
+                Resolver::builder(TokioRuntimeProvider::default())?
+            } else {
+                Resolver::builder_with_config(ResolverConfig::from_parts(
+                    None,
+                    vec![],
+                    vec![NameServerConfig::udp_and_tcp(std::net::Ipv6Addr::LOCALHOST.into())],
+                ),
+                    TokioRuntimeProvider::default())
             };
+            dns_resolver.options_mut().ip_strategy = LookupIpStrategy::Ipv6Only;
+            let ip_addr = dns_resolver
+                .build()?
+                .lookup_ip(domain.as_str())
+                .await?
+                .iter()
+                .next()
+                .ok_or_else(|| {
+                    format!("API BN domain {domain} does not resolve to any IPv6 address.",)
+                })?;
 
             let addr = SocketAddr::new(ip_addr, 443);
 

--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -2,7 +2,11 @@ use std::{convert::TryFrom, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::body::Body;
 use futures::FutureExt;
-use hickory_resolver::{Resolver, config::{LookupIpStrategy, NameServerConfig, ResolverConfig}, net::runtime::TokioRuntimeProvider};
+use hickory_resolver::{
+    Resolver,
+    config::{LookupIpStrategy, NameServerConfig, ResolverConfig},
+    net::runtime::TokioRuntimeProvider,
+};
 use http_body_util::{BodyExt, Full, LengthLimitError};
 use hyper::{Request, client::conn::http1::SendRequest};
 use hyper_util::rt::TokioIo;
@@ -466,12 +470,16 @@ async fn connect(
             let mut dns_resolver = if !cfg!(test) {
                 Resolver::builder(TokioRuntimeProvider::default())?
             } else {
-                Resolver::builder_with_config(ResolverConfig::from_parts(
-                    None,
-                    vec![],
-                    vec![NameServerConfig::udp_and_tcp(std::net::Ipv6Addr::LOCALHOST.into())],
-                ),
-                    TokioRuntimeProvider::default())
+                Resolver::builder_with_config(
+                    ResolverConfig::from_parts(
+                        None,
+                        vec![],
+                        vec![NameServerConfig::udp_and_tcp(
+                            std::net::Ipv6Addr::LOCALHOST.into(),
+                        )],
+                    ),
+                    TokioRuntimeProvider::default(),
+                )
             };
             dns_resolver.options_mut().ip_strategy = LookupIpStrategy::Ipv6Only;
             let ip_addr = dns_resolver


### PR DESCRIPTION
## Problem

`load_root_delegation_on_cloud_engine_should_contact_api_bn_test` fails under sandboxed remote execution (e.g. namespaced Bazel RBE) with:

```
assertion failed: `Err(Io(Custom { kind: Other, error: "no nameservers found in config" }))`
    does not match `Err(err) if format!("{err:?}").contains("Could not connect to node [::1]:443")`
```

The `CloudEngine` branch of `try_fetch_delegation_from_nns` builds a DNS resolver via `Resolver::builder_tokio()`, which reads `/etc/resolv.conf` **at construction time**. In an environment without nameservers (a sandbox), that call fails with `"no nameservers found in config"` before the code ever reaches the connect step. The test's API BN "domain" is the literal loopback address `::1`, so no DNS is actually needed — but the resolver is built regardless, and its construction reads the (empty) system config.

In non-sandboxed environments (with a populated `resolv.conf`) the resolver builds fine, the literal `::1` short-circuits, and the connection is refused, yielding the expected `"Could not connect to node [::1]:443"`.

## Fix

Avoid reading the system `resolv.conf` in test builds:

- In **production** (`!cfg!(test)`), the resolver is built from the system's default nameservers exactly as before, via `Resolver::builder(TokioRuntimeProvider::default())` (equivalent to the previous `Resolver::builder_tokio()`).
- In **test** builds (`cfg!(test)`), the resolver is built from an explicit `ResolverConfig` containing a single placeholder nameserver (`::1`) instead of reading `/etc/resolv.conf`. This placeholder is never actually contacted, because the domain used by the test is an IP literal (`::1`) which resolves without issuing a query.

This keeps the test hermetic under sandboxed remote execution — it still exercises the full DNS-resolution code path and reaches the connect step, failing with the expected `"Could not connect to node [::1]:443"` — while leaving production DNS behavior unchanged.

## Testing

`bazel test //rs/http_endpoints/nns_delegation_manager:nns_delegation_manager_test` — PASSED (15/15 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)