### PR TITLE
fix(system-tests): keep local backend dnsmasq non-root under RBE sandbox

### DIFF
--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -238,18 +238,36 @@ impl LocalBackend {
                  networking without host capabilities",
             );
         }
-        // Identity-map the caller's uid/gid into the new user namespace, so it
-        // keeps its usual identity (files, `/dev/kvm` and `/dev/net/tun` are
-        // opened exactly as before) while being the namespace owner. `setgroups`
-        // must be denied before an unprivileged process may write `gid_map`; that
-        // is fine here because nothing in the process tree calls `setgroups`
-        // (`dnsmasq`, the only program that would, stays unprivileged and so
-        // skips its privilege-drop entirely — see `start_ra_daemon`).
+        // Map the caller's uid/gid into the new user namespace so it keeps its
+        // usual identity (files, `/dev/kvm` and `/dev/net/tun` are opened exactly
+        // as before) while being the namespace owner. The mapping is an identity
+        // one, with a single exception: if the caller is (fake-)root we map it to
+        // a *non-zero* inner uid/gid instead of `0`.
+        //
+        // The reason: the backend relies on `dnsmasq` staying unprivileged so it
+        // skips its privilege-drop path (see `start_ra_daemon`). That path is
+        // gated purely on `getuid() == 0`, and when taken it fails in this
+        // namespace — `setgroups` is denied (below) and the default `dip` gid is
+        // unmapped. This normally holds because the action runs as an ordinary
+        // user, but under an RBE sandbox that runs actions as uid 0 in its own
+        // user namespace (e.g. Namespace's `namespace_action_isolation=sandboxed`)
+        // an identity map would make the driver root here too and trip that path.
+        // Presenting a non-zero uid keeps `dnsmasq` (and any other root-sensitive
+        // child) out of it regardless of the outer uid. On-disk ownership,
+        // `/dev/kvm` and `/dev/net/tun` are still accessed as the mapping's
+        // *outer* uid, so nothing else changes.
+        //
+        // `setgroups` must be denied before an unprivileged process may write
+        // `gid_map`; that is fine here because nothing in the process tree needs
+        // `setgroups` to succeed. A single-line self-map is always permitted, with
+        // or without `CAP_SETUID`/`CAP_SETGID` in the parent user namespace.
+        let inner_uid = if uid == 0 { 1 } else { uid };
+        let inner_gid = if gid == 0 { 1 } else { gid };
         std::fs::write("/proc/self/setgroups", "deny")
             .context("denying setgroups for the private user namespace")?;
-        std::fs::write("/proc/self/uid_map", format!("{uid} {uid} 1"))
+        std::fs::write("/proc/self/uid_map", format!("{inner_uid} {uid} 1"))
             .context("writing uid_map for the private user namespace")?;
-        std::fs::write("/proc/self/gid_map", format!("{gid} {gid} 1"))
+        std::fs::write("/proc/self/gid_map", format!("{inner_gid} {gid} 1"))
             .context("writing gid_map for the private user namespace")?;
         // Raise the networking capabilities into the ambient set so the
         // unprivileged `ip`/`dnsmasq`/QEMU children inherit them across `exec`.
@@ -635,12 +653,13 @@ impl LocalBackend {
         // (`enp2s0`). `--port=0` disables DNS. `dnsmasq` daemonizes (writing its
         // pid-file) and is signalled via it in teardown.
         //
-        // `dnsmasq` runs unprivileged (the driver keeps
-        // its real, non-root uid — see `ensure_administrable_netns`), so it skips
+        // `dnsmasq` runs unprivileged: `ensure_administrable_netns` guarantees a
+        // non-zero uid inside the driver's user namespace (identity-mapped, or
+        // remapped away from `0` when the caller is fake-root), so `dnsmasq` skips
         // its privilege-drop path entirely, which is what we want. That path is
-        // taken only when started as root and would otherwise `setgroups(2)` —
-        // denied in the driver's user namespace — and drop to a user/group id
-        // that is unmapped there.
+        // gated on `getuid() == 0` and would otherwise `setgroups(2)` — denied in
+        // the driver's user namespace — and drop to a user/group id that is
+        // unmapped there.
         let dnsmasq_path = get_dependency_path_from_env("ENV_DEPS__DNSMASQ_PATH");
         let dnsmasq_script = format!(
             "exec {dnsmasq_path:?} \


### PR DESCRIPTION
## Problem

Under Namespace's RBE sandbox (`--remote_default_exec_properties=namespace_action_isolation=sandboxed`) the `LocalBackend::create_group` step fails while starting the group's `dnsmasq` RA daemon:

```
dnsmasq: failed to change group-id to dip: Operation not permitted
```

The local backend relies on `dnsmasq` staying **unprivileged** so it skips its privilege-drop path. That path is gated purely on `getuid() == 0`, and when taken it fails inside the driver's nested user namespace: `setgroups` is denied (mandatory before an unprivileged `gid_map` write) and the default `dip` gid is unmapped.

This invariant held because `ensure_administrable_netns` identity-maps the caller's uid and the action historically ran as an ordinary (non-root) user. The Namespace sandbox runs actions as **uid 0** in its own user namespace, so the identity map makes the driver root inside its namespace too — flipping `dnsmasq` into the drop path.

## Fix

Map a (fake-)root caller to a **non-zero** inner uid/gid instead of identity-mapping `0 → 0`, so `getuid()` is never `0` inside the driver's namespace and `dnsmasq` (and any other root-sensitive child) skips its privilege-drop path — restoring the invariant the code already documents. The map's *outer* id is still the caller's real uid, so on-disk ownership, `/dev/kvm` and `/dev/net/tun` access are unchanged. A single-line self-map is always permitted, so it is robust to whatever uid the RBE backend uses.

No fix is required on the Namespace side; running sandboxed actions as fake-root is a legitimate sandbox design and this change makes the backend robust to it.

## Testing

This has been successfully tested on https://github.com/dfinity/ic/pull/10579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)