### PR TITLE
fix(system-tests): pin rent_subnet_test to the Farm backend

### DIFF
--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -264,8 +264,8 @@ system_test(
     # + 1 unassigned), demanding ~51 vCPUs and ~328 GiB of RAM. That fits on
     # DFINITY's local-backend runners (64 CPUs, plenty of RAM) but not on a
     # Namespace Bazel Execution Worker (16 CPUs, 32 GiB), where the host thrashes
-    # and nodes never become reachable. Pin this test to the Farm backend, where
-    # each VM runs on its own host.
+    # and nodes never become reachable. Pin this test to the Farm backend, where VMs
+    # are provisioned by the Farm cluster instead of being booted on the Bazel worker.
     backend = "farm",
     cpus = MIN_LOCAL_CPUS + 32 * 1 + 3 * DEFAULT_VCPUS_PER_VM,  # 32 App IC Node VMs with 1 vCPU override + 1 System + 1 fast System + 1 unassigned IC Node VMs * 6 vCPUs.
     tags = [

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -259,6 +259,14 @@ system_test(
 
 system_test(
     name = "rent_subnet_test",
+    # Too big for the "local" backend under Namespace remote execution: this test
+    # boots 36 VMs on a single host (32 App IC Node VMs + 1 System + 1 fast System
+    # + 1 unassigned), demanding ~51 vCPUs and ~328 GiB of RAM. That fits on
+    # DFINITY's local-backend runners (64 CPUs, plenty of RAM) but not on a
+    # Namespace Bazel Execution Worker (16 CPUs, 32 GiB), where the host thrashes
+    # and nodes never become reachable. Pin this test to the Farm backend, where
+    # each VM runs on its own host.
+    backend = "farm",
     cpus = MIN_LOCAL_CPUS + 32 * 1 + 3 * DEFAULT_VCPUS_PER_VM,  # 32 App IC Node VMs with 1 vCPU override + 1 System + 1 fast System + 1 unassigned IC Node VMs * 6 vCPUs.
     tags = [
         "long_test",  # The test takes over 10 minutes so let's not run it on PRs by default.


### PR DESCRIPTION
## Why

`rent_subnet_test` boots a **36-VM** testnet on a single host — 32 App IC Node VMs (the canister-ID-range hack) + 1 System + 1 fast System + 1 unassigned — demanding **~51 vCPUs and ~328 GiB of RAM**.

That fits DFINITY's local-backend runners (**64 CPUs**, plenty of RAM) but massively overcommits a Namespace Bazel Execution Worker (**16 CPUs, 32 GiB**). Under Namespace remote execution (see #10579) the host thrashes and the awaited System-subnet node never becomes reachable, so `setup` times out after ~503s with:

```
await_status_is_healthy ... timed out after 503.2s on attempt 62.
Last error: error sending request ... No route to host (os error 113)
```

Unlike the sibling per-VM memory caps (e.g. `unstuck_subnet_test`), **no memory cap rescues this test**: 32 of the VMs are full replica VMs, and the declared 51 vCPUs alone exceed the worker's 16.

## What

Pin the test to the Farm backend, where each VM runs on its own host. This marks the `_local` variant `manual`, dropping it from the `//rs/tests/...` wildcard on Namespace RBE while the Farm variant keeps running as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)