### PR TITLE
fix(system-tests): cap unstuck_subnet_test per-VM memory on local backend

### DIFF
--- a/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
+++ b/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
@@ -28,9 +28,10 @@ use ic_consensus_system_test_utils::{
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::{
-    ic::{InternetComputer, Subnet},
+    ic::{AmountOfMemoryKiB, InternetComputer, Subnet, VmResourceOverrides},
     test_env::TestEnv,
     test_env_api::*,
+    test_setup::SystemTestBackend,
 };
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::{JournalStreamer, block_on};
@@ -41,14 +42,32 @@ const DKG_INTERVAL: u64 = 9;
 const SUBNET_SIZE: usize = 4;
 const NUM_READ_RETRIES: usize = 10;
 
+// Per-VM memory used on the local backend. There all VMs run on a single host,
+// so the Farm default of 24 GiB per VM would let the 4 System VMs collectively
+// exceed the host's RAM. Under Namespace remote execution the host is an even
+// smaller RBE worker, so the VMs thrash and freeze while the orchestrator
+// unpacks and writes the ~579 MiB update image to disk during the upgrade. The
+// frozen nodes never rejoin, so the test times out waiting for them to report
+// the new version. 4 GiB per VM keeps all 4 VMs comfortably within the host's
+// RAM (matching the sibling `upgrade_downgrade_*_subnet_test`s).
+const LOCAL_BACKEND_VM_MEMORY: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024);
+
 fn config(env: TestEnv) {
-    InternetComputer::new()
-        .add_subnet(
-            Subnet::new(SubnetType::System)
-                .add_nodes(SUBNET_SIZE)
-                .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
-        )
-        .setup_and_start(&env)
+    let mut ic = InternetComputer::new().add_subnet(
+        Subnet::new(SubnetType::System)
+            .add_nodes(SUBNET_SIZE)
+            .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
+    );
+    // On the local backend, cap the per-VM memory so all VMs fit within the
+    // single host's RAM (see `LOCAL_BACKEND_VM_MEMORY`). On Farm, keep the
+    // generous default.
+    if SystemTestBackend::from_env() == SystemTestBackend::Local {
+        ic = ic.with_resource_overrides(VmResourceOverrides {
+            memory_kibibytes: Some(LOCAL_BACKEND_VM_MEMORY),
+            ..Default::default()
+        });
+    }
+    ic.setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());


### PR DESCRIPTION
## Problem

`//rs/tests/consensus/orchestrator:unstuck_subnet_test_local` consistently times out under Remote Build Execution @ Namespace (experiment in #10579), failing its 600s `test` task with `Timeout after 600s`.

Root cause is host **memory exhaustion**, not a per-node bug:

- Each VM boots with the Farm default of **24 GiB** (`DEFAULT_MEMORY_KIB_PER_VM`), so this 4-node System subnet demands **~96 GiB**.
- On the local backend all VMs share a single host. Under Namespace RBE that host is a much smaller worker (the Namespace Bazel Execution Worker is `…-16x32` = 32 GB), and Namespace has **no per-action memory reservation** — the `_local` action only forwards `exec_properties = {"cpu": …}`.
- During the upgrade, the orchestrator unpacks and writes the ~579 MiB update image to disk on all three restarted nodes at once. In the failing run, **two of the three restarted VMs froze within one second of each other** (console heartbeats stopped at 12:30:14 and 12:30:15) and never rebooted. The retry loop waiting for them to report the new version then ran to the 600s task timeout.

On DFINITY's bare-metal runners the test passed only because those hosts have abundant RAM.

## Fix

Cap per-VM memory to **4 GiB** on the local backend (4×4 = 16 GiB fits), keeping the generous Farm default untouched. This mirrors the existing `LOCAL_BACKEND_VM_MEMORY` pattern already used by the sibling `upgrade_downgrade_{app,nns}_subnet_test` and `consensus/backup` tests, whose comments describe the same local-backend thrash-and-starve failure mode.

## Testing

- Successfully tested on https://github.com/dfinity/ic/pull/10579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)