### PR TITLE
test(nns): Drastically reduce the resource requirements of rent_subnet_test

### DIFF
--- a/rs/nns/test_utils/src/itest_helpers.rs
+++ b/rs/nns/test_utils/src/itest_helpers.rs
@@ -510,41 +510,19 @@ pub async fn install_rust_canister_from_path<P: AsRef<Path>>(
     .await
 }
 
-/// Runtime must be built from a node belonging to a subnet that can host
-/// EXCHANGE_RATE_CANISTER_ID.
-///
-/// Warning: This assumes that canisters with ID smaller than that of the
-/// Exchange Rate canister have all already been created.
+/// Runtime must be built from a node belonging to a subnet that hosts
+/// EXCHANGE_RATE_CANISTER_ID and supports creating canisters at specified IDs
+/// in the canister ID range containing it. In system tests, such a subnet can
+/// be obtained with `InternetComputer::use_specified_ids_allocation_range`.
 pub async fn create_and_install_mock_exchange_rate_canister(
     runtime: &'_ Runtime,
     price_of_icp_in_xdr_cents: u64,
 ) {
-    // Step 1: Create the canister.
-
-    // Create canisters in a loop until we hit EXCHANGE_RATE_CANISTER_ID. Yes,
-    // this is a hack. You might think that
-    // runtime.create_canister_with_specified_id(...) would get the desired
-    // effect (more straightforwardly), but trying to create an Exchange Rate
-    // canister that way results in
-    //
-    //     The `specified_id` uf6dk-hyaaa-aaaaq-qaaaq-cai is invalid because it belongs to the canister allocation ranges of the test environment.
-    //
-    // This is because of the way that the routing table is set up in system
-    // tests. If we wanted to get rid of this hack, we would have to change how
-    // the routing table is set up in system tests:
-    // https://github.com/dfinity/ic/pull/6053#discussion_r2329340517
-    //
-    // The "Warning" in the triple slash comments of this function is because of
-    // this hack.
-    let mut found = false;
-    for _ in 0..100 {
-        let canister = runtime.create_canister(Some(0)).await.unwrap();
-        if canister.canister_id() == EXCHANGE_RATE_CANISTER_ID {
-            found = true;
-            break;
-        }
-    }
-    assert!(found);
+    // Step 1: Create the canister at its usual (mainnet) canister ID.
+    runtime
+        .create_canister_at_id_max_cycles_with_retries(EXCHANGE_RATE_CANISTER_ID.get())
+        .await
+        .unwrap();
 
     // Step 2: Install code into the canister.
 
@@ -587,9 +565,13 @@ pub async fn create_and_install_mock_exchange_rate_canister(
 /// Warning: This assumes that canisters with ID smaller than that of the
 /// Subnet Rental canister have all already been created.
 pub async fn create_and_install_mock_subnet_rental_canister(runtime: &'_ Runtime) -> Canister<'_> {
-    // Create canisters in a loop until we hit SUBNET_RENTAL_CANISTER_ID.
-    // This is a hack similar to the one in `create_and_install_mock_exchange_rate_canister`.
-    // See the comment there for more details.
+    // Create canisters in a loop until we hit SUBNET_RENTAL_CANISTER_ID. Yes,
+    // this is a hack. You might think that
+    // runtime.create_canister_with_specified_id(...) would get the desired
+    // effect (more straightforwardly), but the Subnet Rental canister ID
+    // belongs to the canister allocation range of the (root) subnet in test
+    // environments, and creating a canister at a specified ID within a
+    // canister allocation range is not allowed.
     for _ in 0..100 {
         let mut canister = runtime.create_canister(Some(0)).await.unwrap();
         if canister.canister_id() == SUBNET_RENTAL_CANISTER_ID {

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -259,7 +259,7 @@ system_test(
 
 system_test(
     name = "rent_subnet_test",
-    cpus = MIN_LOCAL_CPUS + 32 * 1 + 3 * DEFAULT_VCPUS_PER_VM,  # 32 App IC Node VMs with 1 vCPU override + 1 System + 1 fast System + 1 unassigned IC Node VMs * 6 vCPUs.
+    cpus = MIN_LOCAL_CPUS + 3 * DEFAULT_VCPUS_PER_VM,  # 1 System + 1 fast System + 1 unassigned IC Node VMs * 6 vCPUs.
     tags = [
         "long_test",  # The test takes over 10 minutes so let's not run it on PRs by default.
     ],

--- a/rs/tests/nns/rent_subnet_test.rs
+++ b/rs/tests/nns/rent_subnet_test.rs
@@ -156,10 +156,7 @@ pub fn setup(env: TestEnv) {
         // all mainnet canister IDs (where canisters can be created at
         // specified IDs), and a disjoint one for the allocation of new
         // canister IDs. Without this, no canister ID range in the test
-        // environment would contain the usual Exchange Rate canister ID, and
-        // we would have to pad the routing table by creating 32 bogus
-        // single-node Application subnets to make a system subnet end up with
-        // the canister ID range containing that ID.
+        // environment would contain the usual Exchange Rate canister ID.
         .use_specified_ids_allocation_range()
         .with_unassigned_nodes(1)
         .setup_and_start(&env)
@@ -571,11 +568,10 @@ fn install_nns_canisters(env: &TestEnv) {
         nns_node.node_id
     );
 
-    // at_ids is needed because, with use_specified_ids_allocation_range (see
-    // setup), new canister IDs on the root subnet are no longer allocated
-    // sequentially starting from 0; instead, the NNS canisters must be
-    // explicitly created at their usual canister IDs.
     let mut installer = NnsInstallationBuilder::new()
+        // This causes NNS canisters to be created with their well-known
+        // production IDs. In order for this to work,
+        // use_specified_ids_allocation_range must also be used.
         .at_ids()
         .with_subnet_rental_canister()
         .with_exchange_rate_canister();

--- a/rs/tests/nns/rent_subnet_test.rs
+++ b/rs/tests/nns/rent_subnet_test.rs
@@ -46,7 +46,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
         group::SystemTestGroup,
-        ic::{AmountOfMemoryKiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides},
+        ic::{InternetComputer, Subnet},
         test_env::TestEnv,
         test_env_api::{
             HasPublicApiUrl, HasRegistryVersion, HasTopologySnapshot, IcNodeContainer,
@@ -132,38 +132,36 @@ fn main() -> Result<()> {
 }
 
 pub fn setup(env: TestEnv) {
-    let mut ic = InternetComputer::new();
-
-    // This hack is needed so that we can install a (mock) Exchange Rate
-    // canister at its usual canister ID. This hack is copied from
-    // rs/tests/testnets/src_testing.rs. What this does is ensure that there is
-    // a system subnet that is assigned a canister ID range containing the usual
-    // Exchange Rate canister ID (uf6dk-hyaaa-aaaaq-qaaaq-cai).
-    for _ in 0..32 {
-        ic = ic.add_subnet(
-            Subnet::new(SubnetType::Application)
-                .with_resource_overrides(VmResourceOverrides {
-                    vcpus: Some(NrOfVCPUs::new(1)),
-                    memory_kibibytes: Some(AmountOfMemoryKiB::new(8_389_000)),
-                    ..VmResourceOverrides::default()
+    InternetComputer::new()
+        // The first subnet becomes the root (NNS) subnet. Because of
+        // use_specified_ids_allocation_range below, it is also assigned the
+        // canister ID range that covers all mainnet canister IDs. This allows
+        // us to later install the (mock) Exchange Rate canister at its usual
+        // mainnet canister ID (uf6dk-hyaaa-aaaaq-qaaaq-cai) on this subnet.
+        .add_subnet(
+            Subnet::new(SubnetType::System)
+                .with_features(SubnetFeatures {
+                    http_requests: true,
+                    ..SubnetFeatures::default()
                 })
                 .add_nodes(1),
-        );
-    }
-    ic = ic.add_subnet(
-        Subnet::new(SubnetType::System)
-            .with_features(SubnetFeatures {
-                http_requests: true,
-                ..SubnetFeatures::default()
-            })
-            .add_nodes(1),
-    );
-    ic = ic.add_subnet(Subnet::fast(
-        SubnetType::System,
-        1, // Node count.
-    ));
-
-    ic.with_unassigned_nodes(1)
+        )
+        // A second system subnet, used as the initial DKG subnet when the
+        // rented subnet gets created.
+        .add_subnet(Subnet::fast(
+            SubnetType::System,
+            1, // Node count.
+        ))
+        // Assign the first subnet a pair of canister ID ranges: one covering
+        // all mainnet canister IDs (where canisters can be created at
+        // specified IDs), and a disjoint one for the allocation of new
+        // canister IDs. Without this, no canister ID range in the test
+        // environment would contain the usual Exchange Rate canister ID, and
+        // we would have to pad the routing table by creating 32 bogus
+        // single-node Application subnets to make a system subnet end up with
+        // the canister ID range containing that ID.
+        .use_specified_ids_allocation_range()
+        .with_unassigned_nodes(1)
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
@@ -573,7 +571,12 @@ fn install_nns_canisters(env: &TestEnv) {
         nns_node.node_id
     );
 
+    // at_ids is needed because, with use_specified_ids_allocation_range (see
+    // setup), new canister IDs on the root subnet are no longer allocated
+    // sequentially starting from 0; instead, the NNS canisters must be
+    // explicitly created at their usual canister IDs.
     let mut installer = NnsInstallationBuilder::new()
+        .at_ids()
         .with_subnet_rental_canister()
         .with_exchange_rate_canister();
 


### PR DESCRIPTION
# Motivation

Previously, a very resource-intensive hack was used in order to create a mock Exchange Rate canister at its usual production ID in `rent_subnet_test`.

The hack was to create 32 filler subnets, which requires 328 GiB of RAM (!).

# Changes

To achieve that requirement, we now simply use `use_specified_ids_allocation_range` and `at_ids`. The test's topology thereby shrinks from 35 node VMs (328 GiB of RAM) to 3 (72 GiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)