### PR TITLE
chore: Make HTTP context's cost schedule mandatory and start using it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7970,6 +7970,7 @@ dependencies = [
  "ic-test-utilities-time",
  "ic-test-utilities-types",
  "ic-types",
+ "ic-types-cycles",
  "prometheus",
  "rand 0.8.6",
  "slog",

--- a/rs/consensus/utils/BUILD.bazel
+++ b/rs/consensus/utils/BUILD.bazel
@@ -57,6 +57,7 @@ rust_test(
         "//rs/test_utilities/state",
         "//rs/test_utilities/time",
         "//rs/test_utilities/types",
+        "//rs/types/cycles",
         "//rs/types/management_canister_types",
         "//rs/types/types",
         "@crate_index//:assert_matches",

--- a/rs/consensus/utils/Cargo.toml
+++ b/rs/consensus/utils/Cargo.toml
@@ -30,3 +30,4 @@ ic-test-utilities-registry = { path = "../../test_utilities/registry" }
 ic-test-utilities-state = { path = "../../test_utilities/state" }
 ic-test-utilities-time = { path = "../../test_utilities/time" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
+ic-types-cycles = { path = "../../types/cycles" }

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -511,6 +511,7 @@ mod tests {
         signature::ThresholdSignatureShare,
         time::UNIX_EPOCH,
     };
+    use ic_types_cycles::CanisterCyclesCostSchedule;
 
     /// Test that two shares with the same content are grouped together, and
     /// that a different share is grouped by itself
@@ -739,7 +740,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version,
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         }
     }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -741,7 +741,7 @@ impl ExecutionEnvironment {
                                 "Canister Http request with payload_size {}, max_response_size {}, subnet_size {}, reply_callback_id {}, sender {}, process_id {}",
                                 response.payload_size_bytes().get(),
                                 max_response_size,
-                                registry_settings.subnet_size,
+                                context.subnet_size.get(),
                                 context.request.sender_reply_callback,
                                 context.request.sender,
                                 std::process::id(),

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -137,12 +137,9 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                 id: request_id,
                 context: request_context,
                 socks_proxy_addrs,
-                cost_schedule,
-                subnet_size,
             } = canister_http_request;
 
-            let mut budget =
-                pricing_factory.new_tracker(&request_context, subnet_size, cost_schedule);
+            let mut budget = pricing_factory.new_tracker(&request_context);
             let request_size = request_context.variable_parts_size();
 
             let CanisterHttpRequestContext {
@@ -708,11 +705,9 @@ mod tests {
                 refund_status: RefundStatus::default(),
                 registry_version: RegistryVersion::from(1),
                 subnet_size: NumberOfNodes::from(13),
-                cost_schedule: None,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
             },
             socks_proxy_addrs: vec![],
-            cost_schedule: CanisterCyclesCostSchedule::Normal,
-            subnet_size: NumberOfNodes::from(13),
         }
     }
 

--- a/rs/https_outcalls/consensus/BUILD.bazel
+++ b/rs/https_outcalls/consensus/BUILD.bazel
@@ -113,6 +113,7 @@ rust_bench(
         "//rs/test_utilities/registry",
         "//rs/test_utilities/state",
         "//rs/test_utilities/types",
+        "//rs/types/cycles",
         "//rs/types/types",
         "@crate_index//:criterion",
     ],

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -41,6 +41,7 @@ use ic_types::{
     signature::BasicSignature,
     time::UNIX_EPOCH,
 };
+use ic_types_cycles::CanisterCyclesCostSchedule;
 
 /// Registry version that the whole benchmark operates at. The subnet record,
 /// the node signing keys and the responses' metadata all use this version.
@@ -490,7 +491,7 @@ fn request_context(replication: Replication) -> CanisterHttpRequestContext {
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
-        cost_schedule: None,
+        cost_schedule: CanisterCyclesCostSchedule::Normal,
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -486,12 +486,8 @@ impl CanisterHttpPayloadBuilderImpl {
 
             // Enforce the per-replica spend limit on every receipt in the proof.
             for sig in response.proof.signatures.values() {
-                utils::check_spent_within_limit(
-                    &sig.payment_receipt,
-                    request_context.refund_status.per_replica_allowance,
-                    request_context.cost_schedule,
-                )
-                .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
+                utils::check_spent_within_limit(&sig.payment_receipt, request_context)
+                    .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
             }
             // Reconstruct the per-signer shares from the response proof.
             reconstructed_shares.extend(
@@ -574,12 +570,8 @@ impl CanisterHttpPayloadBuilderImpl {
 
                 // Enforce the per-replica spend limit for divergence shares.
                 for share in grouped_shares.values().flatten() {
-                    utils::check_spent_within_limit(
-                        &share.content.payment_receipt,
-                        context.refund_status.per_replica_allowance,
-                        context.cost_schedule,
-                    )
-                    .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
+                    utils::check_spent_within_limit(&share.content.payment_receipt, context)
+                        .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
                 }
 
                 if !grouped_shares_meet_divergence_criteria(&grouped_shares, faults_tolerated) {
@@ -639,8 +631,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     callback_id,
                     flex_committee,
                     &mut seen_signers,
-                    context.refund_status.per_replica_allowance,
-                    context.cost_schedule,
+                    context,
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
@@ -707,8 +698,7 @@ impl CanisterHttpPayloadBuilderImpl {
                             callback_id,
                             flex_committee,
                             &mut seen_signers,
-                            context.refund_status.per_replica_allowance,
-                            context.cost_schedule,
+                            context,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
@@ -773,8 +763,7 @@ impl CanisterHttpPayloadBuilderImpl {
                             callback_id,
                             flex_committee,
                             &mut seen_signers,
-                            context.refund_status.per_replica_allowance,
-                            context.cost_schedule,
+                            context,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
                     }

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -384,8 +384,6 @@ impl CanisterHttpPayloadBuilderImpl {
             .metadata
             .subnet_call_context_manager
             .canister_http_request_contexts;
-        // TODO: Use cost schedule from the context instead, once it exists.
-        let cost_schedule = state.get_ref().get_own_cost_schedule();
 
         // Validate the timed out calls
         for timeout_id in &payload.timeouts {
@@ -491,7 +489,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 utils::check_spent_within_limit(
                     &sig.payment_receipt,
                     request_context.refund_status.per_replica_allowance,
-                    cost_schedule,
+                    request_context.cost_schedule,
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
             }
@@ -579,7 +577,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     utils::check_spent_within_limit(
                         &share.content.payment_receipt,
                         context.refund_status.per_replica_allowance,
-                        cost_schedule,
+                        context.cost_schedule,
                     )
                     .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
                 }
@@ -642,7 +640,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     flex_committee,
                     &mut seen_signers,
                     context.refund_status.per_replica_allowance,
-                    cost_schedule,
+                    context.cost_schedule,
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
@@ -710,7 +708,7 @@ impl CanisterHttpPayloadBuilderImpl {
                             flex_committee,
                             &mut seen_signers,
                             context.refund_status.per_replica_allowance,
-                            cost_schedule,
+                            context.cost_schedule,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
@@ -776,7 +774,7 @@ impl CanisterHttpPayloadBuilderImpl {
                             flex_committee,
                             &mut seen_signers,
                             context.refund_status.per_replica_allowance,
-                            cost_schedule,
+                            context.cost_schedule,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
                     }

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -31,8 +31,6 @@ use ic_management_canister_types_private::{
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_subnet_features::SubnetFeatures;
-use ic_replicated_state::metadata_state::SubnetTopology;
-use ic_replicated_state::metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting};
 use ic_test_utilities::state_manager::RefMockStateManager;
 use ic_test_utilities_consensus::fake::FakeContentSigner;
 use ic_test_utilities_registry::SubnetRecordBuilder;
@@ -875,7 +873,7 @@ fn non_replicated_request_response_coming_in_gossip_payload_created() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Insert the context in the replicated state
@@ -949,7 +947,7 @@ fn non_replicated_request_with_extra_share_includes_only_delegated_share() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Insert the context in the replicated state
@@ -1024,7 +1022,7 @@ fn non_replicated_share_is_ignored_if_content_is_missing() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         inject_request_contexts(&mut payload_builder, [(callback_id, request_context)]);
@@ -1077,7 +1075,7 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1332,7 +1330,7 @@ fn validate_payload_fails_for_non_replicated_response_with_wrong_signer() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Inject this context into the state reader.
@@ -1403,7 +1401,7 @@ fn validate_payload_fails_for_response_with_no_signatures() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1481,7 +1479,7 @@ fn validate_payload_fails_when_non_replicated_proof_is_for_fully_replicated_requ
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // Inject this context into the state reader.
@@ -1560,7 +1558,7 @@ fn validate_payload_fails_for_duplicate_non_replicated_response() {
             refund_status: ic_types::canister_http::RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         // 2. Inject this context into the state reader
@@ -4722,36 +4720,25 @@ pub(crate) fn inject_request_contexts(
     inject_request_contexts_with_cost_schedule(payload_builder, contexts, None);
 }
 
-/// Like [`inject_request_contexts`], but also pins the validating replica's own
-/// subnet cost schedule. When `cost_schedule` is `Some`, the state's own subnet
-/// topology is set to it, so `get_own_cost_schedule()` returns that value during
-/// validation; when `None`, the default (`Normal`) is left in place.
+/// Like [`inject_request_contexts`], but also overrides the cost schedule pinned
+/// in each injected request context. When `cost_schedule` is `Some`, every
+/// context's `cost_schedule` is set to that value (the single source of truth
+/// used during validation); when `None`, the contexts are left unchanged.
 pub(crate) fn inject_request_contexts_with_cost_schedule(
     payload_builder: &mut CanisterHttpPayloadBuilderImpl,
     contexts: impl IntoIterator<Item = (CallbackId, CanisterHttpRequestContext)>,
     cost_schedule: Option<CanisterCyclesCostSchedule>,
 ) {
     let mut init_state = ic_test_utilities_state::get_initial_state(0, 0);
-    for (cb, ctx) in contexts {
+    for (cb, mut ctx) in contexts {
+        if let Some(cost_schedule) = cost_schedule {
+            ctx.cost_schedule = cost_schedule;
+        }
         init_state
             .metadata
             .subnet_call_context_manager
             .canister_http_request_contexts
             .insert(cb, ctx);
-    }
-    if let Some(cost_schedule) = cost_schedule {
-        let own_subnet_id = init_state.metadata.own_subnet_id;
-        init_state
-            .metadata
-            .modify_network_topology(|network_topology| {
-                network_topology.subnets_mut().insert(
-                    own_subnet_id,
-                    SubnetTopology {
-                        cost_schedule,
-                        ..Default::default()
-                    },
-                );
-            });
     }
     let state_manager = Arc::new(RefMockStateManager::default());
     state_manager
@@ -4792,7 +4779,7 @@ pub(crate) fn request_context(replication: Replication) -> CanisterHttpRequestCo
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
-        cost_schedule: None,
+        cost_schedule: CanisterCyclesCostSchedule::Normal,
     }
 }
 
@@ -4819,7 +4806,7 @@ fn flexible_request_context(
         refund_status: ic_types::canister_http::RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
-        cost_schedule: None,
+        cost_schedule: CanisterCyclesCostSchedule::Normal,
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -7,16 +7,15 @@ use ic_types::{
         FlexibleCanisterHttpResponses, MAX_CANISTER_HTTP_PAYLOAD_SIZE,
     },
     canister_http::{
-        CanisterHttpPaymentReceipt, CanisterHttpResponse, CanisterHttpResponseContent,
-        CanisterHttpResponseMetadata, CanisterHttpResponseProof, CanisterHttpResponseReceipt,
-        CanisterHttpResponseShare, CanisterHttpResponseSignature,
-        CanisterHttpResponseWithConsensus, max_http_outcall_spend,
+        CanisterHttpPaymentReceipt, CanisterHttpRequestContext, CanisterHttpResponse,
+        CanisterHttpResponseContent, CanisterHttpResponseMetadata, CanisterHttpResponseProof,
+        CanisterHttpResponseReceipt, CanisterHttpResponseShare, CanisterHttpResponseSignature,
+        CanisterHttpResponseWithConsensus,
     },
     crypto::{Signed, crypto_hash},
     messages::CallbackId,
     signature::{BasicSigBatchEntry, BasicSignature},
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     mem::size_of,
@@ -77,17 +76,16 @@ pub(crate) fn check_response_consistency(
 
 /// Enforces the per-replica spend limit from the request context: the amount
 /// the replica claims to have `spent` in the payment receipt must never exceed
-/// the maximum returned by [`max_http_outcall_spend`].
+/// the maximum returned by [`CanisterHttpRequestContext::max_http_outcall_spend`].
 ///
 /// On charging subnets this is the `per_replica_allowance`. Free subnets charge
 /// nothing, so their spend (used only for cost accounting) may exceed the (zero)
 /// allowance, but may never exceed [`MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`].
 pub(crate) fn check_spent_within_limit(
     receipt: &CanisterHttpPaymentReceipt,
-    per_replica_allowance: Cycles,
-    cost_schedule: CanisterCyclesCostSchedule,
+    context: &CanisterHttpRequestContext,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
-    let limit = max_http_outcall_spend(cost_schedule, per_replica_allowance);
+    let limit = context.max_http_outcall_spend();
     if receipt.spent > limit {
         return Err(InvalidCanisterHttpPayloadReason::SpentExceedsLimit {
             spent: receipt.spent,
@@ -155,8 +153,7 @@ pub(crate) fn validate_flexible_response_with_proof(
     callback_id: CallbackId,
     flex_committee: &BTreeSet<NodeId>,
     seen_signers: &mut HashSet<NodeId>,
-    per_replica_allowance: Cycles,
-    cost_schedule: CanisterCyclesCostSchedule,
+    context: &CanisterHttpRequestContext,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
     if response_with_proof.response.id != callback_id {
         return Err(
@@ -172,8 +169,7 @@ pub(crate) fn validate_flexible_response_with_proof(
         callback_id,
         flex_committee,
         seen_signers,
-        per_replica_allowance,
-        cost_schedule,
+        context,
     )?;
 
     let calculated_hash = crypto_hash(&response_with_proof.response);
@@ -216,14 +212,9 @@ pub(crate) fn validate_response_share(
     callback_id: CallbackId,
     flex_committee: &BTreeSet<NodeId>,
     seen_signers: &mut HashSet<NodeId>,
-    per_replica_allowance: Cycles,
-    cost_schedule: CanisterCyclesCostSchedule,
+    context: &CanisterHttpRequestContext,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
-    check_spent_within_limit(
-        &share.content.payment_receipt,
-        per_replica_allowance,
-        cost_schedule,
-    )?;
+    check_spent_within_limit(&share.content.payment_receipt, context)?;
 
     if share.content.id() != callback_id {
         return Err(
@@ -544,11 +535,56 @@ pub(crate) fn find_flexible_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ic_types::canister_http::MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET;
+    use ic_types::{
+        CanisterId, NumberOfNodes,
+        canister_http::{
+            CanisterHttpMethod, MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET, PricingVersion, RefundStatus,
+            Replication,
+        },
+        messages::{NO_DEADLINE, Request},
+        time::UNIX_EPOCH,
+    };
+    use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 
     fn receipt(spent: u128) -> CanisterHttpPaymentReceipt {
         CanisterHttpPaymentReceipt {
             spent: Cycles::new(spent),
+        }
+    }
+
+    /// Builds a minimal request context pinning the given cost schedule and
+    /// per-replica allowance — the only fields [`check_spent_within_limit`] reads.
+    fn context(
+        cost_schedule: CanisterCyclesCostSchedule,
+        per_replica_allowance: Cycles,
+    ) -> CanisterHttpRequestContext {
+        CanisterHttpRequestContext {
+            request: Request {
+                receiver: CanisterId::from_u64(1),
+                sender: CanisterId::from_u64(1),
+                sender_reply_callback: CallbackId::from(1),
+                payment: Cycles::zero(),
+                method_name: String::new(),
+                method_payload: Vec::new(),
+                metadata: Default::default(),
+                deadline: NO_DEADLINE,
+            },
+            url: String::new(),
+            max_response_bytes: None,
+            headers: vec![],
+            body: None,
+            http_method: CanisterHttpMethod::GET,
+            transform: None,
+            time: UNIX_EPOCH,
+            replication: Replication::FullyReplicated,
+            pricing_version: PricingVersion::Legacy,
+            refund_status: RefundStatus {
+                per_replica_allowance,
+                ..RefundStatus::default()
+            },
+            registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
+            cost_schedule,
         }
     }
 
@@ -557,8 +593,7 @@ mod tests {
         assert!(
             check_spent_within_limit(
                 &receipt(50),
-                Cycles::new(100),
-                CanisterCyclesCostSchedule::Normal,
+                &context(CanisterCyclesCostSchedule::Normal, Cycles::new(100)),
             )
             .is_ok()
         );
@@ -569,8 +604,7 @@ mod tests {
         assert!(matches!(
             check_spent_within_limit(
                 &receipt(101),
-                Cycles::new(100),
-                CanisterCyclesCostSchedule::Normal,
+                &context(CanisterCyclesCostSchedule::Normal, Cycles::new(100)),
             ),
             Err(InvalidCanisterHttpPayloadReason::SpentExceedsLimit { .. })
         ));
@@ -583,8 +617,7 @@ mod tests {
         assert!(matches!(
             check_spent_within_limit(
                 &receipt(1),
-                Cycles::zero(),
-                CanisterCyclesCostSchedule::Normal,
+                &context(CanisterCyclesCostSchedule::Normal, Cycles::zero()),
             ),
             Err(InvalidCanisterHttpPayloadReason::SpentExceedsLimit { .. })
         ));
@@ -598,8 +631,7 @@ mod tests {
         assert!(
             check_spent_within_limit(
                 &receipt(1_000_000),
-                Cycles::zero(),
-                CanisterCyclesCostSchedule::Free,
+                &context(CanisterCyclesCostSchedule::Free, Cycles::zero()),
             )
             .is_ok()
         );
@@ -611,8 +643,7 @@ mod tests {
         assert!(
             check_spent_within_limit(
                 &receipt(MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET.get()),
-                Cycles::zero(),
-                CanisterCyclesCostSchedule::Free,
+                &context(CanisterCyclesCostSchedule::Free, Cycles::zero()),
             )
             .is_ok()
         );
@@ -625,8 +656,7 @@ mod tests {
         assert!(matches!(
             check_spent_within_limit(
                 &receipt(MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET.get() + 1),
-                Cycles::zero(),
-                CanisterCyclesCostSchedule::Free,
+                &context(CanisterCyclesCostSchedule::Free, Cycles::zero()),
             ),
             Err(InvalidCanisterHttpPayloadReason::SpentExceedsLimit { .. })
         ));

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -16,17 +16,15 @@ use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::*;
 use ic_metrics::MetricsRegistry;
-use ic_protobuf::registry::subnet::v1::CanisterCyclesCostSchedule as CanisterCyclesCostScheduleProto;
 use ic_registry_client_helpers::api_boundary_node::ApiBoundaryNodeRegistry;
 use ic_registry_client_helpers::node::NodeRegistry;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    CountBytes, NodeId, NumBytes, NumberOfNodes, RegistryVersion, ReplicaVersion, canister_http::*,
-    crypto::Signed, messages::CallbackId, replica_config::ReplicaConfig,
+    CountBytes, NodeId, NumBytes, ReplicaVersion, canister_http::*, crypto::Signed,
+    messages::CallbackId, replica_config::ReplicaConfig,
 };
-use ic_types_cycles::CanisterCyclesCostSchedule;
 use std::{
     cell::RefCell,
     collections::{BTreeSet, HashSet},
@@ -246,26 +244,6 @@ impl CanisterHttpPoolManagerImpl {
             .collect::<Vec<String>>()
     }
 
-    /// Reads the subnet's pricing inputs (number of nodes and cycles cost
-    /// schedule) from the registry at `registry_version`. Returns `None` if
-    /// they cannot be determined.
-    fn pricing_inputs(
-        &self,
-        registry_version: RegistryVersion,
-    ) -> Option<(NumberOfNodes, CanisterCyclesCostSchedule)> {
-        let record = self
-            .registry_client
-            .get_subnet_record(self.replica_config.subnet_id, registry_version)
-            .ok()
-            .flatten()?;
-        let subnet_size = u32::try_from(record.membership.len()).ok()?;
-        let cost_schedule =
-            CanisterCyclesCostScheduleProto::try_from(record.canister_cycles_cost_schedule)
-                .ok()
-                .map(CanisterCyclesCostSchedule::from)?;
-        Some((NumberOfNodes::from(subnet_size), cost_schedule))
-    }
-
     /// Returns whether `node_id` belongs to the committee responsible for the
     /// given request, evaluated at the registry version pinned in the request
     /// context.
@@ -346,20 +324,6 @@ impl CanisterHttpPoolManagerImpl {
             }
 
             if !request_ids_already_made.contains(id) {
-                let Some((subnet_size, cost_schedule)) =
-                    self.pricing_inputs(context.registry_version)
-                else {
-                    warn!(
-                        every_n_seconds => 10,
-                        self.log,
-                        "Skipping canister http request {} because the subnet size or cost \
-                         schedule could not be determined at registry version {}",
-                        id,
-                        context.registry_version
-                    );
-                    continue;
-                };
-
                 if let Err(err) = self
                     .http_adapter_shim
                     .lock()
@@ -368,8 +332,6 @@ impl CanisterHttpPoolManagerImpl {
                         id: *id,
                         context: context.clone(),
                         socks_proxy_addrs: socks_proxy_addrs.clone(),
-                        cost_schedule,
-                        subnet_size,
                     })
                 {
                     warn!(
@@ -488,8 +450,6 @@ impl CanisterHttpPoolManagerImpl {
             .metadata
             .subnet_call_context_manager
             .canister_http_request_contexts;
-        // TODO: Use cost schedule from the context instead, once it exists.
-        let cost_schedule = state.get_own_cost_schedule();
         let next_callback_id = self.next_callback_id();
 
         let key_from_share =
@@ -527,7 +487,7 @@ impl CanisterHttpPoolManagerImpl {
                 // nothing, so their spend (used only for cost accounting) may
                 // exceed the zero allowance, up to `MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`.
                 let spend_limit = max_http_outcall_spend(
-                    cost_schedule,
+                    context.cost_schedule,
                     context.refund_status.per_replica_allowance,
                 );
                 if share.content.spent() > spend_limit {
@@ -714,22 +674,18 @@ pub mod test {
     use ic_protobuf::registry::api_boundary_node::v1::ApiBoundaryNodeRecord;
     use ic_protobuf::registry::node::v1::{ConnectionEndpoint, NodeRecord};
     use ic_registry_keys::{make_api_boundary_node_record_key, make_node_record_key};
-    use ic_replicated_state::metadata_state::SubnetTopology;
     use ic_replicated_state::metadata_state::subnet_call_context_manager::SubnetCallContext;
-    use ic_replicated_state::metadata_state::testing::{
-        NetworkTopologyTesting, SystemMetadataTesting,
-    };
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::CountBytes;
     use ic_types::crypto::crypto_hash;
     use ic_types::{
-        Height, NodeId, NumBytes, RegistryVersion,
+        Height, NodeId, NumBytes, NumberOfNodes, RegistryVersion,
         crypto::{CryptoHash, CryptoHashOf},
         messages::CallbackId,
         time::UNIX_EPOCH,
     };
-    use ic_types_cycles::Cycles;
+    use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
     use mockall::predicate::*;
     use mockall::*;
     use std::{collections::BTreeMap, str::FromStr};
@@ -795,7 +751,7 @@ pub mod test {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         }
     }
 
@@ -2523,8 +2479,6 @@ pub mod test {
                         id: CallbackId::from(7),
                         context: request.clone(),
                         socks_proxy_addrs: vec![],
-                        cost_schedule: CanisterCyclesCostSchedule::Normal,
-                        subnet_size: NumberOfNodes::from(4),
                     }))
                     .times(1)
                     .return_const(Ok(()));
@@ -3350,7 +3304,9 @@ pub mod test {
 
                 // A free subnet grants a zero per-replica allowance (nothing is
                 // charged), yet the reported spend is still accumulated for cost
-                // accounting and may exceed that allowance.
+                // accounting and may exceed that allowance. The `Free` cost
+                // schedule is pinned in the request context, raising the spend
+                // limit to `MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`.
                 let request = CanisterHttpRequestContext {
                     refund_status: RefundStatus {
                         refundable_cycles: Cycles::new(0),
@@ -3358,6 +3314,7 @@ pub mod test {
                         refunded_cycles: Cycles::new(0),
                         refunding_nodes: BTreeSet::new(),
                     },
+                    cost_schedule: CanisterCyclesCostSchedule::Free,
                     ..test_request_context(
                         Replication::FullyReplicated,
                         PricingVersion::Legacy,
@@ -3365,21 +3322,8 @@ pub mod test {
                     )
                 };
 
-                // Put the validating replica's own subnet on a `Free` cost
-                // schedule so `get_own_cost_schedule()` returns `Free`, raising
-                // the spend limit to `MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`.
-                let mut state =
+                let state =
                     state_with_pending_http_calls(BTreeMap::from([(CallbackId::from(0), request)]));
-                let own_subnet_id = state.metadata.own_subnet_id;
-                state.metadata.modify_network_topology(|network_topology| {
-                    network_topology.subnets_mut().insert(
-                        own_subnet_id,
-                        SubnetTopology {
-                            cost_schedule: CanisterCyclesCostSchedule::Free,
-                            ..Default::default()
-                        },
-                    );
-                });
 
                 state_manager
                     .get_mut()

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -486,10 +486,7 @@ impl CanisterHttpPoolManagerImpl {
                 // single replica is allowed to consume. Free subnets charge
                 // nothing, so their spend (used only for cost accounting) may
                 // exceed the zero allowance, up to `MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`.
-                let spend_limit = max_http_outcall_spend(
-                    context.cost_schedule,
-                    context.refund_status.per_replica_allowance,
-                );
+                let spend_limit = context.max_http_outcall_spend();
                 if share.content.spent() > spend_limit {
                     return Some(CanisterHttpChangeAction::HandleInvalid(
                         share.clone(),

--- a/rs/https_outcalls/pricing/src/dark_launch.rs
+++ b/rs/https_outcalls/pricing/src/dark_launch.rs
@@ -1,7 +1,7 @@
 use ic_logger::{ReplicaLogger, warn};
 use ic_types::{
     CanisterId, NumBytes, NumInstructions,
-    canister_http::{CanisterHttpPaymentReceipt, ReplicationKind},
+    canister_http::{CanisterHttpPaymentReceipt, CanisterHttpRequestContext, ReplicationKind},
 };
 
 use crate::{AdapterLimits, BudgetTracker, NetworkUsage, PricingError, metrics::PricingMetrics};
@@ -30,16 +30,15 @@ impl DarkLaunchTracker {
     pub fn new(
         real: Box<dyn BudgetTracker>,
         shadow: Box<dyn BudgetTracker>,
-        canister_id: CanisterId,
-        replication: ReplicationKind,
+        context: &CanisterHttpRequestContext,
         metrics: PricingMetrics,
         log: ReplicaLogger,
     ) -> Self {
         Self {
             real,
             shadow,
-            canister_id,
-            replication,
+            canister_id: context.request.sender,
+            replication: context.replication.kind(),
             metrics,
             log,
             error_reported: false,
@@ -122,7 +121,60 @@ mod tests {
     use super::*;
     use ic_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
+    use ic_types::{
+        NodeId, NumberOfNodes, PrincipalId, RegistryVersion,
+        canister_http::{
+            CanisterHttpMethod, CanisterHttpRequestContext, PricingVersion, RefundStatus,
+            Replication,
+        },
+        messages::{CallbackId, NO_DEADLINE, Request},
+        time::UNIX_EPOCH,
+    };
+    use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+    use std::collections::BTreeSet;
     use std::time::Duration;
+
+    fn flexible() -> Replication {
+        Replication::Flexible {
+            committee: BTreeSet::from([NodeId::from(PrincipalId::new_node_test_id(0))]),
+            min_responses: 1,
+            max_responses: 1,
+        }
+    }
+
+    fn non_replicated() -> Replication {
+        Replication::NonReplicated(NodeId::from(PrincipalId::new_node_test_id(0)))
+    }
+
+    /// Builds a minimal request context with the given `replication`. Only the
+    /// sender (canister id) and replication kind are read by `DarkLaunchTracker`.
+    fn context(replication: Replication) -> CanisterHttpRequestContext {
+        CanisterHttpRequestContext {
+            request: Request {
+                receiver: CanisterId::from_u64(7),
+                sender: CanisterId::from_u64(7),
+                sender_reply_callback: CallbackId::from(1),
+                payment: Cycles::zero(),
+                method_name: String::new(),
+                method_payload: Vec::new(),
+                metadata: Default::default(),
+                deadline: NO_DEADLINE,
+            },
+            url: String::new(),
+            max_response_bytes: None,
+            headers: vec![],
+            body: None,
+            http_method: CanisterHttpMethod::GET,
+            transform: None,
+            time: UNIX_EPOCH,
+            replication,
+            pricing_version: PricingVersion::Legacy,
+            refund_status: RefundStatus::default(),
+            registry_version: RegistryVersion::from(1),
+            subnet_size: NumberOfNodes::from(13),
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
+        }
+    }
 
     /// A [`BudgetTracker`] whose accounting steps return preconfigured results.
     struct FakeTracker {
@@ -168,14 +220,13 @@ mod tests {
     fn dark_launch(
         real: FakeTracker,
         shadow: FakeTracker,
-        replication: ReplicationKind,
+        replication: Replication,
         metrics: PricingMetrics,
     ) -> DarkLaunchTracker {
         DarkLaunchTracker::new(
             Box::new(real),
             Box::new(shadow),
-            CanisterId::from_u64(7),
-            replication,
+            &context(replication),
             metrics,
             no_op_logger(),
         )
@@ -211,7 +262,7 @@ mod tests {
         let mut tracker = dark_launch(
             FakeTracker::ok(),
             shadow,
-            ReplicationKind::FullyReplicated,
+            Replication::FullyReplicated,
             metrics.clone(),
         );
 
@@ -234,12 +285,7 @@ mod tests {
             transform: Err(PricingError::InsufficientCycles),
             transformed: Err(PricingError::InsufficientCycles),
         };
-        let mut tracker = dark_launch(
-            FakeTracker::ok(),
-            shadow,
-            ReplicationKind::Flexible,
-            metrics.clone(),
-        );
+        let mut tracker = dark_launch(FakeTracker::ok(), shadow, flexible(), metrics.clone());
 
         assert_eq!(tracker.subtract_network_usage(network_usage()), Ok(()));
         assert_eq!(
@@ -258,7 +304,7 @@ mod tests {
         let mut tracker = dark_launch(
             FakeTracker::ok(),
             FakeTracker::ok(),
-            ReplicationKind::FullyReplicated,
+            Replication::FullyReplicated,
             metrics.clone(),
         );
 
@@ -277,12 +323,7 @@ mod tests {
             network: Err(PricingError::InsufficientCycles),
             ..FakeTracker::ok()
         };
-        let mut tracker = dark_launch(
-            FakeTracker::ok(),
-            shadow,
-            ReplicationKind::NonReplicated,
-            metrics.clone(),
-        );
+        let mut tracker = dark_launch(FakeTracker::ok(), shadow, non_replicated(), metrics.clone());
 
         assert_eq!(tracker.subtract_network_usage(network_usage()), Ok(()));
 

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -1,7 +1,9 @@
 use ic_config::subnet_config::MAX_INSTRUCTIONS_PER_QUERY_MESSAGE;
 use ic_types::{
     NumBytes, NumInstructions,
-    canister_http::{CanisterHttpPaymentReceipt, MAX_CANISTER_HTTP_RESPONSE_BYTES},
+    canister_http::{
+        CanisterHttpPaymentReceipt, CanisterHttpRequestContext, MAX_CANISTER_HTTP_RESPONSE_BYTES,
+    },
 };
 
 use crate::{AdapterLimits, BudgetTracker, MAX_RESPONSE_TIME, NetworkUsage, PricingError};
@@ -11,9 +13,10 @@ pub struct LegacyTracker {
 }
 
 impl LegacyTracker {
-    pub fn new(max_response_bytes: Option<NumBytes>) -> Self {
+    pub fn new(context: &CanisterHttpRequestContext) -> Self {
         Self {
-            max_response_size: max_response_bytes
+            max_response_size: context
+                .max_response_bytes
                 .unwrap_or(NumBytes::from(MAX_CANISTER_HTTP_RESPONSE_BYTES)),
         }
     }

--- a/rs/https_outcalls/pricing/src/lib.rs
+++ b/rs/https_outcalls/pricing/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use ic_logger::ReplicaLogger;
 use ic_metrics::MetricsRegistry;
 use ic_types::{
-    NumBytes, NumInstructions, NumberOfNodes,
+    NumBytes, NumInstructions,
     canister_http::{CanisterHttpPaymentReceipt, CanisterHttpRequestContext, PricingVersion},
 };
 pub use ic_types_cycles::CanisterCyclesCostSchedule;
@@ -92,24 +92,16 @@ impl PricingFactory {
         }
     }
 
-    pub fn new_tracker(
-        &self,
-        context: &CanisterHttpRequestContext,
-        subnet_size: NumberOfNodes,
-        cost_schedule: CanisterCyclesCostSchedule,
-    ) -> Box<dyn BudgetTracker> {
+    pub fn new_tracker(&self, context: &CanisterHttpRequestContext) -> Box<dyn BudgetTracker> {
         match context.pricing_version {
             PricingVersion::Legacy => Box::new(DarkLaunchTracker::new(
-                Box::new(LegacyTracker::new(context.max_response_bytes)),
-                Box::new(PayAsYouGoTracker::new(context, subnet_size, cost_schedule)),
-                context.request.sender,
-                context.replication.kind(),
+                Box::new(LegacyTracker::new(context)),
+                Box::new(PayAsYouGoTracker::new(context)),
+                context,
                 self.metrics.clone(),
                 self.log.clone(),
             )),
-            PricingVersion::PayAsYouGo => {
-                Box::new(PayAsYouGoTracker::new(context, subnet_size, cost_schedule))
-            }
+            PricingVersion::PayAsYouGo => Box::new(PayAsYouGoTracker::new(context)),
         }
     }
 }

--- a/rs/https_outcalls/pricing/src/payg.rs
+++ b/rs/https_outcalls/pricing/src/payg.rs
@@ -53,20 +53,16 @@ pub struct PayAsYouGoTracker {
 }
 
 impl PayAsYouGoTracker {
-    pub fn new(
-        context: &CanisterHttpRequestContext,
-        subnet_size: NumberOfNodes,
-        cost_schedule: CanisterCyclesCostSchedule,
-    ) -> Self {
+    pub fn new(context: &CanisterHttpRequestContext) -> Self {
         Self {
-            subnet_size,
+            subnet_size: context.subnet_size,
             is_gossiping: match context.replication {
                 // Non-replicated outcalls gossip the response, so they are charged
                 // the same way as flexible outcalls.
                 Replication::Flexible { .. } | Replication::NonReplicated(_) => true,
                 Replication::FullyReplicated => false,
             },
-            is_free: match cost_schedule {
+            is_free: match context.cost_schedule {
                 CanisterCyclesCostSchedule::Free => true,
                 CanisterCyclesCostSchedule::Normal => false,
             },
@@ -205,7 +201,7 @@ mod tests {
             },
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         }
     }
 
@@ -220,29 +216,20 @@ mod tests {
         }
     }
 
-    /// Builds a tracker on a `Normal` cost schedule with the given subnet size.
-    fn make_tracker(ctx: &CanisterHttpRequestContext, subnet_size: u32) -> PayAsYouGoTracker {
-        PayAsYouGoTracker::new(
-            ctx,
-            NumberOfNodes::from(subnet_size),
-            CanisterCyclesCostSchedule::Normal,
-        )
-    }
-
     /// Asserts that a gossiping outcall (flexible or non-replicated) charges the
     /// gossip term over the full subnet size.
     fn assert_gossip_charged_over_subnet_size(replication: Replication) {
-        let subnet_size = 13_u32;
         let ctx = context(replication, 1_000_000_000);
-        let mut tracker = make_tracker(&ctx, subnet_size);
+        let mut tracker = PayAsYouGoTracker::new(&ctx);
 
         let transformed_size = 500_u64;
         assert_eq!(
             tracker.subtract_gossip_usage(NumBytes::from(transformed_size)),
             Ok(())
         );
-        let expected =
-            FLEXIBLE_PER_TRANSFORMED_BYTE_NODE_FEE * transformed_size as u128 * subnet_size as u128;
+        let expected = FLEXIBLE_PER_TRANSFORMED_BYTE_NODE_FEE
+            * transformed_size as u128
+            * ctx.subnet_size.get() as u128;
         assert_eq!(tracker.spent, expected);
     }
 
@@ -252,7 +239,7 @@ mod tests {
         // tracker has spent nothing and a zero-usage request records no spend
         // (the full allowance is refunded downstream).
         let ctx = context(Replication::FullyReplicated, 1_000_000);
-        let tracker = make_tracker(&ctx, 13);
+        let tracker = PayAsYouGoTracker::new(&ctx);
         assert_eq!(tracker.spent, 0);
         assert_eq!(tracker.create_payment_receipt().spent, Cycles::zero());
     }
@@ -261,7 +248,7 @@ mod tests {
     fn charges_per_replica_cost_fully_replicated() {
         let allowance = 1_000_000_000_u128;
         let ctx = context(Replication::FullyReplicated, allowance);
-        let mut tracker = make_tracker(&ctx, 13);
+        let mut tracker = PayAsYouGoTracker::new(&ctx);
 
         let response_size = 1_000_u64;
         let response_ms = 2_000_u128;
@@ -310,7 +297,7 @@ mod tests {
     fn returns_pricing_error_when_budget_is_exceeded() {
         let allowance = 100;
         let ctx = context(Replication::FullyReplicated, allowance);
-        let mut tracker = make_tracker(&ctx, 13);
+        let mut tracker = PayAsYouGoTracker::new(&ctx);
         assert_eq!(
             tracker.subtract_network_usage(NetworkUsage {
                 response_size: NumBytes::from(1_000),
@@ -337,12 +324,11 @@ mod tests {
         // A flexible request is used so the gossip term (not charged for
         // fully-replicated requests) is also exercised.
         let subnet_size = 13_u64;
-        let ctx = context(flexible(subnet_size as usize), 0);
-        let mut tracker = PayAsYouGoTracker::new(
-            &ctx,
-            NumberOfNodes::from(subnet_size as u32),
-            CanisterCyclesCostSchedule::Free,
-        );
+        let ctx = CanisterHttpRequestContext {
+            cost_schedule: CanisterCyclesCostSchedule::Free,
+            ..context(flexible(subnet_size as usize), 0)
+        };
+        let mut tracker = PayAsYouGoTracker::new(&ctx);
 
         let response_size = 1_000_000_u64;
         let response_ms = 30_000_u128;
@@ -389,12 +375,11 @@ mod tests {
         // allowance, the reported spend is never unbounded: it is capped at
         // `MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`.
         let subnet_size = 13_u64;
-        let ctx = context(flexible(subnet_size as usize), 0);
-        let mut tracker = PayAsYouGoTracker::new(
-            &ctx,
-            NumberOfNodes::from(subnet_size as u32),
-            CanisterCyclesCostSchedule::Free,
-        );
+        let ctx = CanisterHttpRequestContext {
+            cost_schedule: CanisterCyclesCostSchedule::Free,
+            ..context(flexible(subnet_size as usize), 0)
+        };
+        let mut tracker = PayAsYouGoTracker::new(&ctx);
 
         // A gossip term large enough to push the raw spend past the cap.
         assert_eq!(

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -118,8 +118,7 @@ use ic_types::messages::{
     CertificateDelegationFormat, CertificateDelegationMetadata, SignedSenderInfo,
 };
 use ic_types::{
-    CanisterId, Height, NumInstructions, NumberOfNodes, PrincipalId, RegistryVersion, SnapshotId,
-    SubnetId,
+    CanisterId, Height, NumInstructions, PrincipalId, RegistryVersion, SnapshotId, SubnetId,
     artifact::UnvalidatedArtifactMutation,
     canister_http::{
         CanisterHttpPaymentReceipt, CanisterHttpReject,
@@ -3809,8 +3808,6 @@ impl Operation for ProcessCanisterHttpInternal {
                     id,
                     context,
                     socks_proxy_addrs: vec![],
-                    cost_schedule: CanisterCyclesCostSchedule::Normal,
-                    subnet_size: NumberOfNodes::from(sm.nodes.len() as u32),
                 }) {
                     canister_http.pending.insert(id);
                 }
@@ -3985,8 +3982,6 @@ fn process_mock_canister_https_response(
                     id: canister_http_request_id,
                     context: context.clone(),
                     socks_proxy_addrs: vec![],
-                    cost_schedule: CanisterCyclesCostSchedule::Normal,
-                    subnet_size: NumberOfNodes::from(subnet.nodes.len() as u32),
                 })
                 .unwrap();
             let response = loop {

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -45,7 +45,7 @@ use ic_types::ingress::WasmResult;
 use ic_types::messages::{CallbackId, CanisterCall, Payload, Refund, Request, RequestMetadata};
 use ic_types::time::{CoarseTime, current_time};
 use ic_types::{ExecutionRound, Height, NumberOfNodes, RegistryVersion};
-use ic_types_cycles::{Cycles, NominalCyclesTesting};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles, NominalCyclesTesting};
 use lazy_static::lazy_static;
 use maplit::btreemap;
 use proptest::prelude::*;
@@ -879,7 +879,7 @@ fn subnet_call_contexts_deserialization() {
         refund_status: RefundStatus::default(),
         registry_version: RegistryVersion::from(1),
         subnet_size: NumberOfNodes::from(13),
-        cost_schedule: None,
+        cost_schedule: CanisterCyclesCostSchedule::Normal,
     };
     subnet_call_context_manager.push_context(SubnetCallContext::CanisterHttpRequest(
         canister_http_request,

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1121,21 +1121,21 @@ impl CountBytes for CanisterHttpPaymentReceipt {
 ///
 pub const MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET: Cycles = Cycles::new(1_000_000_000_000);
 
-/// Returns the maximum cycles a single replica may report having `spent` on an
-/// HTTP outcall, given the subnet's `cost_schedule` and the request's
-/// `per_replica_allowance`.
-///
-/// On a [`CanisterCyclesCostSchedule::Normal`] schedule this is the
-/// `per_replica_allowance` (a replica may never spend more than it was granted).
-/// On a [`CanisterCyclesCostSchedule::Free`] schedule nothing is charged, so the
-/// spend is instead bounded by [`MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`].
-pub fn max_http_outcall_spend(
-    cost_schedule: CanisterCyclesCostSchedule,
-    per_replica_allowance: Cycles,
-) -> Cycles {
-    match cost_schedule {
-        CanisterCyclesCostSchedule::Free => MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET,
-        CanisterCyclesCostSchedule::Normal => per_replica_allowance,
+impl CanisterHttpRequestContext {
+    /// Returns the maximum cycles a single replica may report having `spent` on
+    /// this outcall, derived from the cost schedule and per-replica allowance
+    /// pinned in the context.
+    ///
+    /// On a [`CanisterCyclesCostSchedule::Normal`] schedule this is the
+    /// `per_replica_allowance` (a replica may never spend more than it was
+    /// granted). On a [`CanisterCyclesCostSchedule::Free`] schedule nothing is
+    /// charged, so the spend is instead bounded by
+    /// [`MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`].
+    pub fn max_http_outcall_spend(&self) -> Cycles {
+        match self.cost_schedule {
+            CanisterCyclesCostSchedule::Free => MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET,
+            CanisterCyclesCostSchedule::Normal => self.refund_status.per_replica_allowance,
+        }
     }
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -146,7 +146,7 @@ pub struct CanisterHttpRequestContext {
     /// The subnet size at the registry version above.
     pub subnet_size: NumberOfNodes,
     /// The cycles cost schedule at the registry version above.
-    pub cost_schedule: Option<CanisterCyclesCostSchedule>,
+    pub cost_schedule: CanisterCyclesCostSchedule,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
@@ -310,12 +310,7 @@ impl From<&CanisterHttpRequestContext> for pb_metadata::CanisterHttpRequestConte
             refund_status: Some(refund_status),
             registry_version: context.registry_version.get(),
             subnet_size: context.subnet_size.get(),
-            cost_schedule: context
-                .cost_schedule
-                .map(|cost_schedule| {
-                    i32::from(CanisterCyclesCostScheduleProto::from(cost_schedule))
-                })
-                .unwrap_or_default(),
+            cost_schedule: i32::from(CanisterCyclesCostScheduleProto::from(context.cost_schedule)),
         }
     }
 }
@@ -442,16 +437,16 @@ impl TryFrom<pb_metadata::CanisterHttpRequestContext> for CanisterHttpRequestCon
             refund_status,
             registry_version: RegistryVersion::from(context.registry_version),
             subnet_size: NumberOfNodes::from(context.subnet_size),
-            cost_schedule: match CanisterCyclesCostScheduleProto::try_from(context.cost_schedule)
-                .map_err(|err| ProxyDecodeError::ValueOutOfRange {
-                    typ: "CanisterCyclesCostSchedule",
-                    err: format!(
-                        "Failed to convert CanisterCyclesCostSchedule for CanisterHttpRequestContext: {err:?}"
-                    ),
-                })? {
-                CanisterCyclesCostScheduleProto::Unspecified => None,
-                cost_schedule => Some(CanisterCyclesCostSchedule::from(cost_schedule)),
-            },
+            cost_schedule: CanisterCyclesCostSchedule::from(
+                CanisterCyclesCostScheduleProto::try_from(context.cost_schedule).map_err(|err| {
+                    ProxyDecodeError::ValueOutOfRange {
+                        typ: "CanisterCyclesCostSchedule",
+                        err: format!(
+                            "Failed to convert CanisterCyclesCostSchedule for CanisterHttpRequestContext: {err:?}"
+                        ),
+                    }
+                })?,
+            ),
         })
     }
 }
@@ -645,7 +640,7 @@ impl CanisterHttpRequestContext {
             refund_status: RefundStatus::default(),
             registry_version,
             subnet_size: NumberOfNodes::from(node_ids.len() as u32),
-            cost_schedule: Some(cost_schedule),
+            cost_schedule,
         })
     }
 
@@ -755,7 +750,7 @@ impl CanisterHttpRequestContext {
             refund_status: RefundStatus::default(),
             registry_version,
             subnet_size: NumberOfNodes::from(n),
-            cost_schedule: Some(cost_schedule),
+            cost_schedule,
         })
     }
 }
@@ -875,12 +870,6 @@ pub struct CanisterHttpRequest {
     /// The addresses should be sent in the following format: `socks5://[<ip>]:<port>`, for example:
     /// `socks5://[2602:fb2b:110:10:506f:cff:feff:fe69]:1080`
     pub socks_proxy_addrs: Vec<String>,
-    /// The subnet's cycles cost schedule in effect at the request context's
-    /// registry version.
-    pub cost_schedule: CanisterCyclesCostSchedule,
-    /// The number of nodes on the subnet at the request context's registry
-    /// version.
-    pub subnet_size: NumberOfNodes,
 }
 
 /// The content of a response after the transformation
@@ -1353,7 +1342,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         let expected_size = context.url.len()
@@ -1401,7 +1390,7 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
         let expected_size = context.url.len()
@@ -1484,7 +1473,7 @@ mod tests {
                     },
                     registry_version: RegistryVersion::from(7),
                     subnet_size: NumberOfNodes::from(13),
-                    cost_schedule: Some(CanisterCyclesCostSchedule::Free),
+                    cost_schedule: CanisterCyclesCostSchedule::Free,
                 };
 
                 let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
@@ -1519,13 +1508,13 @@ mod tests {
             refund_status: RefundStatus::default(),
             registry_version: RegistryVersion::from(1),
             subnet_size: NumberOfNodes::from(13),
-            cost_schedule: None,
+            cost_schedule: CanisterCyclesCostSchedule::Normal,
         };
 
+        // Every populated cost schedule round-trips unchanged.
         for cost_schedule in [
-            None,
-            Some(CanisterCyclesCostSchedule::Normal),
-            Some(CanisterCyclesCostSchedule::Free),
+            CanisterCyclesCostSchedule::Normal,
+            CanisterCyclesCostSchedule::Free,
         ] {
             let initial = CanisterHttpRequestContext {
                 cost_schedule,
@@ -1533,15 +1522,7 @@ mod tests {
             };
 
             let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();
-            // An unpopulated cost schedule must serialize to the proto default
-            // (`Unspecified` == 0) so that it stays non-existent in the proto
-            // representation for compatibility.
-            if cost_schedule.is_none() {
-                assert_eq!(pb.cost_schedule, 0);
-            }
-
             let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
-            // In particular, `None` must not decode back as `Some(Normal)`.
             assert_eq!(round_trip.cost_schedule, cost_schedule);
             assert_eq!(initial, round_trip);
         }


### PR DESCRIPTION
The HTTP request context's cost schedule and subnet size fields were introduced in https://github.com/dfinity/ic/pull/10712, and set to non-zero values in https://github.com/dfinity/ic/pull/10761. The latter commit is part of new release https://github.com/dfinity/ic/tree/release-2026-07-23_04-21-base.

This PR makes the cost schedule field mandatory, and switches the code to start reading both new fields. This means we no longer have to look up the subnet size and cost schedule in a couple places and can rely on the values of the context.

Additionally, we can remove subnet size and cost schedule from `CanisterHttpRequest` (which is sent to the adapter), because now the context already contains these fields.