### PR TITLE
fix: Unfreeze ingress bench canisters

### DIFF
--- a/rs/ingress_manager/benches/build_payload.rs
+++ b/rs/ingress_manager/benches/build_payload.rs
@@ -80,7 +80,7 @@ where
         replicated_state = replicated_state.with_canister(
             CanisterStateBuilder::new()
                 .with_canister_id(*canister_id)
-                .with_cycles(Cycles::new(500_000_000_000)) /* 500 billion cycles */
+                .with_cycles(Cycles::new(50_000_000_000_000)) /* 50 trillion cycles */
                 .build(),
         );
     }


### PR DESCRIPTION
Several results of ingress benches have been malformed since June 4th. The root cause seems to be https://github.com/dfinity/ic/pull/10292, which introduced a base cost per canister. This influenced the (by default very large) freezing threshold of canisters created by the bench, which is now above the 500B cycles given to each canister. As a result, ingress messages to these canisters were rejected, instead of measured by the benchmark.

This PR fixes the problem by increasing the cycles per canister to 50T.