### PR TITLE
chore: bump bitflags in lmdb-rs

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "85249f409e5a6709d56b2bb9b5e221097d6eaf92280824bb9e00b3ef8ad5c2f1",
+  "checksum": "d5ffecbe5eb539cc383255d2073c58ee29b2e68ff04ebfbcded41ae738abb154",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -45377,7 +45377,7 @@
         "Git": {
           "remote": "https://github.com/dfinity-lab/lmdb-rs",
           "commitish": {
-            "Rev": "64eb770caa940f215190d86d61e4c132511be5e2"
+            "Rev": "a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
           }
         }
       },
@@ -45409,7 +45409,7 @@
         "deps": {
           "common": [
             {
-              "id": "bitflags 1.3.2",
+              "id": "bitflags 2.10.0",
               "target": "bitflags"
             },
             {
@@ -45427,7 +45427,7 @@
           ],
           "selects": {}
         },
-        "edition": "2015",
+        "edition": "2024",
         "version": "0.14.99"
       },
       "license": "Apache-2.0",
@@ -45444,7 +45444,7 @@
         "Git": {
           "remote": "https://github.com/dfinity-lab/lmdb-rs",
           "commitish": {
-            "Rev": "64eb770caa940f215190d86d61e4c132511be5e2"
+            "Rev": "a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
           },
           "strip_prefix": "lmdb-sys",
           "patch_args": [
@@ -45505,7 +45505,7 @@
           ],
           "selects": {}
         },
-        "edition": "2015",
+        "edition": "2024",
         "version": "0.11.99"
       },
       "build_script_attrs": {

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -7835,9 +7835,9 @@ dependencies = [
 [[package]]
 name = "lmdb-rkv"
 version = "0.14.99"
-source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=64eb770caa940f215190d86d61e4c132511be5e2#64eb770caa940f215190d86d61e4c132511be5e2"
+source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=a244a247789fd9ece0fe1a406180c32e5bbc0c3f#a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "byteorder",
  "libc",
  "lmdb-rkv-sys",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "lmdb-rkv-sys"
 version = "0.11.99"
-source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=64eb770caa940f215190d86d61e4c132511be5e2#64eb770caa940f215190d86d61e4c132511be5e2"
+source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=a244a247789fd9ece0fe1a406180c32e5bbc0c3f#a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17581,9 +17581,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "lmdb-rkv"
 version = "0.14.99"
-source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=64eb770caa940f215190d86d61e4c132511be5e2#64eb770caa940f215190d86d61e4c132511be5e2"
+source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=a244a247789fd9ece0fe1a406180c32e5bbc0c3f#a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "byteorder",
  "libc",
  "lmdb-rkv-sys",
@@ -17592,7 +17592,7 @@ dependencies = [
 [[package]]
 name = "lmdb-rkv-sys"
 version = "0.11.99"
-source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=64eb770caa940f215190d86d61e4c132511be5e2#64eb770caa940f215190d86d61e4c132511be5e2"
+source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=a244a247789fd9ece0fe1a406180c32e5bbc0c3f#a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -763,8 +763,8 @@ libcryptsetup-rs = "0.15"
 libflate = "2.1.0"
 libfuzzer-sys = "0.4.7"
 libnss = "0.5.0"
-lmdb-rkv = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "64eb770caa940f215190d86d61e4c132511be5e2" }
-lmdb-rkv-sys = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "64eb770caa940f215190d86d61e4c132511be5e2" }
+lmdb-rkv = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "a244a247789fd9ece0fe1a406180c32e5bbc0c3f" }
+lmdb-rkv-sys = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "a244a247789fd9ece0fe1a406180c32e5bbc0c3f" }
 local-ip-address = "0.5.6"
 loopdev-3 = "0.5"
 lzma-sys = { version = "0.1.20", features = ["static"] }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -967,13 +967,13 @@ crate.spec(
 crate.spec(
     git = "https://github.com/dfinity-lab/lmdb-rs",
     package = "lmdb-rkv",
-    rev = "64eb770caa940f215190d86d61e4c132511be5e2",
+    rev = "a244a247789fd9ece0fe1a406180c32e5bbc0c3f",
 )
 crate.spec(
     default_features = False,
     git = "https://github.com/dfinity-lab/lmdb-rs",
     package = "lmdb-rkv-sys",
-    rev = "64eb770caa940f215190d86d61e4c132511be5e2",
+    rev = "a244a247789fd9ece0fe1a406180c32e5bbc0c3f",
 )
 crate.spec(
     package = "local-ip-address",


### PR DESCRIPTION
This uses a new lmdb-rs version with rust edition 2024 and bitflags 2: https://github.com/dfinity-lab/lmdb-rs