### PR TITLE
feat(cketh): dynamic per-address balance-scan schedule

### DIFF
--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -7,14 +7,25 @@ use crate::eth_rpc_client::{AnyOf, MIN_ATTACHED_CYCLES, ToReducedWithStrategy, r
 use crate::guard::TimerGuard;
 use crate::logs::INFO;
 use crate::numeric::Erc20Value;
+use crate::state::automatic_deposits::DEPOSIT_ADDRESS_SCAN_WINDOW;
 use crate::state::{State, TaskType, mutate_state, read_state};
 use crate::timed_sized_map::Timestamp;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use multicall3::{BalanceOfCall, MULTICALL3_ADDRESS};
+use std::collections::BTreeSet;
 
 const MAX_CALLS_PER_MULTICALL: usize = 200;
+
+/// Cumulative offsets (in seconds) from an address's registration time at which
+/// it is scanned. The per-address scan cadence is governed by this schedule;
+/// after the last offset the address is no longer scanned (it expires at 24h).
+const SCAN_SCHEDULE_SECS: [u64; 33] = [
+    30, 60, 120, 240, 360, 600, 900, 1200, 1500, 1800, 5400, 9000, 12600, 16200, 19800, 23400,
+    27000, 30600, 34200, 37800, 41400, 45000, 48600, 52200, 55800, 59400, 63000, 66600, 70200,
+    73800, 77400, 81000, 84600,
+];
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct BalanceScanStats {
@@ -30,12 +41,13 @@ pub async fn balance_scan() {
         Err(_) => return,
     };
     let now = Timestamp::from_nanos(ic_cdk::api::time());
-    let (addresses_scanned, pairs, calls) = read_state(|s| build_calls(s, now));
+    let (due_accounts, pairs, calls) = read_state(|s| build_due_calls(s, now));
     if calls.is_empty() {
         mutate_state(|s| {
+            prune_dead_progress(s, now);
             s.last_balance_scan = Some(BalanceScanStats {
                 scanned_at_ns: now.as_nanos(),
-                addresses_scanned,
+                addresses_scanned: 0,
                 candidates_found: 0,
                 chunks_failed: 0,
             })
@@ -83,11 +95,17 @@ pub async fn balance_scan() {
         }
     }
 
+    let addresses_scanned = due_accounts.len();
     log!(
         INFO,
         "[balance_scan]: scanned {addresses_scanned} addresses, found {candidates} candidate(s), {chunks_failed} chunk(s) failed",
     );
     mutate_state(|s| {
+        for account in &due_accounts {
+            let entry = s.deposit_scan_progress.entry(*account).or_default();
+            *entry = entry.saturating_add(1);
+        }
+        prune_dead_progress(s, now);
         s.last_balance_scan = Some(BalanceScanStats {
             scanned_at_ns: now.as_nanos(),
             addresses_scanned,
@@ -97,19 +115,32 @@ pub async fn balance_scan() {
     });
 }
 
-fn build_calls(
+fn build_due_calls(
     state: &State,
     now: Timestamp,
-) -> (usize, Vec<(Account, Address)>, Vec<BalanceOfCall>) {
+) -> (Vec<Account>, Vec<(Account, Address)>, Vec<BalanceOfCall>) {
     let tokens: Vec<Address> = state
         .supported_ck_erc20_tokens()
         .map(|token| token.erc20_contract_address)
         .collect();
-    let mut addresses_scanned = 0_usize;
+    let mut due_accounts = Vec::new();
     let mut pairs = Vec::new();
     let mut calls = Vec::new();
-    for (account, deposit_address) in state.automatic_deposits.live_addresses(now) {
-        addresses_scanned += 1;
+    for (account, deposit_address, expires_at) in state.automatic_deposits.live_addresses(now) {
+        let registered_at = Timestamp::from_nanos(
+            expires_at
+                .as_nanos()
+                .saturating_sub(DEPOSIT_ADDRESS_SCAN_WINDOW.as_nanos() as u64),
+        );
+        let scans_done = state
+            .deposit_scan_progress
+            .get(&account)
+            .copied()
+            .unwrap_or(0) as usize;
+        if !is_scan_due(registered_at, scans_done, now) {
+            continue;
+        }
+        due_accounts.push(account);
         for token in &tokens {
             pairs.push((account, *token));
             calls.push(BalanceOfCall {
@@ -118,7 +149,28 @@ fn build_calls(
             });
         }
     }
-    (addresses_scanned, pairs, calls)
+    (due_accounts, pairs, calls)
+}
+
+fn is_scan_due(registered_at: Timestamp, scans_done: usize, now: Timestamp) -> bool {
+    match SCAN_SCHEDULE_SECS.get(scans_done) {
+        None => false,
+        Some(&offset_secs) => {
+            let age_ns = now.as_nanos().saturating_sub(registered_at.as_nanos());
+            age_ns >= offset_secs.saturating_mul(1_000_000_000)
+        }
+    }
+}
+
+fn prune_dead_progress(state: &mut State, now: Timestamp) {
+    let live: BTreeSet<Account> = state
+        .automatic_deposits
+        .live_addresses(now)
+        .map(|(account, _, _)| account)
+        .collect();
+    state
+        .deposit_scan_progress
+        .retain(|account, _| live.contains(account));
 }
 
 fn count_candidates(

--- a/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
@@ -5,6 +5,8 @@ use crate::test_fixtures::initial_state;
 
 const DEPOSIT_ADDRESS: Address = Address::new([0x11; 20]);
 const TOKEN_CONTRACT: Address = Address::new([0x22; 20]);
+const DEPOSIT_ADDRESS_2: Address = Address::new([0x33; 20]);
+const SEC: u64 = 1_000_000_000;
 
 fn account(owner: u8) -> Account {
     Account {
@@ -44,18 +46,60 @@ fn should_count_candidates_at_and_above_minimum_only() {
 }
 
 #[test]
-fn should_build_parallel_calls_for_live_addresses_and_tokens() {
-    let now = Timestamp::from_nanos(1_000);
+fn should_have_valid_scan_schedule() {
+    assert_eq!(SCAN_SCHEDULE_SECS.len(), 33);
+    assert_eq!(SCAN_SCHEDULE_SECS[0], 30);
+    assert_eq!(SCAN_SCHEDULE_SECS[SCAN_SCHEDULE_SECS.len() - 1], 84600);
+
+    for window in SCAN_SCHEDULE_SECS.windows(2) {
+        assert!(
+            window[0] < window[1],
+            "schedule must be strictly increasing"
+        );
+    }
+
+    let day_secs = 86400;
+    assert!(SCAN_SCHEDULE_SECS[SCAN_SCHEDULE_SECS.len() - 1] < day_secs);
+}
+
+#[test]
+fn should_compute_scan_due_from_registration_time() {
+    let t0 = Timestamp::from_nanos(1_000);
+    let at = |secs: u64| Timestamp::from_nanos(t0.as_nanos() + secs * SEC);
+
+    assert!(!is_scan_due(t0, 0, at(29)));
+    assert!(is_scan_due(t0, 0, at(30)));
+    assert!(is_scan_due(t0, 0, at(31)));
+
+    assert!(!is_scan_due(t0, 1, at(59)));
+    assert!(is_scan_due(t0, 1, at(60)));
+
+    assert!(!is_scan_due(t0, 10, at(5399)));
+    assert!(is_scan_due(t0, 10, at(5400)));
+
+    assert!(!is_scan_due(t0, 33, at(1_000_000)));
+    assert!(!is_scan_due(t0, 34, at(1_000_000)));
+}
+
+#[test]
+fn should_select_only_due_addresses() {
+    let t0 = Timestamp::from_nanos(1_000);
     let mut state = initial_state();
     state.record_add_ckerc20_token(sepolia_token());
     state
         .automatic_deposits
-        .watch_address_for_account(now, account(1), DEPOSIT_ADDRESS)
+        .watch_address_for_account(t0, account(1), DEPOSIT_ADDRESS)
         .expect("BUG: failed to register live address");
+    state
+        .automatic_deposits
+        .watch_address_for_account(t0, account(2), DEPOSIT_ADDRESS_2)
+        .expect("BUG: failed to register live address");
+    state.deposit_scan_progress.insert(account(2), 5);
 
-    let (addresses_scanned, pairs, calls) = build_calls(&state, now);
+    let now = Timestamp::from_nanos(t0.as_nanos() + 40 * SEC);
+    let (due_accounts, pairs, calls) = build_due_calls(&state, now);
 
-    assert_eq!(addresses_scanned, 1);
+    assert_eq!(due_accounts, vec![account(1)]);
     assert_eq!(pairs, vec![(account(1), TOKEN_CONTRACT)]);
     assert_eq!(
         calls,
@@ -67,18 +111,59 @@ fn should_build_parallel_calls_for_live_addresses_and_tokens() {
 }
 
 #[test]
-fn should_skip_expired_addresses_in_build_calls() {
-    let now = Timestamp::from_nanos(1_000);
+fn should_keep_due_accounts_pairs_and_calls_parallel() {
+    let t0 = Timestamp::from_nanos(1_000);
     let mut state = initial_state();
     state.record_add_ckerc20_token(sepolia_token());
     state
         .automatic_deposits
-        .watch_address_for_account(now, account(1), DEPOSIT_ADDRESS)
+        .watch_address_for_account(t0, account(1), DEPOSIT_ADDRESS)
+        .expect("BUG: failed to register live address");
+    state
+        .automatic_deposits
+        .watch_address_for_account(t0, account(2), DEPOSIT_ADDRESS_2)
         .expect("BUG: failed to register live address");
 
-    let (addresses_scanned, pairs, calls) = build_calls(&state, Timestamp::from_nanos(u64::MAX));
+    let now = Timestamp::from_nanos(t0.as_nanos() + 30 * SEC);
+    let (due_accounts, pairs, calls) = build_due_calls(&state, now);
 
-    assert_eq!(addresses_scanned, 0);
+    assert_eq!(due_accounts, vec![account(1), account(2)]);
+    assert_eq!(
+        pairs,
+        vec![(account(1), TOKEN_CONTRACT), (account(2), TOKEN_CONTRACT),]
+    );
+    assert_eq!(
+        calls,
+        vec![
+            BalanceOfCall {
+                token: TOKEN_CONTRACT,
+                holder: DEPOSIT_ADDRESS,
+            },
+            BalanceOfCall {
+                token: TOKEN_CONTRACT,
+                holder: DEPOSIT_ADDRESS_2,
+            },
+        ]
+    );
+}
+
+#[test]
+fn should_not_select_addresses_past_schedule_end() {
+    let t0 = Timestamp::from_nanos(1_000);
+    let mut state = initial_state();
+    state.record_add_ckerc20_token(sepolia_token());
+    state
+        .automatic_deposits
+        .watch_address_for_account(t0, account(1), DEPOSIT_ADDRESS)
+        .expect("BUG: failed to register live address");
+    state
+        .deposit_scan_progress
+        .insert(account(1), SCAN_SCHEDULE_SECS.len() as u8);
+
+    let now = Timestamp::from_nanos(t0.as_nanos() + 84_600 * SEC);
+    let (due_accounts, pairs, calls) = build_due_calls(&state, now);
+
+    assert!(due_accounts.is_empty());
     assert!(pairs.is_empty());
     assert!(calls.is_empty());
 }

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -35,8 +35,9 @@ use std::time::Duration;
 
 pub const MAIN_DERIVATION_PATH: Vec<ByteBuf> = vec![];
 pub const SCRAPING_ETH_LOGS_INTERVAL: Duration = Duration::from_secs(3 * 60);
-// provisional
-pub const BALANCE_SCAN_INTERVAL: Duration = Duration::from_secs(60);
+// Tick granularity for the balance-scan task; the per-address scan cadence is
+// governed by `SCAN_SCHEDULE_SECS` (finest step 30s).
+pub const BALANCE_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);
 pub const PROCESS_REIMBURSEMENT: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL: Duration = Duration::from_secs(3 * 60);

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -102,6 +102,7 @@ impl TryFrom<InitArg> for State {
             skipped_blocks: Default::default(),
             active_tasks: Default::default(),
             last_balance_scan: None,
+            deposit_scan_progress: Default::default(),
             http_request_counter: 0,
             last_transaction_price_estimate: None,
             ledger_suite_orchestrator_id: None,

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -90,6 +90,10 @@ pub struct State {
     /// Statistics from the most recent balance scan, if any.
     pub last_balance_scan: Option<BalanceScanStats>,
 
+    /// Per-account number of balance scans already performed, driving the
+    /// per-address dynamic scan schedule.
+    pub deposit_scan_progress: BTreeMap<Account, u8>,
+
     /// Number of HTTP outcalls since the last upgrade.
     /// Used to correlate request and response in logs.
     pub http_request_counter: u64,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -94,12 +94,15 @@ impl AutomaticDeposits {
         self.watchlist.get_entry(now, account)
     }
 
-    /// The deposit address of every account still armed (unexpired) as of `now`.
-    pub fn live_addresses(&self, now: Timestamp) -> impl Iterator<Item = (Account, Address)> + '_ {
+    /// The deposit address (and expiry) of every account still armed as of `now`.
+    pub fn live_addresses(
+        &self,
+        now: Timestamp,
+    ) -> impl Iterator<Item = (Account, Address, Timestamp)> + '_ {
         self.watchlist
             .iter()
             .filter(move |(_, entry)| entry.expires_at >= now)
-            .map(|(account, entry)| (*account, entry.value.address))
+            .map(|(account, entry)| (*account, entry.value.address, entry.expires_at))
     }
 
     /// Full snapshot of the watchlist, faithful enough to reconstruct it exactly

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -173,8 +173,18 @@ fn should_yield_only_live_addresses() {
     // account(1) (armed 10ns later) is still live.
     let now = ts(window_nanos() + 1);
     let live: Vec<_> = deposits.live_addresses(now).collect();
+    assert_eq!(
+        live,
+        vec![(
+            account(1),
+            deposit_address(&account(1)),
+            ts(10 + window_nanos())
+        )]
+    );
 
-    assert_eq!(live, vec![(account(1), deposit_address(&account(1)))]);
+    // Once account(1) also expires, nothing is live.
+    let after_expiry = ts(10 + window_nanos() + 1);
+    assert_eq!(deposits.live_addresses(after_expiry).count(), 0);
 }
 
 fn ts(nanos: u64) -> Timestamp {

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -1067,6 +1067,7 @@ fn state_equivalence() {
         pending_withdrawal_principals: Default::default(),
         active_tasks: Default::default(),
         last_balance_scan: None,
+        deposit_scan_progress: BTreeMap::new(),
         http_request_counter: 100,
         eth_balance: Default::default(),
         erc20_balances: Default::default(),


### PR DESCRIPTION
Implements the design docs per-address detection cadence on top of the D1 balance scan, replacing D1s flat "scan every live address every tick" with a backoff schedule.

Each armed deposit address is now scanned on the `deposit_from_cex.md` "Detection schedule": burst (30s, 60s, 120s, 240s, 360s, 600s), ramp (every 5 min to 30 min), then hourly to 24h — 33 ticks total. A pure `is_scan_due` check compares an address's age (derived from its watchlist expiry) against a cumulative schedule and its per-account scan count; the global tick timer drops to 30s (the finest step) and each tick scans only the addresses that are due. Per-account progress is transient state (excluded from `is_equivalent_to`), pruned when an address is no longer live and reset on upgrade — a restored address simply re-bursts. No `.did` change; still no downstream action on candidates (filter 2 / crediting remains a later PR).

## PR stack
- #10729 — [F3] deposit_erc20 registration state (base of the stack)
- #10873 — [D1] balance scan, filter 1 (this PR's base)
- **this PR** — dynamic per-address scan schedule

Merge bottom-up: #10729 → #10873 → this. Review only the top commit here; the diff below the base belongs to the PRs above.