### PR TITLE
feat: enable replicated fetch_canister_logs

### DIFF
--- a/packages/ic-management-canister-types/README.md
+++ b/packages/ic-management-canister-types/README.md
@@ -18,4 +18,3 @@ The [`ic.did`](tests/ic.did) is sourced from the [Internet Computer Interface Sp
 
 Some methods are excluded (commented out) as follows:
 - Bitcoin API: These functionalities are planned to migrate from the Management Canister to the [Bitcoin Canister](https://github.com/dfinity/bitcoin-canister).
-- `fetch_canister_logs`: This method is only available for ingress messages (using an agent) and cannot be invoked in inter-canister calls.

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -11,7 +11,7 @@ const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
-const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Disabled;
+const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Enabled;
 
 const FLEXIBLE_HTTP_REQUESTS_FEATURE: FlagStatus = FlagStatus::Disabled;
 


### PR DESCRIPTION
Flip the replicated_inter_canister_log_fetch feature flag to Enabled by default so that fetch_canister_logs can be served as a replicated inter-canister request. End-user replicated ingress calls remain rejected and the non-replicated query path is unchanged.

Also drop the now-stale README note claiming fetch_canister_logs cannot be invoked in inter-canister calls.