### PR TITLE
chore: bump nix 0.24.3 -> 0.31.3

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d5ffecbe5eb539cc383255d2073c58ee29b2e68ff04ebfbcded41ae738abb154",
+  "checksum": "b0aadd8852660b43eb49ceb59a3c7bd696e5e73eb91b6e0e3255c7294e3ce1eb",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -21304,7 +21304,7 @@
               "target": "nftables"
             },
             {
-              "id": "nix 0.24.3",
+              "id": "nix 0.31.3",
               "target": "nix"
             },
             {
@@ -47595,91 +47595,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "memoffset 0.6.5": {
-      "name": "memoffset",
-      "version": "0.6.5",
-      "package_url": "https://github.com/Gilnaa/memoffset",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/memoffset/0.6.5/download",
-          "sha256": "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "memoffset",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "memoffset",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "memoffset 0.6.5",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.6.5"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "autocfg 1.5.0",
-              "target": "autocfg"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "memoffset 0.9.0": {
       "name": "memoffset",
       "version": "0.9.0",
@@ -49802,104 +49717,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "nix 0.24.3": {
-      "name": "nix",
-      "version": "0.24.3",
-      "package_url": "https://github.com/nix-rust/nix",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/nix/0.24.3/download",
-          "sha256": "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "nix",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "nix",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "acct",
-            "aio",
-            "default",
-            "dir",
-            "env",
-            "event",
-            "feature",
-            "fs",
-            "hostname",
-            "inotify",
-            "ioctl",
-            "kmod",
-            "memoffset",
-            "mman",
-            "mount",
-            "mqueue",
-            "net",
-            "personality",
-            "poll",
-            "process",
-            "pthread",
-            "ptrace",
-            "quota",
-            "reboot",
-            "resource",
-            "sched",
-            "signal",
-            "socket",
-            "term",
-            "time",
-            "ucontext",
-            "uio",
-            "user",
-            "zerocopy"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "libc 0.2.186",
-              "target": "libc"
-            },
-            {
-              "id": "memoffset 0.6.5",
-              "target": "memoffset"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.24.3"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "nix 0.27.1": {
       "name": "nix",
       "version": "0.27.1",
@@ -50160,6 +49977,121 @@
         },
         "edition": "2021",
         "version": "0.30.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg_aliases 0.2.1",
+              "target": "cfg_aliases"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "nix 0.31.3": {
+      "name": "nix",
+      "version": "0.31.3",
+      "package_url": "https://github.com/nix-rust/nix",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/nix/0.31.3/download",
+          "sha256": "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "nix",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "nix",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "feature",
+            "fs",
+            "ioctl",
+            "memoffset",
+            "mman",
+            "net",
+            "process",
+            "ptrace",
+            "signal",
+            "socket",
+            "time",
+            "uio",
+            "user",
+            "zerocopy"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.10.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "libc 0.2.186",
+              "target": "libc"
+            },
+            {
+              "id": "memoffset 0.9.0",
+              "target": "memoffset"
+            },
+            {
+              "id": "nix 0.31.3",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.31.3"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -97873,7 +97805,7 @@
     "moka 0.12.15",
     "more-asserts 0.3.1",
     "nftables 0.4.1",
-    "nix 0.24.3",
+    "nix 0.31.3",
     "num-bigint 0.4.6",
     "num-bigint-dig 0.9.1",
     "num-traits 0.2.19",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3632,7 +3632,7 @@ dependencies = [
  "moka",
  "more-asserts",
  "nftables",
- "nix 0.24.3",
+ "nix 0.31.3",
  "num-bigint 0.4.6",
  "num-bigint-dig 0.9.1",
  "num-traits",
@@ -8189,15 +8189,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -8542,18 +8533,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -8561,7 +8540,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "libc",
- "memoffset 0.9.0",
+ "memoffset",
 ]
 
 [[package]]
@@ -8586,6 +8565,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -5194,7 +5194,7 @@ dependencies = [
  "itertools 0.12.1",
  "libcryptsetup-rs",
  "mockall 0.13.1",
- "nix 0.24.3",
+ "nix 0.31.3",
  "parking_lot",
  "prometheus",
  "rand 0.8.6",
@@ -5329,7 +5329,7 @@ dependencies = [
  "macaddr",
  "memchr",
  "mockall 0.13.1",
- "nix 0.24.3",
+ "nix 0.31.3",
  "prometheus",
  "regex",
  "sev_host",
@@ -5356,7 +5356,7 @@ dependencies = [
  "ic_os_logging",
  "indoc 1.0.9",
  "network",
- "nix 0.24.3",
+ "nix 0.31.3",
  "serde",
  "serde_json",
  "tracing",
@@ -6372,7 +6372,7 @@ dependencies = [
  "ic-types",
  "lmdb-rkv",
  "lmdb-rkv-sys",
- "nix 0.24.3",
+ "nix 0.31.3",
  "prometheus",
  "prost",
  "rand 0.8.6",
@@ -6654,7 +6654,7 @@ dependencies = [
  "mockall 0.13.1",
  "moka",
  "nftables",
- "nix 0.24.3",
+ "nix 0.31.3",
  "rand 0.8.6",
  "rate-limits-api",
  "ratelimit",
@@ -7061,7 +7061,7 @@ dependencies = [
  "libc",
  "memory_tracker",
  "mockall 0.13.1",
- "nix 0.24.3",
+ "nix 0.31.3",
  "num-traits",
  "object 0.37.3",
  "once_cell",
@@ -9412,7 +9412,7 @@ dependencies = [
  "maplit",
  "memory_tracker",
  "more-asserts",
- "nix 0.24.3",
+ "nix 0.31.3",
  "num-traits",
  "pretty_assertions",
  "prometheus",
@@ -13363,7 +13363,7 @@ dependencies = [
  "ic-types",
  "ic-xnet-payload-builder",
  "libc",
- "nix 0.24.3",
+ "nix 0.31.3",
  "num_cpus",
  "pprof",
  "predicates",
@@ -13518,7 +13518,7 @@ dependencies = [
  "libc",
  "maplit",
  "more-asserts",
- "nix 0.24.3",
+ "nix 0.31.3",
  "phantom_newtype",
  "prometheus",
  "proptest",
@@ -13654,7 +13654,7 @@ dependencies = [
  "ic-rosetta-api",
  "ic-types",
  "icp-ledger",
- "nix 0.24.3",
+ "nix 0.31.3",
  "rand 0.8.6",
  "reqwest",
  "rosetta-core",
@@ -14570,7 +14570,7 @@ dependencies = [
  "ic-validate-eq",
  "ic-wasm-types",
  "maplit",
- "nix 0.24.3",
+ "nix 0.31.3",
  "parking_lot",
  "prometheus",
  "proptest",
@@ -14694,7 +14694,7 @@ dependencies = [
  "ic-test-utilities-privileges",
  "lazy_static",
  "libc",
- "nix 0.24.3",
+ "nix 0.31.3",
  "phantom_newtype",
  "prost",
  "rand 0.8.6",
@@ -14786,7 +14786,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "macaddr",
- "nix 0.24.3",
+ "nix 0.31.3",
  "num_cpus",
  "on_wire",
  "phantom_newtype",
@@ -14910,7 +14910,7 @@ dependencies = [
  "ic-types-cycles",
  "ic-universal-canister",
  "lazy_static",
- "nix 0.24.3",
+ "nix 0.31.3",
  "rusty-fork",
  "serde",
  "serde_cbor",
@@ -15071,7 +15071,7 @@ name = "ic-test-utilities-privileges"
 version = "0.9.0"
 dependencies = [
  "ic-test-utilities-privileges-macros",
- "nix 0.24.3",
+ "nix 0.31.3",
  "tempfile",
 ]
 
@@ -15193,7 +15193,7 @@ dependencies = [
  "ic-system-test-driver",
  "ic-types",
  "ic_consensus_system_test_utils",
- "nix 0.24.3",
+ "nix 0.31.3",
  "once_cell",
  "rand 0.8.6",
  "registry-canister",
@@ -15788,7 +15788,7 @@ dependencies = [
  "ic-xnet-uri",
  "maplit",
  "mockall 0.13.1",
- "nix 0.24.3",
+ "nix 0.31.3",
  "prometheus",
  "proptest",
  "rand 0.8.6",
@@ -16127,7 +16127,7 @@ dependencies = [
  "devicemapper",
  "gpt",
  "loopdev-3",
- "nix 0.24.3",
+ "nix 0.31.3",
  "partition_tools",
  "rand 0.8.6",
  "sys-mount",
@@ -17913,15 +17913,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -17957,7 +17948,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memmap2",
- "nix 0.24.3",
+ "nix 0.31.3",
  "phantom_newtype",
  "proptest",
  "rayon",
@@ -18451,18 +18442,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -18470,7 +18449,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -18499,14 +18478,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -19259,7 +19239,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mockall 0.13.1",
- "nix 0.24.3",
+ "nix 0.31.3",
  "pem",
  "prometheus",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -1232,7 +1232,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1252,7 +1252,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1429,12 +1429,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -3126,7 +3120,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -3707,7 +3701,7 @@ version = "0.34.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d293a7f1bbf5c26698df385d519b833946770272f1125250acb4898e9dd126a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "devicemapper-sys",
  "env_logger",
@@ -3949,7 +3943,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -5000,7 +4994,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7143bdeb50c2871c11628ebd913d22c4182b41d1793912e6f89ecbcb6b48d596"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "either",
  "hardware-address",
@@ -5149,7 +5143,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crc",
  "simple-bytes",
  "uuid",
@@ -5623,7 +5617,7 @@ checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "cfg-if",
  "data-encoding",
@@ -5658,7 +5652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "aws-lc-rs",
- "bitflags 2.11.0",
+ "bitflags",
  "data-encoding",
  "idna",
  "ipnet",
@@ -16644,7 +16638,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "futures-util",
  "inotify-sys",
  "libc",
@@ -16786,7 +16780,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bc9535b4a1d67bfcd48132d801bedcba48364615bd718b1d63da985e93d5310"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "ipnet",
  "paste",
 ]
@@ -17329,7 +17323,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ba8f9447e9320030e045b3c7f1b1a978355c43cd05cdaba7e618d1e080519dd"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "either",
  "libc",
  "libcryptsetup-rs-sys",
@@ -17440,7 +17434,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -17549,7 +17543,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
 ]
 
@@ -17583,7 +17577,7 @@ name = "lmdb-rkv"
 version = "0.14.99"
 source = "git+https://github.com/dfinity-lab/lmdb-rs?rev=a244a247789fd9ece0fe1a406180c32e5bbc0c3f#a244a247789fd9ece0fe1a406180c32e5bbc0c3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "libc",
  "lmdb-rkv-sys",
@@ -18446,7 +18440,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
@@ -18458,7 +18452,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -18470,7 +18464,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -18482,7 +18476,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -19009,7 +19003,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -20307,7 +20301,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -20319,7 +20313,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hex",
 ]
 
@@ -20360,7 +20354,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand 0.8.6",
@@ -20523,7 +20517,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -20810,7 +20804,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -20926,7 +20920,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -20984,7 +20978,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -20993,7 +20987,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -21731,7 +21725,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
@@ -21848,7 +21842,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -21861,7 +21855,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -22367,7 +22361,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -22380,7 +22374,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -22403,7 +22397,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cssparser",
  "derive_more 0.99.20",
  "fxhash",
@@ -22690,7 +22684,7 @@ checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
 dependencies = [
  "base64 0.22.1",
  "bitfield",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "dirs",
  "hex",
@@ -23296,7 +23290,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "libssh2-sys",
  "parking_lot",
@@ -23656,7 +23650,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d361f5431256ea04c657c0dce767ad95e24fb054d99f0b8a9275cb1c9ea14bfb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "loopdev-3",
  "smart-default",
@@ -23670,7 +23664,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -24465,7 +24459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -24490,7 +24484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "http 1.4.0",
@@ -25462,7 +25456,7 @@ version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.14.0",
 ]
 
@@ -25472,7 +25466,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -25484,7 +25478,7 @@ version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "semver",
@@ -25497,7 +25491,7 @@ version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver",
@@ -25510,7 +25504,7 @@ version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver",
@@ -25523,7 +25517,7 @@ version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver",
@@ -25549,7 +25543,7 @@ checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -26297,7 +26291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -778,7 +778,7 @@ mockall = "0.13.0"
 mockito = "1.6.1"
 more-asserts = "0.3.1"
 nftables = "0.4"
-nix = { version = "0.24.3", features = ["ptrace", "user", "signal"] }
+nix = { version = "0.31.3", features = ["fs", "ioctl", "mman", "net", "process", "ptrace", "signal", "socket", "time", "user", "zerocopy"] }
 num-bigint = "0.4.6"
 num-traits = { version = "0.2.12", features = ["libm"] }
 num_cpus = "1.16.0"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1071,12 +1071,20 @@ crate.spec(
 )
 crate.spec(
     features = [
-        "ptrace",
-        "user",
-        "signal",
+        "fs",  # used by ic-sys/state_manager for memfd_create, dup, flock, renameat2
+        "ioctl",  # used by ic-os device for the ioctl_read! macro
+        "mman",  # used by replicated_state/memory_tracker/embedders for mmap/mprotect/madvise
+        "net",  # used by xnet payload_builder tests for SockaddrIn
+        "process",  # used by canister_sandbox/execution_environment for sys::wait
+        "ptrace",  # used by execution_environment fuzzer for sys::ptrace
+        "signal",  # used by canister_sandbox/guestos_tool for sys::signal
+        "socket",  # used by xnet payload_builder tests for socket/bind/getsockname
+        "time",  # used by state_manager tests for TimeSpec (utimensat)
+        "user",  # used by test_utilities/ic-os for getuid/geteuid/getegid
+        "zerocopy",  # used by ic-sys for fcntl::copy_file_range
     ],
     package = "nix",
-    version = "^0.24.3",
+    version = "^0.31.3",
 )
 crate.spec(
     package = "num-bigint",

--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -407,8 +407,11 @@ fn create_db_env(path: &Path, read_only: bool, max_dbs: c_uint) -> Environment {
         // canister sandbox process. Details in NODE-166
         let mut fd: lmdb_sys::mdb_filehandle_t = lmdb_sys::mdb_filehandle_t::default();
         lmdb_sys::mdb_env_get_fd(db_env.env(), &mut fd);
-        nix::fcntl::fcntl(fd, nix::fcntl::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC))
-            .expect("Unable to mark FD_CLOEXEC");
+        nix::fcntl::fcntl(
+            std::os::fd::BorrowedFd::borrow_raw(fd),
+            nix::fcntl::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC),
+        )
+        .expect("Unable to mark FD_CLOEXEC");
     };
     db_env
 }

--- a/rs/canister_sandbox/src/sandbox_manager.rs
+++ b/rs/canister_sandbox/src/sandbox_manager.rs
@@ -514,7 +514,7 @@ impl SandboxManager {
                 let mmap_ptr = unsafe {
                     mmap(
                         None,
-                        NonZeroUsize::new(mmap_size).expect("mmap length must be non-zero"),
+                        NonZeroUsize::new(mmap_size).expect("`mmap_size` is checked above and is non-zero"),
                         ProtFlags::PROT_READ,
                         MapFlags::MAP_PRIVATE,
                         &initial_state_data,

--- a/rs/canister_sandbox/src/sandbox_manager.rs
+++ b/rs/canister_sandbox/src/sandbox_manager.rs
@@ -499,7 +499,9 @@ impl SandboxManager {
         // we can mmap the data without mutating the fd.
         let initial_state_data: InitialStateData = {
             use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap};
-            use std::os::{fd::AsRawFd, unix::fs::MetadataExt};
+            use std::num::NonZeroUsize;
+            use std::os::unix::fs::MetadataExt;
+            use std::ptr::NonNull;
 
             let mmap_size = initial_state_data.metadata().unwrap().size() as usize;
             if mmap_size == 0 {
@@ -511,16 +513,16 @@ impl SandboxManager {
                 // `File`. We're mapping privately so the data won't be mutated.
                 let mmap_ptr = unsafe {
                     mmap(
-                        std::ptr::null_mut(),
-                        mmap_size,
+                        None,
+                        NonZeroUsize::new(mmap_size).expect("mmap length must be non-zero"),
                         ProtFlags::PROT_READ,
                         MapFlags::MAP_PRIVATE,
-                        initial_state_data.as_raw_fd(),
+                        &initial_state_data,
                         0,
                     )
                 }
                 .unwrap_or_else(|err| panic!("Reading InitialStateData failed: {err:?}"))
-                    as *mut u8;
+                .as_ptr() as *mut u8;
                 // SAFETY: We've mmapped `mmap_size` and gotten a succesful
                 // reply at address `mmap_ptr` and the mapping is readonly
                 // private.
@@ -529,8 +531,12 @@ impl SandboxManager {
                 // SAFETY: `mmap_ptr`/`mmap_size` are exactly what `mmap` returned;
                 // `data` is not used past this point.
                 unsafe {
-                    munmap(mmap_ptr as *mut std::ffi::c_void, mmap_size)
-                        .expect("Unable to unmap initial state data file");
+                    munmap(
+                        NonNull::new(mmap_ptr as *mut std::ffi::c_void)
+                            .expect("mmap pointer is null"),
+                        mmap_size,
+                    )
+                    .expect("Unable to unmap initial state data file");
                 }
                 initial_state_data
             }

--- a/rs/canister_sandbox/src/sandbox_manager.rs
+++ b/rs/canister_sandbox/src/sandbox_manager.rs
@@ -514,7 +514,8 @@ impl SandboxManager {
                 let mmap_ptr = unsafe {
                     mmap(
                         None,
-                        NonZeroUsize::new(mmap_size).expect("`mmap_size` is checked above and is non-zero"),
+                        NonZeroUsize::new(mmap_size)
+                            .expect("`mmap_size` is checked above and is non-zero"),
                         ProtFlags::PROT_READ,
                         MapFlags::MAP_PRIVATE,
                         &initial_state_data,

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -244,7 +244,10 @@ mod tests {
         let mut fds: Vec<&mut std::os::unix::io::RawFd> = vec![];
         memory.enumerate_fds(&mut fds);
         for fd in fds.into_iter() {
-            *fd = nix::unistd::dup(*fd).unwrap();
+            use std::os::fd::{BorrowedFd, IntoRawFd};
+            // SAFETY: `*fd` is a valid file descriptor.
+            let borrowed = unsafe { BorrowedFd::borrow_raw(*fd) };
+            *fd = nix::unistd::dup(borrowed).unwrap().into_raw_fd();
         }
         memory
     }

--- a/rs/embedders/src/serialized_module.rs
+++ b/rs/embedders/src/serialized_module.rs
@@ -1,11 +1,6 @@
 use std::{
-    collections::BTreeSet,
-    convert::TryFrom,
-    fs::File,
-    io::Write,
-    os::{fd::AsRawFd, unix::fs::MetadataExt},
-    path::Path,
-    sync::Arc,
+    collections::BTreeSet, convert::TryFrom, fs::File, io::Write, num::NonZeroUsize,
+    os::unix::fs::MetadataExt, path::Path, ptr::NonNull, sync::Arc,
 };
 
 use ic_heap_bytes::DeterministicHeapBytes;
@@ -246,17 +241,18 @@ impl OnDiskSerializedModule {
         // argument implies that this won't mess with any existing memory.
         let mmap_ptr = unsafe {
             mmap(
-                std::ptr::null_mut(),
-                mmap_size,
+                None,
+                NonZeroUsize::new(mmap_size).expect("mmap length must be non-zero"),
                 ProtFlags::PROT_READ,
                 MapFlags::MAP_PRIVATE,
-                self.initial_state_data.as_raw_fd(),
+                &self.initial_state_data,
                 0,
             )
         }
         .unwrap_or_else(|err| {
             panic!("Reading OnDiskSerializedModule initial_state failed: {err:?}")
-        }) as *mut u8;
+        })
+        .as_ptr() as *mut u8;
         // Safety: allocation was made with length `mmap_size`.
         let data = unsafe { std::slice::from_raw_parts(mmap_ptr, mmap_size) };
         let initial_state_data = bincode::deserialize::<InitialStateData>(data)
@@ -264,8 +260,11 @@ impl OnDiskSerializedModule {
         // Safety: `mmap_ptr`/`mmap_size` are the pointer and length returned by
         // the `mmap` above; `data` is not used past this point.
         unsafe {
-            munmap(mmap_ptr as *mut std::ffi::c_void, mmap_size)
-                .expect("Unable to unmap initial state data file");
+            munmap(
+                NonNull::new(mmap_ptr as *mut std::ffi::c_void).expect("mmap pointer is null"),
+                mmap_size,
+            )
+            .expect("Unable to unmap initial state data file");
         }
         initial_state_data
     }
@@ -283,16 +282,16 @@ mod test {
         let mmap_size = file.metadata().unwrap().size() as usize;
         let mmap_ptr = unsafe {
             mmap(
-                std::ptr::null_mut(),
-                mmap_size,
+                None,
+                NonZeroUsize::new(mmap_size).expect("mmap length must be non-zero"),
                 ProtFlags::PROT_READ,
                 MapFlags::MAP_PRIVATE,
-                file.as_raw_fd(),
+                file,
                 0,
             )
         }
         .unwrap_or_else(|err| panic!("Reading OnDiskSerializedModule failed: {err:?}"))
-            as *mut u8;
+        .as_ptr() as *mut u8;
         unsafe { std::slice::from_raw_parts(mmap_ptr, mmap_size) }.to_vec()
     }
 

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -778,7 +778,8 @@ impl WasmtimeEmbedder {
                 // SAFETY: This is the array we created in the host_memory creator, so we know it is a valid memory region that we own.
                 unsafe {
                     mman::mprotect(
-                        addr as *mut _,
+                        std::ptr::NonNull::new(addr as *mut std::ffi::c_void)
+                            .expect("mprotect address is null"),
                         size_in_bytes,
                         mman::ProtFlags::PROT_READ | mman::ProtFlags::PROT_WRITE,
                     )

--- a/rs/memory_tracker/benches/bit_vec.rs
+++ b/rs/memory_tracker/benches/bit_vec.rs
@@ -78,7 +78,7 @@ fn vec_from_mmap(memory_size: usize, page_size: PageSize) {
                 None,
                 NonZeroUsize::new(size).expect("mmap length must be non-zero"),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON,
+                MapFlags::MAP_PRIVATE,
             )
             .unwrap()
         }

--- a/rs/memory_tracker/benches/bit_vec.rs
+++ b/rs/memory_tracker/benches/bit_vec.rs
@@ -1,7 +1,9 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap};
+use nix::sys::mman::{MapFlags, ProtFlags, mmap_anonymous, munmap};
+use std::num::NonZeroUsize;
+use std::ptr::NonNull;
 
 const KIB: usize = 1024;
 const MIB: usize = 1024 * KIB;
@@ -72,19 +74,18 @@ fn vec_from_mmap(memory_size: usize, page_size: PageSize) {
     let size = num_blocks * size_of::<u32>();
     for _ in 0..NUM_EXECUTIONS {
         let addr = unsafe {
-            mmap(
-                std::ptr::null_mut(),
-                size,
+            mmap_anonymous(
+                None,
+                NonZeroUsize::new(size).expect("mmap length must be non-zero"),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON,
-                -1,
-                0,
             )
             .unwrap()
-        };
+        }
+        .as_ptr();
         let vec = black_box(unsafe { Vec::from_raw_parts(addr as *mut u32, 0, num_blocks) });
         let _manually_drop = std::mem::ManuallyDrop::new(vec);
-        unsafe { munmap(addr, size).unwrap() }
+        unsafe { munmap(NonNull::new(addr).expect("addr is null"), size).unwrap() }
     }
 }
 

--- a/rs/memory_tracker/benches/traps.rs
+++ b/rs/memory_tracker/benches/traps.rs
@@ -38,7 +38,7 @@ fn criterion_fault_handler_sim_read(criterion: &mut Criterion) {
             None,
             NonZeroUsize::new(PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
-            MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
+            MapFlags::MAP_PRIVATE,
         )
         .unwrap()
     }
@@ -88,7 +88,7 @@ fn criterion_fault_handler_sim_write(criterion: &mut Criterion) {
             None,
             NonZeroUsize::new(PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
-            MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
+            MapFlags::MAP_PRIVATE,
         )
         .unwrap()
     }

--- a/rs/memory_tracker/benches/traps.rs
+++ b/rs/memory_tracker/benches/traps.rs
@@ -6,8 +6,8 @@ use memory_tracker::{
 
 use libc::{self, c_void};
 use memory_tracker::signal_mutex::SignalMutex;
-use nix::sys::mman::{MapFlags, ProtFlags, mmap};
-use std::ptr;
+use nix::sys::mman::{MapFlags, ProtFlags, mmap_anonymous};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,16 +34,15 @@ fn criterion_fault_handler_sim_read(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("fault_handler");
 
     let ptr: *mut c_void = unsafe {
-        mmap(
-            ptr::null_mut(),
-            PAGE_SIZE,
+        mmap_anonymous(
+            None,
+            NonZeroUsize::new(PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
             MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
-            0,
-            0,
         )
         .unwrap()
-    };
+    }
+    .as_ptr();
 
     group.bench_function("fault handler sim read", |bench| {
         bench.iter_with_setup(
@@ -85,16 +84,15 @@ fn criterion_fault_handler_sim_write(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("fault_handler");
 
     let ptr: *mut c_void = unsafe {
-        mmap(
-            ptr::null_mut(),
-            PAGE_SIZE,
+        mmap_anonymous(
+            None,
+            NonZeroUsize::new(PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
             MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
-            0,
-            0,
         )
         .unwrap()
-    };
+    }
+    .as_ptr();
 
     group.bench_function("fault handler sim write", |bench| {
         bench.iter_with_setup(

--- a/rs/memory_tracker/src/deterministic.rs
+++ b/rs/memory_tracker/src/deterministic.rs
@@ -263,7 +263,7 @@ impl DeterministicState {
         // SAFETY: We just checked that the Wasm page was accessed (mapped), so it must be valid.
         unsafe {
             mprotect(
-                page_start_addr,
+                std::ptr::NonNull::new(page_start_addr).expect("mprotect address is null"),
                 range_size_in_bytes(&page_range),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             )

--- a/rs/memory_tracker/src/lib.rs
+++ b/rs/memory_tracker/src/lib.rs
@@ -12,7 +12,10 @@ use nix::{
 };
 use std::{
     cell::Cell,
+    num::NonZeroUsize,
     ops::Range,
+    os::unix::io::BorrowedFd,
+    ptr::NonNull,
     sync::{
         Arc,
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -582,11 +585,12 @@ fn apply_memory_instructions(
                 metrics.mmap_count.fetch_add(1, Ordering::Relaxed);
                 unsafe {
                     mmap(
-                        memory_area.page_start_addr_from(range.start),
-                        range_size_in_bytes(&range),
+                        NonZeroUsize::new(memory_area.page_start_addr_from(range.start) as usize),
+                        NonZeroUsize::new(range_size_in_bytes(&range))
+                            .expect("mmap length must be non-zero"),
                         current_prot_flags,
                         MapFlags::MAP_PRIVATE | MapFlags::MAP_FIXED,
-                        fd,
+                        BorrowedFd::borrow_raw(fd),
                         offset as i64,
                     )
                     .map_err(print_enomem_help)
@@ -603,7 +607,8 @@ fn apply_memory_instructions(
                     current_prot_flags = ProtFlags::PROT_READ | ProtFlags::PROT_WRITE;
                     unsafe {
                         mprotect(
-                            memory_area.page_start_addr_from(prefetch_range.start),
+                            NonNull::new(memory_area.page_start_addr_from(prefetch_range.start))
+                                .expect("mprotect address is null"),
                             range_size_in_bytes(&prefetch_range),
                             current_prot_flags,
                         )
@@ -631,7 +636,8 @@ fn apply_memory_instructions(
     if page_protection_flags != current_prot_flags {
         unsafe {
             mprotect(
-                memory_area.page_start_addr_from(prefetch_range.start),
+                NonNull::new(memory_area.page_start_addr_from(prefetch_range.start))
+                    .expect("mprotect address is null"),
                 range_size_in_bytes(&prefetch_range),
                 page_protection_flags,
             )

--- a/rs/memory_tracker/src/prefetching.rs
+++ b/rs/memory_tracker/src/prefetching.rs
@@ -9,6 +9,7 @@ use nix::sys::mman::{ProtFlags, mprotect};
 use std::{
     cell::RefCell,
     ops::Range,
+    ptr::NonNull,
     sync::{Arc, atomic::Ordering},
 };
 
@@ -112,7 +113,13 @@ impl MemoryTracker for PrefetchingMemoryTracker {
                 &tracker.metrics,
             );
         } else {
-            unsafe { mprotect(start, size.get() as usize, ProtFlags::PROT_NONE)? }
+            unsafe {
+                mprotect(
+                    NonNull::new(start).expect("mprotect address is null"),
+                    size.get() as usize,
+                    ProtFlags::PROT_NONE,
+                )?
+            }
             tracker
                 .metrics
                 .mprotect_count
@@ -249,7 +256,8 @@ pub fn basic_signal_handler(
         // Upgrade its protection to read+write.
         unsafe {
             nix::sys::mman::mprotect(
-                fault_address_page_boundary as *mut libc::c_void,
+                NonNull::new(fault_address_page_boundary as *mut libc::c_void)
+                    .expect("mprotect address is null"),
                 PAGE_SIZE,
                 nix::sys::mman::ProtFlags::PROT_READ | nix::sys::mman::ProtFlags::PROT_WRITE,
             )
@@ -266,7 +274,8 @@ pub fn basic_signal_handler(
         // data
         unsafe {
             nix::sys::mman::mprotect(
-                fault_address_page_boundary as *mut libc::c_void,
+                NonNull::new(fault_address_page_boundary as *mut libc::c_void)
+                    .expect("mprotect address is null"),
                 PAGE_SIZE,
                 nix::sys::mman::ProtFlags::PROT_READ | nix::sys::mman::ProtFlags::PROT_WRITE,
             )
@@ -288,7 +297,8 @@ pub fn basic_signal_handler(
         // Now reduce the access privileges to read-only
         unsafe {
             nix::sys::mman::mprotect(
-                fault_address_page_boundary as *mut libc::c_void,
+                NonNull::new(fault_address_page_boundary as *mut libc::c_void)
+                    .expect("mprotect address is null"),
                 PAGE_SIZE,
                 nix::sys::mman::ProtFlags::PROT_READ,
             )
@@ -441,7 +451,7 @@ pub fn prefetching_signal_handler(
                     .page_start_addr_from(prefetch_range.start);
                 unsafe {
                     mprotect(
-                        page_start_addr,
+                        NonNull::new(page_start_addr).expect("mprotect address is null"),
                         range_size_in_bytes(&prefetch_range),
                         ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                     )

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -67,7 +67,7 @@ fn setup(
             None,
             NonZeroUsize::new(memory_pages * PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
-            MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON,
+            MapFlags::MAP_PRIVATE
         )
         .unwrap()
     }

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -67,7 +67,7 @@ fn setup(
             None,
             NonZeroUsize::new(memory_pages * PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
-            MapFlags::MAP_PRIVATE
+            MapFlags::MAP_PRIVATE,
         )
         .unwrap()
     }

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -9,8 +9,9 @@ use ic_replicated_state::{
 use ic_sys::{PAGE_SIZE, PageBytes};
 use ic_types::{NumBytes, NumOsPages};
 use libc::c_void;
-use nix::sys::mman::{MapFlags, ProtFlags, mmap};
+use nix::sys::mman::{MapFlags, ProtFlags, mmap_anonymous};
 use rstest::rstest;
+use std::num::NonZeroUsize;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
@@ -62,16 +63,15 @@ fn setup(
     page_map.update(&pages);
 
     let memory = unsafe {
-        mmap(
-            std::ptr::null_mut(),
-            memory_pages * PAGE_SIZE,
+        mmap_anonymous(
+            None,
+            NonZeroUsize::new(memory_pages * PAGE_SIZE).expect("mmap length must be non-zero"),
             ProtFlags::PROT_NONE,
             MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON,
-            -1,
-            0,
         )
         .unwrap()
-    };
+    }
+    .as_ptr();
 
     match missing_page_handler_kind {
         MissingPageHandlerKind::Deterministic => {

--- a/rs/replicated_state/src/page_map/page_allocator/mmap.rs
+++ b/rs/replicated_state/src/page_map/page_allocator/mmap.rs
@@ -14,8 +14,10 @@ use libc::{c_void, close};
 use nix::sys::mman::{MapFlags, MmapAdvise, ProtFlags, madvise, mmap, munmap};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
 use std::os::raw::c_int;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{BorrowedFd, RawFd};
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -495,7 +497,8 @@ struct MmapBasedPageAllocatorCore {
 impl Drop for MmapBasedPageAllocatorCore {
     fn drop(&mut self) {
         for chunk in self.chunks.iter() {
-            let ptr = chunk.ptr as *mut c_void;
+            // `chunk.ptr` is a non-null mapping returned by `mmap`.
+            let ptr = NonNull::new(chunk.ptr as *mut c_void).expect("chunk pointer is null");
             // SAFETY: The chunk was created using `mmap`, so `munmap` should work.
             unsafe { munmap(ptr, chunk.size) }.unwrap_or_else(|err| {
                 panic!(
@@ -606,11 +609,11 @@ impl MmapBasedPageAllocatorCore {
         // SAFETY: The parameters are valid.
         let mmap_ptr = unsafe {
             mmap(
-                std::ptr::null_mut(),
-                mmap_size,
+                None,
+                NonZeroUsize::new(mmap_size).expect("mmap_size must be non-zero"),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                self.file_descriptor,
+                BorrowedFd::borrow_raw(self.file_descriptor),
                 mmap_file_offset,
             )
         }
@@ -620,7 +623,8 @@ impl MmapBasedPageAllocatorCore {
                  at offset {} while allocating a new memory block: {}",
                 mmap_size, self.file_descriptor, mmap_file_offset, err,
             )
-        }) as *mut u8;
+        })
+        .as_ptr() as *mut u8;
 
         // Do madvise transparent huge page performance optimization only on Linux.
         #[cfg(target_os = "linux")]
@@ -630,7 +634,7 @@ impl MmapBasedPageAllocatorCore {
             if mmap_size >= MIN_NUM_HUGE_PAGES_FOR_OPTIMIZATION.get() as usize * HUGE_PAGE_SIZE {
                 unsafe {
                     madvise(
-                        mmap_ptr as *mut c_void,
+                        NonNull::new(mmap_ptr as *mut c_void).expect("mmap pointer is null"),
                         mmap_size,
                         MmapAdvise::MADV_HUGEPAGE,
                     )
@@ -691,11 +695,11 @@ impl MmapBasedPageAllocatorCore {
         // SAFETY: The parameters are valid.
         let mmap_ptr = unsafe {
             mmap(
-                std::ptr::null_mut(),
-                mmap_size,
+                None,
+                NonZeroUsize::new(mmap_size).expect("mmap_size must be non-zero"),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                self.file_descriptor,
+                BorrowedFd::borrow_raw(self.file_descriptor),
                 mmap_file_offset,
             )
         }
@@ -705,7 +709,8 @@ impl MmapBasedPageAllocatorCore {
                          at offset {} for deserialization: {}",
                 mmap_size, self.file_descriptor, mmap_file_offset, err,
             )
-        }) as *mut u8;
+        })
+        .as_ptr() as *mut u8;
 
         self.chunks.push(Chunk {
             ptr: mmap_ptr,
@@ -767,7 +772,7 @@ impl MmapBasedPageAllocatorCore {
 // - the range is not empty.
 unsafe fn madvise_remove(start_ptr: *mut u8, end_ptr: *mut u8) {
     unsafe {
-        let ptr = start_ptr as *mut c_void;
+        let ptr = NonNull::new(start_ptr as *mut c_void).expect("start pointer is null");
         let size = end_ptr.offset_from(start_ptr);
         assert!(size > 0);
         // MacOS does not support punching holes in the file with `MADV_REMOVE`.

--- a/rs/replicated_state/src/page_map/page_allocator/tests.rs
+++ b/rs/replicated_state/src/page_map/page_allocator/tests.rs
@@ -4,7 +4,15 @@ use crate::page_map::{
 
 use super::{PageAllocator, PageAllocatorSerialization, PageSerialization};
 use ic_sys::{PAGE_SIZE, PageIndex};
-use nix::unistd::dup;
+use std::os::fd::{BorrowedFd, IntoRawFd, RawFd};
+
+/// Wrapper around `nix::unistd::dup` that keeps the raw-fd based signature these
+/// tests rely on (nix 0.31 takes an `AsFd` and returns an `OwnedFd`).
+fn dup(fd: RawFd) -> nix::Result<RawFd> {
+    // SAFETY: `fd` is a valid file descriptor for the duration of the call.
+    let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+    nix::unistd::dup(borrowed).map(IntoRawFd::into_raw_fd)
+}
 
 fn duplicate_file_descriptors(
     page_allocator: PageAllocatorSerialization,

--- a/rs/replicated_state/src/page_map/tests.rs
+++ b/rs/replicated_state/src/page_map/tests.rs
@@ -11,9 +11,17 @@ use ic_config::state_manager::LsmtConfig;
 use ic_metrics::MetricsRegistry;
 use ic_sys::PAGE_SIZE;
 use ic_types::{Height, MAX_STABLE_MEMORY_IN_BYTES};
-use nix::unistd::dup;
+use std::os::fd::{BorrowedFd, IntoRawFd, RawFd};
 use std::sync::Arc;
 use tempfile::{Builder, TempDir};
+
+/// Wrapper around `nix::unistd::dup` that keeps the raw-fd based signature these
+/// tests rely on (nix 0.31 takes an `AsFd` and returns an `OwnedFd`).
+fn dup(fd: RawFd) -> nix::Result<RawFd> {
+    // SAFETY: `fd` is a valid file descriptor for the duration of the call.
+    let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+    nix::unistd::dup(borrowed).map(IntoRawFd::into_raw_fd)
+}
 
 fn assert_equal_page_maps(page_map1: &PageMap, page_map2: &PageMap) {
     assert_eq!(page_map1.num_host_pages(), page_map2.num_host_pages());

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -4493,11 +4493,8 @@ impl PageAllocatorFileDescriptorImpl {
             return self.create_backing_file_portable();
         }
 
-        match nix::sys::memfd::memfd_create(
-            &std::ffi::CString::default(),
-            nix::sys::memfd::MemFdCreateFlag::empty(),
-        ) {
-            Ok(fd) => fd,
+        match nix::sys::memfd::memfd_create(c"", nix::sys::memfd::MFdFlags::empty()) {
+            Ok(fd) => fd.into_raw_fd(),
             Err(err) => {
                 panic!("MmapPageAllocatorCore failed to create the memory backing file {err}")
             }

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -6402,7 +6402,7 @@ fn remove_old_diverged_checkpoint() {
                     .state_layout()
                     .diverged_checkpoint_path(Height(1));
                 let Ok(_) = utimensat(
-                    None,
+                    nix::fcntl::AT_FDCWD,
                     &path,
                     &TimeSpec::zero(),
                     &TimeSpec::zero(),
@@ -6492,7 +6492,7 @@ fn dont_remove_diverged_checkpoint_if_there_was_no_progress() {
                     .state_layout()
                     .diverged_checkpoint_path(Height(2));
                 let Ok(_) = utimensat(
-                    None,
+                    nix::fcntl::AT_FDCWD,
                     &path,
                     &TimeSpec::zero(),
                     &TimeSpec::zero(),

--- a/rs/sys/src/fs.rs
+++ b/rs/sys/src/fs.rs
@@ -622,13 +622,12 @@ pub fn copy_file_range_all(
     mut dst_offset: i64,
     len: usize,
 ) -> Result<(), CopyFileRangeAllError> {
-    use std::os::unix::io::AsRawFd;
     let mut copied_total = 0;
     while copied_total < len {
         let copied = nix::fcntl::copy_file_range(
-            src.as_raw_fd(),
+            src,
             Some(&mut src_offset),
-            dst.as_raw_fd(),
+            dst,
             Some(&mut dst_offset),
             len - copied_total,
         );

--- a/rs/sys/src/mmap.rs
+++ b/rs/sys/src/mmap.rs
@@ -4,8 +4,10 @@ mod tests;
 use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap};
 use std::convert::AsRef;
 use std::io;
-use std::os::unix::io::AsRawFd;
+use std::num::NonZeroUsize;
+use std::os::unix::io::{AsRawFd, BorrowedFd};
 use std::path::Path;
+use std::ptr::NonNull;
 
 /// `ScopedMmap` contains a memory region that is automatically
 /// unmapped when the value is dropped.
@@ -35,18 +37,21 @@ impl ScopedMmap {
             });
         }
 
+        // `len == 0` is handled above, so the `unwrap` cannot panic.
+        let non_zero_len = NonZeroUsize::new(len).unwrap();
         // It's not clear why mmap-ing a file is considered unsafe.  Using the
         // address is indeed unsafe, but mmap itself doesn't do anything bad.
         let addr = unsafe {
             mmap(
-                std::ptr::null_mut(),
-                len,
+                None,
+                non_zero_len,
                 ProtFlags::PROT_READ,
                 MapFlags::MAP_SHARED,
-                fd.as_raw_fd(),
+                BorrowedFd::borrow_raw(fd.as_raw_fd()),
                 offset,
             )
-        }?;
+        }?
+        .as_ptr();
         Ok(Self { addr, len })
     }
 
@@ -96,7 +101,9 @@ impl ScopedMmap {
 impl Drop for ScopedMmap {
     fn drop(&mut self) {
         if self.len > 0 {
-            unsafe { munmap(self.addr, self.len) }.expect("Failed to unmap");
+            // `len > 0` guarantees `addr` is a non-null mapping created by `mmap`.
+            let addr = NonNull::new(self.addr).expect("mapping with non-zero length has null addr");
+            unsafe { munmap(addr, self.len) }.expect("Failed to unmap");
         }
     }
 }

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -901,7 +901,7 @@ impl LocalBackend {
     /// overlays at the end of the group.
     fn ensure_base_image(&self, src: &Path) -> Result<PathBuf> {
         use ic_crypto_sha2::Sha256;
-        use std::os::unix::io::AsRawFd;
+        use nix::fcntl::{Flock, FlockArg};
 
         let cache_dir = self.active_local_backend.working_dir.join("image_cache");
         std::fs::create_dir_all(&cache_dir)
@@ -921,13 +921,14 @@ impl LocalBackend {
             .append(true)
             .open(&lock_path)
             .with_context(|| format!("opening image cache lock {}", lock_path.display()))?;
-        nix::fcntl::flock(lock.as_raw_fd(), nix::fcntl::FlockArg::LockExclusive)
+        // Hold an exclusive advisory lock through a `Flock` guard. The lock is
+        // released when the guard is dropped at the end of this function (which
+        // also closes the underlying `File`). Rust opens files `O_CLOEXEC`, so a
+        // forked task subprocess that `exec`s does not inherit this fd and
+        // therefore cannot keep the lock held after we return.
+        let _image_cache_lock = Flock::lock(lock, FlockArg::LockExclusive)
+            .map_err(|(_, errno)| errno)
             .with_context(|| format!("locking image cache lock {}", lock_path.display()))?;
-        // The lock is released when `lock` is dropped at the end of this function
-        // (its `File` closes the fd, which drops the advisory lock). Rust opens
-        // files `O_CLOEXEC`, so a forked task subprocess that `exec`s does not
-        // inherit this fd and therefore cannot keep the lock held after we
-        // return.
 
         if !base.exists() {
             // Extract to a temp file on the same filesystem, then atomically

--- a/rs/tests/driver/src/driver/logger.rs
+++ b/rs/tests/driver/src/driver/logger.rs
@@ -2,19 +2,43 @@
 
 use crate::driver::constants;
 use anyhow::Result;
+use nix::fcntl::{Flock, FlockArg};
 use slog::{Drain, KV, Key, Level, Logger, OwnedKVList, Record, o};
 use slog_term::Decorator;
+use std::path::Path;
 use std::{fmt, fs::File, io};
-use std::{os::unix::prelude::AsRawFd, path::Path};
 
-fn open_append_and_lock_exclusive<P: AsRef<Path>>(p: P) -> Result<File> {
-    let f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(p)?;
-    let fd = f.as_raw_fd();
-    nix::fcntl::flock(fd, nix::fcntl::FlockArg::LockExclusiveNonblock)?;
-    Ok(f)
+/// A log file that holds an exclusive advisory `flock` for as long as it stays
+/// open; the lock is released when the value is dropped. Holding the `Flock`
+/// guard (rather than a bare `File`) is what keeps the lock alive for the
+/// lifetime of the logger the file is handed to.
+pub(crate) struct LockedLogFile(Flock<File>);
+
+impl LockedLogFile {
+    /// Opens `p` for appending, creating it if needed, and takes an exclusive
+    /// advisory lock on it. Fails immediately (rather than blocking) if another
+    /// process already holds the lock.
+    pub(crate) fn open_append_and_lock_exclusive<P: AsRef<Path>>(p: P) -> Result<Self> {
+        let f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)?;
+        let locked = Flock::lock(f, FlockArg::LockExclusiveNonblock).map_err(|(_, errno)| errno)?;
+        Ok(Self(locked))
+    }
+}
+
+impl io::Write for LockedLogFile {
+    // Faithfully forwards the `Write::write` contract to the locked file, so the
+    // partial-write check does not apply here.
+    #[allow(clippy::disallowed_methods)]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
 }
 
 fn async_drain<D>(d: D) -> slog::Fuse<slog_async::Async>
@@ -32,7 +56,7 @@ where
 /// don't exist.
 fn new_file_logger<P: AsRef<Path>>(p: P) -> Result<Logger> {
     std::fs::create_dir_all(p.as_ref().parent().expect("no parent"))?;
-    let log_file = open_append_and_lock_exclusive(p)?;
+    let log_file = LockedLogFile::open_append_and_lock_exclusive(p)?;
     let file_drain = slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(log_file))
         .build()
         .fuse();

--- a/rs/tests/driver/src/driver/test_env.rs
+++ b/rs/tests/driver/src/driver/test_env.rs
@@ -9,7 +9,6 @@ use serde::de::DeserializeOwned;
 use slog::{Drain, Logger, info, o, warn};
 use slog_async::OverflowStrategy;
 use std::fs::{self, File};
-use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,6 +17,7 @@ use crate::driver::driver_setup::{SSH_AUTHORIZED_PRIV_KEYS_DIR, SSH_AUTHORIZED_P
 use crate::driver::pot_dsl::TestPath;
 
 use crate::driver::constants::{SSH_USERNAME, SUBREPORT_LOG_PREFIX};
+use crate::driver::logger::LockedLogFile;
 
 use super::farm::HostFeature;
 
@@ -45,7 +45,7 @@ pub struct TestEnvInner {
 impl TestEnv {
     pub fn new<P: AsRef<Path>>(path: P, logger: Logger) -> Result<TestEnv> {
         let base_path = PathBuf::from(path.as_ref());
-        let log_file = append_and_lock_exclusive(base_path.join("test.log"))?;
+        let log_file = LockedLogFile::open_append_and_lock_exclusive(base_path.join("test.log"))?;
         let file_drain = slog_term::FullFormat::new(slog_term::PlainDecorator::new(log_file))
             .build()
             .fuse();
@@ -318,16 +318,6 @@ fn ic_prep_path(base_path: PathBuf, name: &str) -> PathBuf {
         format!("ic_prep_{name}")
     };
     base_path.join(dir_name)
-}
-
-fn append_and_lock_exclusive<P: AsRef<Path>>(p: P) -> Result<File> {
-    let f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(p)?;
-    let fd = f.as_raw_fd();
-    nix::fcntl::flock(fd, nix::fcntl::FlockArg::LockExclusiveNonblock)?;
-    Ok(f)
 }
 
 pub trait SshKeyGen {

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -877,9 +877,9 @@ async fn patch_env_local_store(env: &TestEnv) {
 
     // Atomically swap the local stores, see `man 2 renameat2` for details.
     nix::fcntl::renameat2(
-        None,
+        nix::fcntl::AT_FDCWD,
         &fs::canonicalize(env.get_path("tmp_new_local_store")).unwrap(),
-        None,
+        nix::fcntl::AT_FDCWD,
         &fs::canonicalize(
             env.prep_dir("")
                 .map(|v| v.registry_local_store_path())

--- a/rs/xnet/payload_builder/src/xnet_client_tests.rs
+++ b/rs/xnet/payload_builder/src/xnet_client_tests.rs
@@ -212,6 +212,7 @@ async fn query_request_failed() {
     use nix::sys::socket::{
         AddressFamily, SockFlag, SockType, SockaddrIn, bind, getsockname, socket,
     };
+    use std::os::fd::AsRawFd;
 
     let metrics = &MetricsRegistry::new();
 
@@ -225,8 +226,8 @@ async fn query_request_failed() {
         None,
     )
     .expect("Socket creation failed");
-    bind(socket, &address).expect("bind() failed");
-    let sa = getsockname::<SockaddrIn>(socket).expect("getsockname() failed");
+    bind(socket.as_raw_fd(), &address).expect("bind() failed");
+    let sa = getsockname::<SockaddrIn>(socket.as_raw_fd()).expect("getsockname() failed");
 
     // URL to query a server that would be running on the allocated port.
     let url = format!("http://{sa}").parse::<Uri>().unwrap();


### PR DESCRIPTION
Most of the changes in the code come from `nix` making its interface a bit more type safe:
* `NonNullUsize` is needed in a couple of places so that the code panics at the Rust level if the invariant doesn't hold
* `flock` vs `Flock`: since `0.28` `nix` requires an explicit `Flock` object that unlocks the `flock` when `Drop`ped.