### PR TITLE
feat: Make query limits configurable in the SubnetRecord

### DIFF
--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -38,7 +38,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
-  maximum_query_call_walltime_seconds : opt nat64;
+  maximum_query_walltime_seconds : opt nat64;
 };
 
 // Mirror of the subset of registry types referenced by UpdateSubnetPayload.

--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -38,6 +38,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
+  maximum_query_call_walltime_seconds : opt nat64;
 };
 
 // Mirror of the subset of registry types referenced by UpdateSubnetPayload.

--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -37,6 +37,7 @@ type SubnetFeatures = record {
 type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
+  maximum_query_instructions : opt nat64;
 };
 
 // Mirror of the subset of registry types referenced by UpdateSubnetPayload.

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2966,6 +2966,7 @@ fn maximum_state_size() {
     let resource_limits = ResourceLimits {
         maximum_state_size: Some(maximum_state_size),
         maximum_state_delta: None,
+        ..Default::default()
     };
     let subnet_config = SubnetConfig::new(SubnetType::Application);
     let hypervisor_config = HypervisorConfig {
@@ -3004,6 +3005,7 @@ fn maximum_state_delta() {
     let resource_limits = ResourceLimits {
         maximum_state_size: None,
         maximum_state_delta: Some(maximum_state_delta),
+        ..Default::default()
     };
     let subnet_config = SubnetConfig::new(SubnetType::Application);
     // We disable per-canister rate-limiting of heap delta to simplify the test.

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -749,6 +749,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             resource_limits: ResourceLimits {
                 maximum_state_size: Some(own_maximum_state_size),
                 maximum_state_delta: Some(own_maximum_state_delta),
+                ..Default::default()
             },
 
             ..Default::default()

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -38,7 +38,8 @@ use ic_types::crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTranscript};
 use ic_types::time::Time;
 use ic_types::xnet::{StreamIndexedQueue, StreamSlice};
 use ic_types::{
-    CanisterId, ExecutionRound, NodeId, NumBytes, PrincipalId, Randomness, ReplicaVersion,
+    CanisterId, ExecutionRound, NodeId, NumBytes, NumInstructions, PrincipalId, Randomness,
+    ReplicaVersion,
 };
 use maplit::{btreemap, btreeset};
 use std::{fmt::Debug, str::FromStr, sync::Arc, time::Duration};
@@ -714,6 +715,8 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         let own_subnet_id = subnet_test_id(13);
         let own_maximum_state_size = NumBytes::new(1 << 30);
         let own_maximum_state_delta = NumBytes::new(1 << 20);
+        let own_maximum_query_instructions = NumInstructions::new(7_000_000_000);
+        let own_maximum_query_call_walltime_seconds = 15;
         let own_subnet_record = SubnetRecord {
             membership: &[node_test_id(1), node_test_id(2)],
             subnet_type: SubnetType::Application,
@@ -749,7 +752,8 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             resource_limits: ResourceLimits {
                 maximum_state_size: Some(own_maximum_state_size),
                 maximum_state_delta: Some(own_maximum_state_delta),
-                ..Default::default()
+                maximum_query_instructions: Some(own_maximum_query_instructions),
+                maximum_query_call_walltime_seconds: Some(own_maximum_query_call_walltime_seconds),
             },
 
             ..Default::default()
@@ -1057,6 +1061,16 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         assert_eq!(
             latest_state.resource_limits().maximum_state_delta,
             Some(own_maximum_state_delta)
+        );
+        assert_eq!(
+            latest_state.resource_limits().maximum_query_instructions,
+            Some(own_maximum_query_instructions)
+        );
+        assert_eq!(
+            latest_state
+                .resource_limits()
+                .maximum_query_call_walltime_seconds,
+            Some(own_maximum_query_call_walltime_seconds)
         );
         assert_eq!(
             *registry_settings.lock().unwrap(),

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -716,7 +716,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         let own_maximum_state_size = NumBytes::new(1 << 30);
         let own_maximum_state_delta = NumBytes::new(1 << 20);
         let own_maximum_query_instructions = NumInstructions::new(7_000_000_000);
-        let own_maximum_query_call_walltime_seconds = 15;
+        let own_maximum_query_walltime_seconds = 15;
         let own_subnet_record = SubnetRecord {
             membership: &[node_test_id(1), node_test_id(2)],
             subnet_type: SubnetType::Application,
@@ -753,7 +753,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
                 maximum_state_size: Some(own_maximum_state_size),
                 maximum_state_delta: Some(own_maximum_state_delta),
                 maximum_query_instructions: Some(own_maximum_query_instructions),
-                maximum_query_call_walltime_seconds: Some(own_maximum_query_call_walltime_seconds),
+                maximum_query_walltime_seconds: Some(own_maximum_query_walltime_seconds),
             },
 
             ..Default::default()
@@ -1069,8 +1069,8 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
         assert_eq!(
             latest_state
                 .resource_limits()
-                .maximum_query_call_walltime_seconds,
-            Some(own_maximum_query_call_walltime_seconds)
+                .maximum_query_walltime_seconds,
+            Some(own_maximum_query_walltime_seconds)
         );
         assert_eq!(
             *registry_settings.lock().unwrap(),

--- a/rs/messaging/tests/common/mod.rs
+++ b/rs/messaging/tests/common/mod.rs
@@ -250,6 +250,7 @@ impl TestSubnetConfig {
             maximum_state_delta: Some(heap_delta_capacity_for_message_memory(NumBytes::from(
                 self.guaranteed_response_message_memory_capacity,
             ))),
+            ..Default::default()
         })
     }
 }

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -406,4 +406,12 @@ enum CanisterCyclesCostSchedule {
 message ResourceLimits {
   optional uint64 maximum_state_size = 1;
   optional uint64 maximum_state_delta = 2;
+  // The maximum number of instructions a single query (or composite query)
+  // method execution is allowed to consume.
+  // The protocol uses a default value if the limit of `0` is specified.
+  optional uint64 maximum_query_instructions = 3;
+  // The maximum number of instructions allowed across an entire composite query
+  // call graph.
+  // The protocol uses a default value if the limit of `0` is specified.
+  optional uint64 maximum_composite_query_instructions = 4;
 }

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -405,7 +405,9 @@ enum CanisterCyclesCostSchedule {
 // Limits on resource consumption (e.g., memory usage).
 message ResourceLimits {
   optional uint64 maximum_state_size = 1;
+
   optional uint64 maximum_state_delta = 2;
+
   // The maximum number of instructions a query may consume. This applies both to a single
   // (non-composite) query method execution and to the total across an entire composite query
   // call graph.

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -406,12 +406,9 @@ enum CanisterCyclesCostSchedule {
 message ResourceLimits {
   optional uint64 maximum_state_size = 1;
   optional uint64 maximum_state_delta = 2;
-  // The maximum number of instructions a single query (or composite query)
-  // method execution is allowed to consume.
-  // The protocol uses a default value if the limit of `0` is specified.
-  optional uint64 maximum_query_instructions = 3;
-  // The maximum number of instructions allowed across an entire composite query
+  // The maximum number of instructions a query may consume. This applies both to a single
+  // (non-composite) query method execution and to the total across an entire composite query
   // call graph.
   // The protocol uses a default value if the limit of `0` is specified.
-  optional uint64 maximum_composite_query_instructions = 4;
+  optional uint64 maximum_query_instructions = 3;
 }

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -413,4 +413,8 @@ message ResourceLimits {
   // call graph.
   // The protocol uses a default value if the limit of `0` is specified.
   optional uint64 maximum_query_instructions = 3;
+  // The maximum wall-clock time, in seconds, that a query (including a composite query call
+  // graph) is allowed to run.
+  // The protocol uses a default value if the limit of `0` is specified.
+  optional uint64 maximum_query_call_walltime_seconds = 4;
 }

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -416,5 +416,5 @@ message ResourceLimits {
   // The maximum wall-clock time, in seconds, that a query (including a composite query call
   // graph) is allowed to run.
   // The protocol uses a default value if the limit of `0` is specified.
-  optional uint64 maximum_query_call_walltime_seconds = 4;
+  optional uint64 maximum_query_walltime_seconds = 4;
 }

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -437,6 +437,16 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
+    /// The maximum number of instructions a single query (or composite query)
+    /// method execution is allowed to consume.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "3")]
+    pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum number of instructions allowed across an entire composite query
+    /// call graph.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(
     serde::Serialize,

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -443,6 +443,11 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum wall-clock time, in seconds, that a query (including a composite query call
+    /// graph) is allowed to run.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(
     serde::Serialize,

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -437,16 +437,12 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
-    /// The maximum number of instructions a single query (or composite query)
-    /// method execution is allowed to consume.
+    /// The maximum number of instructions a query may consume. This applies both to a single
+    /// (non-composite) query method execution and to the total across an entire composite query
+    /// call graph.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
-    /// The maximum number of instructions allowed across an entire composite query
-    /// call graph.
-    /// The protocol uses a default value if the limit of `0` is specified.
-    #[prost(uint64, optional, tag = "4")]
-    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(
     serde::Serialize,

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -447,7 +447,7 @@ pub struct ResourceLimits {
     /// graph) is allowed to run.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "4")]
-    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
+    pub maximum_query_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(
     serde::Serialize,

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -415,6 +415,16 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
+    /// The maximum number of instructions a single query (or composite query)
+    /// method execution is allowed to consume.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "3")]
+    pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum number of instructions allowed across an entire composite query
+    /// call graph.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -425,7 +425,7 @@ pub struct ResourceLimits {
     /// graph) is allowed to run.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "4")]
-    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
+    pub maximum_query_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -415,16 +415,12 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
-    /// The maximum number of instructions a single query (or composite query)
-    /// method execution is allowed to consume.
+    /// The maximum number of instructions a query may consume. This applies both to a single
+    /// (non-composite) query method execution and to the total across an entire composite query
+    /// call graph.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
-    /// The maximum number of instructions allowed across an entire composite query
-    /// call graph.
-    /// The protocol uses a default value if the limit of `0` is specified.
-    #[prost(uint64, optional, tag = "4")]
-    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -421,6 +421,11 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum wall-clock time, in seconds, that a query (including a composite query call
+    /// graph) is allowed to run.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -415,6 +415,16 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
+    /// The maximum number of instructions a single query (or composite query)
+    /// method execution is allowed to consume.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "3")]
+    pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum number of instructions allowed across an entire composite query
+    /// call graph.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -425,7 +425,7 @@ pub struct ResourceLimits {
     /// graph) is allowed to run.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "4")]
-    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
+    pub maximum_query_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -415,16 +415,12 @@ pub struct ResourceLimits {
     pub maximum_state_size: ::core::option::Option<u64>,
     #[prost(uint64, optional, tag = "2")]
     pub maximum_state_delta: ::core::option::Option<u64>,
-    /// The maximum number of instructions a single query (or composite query)
-    /// method execution is allowed to consume.
+    /// The maximum number of instructions a query may consume. This applies both to a single
+    /// (non-composite) query method execution and to the total across an entire composite query
+    /// call graph.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
-    /// The maximum number of instructions allowed across an entire composite query
-    /// call graph.
-    /// The protocol uses a default value if the limit of `0` is specified.
-    #[prost(uint64, optional, tag = "4")]
-    pub maximum_composite_query_instructions: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -421,6 +421,11 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[prost(uint64, optional, tag = "3")]
     pub maximum_query_instructions: ::core::option::Option<u64>,
+    /// The maximum wall-clock time, in seconds, that a query (including a composite query call
+    /// graph) is allowed to run.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[prost(uint64, optional, tag = "4")]
+    pub maximum_query_call_walltime_seconds: ::core::option::Option<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rs/registry/admin/bin/update_subnet.rs
+++ b/rs/registry/admin/bin/update_subnet.rs
@@ -346,14 +346,24 @@ impl ProposeToUpdateSubnetCmd {
             let ResourceLimits {
                 maximum_state_size,
                 maximum_state_delta,
+                maximum_query_instructions,
+                maximum_composite_query_instructions,
             } = resource_limits;
             let maximum_state_size =
                 maximum_state_size.or(subnet_record.resource_limits.maximum_state_size);
             let maximum_state_delta =
                 maximum_state_delta.or(subnet_record.resource_limits.maximum_state_delta);
+            let maximum_query_instructions = maximum_query_instructions
+                .or(subnet_record.resource_limits.maximum_query_instructions);
+            let maximum_composite_query_instructions =
+                maximum_composite_query_instructions.or(subnet_record
+                    .resource_limits
+                    .maximum_composite_query_instructions);
             ResourceLimits {
                 maximum_state_size,
                 maximum_state_delta,
+                maximum_query_instructions,
+                maximum_composite_query_instructions,
             }
         });
 
@@ -417,7 +427,7 @@ mod tests {
         EcdsaCurve, EcdsaKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve, VetKdKeyId,
     };
     use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
-    use ic_types::{NumBytes, PrincipalId};
+    use ic_types::{NumBytes, NumInstructions, PrincipalId};
 
     use super::*;
 
@@ -870,6 +880,7 @@ mod tests {
         let initial_resource_limits = ResourceLimits {
             maximum_state_size: Some(NumBytes::new(42)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         };
 
         let resource_limits_mutation = None;
@@ -889,17 +900,20 @@ mod tests {
         let initial_resource_limits = ResourceLimits {
             maximum_state_size: Some(NumBytes::new(42)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         };
 
         let resource_limits_mutation = Some(ResourceLimits {
             maximum_state_size: None,
             maximum_state_delta: None,
+            ..Default::default()
         });
 
         // `expected_resource_limits` are `None` if and only if `resource_limits_mutation` is None
         let expected_resource_limits = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(42)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         });
 
         assert_expected_resource_limits_eq(
@@ -914,11 +928,13 @@ mod tests {
         let initial_resource_limits = ResourceLimits {
             maximum_state_size: Some(NumBytes::new(42)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         };
 
         let resource_limits_mutation = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: None,
+            ..Default::default()
         });
 
         // `maximum_state_size` is overriden according to `resource_limits_mutation`,
@@ -927,6 +943,7 @@ mod tests {
         let expected_resource_limits = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         });
 
         assert_expected_resource_limits_eq(
@@ -941,11 +958,13 @@ mod tests {
         let initial_resource_limits = ResourceLimits {
             maximum_state_size: None,
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         };
 
         let resource_limits_mutation = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: None,
+            ..Default::default()
         });
 
         // `maximum_state_size` is overriden according to `resource_limits_mutation`,
@@ -954,6 +973,7 @@ mod tests {
         let expected_resource_limits = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         });
 
         assert_expected_resource_limits_eq(
@@ -968,16 +988,49 @@ mod tests {
         let initial_resource_limits = ResourceLimits {
             maximum_state_size: Some(NumBytes::new(42)),
             maximum_state_delta: Some(NumBytes::new(64)),
+            ..Default::default()
         };
 
         let resource_limits_mutation = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: Some(NumBytes::new(256)),
+            ..Default::default()
         });
 
         let expected_resource_limits = Some(ResourceLimits {
             maximum_state_size: Some(NumBytes::new(128)),
             maximum_state_delta: Some(NumBytes::new(256)),
+            ..Default::default()
+        });
+
+        assert_expected_resource_limits_eq(
+            initial_resource_limits,
+            resource_limits_mutation,
+            expected_resource_limits,
+        );
+    }
+
+    #[test]
+    fn cli_to_payload_conversion_works_for_resource_limits_instruction_limits() {
+        let initial_resource_limits = ResourceLimits {
+            maximum_query_instructions: Some(NumInstructions::new(42)),
+            maximum_composite_query_instructions: Some(NumInstructions::new(64)),
+            ..Default::default()
+        };
+
+        let resource_limits_mutation = Some(ResourceLimits {
+            maximum_query_instructions: Some(NumInstructions::new(128)),
+            maximum_composite_query_instructions: None,
+            ..Default::default()
+        });
+
+        // `maximum_query_instructions` is overriden according to `resource_limits_mutation`,
+        // `maximum_composite_query_instructions` is not set in `resource_limits_mutation` and thus
+        // the value from `initial_resource_limits` is used.
+        let expected_resource_limits = Some(ResourceLimits {
+            maximum_query_instructions: Some(NumInstructions::new(128)),
+            maximum_composite_query_instructions: Some(NumInstructions::new(64)),
+            ..Default::default()
         });
 
         assert_expected_resource_limits_eq(

--- a/rs/registry/admin/bin/update_subnet.rs
+++ b/rs/registry/admin/bin/update_subnet.rs
@@ -342,24 +342,9 @@ impl ProposeToUpdateSubnetCmd {
             }
         }
 
-        let resource_limits = self.resource_limits.map(|resource_limits| {
-            let ResourceLimits {
-                maximum_state_size,
-                maximum_state_delta,
-                maximum_query_instructions,
-            } = resource_limits;
-            let maximum_state_size =
-                maximum_state_size.or(subnet_record.resource_limits.maximum_state_size);
-            let maximum_state_delta =
-                maximum_state_delta.or(subnet_record.resource_limits.maximum_state_delta);
-            let maximum_query_instructions = maximum_query_instructions
-                .or(subnet_record.resource_limits.maximum_query_instructions);
-            ResourceLimits {
-                maximum_state_size,
-                maximum_state_delta,
-                maximum_query_instructions,
-            }
-        });
+        let resource_limits = self
+            .resource_limits
+            .map(|resource_limits| resource_limits.inherit_from(&subnet_record.resource_limits));
 
         do_update_subnet::UpdateSubnetPayload {
             subnet_id,

--- a/rs/registry/admin/bin/update_subnet.rs
+++ b/rs/registry/admin/bin/update_subnet.rs
@@ -347,7 +347,6 @@ impl ProposeToUpdateSubnetCmd {
                 maximum_state_size,
                 maximum_state_delta,
                 maximum_query_instructions,
-                maximum_composite_query_instructions,
             } = resource_limits;
             let maximum_state_size =
                 maximum_state_size.or(subnet_record.resource_limits.maximum_state_size);
@@ -355,15 +354,10 @@ impl ProposeToUpdateSubnetCmd {
                 maximum_state_delta.or(subnet_record.resource_limits.maximum_state_delta);
             let maximum_query_instructions = maximum_query_instructions
                 .or(subnet_record.resource_limits.maximum_query_instructions);
-            let maximum_composite_query_instructions =
-                maximum_composite_query_instructions.or(subnet_record
-                    .resource_limits
-                    .maximum_composite_query_instructions);
             ResourceLimits {
                 maximum_state_size,
                 maximum_state_delta,
                 maximum_query_instructions,
-                maximum_composite_query_instructions,
             }
         });
 
@@ -1011,25 +1005,43 @@ mod tests {
     }
 
     #[test]
-    fn cli_to_payload_conversion_works_for_resource_limits_instruction_limits() {
+    fn cli_to_payload_conversion_works_for_maximum_query_instructions() {
+        // Override an existing `maximum_query_instructions` value.
         let initial_resource_limits = ResourceLimits {
             maximum_query_instructions: Some(NumInstructions::new(42)),
-            maximum_composite_query_instructions: Some(NumInstructions::new(64)),
             ..Default::default()
         };
 
         let resource_limits_mutation = Some(ResourceLimits {
             maximum_query_instructions: Some(NumInstructions::new(128)),
-            maximum_composite_query_instructions: None,
             ..Default::default()
         });
 
-        // `maximum_query_instructions` is overriden according to `resource_limits_mutation`,
-        // `maximum_composite_query_instructions` is not set in `resource_limits_mutation` and thus
-        // the value from `initial_resource_limits` is used.
         let expected_resource_limits = Some(ResourceLimits {
             maximum_query_instructions: Some(NumInstructions::new(128)),
-            maximum_composite_query_instructions: Some(NumInstructions::new(64)),
+            ..Default::default()
+        });
+
+        assert_expected_resource_limits_eq(
+            initial_resource_limits,
+            resource_limits_mutation,
+            expected_resource_limits,
+        );
+
+        // A mutation that does not set `maximum_query_instructions` leaves the existing value.
+        let initial_resource_limits = ResourceLimits {
+            maximum_query_instructions: Some(NumInstructions::new(42)),
+            ..Default::default()
+        };
+
+        let resource_limits_mutation = Some(ResourceLimits {
+            maximum_state_size: Some(NumBytes::new(128)),
+            ..Default::default()
+        });
+
+        let expected_resource_limits = Some(ResourceLimits {
+            maximum_state_size: Some(NumBytes::new(128)),
+            maximum_query_instructions: Some(NumInstructions::new(42)),
             ..Default::default()
         });
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -84,6 +84,8 @@ type CompleteCanisterMigrationPayload = record {
 type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
+  maximum_query_instructions : opt nat64;
+  maximum_composite_query_instructions : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -85,7 +85,6 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
-  maximum_composite_query_instructions : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -85,6 +85,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
+  maximum_query_call_walltime_seconds : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -85,7 +85,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
-  maximum_query_call_walltime_seconds : opt nat64;
+  maximum_query_walltime_seconds : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -84,6 +84,8 @@ type CompleteCanisterMigrationPayload = record {
 type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
+  maximum_query_instructions : opt nat64;
+  maximum_composite_query_instructions : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -85,7 +85,6 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
-  maximum_composite_query_instructions : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -85,6 +85,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
+  maximum_query_call_walltime_seconds : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -85,7 +85,7 @@ type ResourceLimits = record {
   maximum_state_size : opt nat64;
   maximum_state_delta : opt nat64;
   maximum_query_instructions : opt nat64;
-  maximum_query_call_walltime_seconds : opt nat64;
+  maximum_query_walltime_seconds : opt nat64;
 };
 
 type CreateSubnetPayload = record {

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -788,6 +788,7 @@ mod tests {
                 ResourceLimits {
                     maximum_state_size: Some(NumBytes::new(42)),
                     maximum_state_delta: Some(NumBytes::new(64)),
+                    ..Default::default()
                 }
                 .into(),
             ),
@@ -847,6 +848,7 @@ mod tests {
                     ResourceLimits {
                         maximum_state_size: Some(NumBytes::new(42)),
                         maximum_state_delta: Some(NumBytes::new(64)),
+                        ..Default::default()
                     }
                     .into()
                 ),
@@ -883,6 +885,7 @@ mod tests {
                 ResourceLimits {
                     maximum_state_size: Some(NumBytes::new(42)),
                     maximum_state_delta: Some(NumBytes::new(64)),
+                    ..Default::default()
                 }
                 .into(),
             ),
@@ -956,6 +959,7 @@ mod tests {
                     ResourceLimits {
                         maximum_state_size: Some(NumBytes::new(42)),
                         maximum_state_delta: Some(NumBytes::new(64)),
+                        ..Default::default()
                     }
                     .into()
                 ),
@@ -971,6 +975,7 @@ mod tests {
                 ResourceLimits {
                     maximum_state_size: Some(NumBytes::new(42)),
                     maximum_state_delta: Some(NumBytes::new(64)),
+                    ..Default::default()
                 }
                 .into(),
             ),
@@ -988,6 +993,7 @@ mod tests {
                 ResourceLimits {
                     maximum_state_size: Some(NumBytes::new(128)),
                     maximum_state_delta: None,
+                    ..Default::default()
                 }
                 .into(),
             ),
@@ -1000,6 +1006,7 @@ mod tests {
                     ResourceLimits {
                         maximum_state_size: Some(NumBytes::new(128)),
                         maximum_state_delta: None,
+                        ..Default::default()
                     }
                     .into()
                 ),

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -789,7 +789,7 @@ mod tests {
                     maximum_state_size: Some(NumBytes::new(42)),
                     maximum_state_delta: Some(NumBytes::new(64)),
                     maximum_query_instructions: Some(NumInstructions::new(128)),
-                    maximum_query_call_walltime_seconds: Some(30),
+                    maximum_query_walltime_seconds: Some(30),
                 }
                 .into(),
             ),
@@ -850,7 +850,7 @@ mod tests {
                         maximum_state_size: Some(NumBytes::new(42)),
                         maximum_state_delta: Some(NumBytes::new(64)),
                         maximum_query_instructions: Some(NumInstructions::new(128)),
-                        maximum_query_call_walltime_seconds: Some(30),
+                        maximum_query_walltime_seconds: Some(30),
                     }
                     .into()
                 ),

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -673,7 +673,7 @@ mod tests {
     use ic_registry_subnet_features::DEFAULT_ECDSA_MAX_QUEUE_SIZE;
     use ic_registry_subnet_type::SubnetType;
     use ic_test_utilities_types::ids::subnet_test_id;
-    use ic_types::{NumBytes, PrincipalId, ReplicaVersion, SubnetId};
+    use ic_types::{NumBytes, NumInstructions, PrincipalId, ReplicaVersion, SubnetId};
     use maplit::btreemap;
     use std::str::FromStr;
 
@@ -788,7 +788,8 @@ mod tests {
                 ResourceLimits {
                     maximum_state_size: Some(NumBytes::new(42)),
                     maximum_state_delta: Some(NumBytes::new(64)),
-                    ..Default::default()
+                    maximum_query_instructions: Some(NumInstructions::new(128)),
+                    maximum_query_call_walltime_seconds: Some(30),
                 }
                 .into(),
             ),
@@ -848,7 +849,8 @@ mod tests {
                     ResourceLimits {
                         maximum_state_size: Some(NumBytes::new(42)),
                         maximum_state_delta: Some(NumBytes::new(64)),
-                        ..Default::default()
+                        maximum_query_instructions: Some(NumInstructions::new(128)),
+                        maximum_query_call_walltime_seconds: Some(30),
                     }
                     .into()
                 ),

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,6 +9,11 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added `maximum_query_instructions` and `maximum_composite_query_instructions` fields
+  to the subnet record's `ResourceLimits`, allowing the query instruction limits to
+  be configured per subnet via `create_subnet` and `update_subnet`. A value of `0`
+  (or unset) means the replica's default is used.
+
 ## Changed
 
 ## Deprecated

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,10 +9,11 @@ on the process that this file is part of, see
 
 ## Added
 
-* Added `maximum_query_instructions` and `maximum_composite_query_instructions` fields
-  to the subnet record's `ResourceLimits`, allowing the query instruction limits to
-  be configured per subnet via `create_subnet` and `update_subnet`. A value of `0`
-  (or unset) means the replica's default is used.
+* Added a `maximum_query_instructions` field to the subnet record's `ResourceLimits`,
+  allowing the query instruction limit to be configured per subnet via `create_subnet`
+  and `update_subnet`. It applies both to a single (non-composite) query method execution
+  and to the total across a composite query call graph. A value of `0` (or unset) means
+  the replica's default is used.
 
 ## Changed
 

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,11 +9,13 @@ on the process that this file is part of, see
 
 ## Added
 
-* Added a `maximum_query_instructions` field to the subnet record's `ResourceLimits`,
-  allowing the query instruction limit to be configured per subnet via `create_subnet`
-  and `update_subnet`. It applies both to a single (non-composite) query method execution
-  and to the total across a composite query call graph. A value of `0` (or unset) means
-  the replica's default is used.
+* Added `maximum_query_instructions` and `maximum_query_call_walltime_seconds` fields to the
+  subnet record's `ResourceLimits`, allowing the query instruction limit and the maximum query
+  wall-clock time to be configured per subnet via `create_subnet` and `update_subnet`.
+  `maximum_query_instructions` applies both to a single (non-composite) query method execution
+  and to the total across a composite query call graph; `maximum_query_call_walltime_seconds`
+  bounds the wall-clock time a query (including a composite query call graph) may run. For each,
+  a value of `0` (or unset) means the replica's default is used.
 
 ## Changed
 

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,11 +9,11 @@ on the process that this file is part of, see
 
 ## Added
 
-* Added `maximum_query_instructions` and `maximum_query_call_walltime_seconds` fields to the
+* Added `maximum_query_instructions` and `maximum_query_walltime_seconds` fields to the
   subnet record's `ResourceLimits`, allowing the query instruction limit and the maximum query
   wall-clock time to be configured per subnet via `create_subnet` and `update_subnet`.
   `maximum_query_instructions` applies both to a single (non-composite) query method execution
-  and to the total across a composite query call graph; `maximum_query_call_walltime_seconds`
+  and to the total across a composite query call graph; `maximum_query_walltime_seconds`
   bounds the wall-clock time a query (including a composite query call graph) may run. For each,
   a value of `0` (or unset) means the replica's default is used.
 

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -6,7 +6,7 @@
 use candid::CandidType;
 use clap::Args;
 use ic_protobuf::registry::subnet::v1 as pb;
-use ic_types::NumBytes;
+use ic_types::{NumBytes, NumInstructions};
 use serde::{Deserialize, Serialize};
 
 /// Limits on resource consumption (e.g., memory usage).
@@ -24,6 +24,15 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[arg(long)]
     pub maximum_state_delta: Option<NumBytes>,
+    /// The maximum number of instructions a single query (or composite query) method execution
+    /// is allowed to consume.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[arg(long)]
+    pub maximum_query_instructions: Option<NumInstructions>,
+    /// The maximum number of instructions allowed across an entire composite query call graph.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[arg(long)]
+    pub maximum_composite_query_instructions: Option<NumInstructions>,
 }
 
 impl ResourceLimits {
@@ -51,6 +60,10 @@ impl From<ResourceLimits> for pb::ResourceLimits {
         Self {
             maximum_state_size: resource_limits.maximum_state_size.map(|x| x.get()),
             maximum_state_delta: resource_limits.maximum_state_delta.map(|x| x.get()),
+            maximum_query_instructions: resource_limits.maximum_query_instructions.map(|x| x.get()),
+            maximum_composite_query_instructions: resource_limits
+                .maximum_composite_query_instructions
+                .map(|x| x.get()),
         }
     }
 }
@@ -60,6 +73,12 @@ impl From<pb::ResourceLimits> for ResourceLimits {
         Self {
             maximum_state_size: resource_limits.maximum_state_size.map(NumBytes::from),
             maximum_state_delta: resource_limits.maximum_state_delta.map(NumBytes::from),
+            maximum_query_instructions: resource_limits
+                .maximum_query_instructions
+                .map(NumInstructions::from),
+            maximum_composite_query_instructions: resource_limits
+                .maximum_composite_query_instructions
+                .map(NumInstructions::from),
         }
     }
 }

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -24,15 +24,12 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[arg(long)]
     pub maximum_state_delta: Option<NumBytes>,
-    /// The maximum number of instructions a single query (or composite query) method execution
-    /// is allowed to consume.
+    /// The maximum number of instructions a query may consume. This applies both to a single
+    /// (non-composite) query method execution and to the total across an entire composite query
+    /// call graph.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[arg(long)]
     pub maximum_query_instructions: Option<NumInstructions>,
-    /// The maximum number of instructions allowed across an entire composite query call graph.
-    /// The protocol uses a default value if the limit of `0` is specified.
-    #[arg(long)]
-    pub maximum_composite_query_instructions: Option<NumInstructions>,
 }
 
 impl ResourceLimits {
@@ -61,9 +58,6 @@ impl From<ResourceLimits> for pb::ResourceLimits {
             maximum_state_size: resource_limits.maximum_state_size.map(|x| x.get()),
             maximum_state_delta: resource_limits.maximum_state_delta.map(|x| x.get()),
             maximum_query_instructions: resource_limits.maximum_query_instructions.map(|x| x.get()),
-            maximum_composite_query_instructions: resource_limits
-                .maximum_composite_query_instructions
-                .map(|x| x.get()),
         }
     }
 }
@@ -75,9 +69,6 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             maximum_state_delta: resource_limits.maximum_state_delta.map(NumBytes::from),
             maximum_query_instructions: resource_limits
                 .maximum_query_instructions
-                .map(NumInstructions::from),
-            maximum_composite_query_instructions: resource_limits
-                .maximum_composite_query_instructions
                 .map(NumInstructions::from),
         }
     }

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -34,7 +34,7 @@ pub struct ResourceLimits {
     /// graph) is allowed to run.
     /// The protocol uses a default value if the limit of `0` is specified.
     #[arg(long)]
-    pub maximum_query_call_walltime_seconds: Option<u64>,
+    pub maximum_query_walltime_seconds: Option<u64>,
 }
 
 impl ResourceLimits {
@@ -49,9 +49,9 @@ impl ResourceLimits {
             maximum_query_instructions: self
                 .maximum_query_instructions
                 .or(base.maximum_query_instructions),
-            maximum_query_call_walltime_seconds: self
-                .maximum_query_call_walltime_seconds
-                .or(base.maximum_query_call_walltime_seconds),
+            maximum_query_walltime_seconds: self
+                .maximum_query_walltime_seconds
+                .or(base.maximum_query_walltime_seconds),
         }
     }
 
@@ -80,8 +80,7 @@ impl From<ResourceLimits> for pb::ResourceLimits {
             maximum_state_size: resource_limits.maximum_state_size.map(|x| x.get()),
             maximum_state_delta: resource_limits.maximum_state_delta.map(|x| x.get()),
             maximum_query_instructions: resource_limits.maximum_query_instructions.map(|x| x.get()),
-            maximum_query_call_walltime_seconds: resource_limits
-                .maximum_query_call_walltime_seconds,
+            maximum_query_walltime_seconds: resource_limits.maximum_query_walltime_seconds,
         }
     }
 }
@@ -94,8 +93,7 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             maximum_query_instructions: resource_limits
                 .maximum_query_instructions
                 .map(NumInstructions::from),
-            maximum_query_call_walltime_seconds: resource_limits
-                .maximum_query_call_walltime_seconds,
+            maximum_query_walltime_seconds: resource_limits.maximum_query_walltime_seconds,
         }
     }
 }

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -80,7 +80,8 @@ impl From<ResourceLimits> for pb::ResourceLimits {
             maximum_state_size: resource_limits.maximum_state_size.map(|x| x.get()),
             maximum_state_delta: resource_limits.maximum_state_delta.map(|x| x.get()),
             maximum_query_instructions: resource_limits.maximum_query_instructions.map(|x| x.get()),
-            maximum_query_call_walltime_seconds: resource_limits.maximum_query_call_walltime_seconds,
+            maximum_query_call_walltime_seconds: resource_limits
+                .maximum_query_call_walltime_seconds,
         }
     }
 }
@@ -93,7 +94,8 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             maximum_query_instructions: resource_limits
                 .maximum_query_instructions
                 .map(NumInstructions::from),
-            maximum_query_call_walltime_seconds: resource_limits.maximum_query_call_walltime_seconds,
+            maximum_query_call_walltime_seconds: resource_limits
+                .maximum_query_call_walltime_seconds,
         }
     }
 }

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -33,6 +33,20 @@ pub struct ResourceLimits {
 }
 
 impl ResourceLimits {
+    /// Returns a copy of `self` where every unset (`None`) field inherits its value from `base`.
+    ///
+    /// This is used when updating a subnet: fields not specified in the update keep the value
+    /// currently used in production (taken from the existing subnet record).
+    pub fn inherit_from(&self, base: &Self) -> Self {
+        Self {
+            maximum_state_size: self.maximum_state_size.or(base.maximum_state_size),
+            maximum_state_delta: self.maximum_state_delta.or(base.maximum_state_delta),
+            maximum_query_instructions: self
+                .maximum_query_instructions
+                .or(base.maximum_query_instructions),
+        }
+    }
+
     /// Returns the subnet memory capacity.
     ///
     /// This is `maximum_state_size` if not `0`, otherwise the provided `default`.

--- a/rs/registry/resource_limits/src/lib.rs
+++ b/rs/registry/resource_limits/src/lib.rs
@@ -30,6 +30,11 @@ pub struct ResourceLimits {
     /// The protocol uses a default value if the limit of `0` is specified.
     #[arg(long)]
     pub maximum_query_instructions: Option<NumInstructions>,
+    /// The maximum wall-clock time, in seconds, that a query (including a composite query call
+    /// graph) is allowed to run.
+    /// The protocol uses a default value if the limit of `0` is specified.
+    #[arg(long)]
+    pub maximum_query_call_walltime_seconds: Option<u64>,
 }
 
 impl ResourceLimits {
@@ -44,6 +49,9 @@ impl ResourceLimits {
             maximum_query_instructions: self
                 .maximum_query_instructions
                 .or(base.maximum_query_instructions),
+            maximum_query_call_walltime_seconds: self
+                .maximum_query_call_walltime_seconds
+                .or(base.maximum_query_call_walltime_seconds),
         }
     }
 
@@ -72,6 +80,7 @@ impl From<ResourceLimits> for pb::ResourceLimits {
             maximum_state_size: resource_limits.maximum_state_size.map(|x| x.get()),
             maximum_state_delta: resource_limits.maximum_state_delta.map(|x| x.get()),
             maximum_query_instructions: resource_limits.maximum_query_instructions.map(|x| x.get()),
+            maximum_query_call_walltime_seconds: resource_limits.maximum_query_call_walltime_seconds,
         }
     }
 }
@@ -84,6 +93,7 @@ impl From<pb::ResourceLimits> for ResourceLimits {
             maximum_query_instructions: resource_limits
                 .maximum_query_instructions
                 .map(NumInstructions::from),
+            maximum_query_call_walltime_seconds: resource_limits.maximum_query_call_walltime_seconds,
         }
     }
 }

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -371,6 +371,15 @@ fn system_metadata_roundtrip_encoding() {
     std::sync::Arc::make_mut(&mut system_metadata.own_subnet_info).node_public_keys = btreemap! {
         node_test_id(1) => pk_der,
     };
+    std::sync::Arc::make_mut(&mut system_metadata.own_subnet_info).resource_limits =
+        ResourceLimits {
+            maximum_state_size: Some(NumBytes::new(1 << 30)),
+            maximum_state_delta: Some(NumBytes::new(1 << 20)),
+            maximum_query_instructions: Some(ic_types::NumInstructions::new(7_000_000_000)),
+            maximum_composite_query_instructions: Some(ic_types::NumInstructions::new(
+                9_000_000_000,
+            )),
+        };
     system_metadata.bitcoin_get_successors_follow_up_responses =
         btreemap! { 10.into() => vec![vec![1], vec![2]] };
 

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -376,9 +376,6 @@ fn system_metadata_roundtrip_encoding() {
             maximum_state_size: Some(NumBytes::new(1 << 30)),
             maximum_state_delta: Some(NumBytes::new(1 << 20)),
             maximum_query_instructions: Some(ic_types::NumInstructions::new(7_000_000_000)),
-            maximum_composite_query_instructions: Some(ic_types::NumInstructions::new(
-                9_000_000_000,
-            )),
         };
     system_metadata.bitcoin_get_successors_follow_up_responses =
         btreemap! { 10.into() => vec![vec![1], vec![2]] };

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -376,6 +376,7 @@ fn system_metadata_roundtrip_encoding() {
             maximum_state_size: Some(NumBytes::new(1 << 30)),
             maximum_state_delta: Some(NumBytes::new(1 << 20)),
             maximum_query_instructions: Some(ic_types::NumInstructions::new(7_000_000_000)),
+            maximum_query_call_walltime_seconds: Some(15),
         };
     system_metadata.bitcoin_get_successors_follow_up_responses =
         btreemap! { 10.into() => vec![vec![1], vec![2]] };

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -376,7 +376,7 @@ fn system_metadata_roundtrip_encoding() {
             maximum_state_size: Some(NumBytes::new(1 << 30)),
             maximum_state_delta: Some(NumBytes::new(1 << 20)),
             maximum_query_instructions: Some(ic_types::NumInstructions::new(7_000_000_000)),
-            maximum_query_call_walltime_seconds: Some(15),
+            maximum_query_walltime_seconds: Some(15),
         };
     system_metadata.bitcoin_get_successors_follow_up_responses =
         btreemap! { 10.into() => vec![vec![1], vec![2]] };

--- a/rs/tests/execution/resource_limits_test.rs
+++ b/rs/tests/execution/resource_limits_test.rs
@@ -32,6 +32,7 @@ pub fn setup(env: TestEnv) {
     let resource_limits = ResourceLimits {
         maximum_state_size: Some(maximum_state_size()),
         maximum_state_delta: None,
+        ..Default::default()
     };
     InternetComputer::new()
         .add_subnet(


### PR DESCRIPTION
This commit adds new fields to ResourceLimits (and therefore SubnetRecord) in the registry canister:
- maximum_query_instructions
- maximum_query_walltime_seconds

This way, individual subnets and/or engines can be independently configured to allow more expensive queries. The drawback of setting the value too large is that it will be easy for expensive queries to use up all the resources that other queries/canisters might want to use.

This PR only makes it possible to set the values in the registry. They are read and stored by the replica due to the shared types, but otherwise they are still ignored by the replica until the follow-up PR.