### PR TITLE
feat(registry): Enable blank replica_version_id for engines.

### DIFF
--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -9,7 +9,7 @@ thread_local! {
     static IS_SUBNET_SPLITTING_ENABLED: Cell<bool> = const { Cell::new(false) };
     static IS_CHUNKIFYING_LARGE_VALUES_ENABLED: Cell<bool> = const { Cell::new(true) };
     static IS_NODE_SWAPPING_ENABLED: Cell<bool> = const { Cell::new(true) };
-    static IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED: Cell<bool> = const { Cell::new(false) };
+    static IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED: Cell<bool> = const { Cell::new(true) };
 
     // Temporary flags related to the node swapping feature.
     //

--- a/rs/registry/canister/src/invariants/replica_version.rs
+++ b/rs/registry/canister/src/invariants/replica_version.rs
@@ -33,10 +33,9 @@ use prost::Message;
 /// * Each URL is well-formed.
 /// * Release package hash is a well-formed hex-encoded SHA256 value.
 ///
-/// Exception: a CloudEngine can have a blank replica_version_id in its
-/// SubnetRecord if there is a StandardEngineReplicaVersionRecord. As of July
-/// 22, 2026, this feature is disabled via a flag (but the plan is to enable it
-/// in the not too distant future).
+/// Exception: a CloudEngine is allowed to have a blank replica_version_id in
+/// its SubnetRecord, provided a StandardEngineReplicaVersionRecord exists. In
+/// that case, that record determines the Cloud Engine's replica version.
 pub(crate) fn check_replica_version_invariants(
     snapshot: &RegistrySnapshot,
 ) -> Result<(), InvariantCheckError> {

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,10 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Cloud Engines are now allowed to have blank `replica_version_id` (in their
+  `SubnetRecord`). In this case, `StandardEngineReplicaVersionRecord` is used to
+  determine the Cloud Engine's replica version.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
This is "just" a flag flip, but it suddenly makes a whole bunch of code active.

# Future Work

Existing engines cannot yet transition to blank replica_version_id. That will be fixed in an upcoming PR.

# References

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/10885