### PR TITLE
fix: Add IC_GATEWAY_RUNTIME_DEPS to the large testnet target 

### DIFF
--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -286,7 +286,7 @@ system_test_nns(
         "dynamic_testnet",
         "manual",
     ],
-    runtime_deps = SNS_CANISTER_RUNTIME_DEPS | {
+    runtime_deps = IC_GATEWAY_RUNTIME_DEPS | SNS_CANISTER_RUNTIME_DEPS | {
         "II_BACKEND_WASM_PATH": "@mainnet_canisters//:internet_identity_backend.wasm.gz",
         "II_FRONTEND_WASM_PATH": "@mainnet_canisters//:internet_identity_frontend.wasm.gz",
         "NNS_DAPP_WASM_PATH": "@nns_dapp_canister//file",


### PR DESCRIPTION
The large testnet deploys an ic-gateway VM (large.rs), but its Bazel target was missing IC_GATEWAY_RUNTIME_DEPS, so IC_GATEWAY_UVM_CONFIG_IMAGE_PATH was not set and the setup task failed. All other testnet targets that deploy an ic-gateway VM already declare this dependency.