### PR TITLE
fix(ic-admin): A sender is needed by propose-to-bless-alternative-guest-os-version.

### DIFF
--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -4607,6 +4607,7 @@ async fn main() {
             SubCommand::ProposeToAddOrRemoveDataCenters(_) => (),
             SubCommand::ProposeToAddOrRemoveNodeProvider(_) => (),
             SubCommand::ProposeToAddWasmToSnsWasm(_) => (),
+            SubCommand::ProposeToBlessAlternativeGuestOsVersion(_) => (),
             SubCommand::ProposeToChangeNnsCanister(_) => (),
             SubCommand::ProposeToChangeSubnetMembership(_) => (),
             SubCommand::ProposeToChangeSubnetTypeAssignment(_) => (),


### PR DESCRIPTION
This bug was noticed by copilot.