### PR TITLE
chore: remove unnecessary requires-network for guest_upgrade_tests

### DIFF
--- a/rs/ic_os/guest_upgrade/tests/BUILD.bazel
+++ b/rs/ic_os/guest_upgrade/tests/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 rust_test(
     name = "guest_upgrade_tests",
     srcs = glob(["src/**/*.rs"]),
-    tags = ["requires-network"],
     deps = [
         "//rs/ic_os/config/types:config_types",
         "//rs/ic_os/guest_upgrade/client:lib",


### PR DESCRIPTION
The `guest_upgrade_tests` only requires an internal network so there's no need for external network connectivity.