### PR TITLE
fix: run infer-bazel-targets on namespace

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -168,29 +168,40 @@ jobs:
     needs: [config]
     steps:
       # calculate which bazel targets may need to be rebuilt
+      - uses: ./.github/actions/netrc
+      - name: Set up Bazel cache
+        run: |
+          # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
+          nsc bazel cache setup --enable_remote_asset_api --bazelrc=/tmp/bazel-cache.bazelrc
+          cat /tmp/bazel-cache.bazelrc
       - *checkout
       - name: Infer Targets
-        uses: ./.github/actions/bazel
-        with:
-          run: |
-            targets_args=()
-            if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
-              targets_args+=("--skip_long_tests")
-            fi
-            if [[ '${{ needs.config.outputs.skip_buf_checks }}' == 'true' ]]; then
-              targets_args+=("--exclude_tags=buf")
-            fi
-            if [[ '${{ needs.config.outputs.diff-only }}' == 'true' ]]; then
-              targets_args+=(
-                '--base=${{ github.event.pull_request.base.sha }}'
-                '--head=${{ github.event.pull_request.head.sha }}'
-                )
-            fi
+        shell: bash
+        run: |
+          targets_args=()
+          if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
+            targets_args+=("--skip_long_tests")
+          fi
+          if [[ '${{ needs.config.outputs.skip_buf_checks }}' == 'true' ]]; then
+            targets_args+=("--exclude_tags=buf")
+          fi
+          if [[ '${{ needs.config.outputs.diff-only }}' == 'true' ]]; then
+            targets_args+=(
+              '--base=${{ github.event.pull_request.base.sha }}'
+              '--head=${{ github.event.pull_request.head.sha }}'
+              )
+          fi
+          targets_args+=(
+            --
+            --noworkspace_rc
+            --bazelrc=./bazel/conf/.bazelrc.build
+            --bazelrc=/tmp/bazel-cache.bazelrc
+          )
 
-            # creates a list of targets suitable for --target_pattern_file and list
-            # the targets on the step summary
-            /usr/bin/time ci/scripts/targets.py build "${targets_args[@]}" >"${{ runner.temp }}/build-targets"
-            /usr/bin/time ci/scripts/targets.py test "${targets_args[@]}" >"${{ runner.temp }}/test-targets"
+          # creates a list of targets suitable for --target_pattern_file and list
+          # the targets on the step summary
+          /usr/bin/time ci/scripts/targets.py build "${targets_args[@]}" >"${{ runner.temp }}/build-targets"
+          /usr/bin/time ci/scripts/targets.py test "${targets_args[@]}" >"${{ runner.temp }}/test-targets"
 
       - name: Upload target files
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
-          nsc bazel cache setup --enable_remote_asset_api --bazelrc=/tmp/bazel-cache.bazelrc
+          nsc bazel cache setup --enable_remote_asset_api --command common --bazelrc=/tmp/bazel-cache.bazelrc
           cat /tmp/bazel-cache.bazelrc
       - name: Infer Targets
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -164,7 +164,7 @@ jobs:
 
   infer-bazel-targets:
     name: Infer Bazel Targets
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-rbe-driver-amd64-linux-16x32
     needs: [config]
     steps:
       # calculate which bazel targets may need to be rebuilt

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -168,13 +168,13 @@ jobs:
     needs: [config]
     steps:
       # calculate which bazel targets may need to be rebuilt
+      - *checkout
       - uses: ./.github/actions/netrc
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
           nsc bazel cache setup --enable_remote_asset_api --bazelrc=/tmp/bazel-cache.bazelrc
           cat /tmp/bazel-cache.bazelrc
-      - *checkout
       - name: Infer Targets
         shell: bash
         run: |

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -9,6 +9,12 @@ common --lockfile_mode=off
 common --experimental_remote_downloader_local_fallback
 common --experimental_remote_downloader_propagate_credentials
 
+# On a repository-cache hit, hardlink the file into the repo directory instead
+# of copying it. Saves one copy per multi-GB blob (e.g. the mainnet ICOS
+# images). Requires the repository cache and the output base to live on the
+# same filesystem (both default to the output user root).
+common --experimental_repository_cache_hardlinks
+
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558
 # (Removing this still builds, but reverts to compiling protoc/libprotoc from source.)

--- a/bazel/mainnet-canisters.bzl
+++ b/bazel/mainnet-canisters.bzl
@@ -62,6 +62,13 @@ def _canisters_impl(repository_ctx):
 
     repository_ctx.file("BUILD.bazel", content = 'exports_files(glob(["*"]))', executable = False)
 
+    # This repo is reproducible: all downloads are pinned by sha256 and
+    # everything else is derived from the watched canister-revisions JSON and
+    # the rule attributes. Declaring this makes the repo eligible for Bazel 9's
+    # repo contents cache so the canister WASMs are shared across output
+    # bases/workspaces instead of being re-downloaded on every fetch.
+    return repository_ctx.repo_metadata(reproducible = True)
+
 canisters = repository_rule(
     implementation = _canisters_impl,
     attrs = {

--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -90,6 +90,15 @@ genrule(
     """.format(EXPORTED_FILES = str(exported_files))
     repository_ctx.file("BUILD.bazel", content = BUILD)
 
+    # This repo is reproducible: the multi-GB image downloads are pinned by
+    # sha256 and everything else is derived from the watched revisions JSON and
+    # the rule attributes. Declaring this makes the repo eligible for Bazel 9's
+    # repo contents cache ({repository_cache}/contents), so the images are
+    # shared across output bases/workspaces (e.g. persisted CI runner caches)
+    # instead of being re-downloaded on every fetch. Without this return value
+    # the repo is never contents-cached.
+    return repository_ctx.repo_metadata(reproducible = True)
+
 mainnet_icos_images = repository_rule(
     implementation = _mainnet_icos_images_impl,
     attrs = {

--- a/ci/scripts/targets.py
+++ b/ci/scripts/targets.py
@@ -217,12 +217,13 @@ def targets(
 
     args = ["bazel", *bazel_args, "query", "--keep_going", query]
     log(shlex.join(args))
-    result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    result = subprocess.run(args, stdout=subprocess.PIPE, text=True)
 
     # As described above, when the query contains files not tracked by bazel,
     # --keep_going will ignore them but will return the special exit code 3 which we ignore:
     if result.returncode not in (0, 3):
-        log(f"Error running `bazel query --keep_going '{query}'`:\n" + result.stderr)
+        log(f"`bazel query --keep_going '{query}'` failed with exit code {result.returncode} (see its output above)")
         sys.exit(result.returncode)
 
     result_targets = result.stdout.splitlines()

--- a/ci/scripts/targets.py
+++ b/ci/scripts/targets.py
@@ -195,7 +195,8 @@ def targets(
     head: str | None,
     bazel_args: list[str],
 ):
-    """Print the bazel targets to build or test to stdout.
+    """
+    Print the bazel targets to build or test to stdout.
 
     `bazel_args` are passed verbatim to `bazel` as startup options (before the `query` subcommand).
     """

--- a/ci/scripts/targets.py
+++ b/ci/scripts/targets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#   targets.py [-h] [--skip_long_tests] [--base BASE] [--head HEAD] {build,test,check}
+#   targets.py [-h] [--skip_long_tests] [--base BASE] [--head HEAD] {build,test,check} [-- BAZEL_ARG ...]
 #
 # This script determines which Bazel targets should be built or tested and writes them separated by newlines to stdout.
 #
@@ -18,6 +18,10 @@
 # whenever its Farm sibling is already selected.
 #
 # When the command is `check` the PULL_REQUEST_BAZEL_TARGETS file is checked for correctness.
+#
+# Any arguments following a `--` separator are passed verbatim to the `bazel` command as startup
+# options (i.e. before the `query` subcommand). This is used e.g. to point the query at an
+# additional bazelrc: `targets.py test -- --bazelrc=/tmp/bazel-cache.bazelrc`.
 #
 # The script will print the bazel query to stderr which is useful for debugging:
 #   ci/scripts/targets.py --skip_long_tests --base=master test
@@ -189,8 +193,12 @@ def targets(
     exclude_tags: list[str],
     base: str | None,
     head: str | None,
+    bazel_args: list[str],
 ):
-    """Print the bazel targets to build or test to stdout."""
+    """Print the bazel targets to build or test to stdout.
+
+    `bazel_args` are passed verbatim to `bazel` as startup options (before the `query` subcommand).
+    """
     # If no base is specified, form a query to return all targets
     # but exclude those tagged with 'long_test' (in case --skip_long_tests was specified)
     # and those with any of the excluded tags.
@@ -206,7 +214,7 @@ def targets(
     excluded_tags_regex = "|".join(EXCLUDED_TAGS + exclude_tags)
     query = f'({query}) except attr(tags, "{excluded_tags_regex}", //...)'
 
-    args = ["bazel", "query", "--keep_going", query]
+    args = ["bazel", *bazel_args, "query", "--keep_going", query]
     log(shlex.join(args))
     result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
@@ -235,7 +243,7 @@ def targets(
         print("\n".join(result_targets))
 
 
-def check():
+def check(bazel_args: list[str]):
     """
     Exit successfully with 0 if PULL_REQUEST_BAZEL_TARGETS:
     * can be read and parsed.
@@ -243,6 +251,8 @@ def check():
     * each pattern has at least one explicit target.
     * each target is valid and when queried results in at least one target after excluding all excluded targets.
     Otherwise print all errors to stderr and exit erroneously with 1.
+
+    `bazel_args` are passed verbatim to `bazel` as startup options (before the `query` subcommand).
     """
     try:
         explicit_targets = load_explicit_targets()
@@ -272,7 +282,7 @@ def check():
         for target in explicit_targets_for_pattern:
             excluded_tags_regex = "|".join(EXCLUDED_TAGS)
             query = f'({target}) except attr(tags, "{excluded_tags_regex}", //...)'
-            result = subprocess.run(["bazel", "query", query], capture_output=True, text=True)
+            result = subprocess.run(["bazel", *bazel_args, "query", query], capture_output=True, text=True)
             if result.returncode != 0:
                 indented_error_msg = f"{indentation}" + f"\n{indentation}".join(result.stderr.strip().splitlines())
                 errors.append(f"Pattern '{pattern}' has problematic target '{target}':\n{indented_error_msg}")
@@ -295,7 +305,20 @@ def check():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Return bazel targets which should be build/tested")
+    # Split off any arguments following a `--` separator; these are passed verbatim to `bazel`
+    # as startup options (before the `query` subcommand), e.g.:
+    #   targets.py test -- --bazelrc=/tmp/bazel-cache.bazelrc
+    argv = sys.argv[1:]
+    bazel_args: list[str] = []
+    if "--" in argv:
+        i = argv.index("--")
+        argv, bazel_args = argv[:i], argv[i + 1 :]
+
+    parser = argparse.ArgumentParser(
+        description="Return bazel targets which should be build/tested",
+        epilog="Arguments after a `--` separator are passed verbatim to `bazel` as startup options, "
+        "e.g. `targets.py test -- --bazelrc=/tmp/bazel-cache.bazelrc`.",
+    )
     parser.add_argument(
         "command",
         choices=["build", "test", "check"],
@@ -310,12 +333,12 @@ def main():
         help="Only include targets with modified inputs in `git diff --name-only --merge-base $BASE [$HEAD]` where $HEAD is from --head if specified.",
     )
     parser.add_argument("--head", help="See --base.")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.command == "check":
-        check()
+        check(bazel_args)
 
-    targets(args.command, args.skip_long_tests, args.exclude_tags, args.base, args.head)
+    targets(args.command, args.skip_long_tests, args.exclude_tags, args.base, args.head, bazel_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `infer-bazel-targets`, which runs on `ubuntu-latest` is very unstable ([example](https://github.com/dfinity/ic/actions/runs/30082683528/job/89447672173?pr=10895)) and often very slow. This switches the job to run on Namespace (on the same runner profile which is [going to be used](https://github.com/dfinity/ic/pull/10579) for running our bazel build and test invocations) which runs the job in under 2 minutes.

These were the resources used when running `infer-bazel-targets` on the Namespace runner:
<img width="1457" height="155" alt="Screenshot 2026-07-24 at 11 43 01" src="https://github.com/user-attachments/assets/96ce9050-441e-4aba-85c7-2247d3106f49" />

We could potentially go one class below to 8x16 but considering the RBE setup is using 16x32 for the driver and 16x32 for the RBE workers to I rather use 16x32 for  `infer-bazel-targets` as well to keep things simple and consistent for now. We can always lower it later if needed.
