### PR TITLE
perf: make mainnet ICOS image and canister repos eligible for the repo contents cache

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -9,6 +9,12 @@ common --lockfile_mode=off
 common --experimental_remote_downloader_local_fallback
 common --experimental_remote_downloader_propagate_credentials
 
+# On a repository-cache hit, hardlink the file into the repo directory instead
+# of copying it. Saves one copy per multi-GB blob (e.g. the mainnet ICOS
+# images). Requires the repository cache and the output base to live on the
+# same filesystem (both default to the output user root).
+common --experimental_repository_cache_hardlinks
+
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558
 # (Removing this still builds, but reverts to compiling protoc/libprotoc from source.)

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -9,8 +9,6 @@ common --lockfile_mode=off
 common --experimental_remote_downloader_local_fallback
 common --experimental_remote_downloader_propagate_credentials
 
-common --experimental_repository_cache_hardlinks
-
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.
 # See https://github.com/protocolbuffers/protobuf/issues/19558
 # (Removing this still builds, but reverts to compiling protoc/libprotoc from source.)

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -9,10 +9,6 @@ common --lockfile_mode=off
 common --experimental_remote_downloader_local_fallback
 common --experimental_remote_downloader_propagate_credentials
 
-# On a repository-cache hit, hardlink the file into the repo directory instead
-# of copying it. Saves one copy per multi-GB blob (e.g. the mainnet ICOS
-# images). Requires the repository cache and the output base to live on the
-# same filesystem (both default to the output user root).
 common --experimental_repository_cache_hardlinks
 
 # Use prebuilt protoc binary via toolchain resolution instead of compiling from C++ source.

--- a/bazel/mainnet-canisters.bzl
+++ b/bazel/mainnet-canisters.bzl
@@ -62,6 +62,13 @@ def _canisters_impl(repository_ctx):
 
     repository_ctx.file("BUILD.bazel", content = 'exports_files(glob(["*"]))', executable = False)
 
+    # This repo is reproducible: all downloads are pinned by sha256 and
+    # everything else is derived from the watched canister-revisions JSON and
+    # the rule attributes. Declaring this makes the repo eligible for Bazel 9's
+    # repo contents cache so the canister WASMs are shared across output
+    # bases/workspaces instead of being re-downloaded on every fetch.
+    return repository_ctx.repo_metadata(reproducible = True)
+
 canisters = repository_rule(
     implementation = _canisters_impl,
     attrs = {

--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -90,6 +90,15 @@ genrule(
     """.format(EXPORTED_FILES = str(exported_files))
     repository_ctx.file("BUILD.bazel", content = BUILD)
 
+    # This repo is reproducible: the multi-GB image downloads are pinned by
+    # sha256 and everything else is derived from the watched revisions JSON and
+    # the rule attributes. Declaring this makes the repo eligible for Bazel 9's
+    # repo contents cache ({repository_cache}/contents), so the images are
+    # shared across output bases/workspaces (e.g. persisted CI runner caches)
+    # instead of being re-downloaded on every fetch. Without this return value
+    # the repo is never contents-cached.
+    return repository_ctx.repo_metadata(reproducible = True)
+
 mainnet_icos_images = repository_rule(
     implementation = _mainnet_icos_images_impl,
     attrs = {


### PR DESCRIPTION
Declare the `mainnet_icos_images` and `canisters` rules as reproducible such that they're cached in the remote repo contents cache.