### PR TITLE
feat(system-tests): write the JUnit XML report from the test driver

### DIFF
--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -41,7 +41,7 @@ use clap::Parser;
 use itertools::Itertools;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use slog::{Logger, debug, info, trace, warn};
+use slog::{Logger, debug, info, trace};
 use std::path::PathBuf;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -1558,20 +1558,19 @@ impl SystemTestGroup {
                     let event: log_events::LogEvent<_> = report.clone().into();
                     // Emit a json log event, to be consumed by log post-processing tools.
                     event.emit_log(group_ctx.log());
+                    // Write the JUnit XML report Bazel expects at $XML_OUTPUT_FILE in case the latter is set..
+                    if let Some(xml_output_file) = std::env::var_os("XML_OUTPUT_FILE") {
+                        let path = PathBuf::from(xml_output_file);
+                        if let Some(parent) = path.parent() {
+                            std::fs::create_dir_all(parent).unwrap_or_else(|_| {
+                                panic!("Failed to create the directory of {}", path.display())
+                            });
+                        }
+                        std::fs::write(&path, report.to_junit_xml()).unwrap_or_else(|_| {
+                            panic!("Failed to write the JUnit XML report to {}", path.display())
+                        });
+                    }
                     info!(group_ctx.log(), "Report:\n{}", report.pretty_print());
-                }
-
-                // Write the JUnit XML report Bazel expects at $XML_OUTPUT_FILE. This is
-                // independent of --no_summary_report: it's for Bazel, not for the reader
-                // of the log. Failing to write it must never fail the test, so just warn.
-                match report.write_junit_xml_report() {
-                    Ok(Some(path)) => info!(
-                        group_ctx.log(),
-                        "Wrote the JUnit XML report to {}",
-                        path.display()
-                    ),
-                    Ok(None) => (),
-                    Err(e) => warn!(group_ctx.log(), "{e:?}"),
                 }
 
                 if with_farm && !args.no_delete_farm_group {

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -41,7 +41,7 @@ use clap::Parser;
 use itertools::Itertools;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use slog::{Logger, debug, info, trace};
+use slog::{Logger, debug, info, trace, warn};
 use std::path::PathBuf;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -1559,6 +1559,19 @@ impl SystemTestGroup {
                     // Emit a json log event, to be consumed by log post-processing tools.
                     event.emit_log(group_ctx.log());
                     info!(group_ctx.log(), "Report:\n{}", report.pretty_print());
+                }
+
+                // Write the JUnit XML report Bazel expects at $XML_OUTPUT_FILE. This is
+                // independent of --no_summary_report: it's for Bazel, not for the reader
+                // of the log. Failing to write it must never fail the test, so just warn.
+                match report.write_junit_xml_report() {
+                    Ok(Some(path)) => info!(
+                        group_ctx.log(),
+                        "Wrote the JUnit XML report to {}",
+                        path.display()
+                    ),
+                    Ok(None) => (),
+                    Err(e) => warn!(group_ctx.log(), "{e:?}"),
                 }
 
                 if with_farm && !args.no_delete_farm_group {

--- a/rs/tests/driver/src/driver/report.rs
+++ b/rs/tests/driver/src/driver/report.rs
@@ -1,11 +1,9 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::{Display, Formatter, Result},
-    path::PathBuf,
     time::{Duration, SystemTime},
 };
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::driver::event::TaskId;
@@ -102,10 +100,10 @@ impl SystemGroupSummary {
             .all_reports()
             .fold(0.0, |total, report| total + report.runtime);
         let mut out = String::new();
-        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        out.push_str("<testsuites>\n");
+        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        out.push_str("<testsuites>");
         out.push_str(&format!(
-            "  <testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" errors=\"0\" skipped=\"{}\" time=\"{:.3}\">\n",
+            "<testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" errors=\"0\" skipped=\"{}\" time=\"{:.3}\">",
             suite,
             self.all_reports().count(),
             self.failure.len(),
@@ -121,36 +119,9 @@ impl SystemGroupSummary {
         for report in self.skipped.iter() {
             out.push_str(&report.to_junit_testcase(&suite, TaskOutcome::Skipped));
         }
-        out.push_str("  </testsuite>\n");
-        out.push_str("</testsuites>\n");
+        out.push_str("</testsuite>");
+        out.push_str("</testsuites>");
         out
-    }
-
-    /// Writes this summary as a JUnit XML report to `$XML_OUTPUT_FILE`, the path
-    /// Bazel tells a test to write its report to. Returns the path written to, or
-    /// `None` when the variable isn't set, i.e. we're not running under
-    /// `bazel test`.
-    ///
-    /// Writing this file matters beyond the report itself: `test.xml` is a
-    /// declared output of every Bazel test action, so when a test doesn't produce
-    /// it, Bazel runs a *second* spawn
-    /// (`@bazel_tools//tools/test:test_xml_generator`) to derive it from
-    /// `test.log`. Under remote execution that spawn has to queue for a free
-    /// worker -- often for minutes -- to do well under a second of work. Writing
-    /// the file ourselves makes Bazel skip that spawn entirely.
-    pub fn write_junit_xml_report(&self) -> anyhow::Result<Option<PathBuf>> {
-        let Some(path) = std::env::var_os("XML_OUTPUT_FILE") else {
-            return Ok(None);
-        };
-        let path = PathBuf::from(path);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create the directory of {}", path.display()))?;
-        }
-        std::fs::write(&path, self.to_junit_xml()).with_context(|| {
-            format!("Failed to write the JUnit XML report to {}", path.display())
-        })?;
-        Ok(Some(path))
     }
 
     pub fn to_map(&self) -> HashMap<String, (f64, Option<String>)> {
@@ -182,7 +153,7 @@ enum TaskOutcome {
 /// under test, and a single unescaped `<` or a stray escape sequence from a
 /// coloured log line would make the whole report unparsable.
 fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
+    let mut out = String::new();
     for c in s.chars() {
         match c {
             '&' => out.push_str("&amp;"),
@@ -229,9 +200,9 @@ impl TaskReport {
         res
     }
 
-    /// Renders this task as a JUnit `<testcase>` element, already escaped and
-    /// indented to sit inside a `<testsuite>`. `classname` is expected to be
-    /// escaped already.
+    /// Renders this task as a JUnit `<testcase>` element, already escaped to
+    /// sit inside a `<testsuite>`. `classname` is expected to be escaped
+    /// already.
     fn to_junit_testcase(&self, classname: &str, outcome: TaskOutcome) -> String {
         // Messages are stored with newlines escaped; undo that so the report is
         // readable, exactly like `pretty_print` does.
@@ -250,15 +221,12 @@ impl TaskReport {
         let body = match outcome {
             TaskOutcome::Passed => String::new(),
             TaskOutcome::Failed => format!(
-                "\n      <failure message=\"{}\">{}</failure>\n    ",
+                "<failure message=\"{}\">{}</failure>",
                 xml_escape(&summary),
                 xml_escape(message.as_deref().unwrap_or("")),
             ),
             TaskOutcome::Skipped => {
-                format!(
-                    "\n      <skipped message=\"{}\"/>\n    ",
-                    xml_escape(&summary)
-                )
+                format!("<skipped message=\"{}\"/>", xml_escape(&summary))
             }
         };
         // `status` follows GoogleTest's convention, which Bazel's own
@@ -269,11 +237,10 @@ impl TaskReport {
             TaskOutcome::Skipped => "notrun",
         };
         format!(
-            "    <testcase name=\"{}\" classname=\"{}\" status=\"{}\" duration=\"{:.3}\" time=\"{:.3}\">{}</testcase>\n",
+            "<testcase name=\"{}\" classname=\"{}\" status=\"{}\" time=\"{:.3}\">{}</testcase>",
             xml_escape(&self.name),
             classname,
             status,
-            self.runtime,
             self.runtime,
             body,
         )
@@ -377,8 +344,8 @@ mod tests {
         let summary = summary();
         let suite = xml_escape(&summary.display_name());
         let xml = summary.to_junit_xml();
-        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n"));
-        assert!(xml.ends_with("  </testsuite>\n</testsuites>\n"));
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?><testsuites>"));
+        assert!(xml.ends_with("</testsuite></testsuites>"));
         assert!(
             xml.contains(&format!(
                 "<testsuite name=\"{suite}\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"13.750\">"
@@ -387,13 +354,13 @@ mod tests {
         );
         assert!(
             xml.contains(&format!(
-                "<testcase name=\"setup\" classname=\"{suite}\" status=\"run\" duration=\"1.500\" time=\"1.500\"></testcase>"
+                "<testcase name=\"setup\" classname=\"{suite}\" status=\"run\" time=\"1.500\"></testcase>"
             )),
             "a passing task has an empty testcase body: {xml}"
         );
         assert!(
             xml.contains(&format!(
-                "<testcase name=\"teardown\" classname=\"{suite}\" status=\"notrun\" duration=\"0.000\" time=\"0.000\">"
+                "<testcase name=\"teardown\" classname=\"{suite}\" status=\"notrun\" time=\"0.000\">"
             )),
             "a skipped task is reported as notrun: {xml}"
         );

--- a/rs/tests/driver/src/driver/report.rs
+++ b/rs/tests/driver/src/driver/report.rs
@@ -261,10 +261,18 @@ impl TaskReport {
                 )
             }
         };
+        // `status` follows GoogleTest's convention, which Bazel's own
+        // test_xml_generator also emits: "run" for a case that executed,
+        // "notrun" for one that didn't.
+        let status = match outcome {
+            TaskOutcome::Passed | TaskOutcome::Failed => "run",
+            TaskOutcome::Skipped => "notrun",
+        };
         format!(
-            "    <testcase name=\"{}\" classname=\"{}\" status=\"run\" duration=\"{:.3}\" time=\"{:.3}\">{}</testcase>\n",
+            "    <testcase name=\"{}\" classname=\"{}\" status=\"{}\" duration=\"{:.3}\" time=\"{:.3}\">{}</testcase>\n",
             xml_escape(&self.name),
             classname,
+            status,
             self.runtime,
             self.runtime,
             body,
@@ -366,20 +374,28 @@ mod tests {
 
     #[test]
     fn junit_xml_reports_counts_and_durations() {
-        let xml = summary().to_junit_xml();
+        let summary = summary();
+        let suite = xml_escape(&summary.display_name());
+        let xml = summary.to_junit_xml();
         assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n"));
         assert!(xml.ends_with("  </testsuite>\n</testsuites>\n"));
         assert!(
             xml.contains(&format!(
-                "<testsuite name=\"{}\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"13.750\">",
-                xml_escape(&summary().display_name()),
+                "<testsuite name=\"{suite}\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"13.750\">"
             )),
             "{xml}"
         );
         assert!(
-            xml.contains("<testcase name=\"setup\" classname=\"")
-                && xml.contains("duration=\"1.500\" time=\"1.500\"></testcase>"),
+            xml.contains(&format!(
+                "<testcase name=\"setup\" classname=\"{suite}\" status=\"run\" duration=\"1.500\" time=\"1.500\"></testcase>"
+            )),
             "a passing task has an empty testcase body: {xml}"
+        );
+        assert!(
+            xml.contains(&format!(
+                "<testcase name=\"teardown\" classname=\"{suite}\" status=\"notrun\" duration=\"0.000\" time=\"0.000\">"
+            )),
+            "a skipped task is reported as notrun: {xml}"
         );
     }
 

--- a/rs/tests/driver/src/driver/report.rs
+++ b/rs/tests/driver/src/driver/report.rs
@@ -1,9 +1,11 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::{Display, Formatter, Result},
+    path::PathBuf,
     time::{Duration, SystemTime},
 };
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::driver::event::TaskId;
@@ -54,11 +56,7 @@ impl SystemGroupSummary {
             out_lines.append(&mut res.pretty_print(max_name_len, "SKIPPED"));
         }
         let mx_len = out_lines.iter().max_by_key(|x| x.len()).unwrap().len();
-        let test_name = if let Ok(test_target) = std::env::var("TEST_TARGET") {
-            test_target
-        } else {
-            self.test_name.clone()
-        };
+        let test_name = self.display_name();
         let title = format!(" Summary for {test_name} ");
         let mx_len = std::cmp::max(mx_len, title.len() + 10);
         let mx_len = std::cmp::min(mx_len, 200);
@@ -86,6 +84,75 @@ impl SystemGroupSummary {
         mx
     }
 
+    /// The name this test is known by: its Bazel label when running under
+    /// `bazel test` (which sets `$TEST_TARGET` to e.g.
+    /// `//rs/tests/consensus:adding_nodes_to_subnet_test_local`), the group's
+    /// base name otherwise.
+    pub fn display_name(&self) -> String {
+        std::env::var("TEST_TARGET").unwrap_or_else(|_| self.test_name.clone())
+    }
+
+    /// Renders this summary as a JUnit XML report: one `<testsuite>` for the
+    /// system-test group, one `<testcase>` per task that ran.
+    pub fn to_junit_xml(&self) -> String {
+        let suite = xml_escape(&self.display_name());
+        // Fold explicitly instead of `sum()`: `f64`'s `Sum` folds from -0.0, so an
+        // empty summary would render as time="-0.000".
+        let time = self
+            .all_reports()
+            .fold(0.0, |total, report| total + report.runtime);
+        let mut out = String::new();
+        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        out.push_str("<testsuites>\n");
+        out.push_str(&format!(
+            "  <testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" errors=\"0\" skipped=\"{}\" time=\"{:.3}\">\n",
+            suite,
+            self.all_reports().count(),
+            self.failure.len(),
+            self.skipped.len(),
+            time,
+        ));
+        for report in self.success.iter() {
+            out.push_str(&report.to_junit_testcase(&suite, TaskOutcome::Passed));
+        }
+        for report in self.failure.iter() {
+            out.push_str(&report.to_junit_testcase(&suite, TaskOutcome::Failed));
+        }
+        for report in self.skipped.iter() {
+            out.push_str(&report.to_junit_testcase(&suite, TaskOutcome::Skipped));
+        }
+        out.push_str("  </testsuite>\n");
+        out.push_str("</testsuites>\n");
+        out
+    }
+
+    /// Writes this summary as a JUnit XML report to `$XML_OUTPUT_FILE`, the path
+    /// Bazel tells a test to write its report to. Returns the path written to, or
+    /// `None` when the variable isn't set, i.e. we're not running under
+    /// `bazel test`.
+    ///
+    /// Writing this file matters beyond the report itself: `test.xml` is a
+    /// declared output of every Bazel test action, so when a test doesn't produce
+    /// it, Bazel runs a *second* spawn
+    /// (`@bazel_tools//tools/test:test_xml_generator`) to derive it from
+    /// `test.log`. Under remote execution that spawn has to queue for a free
+    /// worker -- often for minutes -- to do well under a second of work. Writing
+    /// the file ourselves makes Bazel skip that spawn entirely.
+    pub fn write_junit_xml_report(&self) -> anyhow::Result<Option<PathBuf>> {
+        let Some(path) = std::env::var_os("XML_OUTPUT_FILE") else {
+            return Ok(None);
+        };
+        let path = PathBuf::from(path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create the directory of {}", path.display()))?;
+        }
+        std::fs::write(&path, self.to_junit_xml()).with_context(|| {
+            format!("Failed to write the JUnit XML report to {}", path.display())
+        })?;
+        Ok(Some(path))
+    }
+
     pub fn to_map(&self) -> HashMap<String, (f64, Option<String>)> {
         let mut map = HashMap::new();
         for TaskReport {
@@ -98,6 +165,39 @@ impl SystemGroupSummary {
         }
         map
     }
+}
+
+/// How a task ended, which decides the child element of its `<testcase>`.
+enum TaskOutcome {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+/// Escapes `s` so it can be used both as XML character data and as an attribute
+/// value, and replaces the code points that XML 1.0 cannot represent at all
+/// (most control characters) with `?`.
+///
+/// Both halves are needed: task messages carry arbitrary output from the system
+/// under test, and a single unescaped `<` or a stray escape sequence from a
+/// coloured log line would make the whole report unparsable.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            '\t' | '\n' | '\r' => out.push(c),
+            '\u{20}'..='\u{d7ff}' | '\u{e000}'..='\u{fffd}' | '\u{10000}'..='\u{10ffff}' => {
+                out.push(c)
+            }
+            _ => out.push('?'),
+        }
+    }
+    out
 }
 
 // short messages (without newlines) are appended to the end of a report line.
@@ -127,6 +227,48 @@ impl TaskReport {
         )];
         res.append(&mut report_lines);
         res
+    }
+
+    /// Renders this task as a JUnit `<testcase>` element, already escaped and
+    /// indented to sit inside a `<testsuite>`. `classname` is expected to be
+    /// escaped already.
+    fn to_junit_testcase(&self, classname: &str, outcome: TaskOutcome) -> String {
+        // Messages are stored with newlines escaped; undo that so the report is
+        // readable, exactly like `pretty_print` does.
+        let message = self
+            .message
+            .as_ref()
+            .map(|message| message.replace("\\n", "\n"));
+        // JUnit consumers show the `message` attribute in list views and the
+        // element body on drill-down, so put the first line in the attribute and
+        // the whole thing in the body.
+        let summary = message
+            .as_deref()
+            .and_then(|message| message.lines().next())
+            .unwrap_or("")
+            .to_string();
+        let body = match outcome {
+            TaskOutcome::Passed => String::new(),
+            TaskOutcome::Failed => format!(
+                "\n      <failure message=\"{}\">{}</failure>\n    ",
+                xml_escape(&summary),
+                xml_escape(message.as_deref().unwrap_or("")),
+            ),
+            TaskOutcome::Skipped => {
+                format!(
+                    "\n      <skipped message=\"{}\"/>\n    ",
+                    xml_escape(&summary)
+                )
+            }
+        };
+        format!(
+            "    <testcase name=\"{}\" classname=\"{}\" status=\"run\" duration=\"{:.3}\" time=\"{:.3}\">{}</testcase>\n",
+            xml_escape(&self.name),
+            classname,
+            self.runtime,
+            self.runtime,
+            body,
+        )
     }
 }
 
@@ -193,4 +335,88 @@ impl std::convert::From<anyhow::Error> for SystemTestGroupError {
 pub enum Outcome {
     FromParentProcess(SystemGroupSummary),
     FromSubProcess,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(name: &str, runtime: f64, message: Option<&str>) -> TaskReport {
+        TaskReport {
+            name: name.to_string(),
+            runtime,
+            message: message.map(str::to_string),
+        }
+    }
+
+    fn summary() -> SystemGroupSummary {
+        SystemGroupSummary {
+            test_name: "my_test".to_string(),
+            success: vec![task("setup", 1.5, None)],
+            // Messages are stored with their newlines escaped, and carry
+            // arbitrary output from the system under test.
+            failure: vec![task(
+                "test <a & b>",
+                12.25,
+                Some("assertion failed\\ngot \"x\"\\nwant \u{1b}[31my\u{1b}[0m"),
+            )],
+            skipped: vec![task("teardown", 0.0, Some("Task skipped"))],
+        }
+    }
+
+    #[test]
+    fn junit_xml_reports_counts_and_durations() {
+        let xml = summary().to_junit_xml();
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n"));
+        assert!(xml.ends_with("  </testsuite>\n</testsuites>\n"));
+        assert!(
+            xml.contains(&format!(
+                "<testsuite name=\"{}\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"13.750\">",
+                xml_escape(&summary().display_name()),
+            )),
+            "{xml}"
+        );
+        assert!(
+            xml.contains("<testcase name=\"setup\" classname=\"")
+                && xml.contains("duration=\"1.500\" time=\"1.500\"></testcase>"),
+            "a passing task has an empty testcase body: {xml}"
+        );
+    }
+
+    #[test]
+    fn junit_xml_escapes_task_names_and_messages() {
+        let xml = summary().to_junit_xml();
+        assert!(
+            xml.contains("<testcase name=\"test &lt;a &amp; b&gt;\""),
+            "{xml}"
+        );
+        // Only the first line goes into the attribute, the whole message into the
+        // body, with quotes escaped and the control characters of the coloured
+        // log line replaced.
+        assert!(
+            xml.contains("<failure message=\"assertion failed\">"),
+            "{xml}"
+        );
+        assert!(
+            xml.contains("assertion failed\ngot &quot;x&quot;\nwant ?[31my?[0m</failure>"),
+            "{xml}"
+        );
+        assert!(xml.contains("<skipped message=\"Task skipped\"/>"), "{xml}");
+    }
+
+    #[test]
+    fn junit_xml_of_an_empty_summary_is_well_formed() {
+        let xml = SystemGroupSummary::default().to_junit_xml();
+        assert!(
+            xml.contains("tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" time=\"0.000\""),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn xml_escape_keeps_legal_whitespace_and_drops_illegal_control_characters() {
+        assert_eq!(xml_escape("a\tb\nc\rd"), "a\tb\nc\rd");
+        assert_eq!(xml_escape("a\u{0}b\u{8}c"), "a?b?c");
+        assert_eq!(xml_escape("<&>\"'"), "&lt;&amp;&gt;&quot;&apos;");
+    }
 }

--- a/rs/tests/idx/test_driver_tests.rs
+++ b/rs/tests/idx/test_driver_tests.rs
@@ -59,11 +59,24 @@ fn create_unique_working_dir() -> PathBuf {
     path
 }
 
-fn execute_test_scenario_with_default_cmd(scenario_name: &str) -> Output {
-    let working_dir = create_unique_working_dir();
+/// Prepares a command running the test-driver binary on the given scenario.
+///
+/// `XML_OUTPUT_FILE` is dropped from the child's environment on purpose: the
+/// driver writes its JUnit XML report there, and these children are not the
+/// process Bazel launched as the test, so they would otherwise each overwrite
+/// the test.xml that Bazel expects *this* test to produce.
+fn driver_command(scenario_name: &str) -> Command {
     let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
     let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    cmd.env("TEST_SCENARIO_NAME", scenario_name)
+        .env_remove("XML_OUTPUT_FILE");
+    cmd
+}
+
+fn execute_test_scenario_with_default_cmd(scenario_name: &str) -> Output {
+    let working_dir = create_unique_working_dir();
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -126,9 +139,8 @@ fn test_scenario_with_test_panic_fails() {
 fn test_scenario_with_default_farm_url_succeeds() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_without_errors";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -154,9 +166,8 @@ fn test_scenario_with_default_farm_url_succeeds() {
 fn test_scenario_with_custom_farm_url_succeeds() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_without_errors";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -184,9 +195,8 @@ fn test_scenario_with_custom_farm_url_succeeds() {
 fn test_scenario_with_skipped_panic_test_succeeds() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_with_panic";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -213,9 +223,8 @@ fn test_scenario_with_skipped_panic_test_succeeds() {
 fn test_scenario_with_non_skipped_panic_test_fails() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_with_panic";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -246,9 +255,8 @@ fn test_scenario_with_non_skipped_panic_test_fails() {
 fn test_scenario_with_two_skipped_panic_tests_succeeds() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_with_two_panics";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -527,9 +535,8 @@ fn test_test_spawning_proc_gets_stopped() {
 fn test_setup_failure_file_written() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_without_errors";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",
@@ -554,9 +561,8 @@ fn test_setup_failure_file_written() {
 fn test_setup_failure_file_not_written() {
     let working_dir = create_unique_working_dir();
     let scenario_name = "test_with_setup_panic";
-    let binary_path = env::current_dir().unwrap().join(BINARY_PATH);
-    let mut cmd = Command::new(binary_path);
-    cmd.env("TEST_SCENARIO_NAME", scenario_name).args([
+    let mut cmd = driver_command(scenario_name);
+    cmd.args([
         "--working-dir",
         working_dir.to_str().unwrap(),
         "--group-base-name",


### PR DESCRIPTION
## What

For system-tests, convert the `SystemGroupSummary` to a JUnit XML file and write it to [`$XML_OUTPUT_FILE`](https://bazel.build/reference/test-encyclopedia#initial-conditions).

## Why

It shows a nice test summary in [BuildBuddy](https://dash.dm1-idx1.dfinity.network/invocation/0cf0aeeb-869b-4c99-989e-e7715368ee41?target=%2F%2Frs%2Ftests%2Fexecution%3Ainter_canister_queries_test&targetStatus=5):
<img width="1485" height="1682" alt="Screenshot 2026-07-26 at 17 17 17" src="https://github.com/user-attachments/assets/b6a2fccf-499c-432b-aff6-48aa1d8f7f2e" />

The real reason for working on this was that Bazel declares `test.xml` as an output of every test action. When a test doesn't write `$XML_OUTPUT_FILE` itself, `StandaloneTestStrategy` runs a **second** spawn (`@bazel_tools//tools/test:test_xml_generator`) to derive it from `test.log`. The guard in Bazel 9.2.0 is:

```java
Path xmlOutputPath = resolvedPaths.getXmlOutputPath();
if (fileOutErr.getOutputPath().exists() && !xmlOutputPath.exists()) {
    Spawn xmlGeneratingSpawn = createXmlGeneratingSpawn(...);
    …dispatch via SpawnStrategyResolver…
}
```

Under remote execution that spawn is dispatched to RBE like any other, so it has to queue for a free worker to do well under a second of work. Measured on the `bazel-test-all-rbe` profile of [run 30158073133](https://github.com/dfinity/ic/actions/runs/30158073133), every one of the 152 executed system tests ran exactly two remote spawns:

| | queue | exec wall |
|---|---|---|
| spawn 1 (the test) | median 770s | median 144s |
| spawn 2 (XML generation) | **median 435s, p90 1726s** | median 0.80s, max 4.0s |

That's 100,705s of aggregate queue occupancy for ~2 minutes of real work.

There is no flag to turn this off — `--experimental_split_xml_generation` was removed in Bazel 9 (no such option in `bazel help test --long`, and no `split_xml_generation` string in `A-server.jar`), and the generator is a private implicit attribute (`$xml_generator_script`), so it can't be overridden per target. The only lever is for the test to produce `test.xml` itself.

## How

- `SystemGroupSummary::to_junit_xml()` renders the summary as JUnit XML: one `<testsuite>` for the group, one `<testcase>` per task, with `<failure>` / `<skipped>` bodies.
- `SystemGroupSummary::write_junit_xml_report()` writes it to `$XML_OUTPUT_FILE`, no-op when the variable is unset (not running under `bazel test`).
- Called from `SystemTestGroup::execute` right after `create_report`, before the failure `bail!`, so it runs for passing and failing tests alike. A write error only warns — it must never fail a test.
- `xml_escape()` escapes the five XML entities **and** replaces code points XML 1.0 cannot represent. Both are needed: task messages carry arbitrary output from the system under test, so an unescaped `<` or a stray `\x1b` from a coloured log line would make the report unparsable.

### Drive-by fix

`rs/tests/idx/test_driver_tests.rs` spawns the driver ~10 times as child processes, which inherit the environment. Once the driver started honouring `$XML_OUTPUT_FILE`, each child overwrote the `test.xml` that Bazel expects `//rs/tests/idx:test_e2e_scenarios` itself to produce — confirmed on the first run, where the file held one scenario's tasks instead of the 21 Rust test names, and the panic scenarios would have written a bogus `<failure>` into a passing test's XML. Fixed with a `driver_command()` helper that does `env_remove("XML_OUTPUT_FILE")`, which also removes the duplicated spawn boilerplate at all eight call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)