### PR TITLE
chore(system-tests): oversubscribe cpus

### DIFF
--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -44,6 +44,7 @@ def system_test(
         logs = True,
         vm_allocation_mode = None,
         cpus = None,
+        cpus_oversubscription_factor = 2,
         **kwargs):
     """Declares a system-test.
 
@@ -98,9 +99,12 @@ def system_test(
         `"performanceOptimizedAllocation"`,
         `"minIntraDistanceLoadBalanceAllocation"` or `"distributeAcrossDcs"`.
         When None it defaults to `"minIntraDistanceLoadBalanceAllocation"`.
-      cpus: Optional number of CPU cores to reserve for the local variant of the test.
-        This will translate into an `exec_properties = {"cpu": str(cpus)}` setting for the `_local` variant.
-        Heuristic: set it to MIN_LOCAL_CPUS + number of vCPUs required for the whole testnet. DEFAULT_VCPUS_PER_VM can be used for the default number of vCPUs per VM if not overridden.
+      cpus: Optional number of CPU cores the test actually needs.
+        Heuristic: MIN_LOCAL_CPUS + the number of vCPUs required for the whole testnet
+          (DEFAULT_VCPUS_PER_VM is the per-VM default).
+        The `_local` variant only *reserves* ceil(cpus / cpus_oversubscription_factor) via exec_properties,
+        i.e. deliberately less than the test uses.
+      cpus_oversubscription_factor: factor to divide the requested cpus with which allows to pack more system-tests on a single worker by effectively overloading it.
       **kwargs: additional arguments to pass to the rust_binary rule.
 
     Returns:
@@ -315,6 +319,9 @@ def system_test(
     # (--stream-console-logs).
     local_args = ([] if "--no-logs" in extra_args_simple else ["--no-logs"]) + ["--stream-ic-node-logs", "--stream-console-logs"]
 
+    # There's no math.ceil() in Starlark so we calculate it ourselves:
+    reserved_cpus = -(-cpus // cpus_oversubscription_factor) if cpus != None else None
+
     sh_test(
         name = test_name + "_local",
         srcs = ["//rs/tests:run_systest.sh"],
@@ -328,7 +335,7 @@ def system_test(
         env_inherit = env_inherit,
         tags = tags + ["local_system_test"] + (["manual"] if backend == "farm" else []),
         # The `cpu:n` tag is not forwarded to the Remote Execution API, so we set the execution properties explicitly:
-        exec_properties = {"cpu": str(cpus)} if cpus != None else {},
+        exec_properties = {"cpu": str(reserved_cpus)} if reserved_cpus != None else {},
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,
         visibility = visibility,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -102,9 +102,12 @@ def system_test(
       cpus: Optional number of CPU cores the test actually needs.
         Heuristic: MIN_LOCAL_CPUS + the number of vCPUs required for the whole testnet
           (DEFAULT_VCPUS_PER_VM is the per-VM default).
-        The `_local` variant only *reserves* ceil(cpus / cpus_oversubscription_factor) via exec_properties,
-        i.e. deliberately less than the test uses.
-      cpus_oversubscription_factor: factor to divide the requested cpus with which allows to pack more system-tests on a single worker by effectively overloading it.
+        Must be an int >= 1. Note that the `_local` variant doesn't reserve `cpus` but only
+        ceil(cpus / cpus_oversubscription_factor) via exec_properties.
+      cpus_oversubscription_factor: positive integer by which `cpus` is divided to
+        determine how many CPUs to reserve. Reserving less than the test uses lets
+        more system-tests be packed onto a single worker, at the cost of
+        deliberately overloading it. A factor of 1 disables oversubscription.
       **kwargs: additional arguments to pass to the rust_binary rule.
 
     Returns:
@@ -319,8 +322,18 @@ def system_test(
     # (--stream-console-logs).
     local_args = ([] if "--no-logs" in extra_args_simple else ["--no-logs"]) + ["--stream-ic-node-logs", "--stream-console-logs"]
 
-    # There's no math.ceil() in Starlark so we calculate it ourselves:
-    reserved_cpus = -(-cpus // cpus_oversubscription_factor) if cpus != None else None
+    if type(cpus_oversubscription_factor) != "int" or cpus_oversubscription_factor < 1:
+        fail("Invalid cpus_oversubscription_factor {}: must be an int >= 1".format(
+            repr(cpus_oversubscription_factor),
+        ))
+
+    reserved_cpus = None
+    if cpus != None:
+        if type(cpus) != "int" or cpus < 1:
+            fail("Invalid cpus {}: must be an int >= 1".format(repr(cpus)))
+
+        # Starlark has no math.ceil() so we round up using integer division.
+        reserved_cpus = (cpus + cpus_oversubscription_factor - 1) // cpus_oversubscription_factor
 
     sh_test(
         name = test_name + "_local",


### PR DESCRIPTION
Adds a `cpus_oversubscription_factor` param (default 2) to `system_test`; the `_local` variant now reserves `ceil(cpus / cpus_oversubscription_factor)` via `exec_properties["cpu"]` instead of the full `cpus`, allowing more local system-tests to be packed onto a single worker. 

We [know from Farm](https://github.com/dfinity-lab/farm/blob/master/dcs.tf#L6-L8) we can safely go as high as 4 (and possibly higher) but we start with 2 to be on the safe side.
