### PR TITLE
fix: Use regular cost for Wasm64 compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9572,7 +9572,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "wasmparser 0.251.0",
  "wat",
  "wirm",
 ]

--- a/rs/embedders/src/wasm_utils/decoding.rs
+++ b/rs/embedders/src/wasm_utils/decoding.rs
@@ -60,6 +60,9 @@ pub fn decoded_wasm_size(module_bytes: &[u8]) -> Result<usize, WasmValidationErr
 }
 
 /// Decodes a WebAssembly module, uncompressing it if required.
+///
+/// # Warning
+/// Do not call this function outside of the sandbox.
 pub fn decode_wasm(
     max_size: NumBytes,
     module: Arc<Vec<u8>>,

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -57,7 +57,6 @@ rust_library(
         "@crate_index//:tokio",
         "@crate_index//:tower",
         "@crate_index//:tracing",
-        "@crate_index//:wasmparser",
     ],
 )
 

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -55,7 +55,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
-wasmparser = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -16,12 +16,10 @@ use crate::types::{IngressResponse, Response};
 use crate::util::{GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID};
 
 use ic_base_types::EnvironmentVariables;
-use ic_config::embedders::Config as EmbeddersConfig;
 use ic_config::flag_status::FlagStatus;
 use ic_cycles_account_manager::{
     CyclesAccountManager, CyclesAccountManagerSubnetConfig, ResourceSaturation,
 };
-use ic_embedders::wasm_utils::decoding::decode_wasm;
 use ic_embedders::wasmtime_embedder::system_api::{ExecutionParameters, InstructionLimits};
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_limits::LOG_CANISTER_OPERATION_CYCLES_THRESHOLD;
@@ -891,7 +889,8 @@ impl CanisterManager {
             };
         }
 
-        let wasm_execution_mode = wasm_execution_mode(context.wasm_source.clone());
+        // For installing code, Wasm64 does not differ from Wasm32.
+        let wasm_execution_mode = WasmExecutionMode::Wasm32;
 
         let prepaid_execution_cycles = match prepaid_execution_cycles {
             Some(prepaid_execution_cycles) => prepaid_execution_cycles,
@@ -2236,9 +2235,13 @@ impl CanisterManager {
         }
 
         // All basic checks have passed, prepay cycles for instructions.
-        let wasm_execution_mode = wasm_execution_mode(WasmSource::CanisterModule(
-            snapshot.execution_snapshot().wasm_binary.clone(),
-        ));
+        //
+        // The Wasm execution mode is only used to pick the per-instruction rate
+        // for prepaying (and later refunding) this message. Determining the
+        // actual mode would require decompressing and parsing the untrusted
+        // module outside the sandbox, so we default to Wasm32 (undercharging
+        // Wasm64 canisters for this message only).
+        let wasm_execution_mode = WasmExecutionMode::Wasm32;
         let memory_usage = canister.memory_usage();
         let message_memory_usage = canister.message_memory_usage();
         let compute_allocation = canister.compute_allocation();
@@ -3171,41 +3174,6 @@ pub fn uninstall_canister(
                 }
             }
         })
-}
-
-/// Derives the wasm execution mode of the given module.
-/// This is solely for the purpose of installing code and loading canister snapshot
-/// when we need the wasm execution mode to prepay accordingly.
-/// In case of errors, we simply return `WasmExecutionMode::Wasm32`
-/// since the errors will be caught and handled by the sandbox later
-/// without incurring extra overhead specific to `WasmExecutionMode::Wasm64`.
-pub fn wasm_execution_mode(wasm_module_source: WasmSource) -> WasmExecutionMode {
-    let wasm_module = match wasm_module_source.into_canister_module() {
-        Ok(wasm_module) => wasm_module,
-        Err(_err) => {
-            return WasmExecutionMode::Wasm32;
-        }
-    };
-
-    let decoded_wasm_module = match decode_wasm(
-        EmbeddersConfig::new().wasm_max_size,
-        Arc::new(wasm_module.as_slice().to_vec()),
-    ) {
-        Ok(decoded_wasm_module) => decoded_wasm_module,
-        Err(_err) => {
-            return WasmExecutionMode::Wasm32;
-        }
-    };
-
-    let parser = wasmparser::Parser::new(0);
-    for section in parser.parse_all(decoded_wasm_module.as_slice()).flatten() {
-        if let wasmparser::Payload::MemorySection(reader) = section
-            && let Some(memory) = reader.into_iter().flatten().next()
-        {
-            return WasmExecutionMode::from_is_wasm64(memory.memory64);
-        }
-    }
-    WasmExecutionMode::Wasm32
 }
 
 fn globals_match(g1: &[Global], g2: &[Global]) -> bool {

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -5999,8 +5999,12 @@ fn check_install_code_in_wasm64_mode_is_charged_correctly() {
     let (balance32, execution_cost32) = run_canister_in_wasm_mode(false, false);
     let (balance64, execution_cost64) = run_canister_in_wasm_mode(true, false);
 
-    assert_lt!(balance64, balance32);
-    assert_lt!(execution_cost32, execution_cost64);
+    // Install messages are always charged at the Wasm32 rate because the
+    // execution mode of the new module is not known before it is compiled in
+    // the sandbox, so installing the (otherwise identical) Wasm64 module
+    // costs the same as the Wasm32 one.
+    assert_eq!(balance64, balance32);
+    assert_eq!(execution_cost32, execution_cost64);
 }
 
 #[test]

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -20,7 +20,6 @@ pub use crate::canister_logs::fetch_canister_logs_response_for_bench;
 pub use crate::ic00_permissions::Ic00MethodPermissions;
 use crate::ingress_filter::IngressFilterServiceImpl;
 pub use canister_manager::types::WasmSource;
-pub use canister_manager::wasm_execution_mode;
 use canister_manager::{CanisterManager, types::CanisterMgrConfig};
 pub use execution_environment::{
     CompilationCostHandling, ExecuteMessageResult, ExecuteSubnetMessageResultType,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -22,8 +22,8 @@ use ic_execution_environment::Ic00MethodPermissions;
 use ic_execution_environment::{
     CompilationCostHandling, DataCertificateWithDelegationMetadata, ExecuteMessageResult,
     ExecuteSubnetMessageResultType, ExecutionEnvironment, ExecutionServicesForTesting, Hypervisor,
-    IngressFilterMetrics, InternalHttpQueryHandler, RoundInstructions, RoundLimits, WasmSource,
-    abort_all_paused_executions, execute_canister, wasm_execution_mode,
+    IngressFilterMetrics, InternalHttpQueryHandler, RoundInstructions, RoundLimits,
+    abort_all_paused_executions, execute_canister,
 };
 use ic_interfaces::execution_environment::{
     ChainKeySettings, ExecutionMode, IngressHistoryWriter, RegistryExecutionSettings,
@@ -38,10 +38,9 @@ use ic_logger::{
 use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterInstallMode, CanisterInstallModeV2, CanisterMetricsArgs,
     CanisterMetricsResult, CanisterSettingsArgs, CanisterSettingsArgsBuilder,
-    CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions, EmptyBlob,
-    InstallChunkedCodeArgs, InstallCodeArgs, InstallCodeArgsV2, LoadCanisterSnapshotArgs,
-    LogVisibilityV2, MasterPublicKeyId, Method, Payload, ProvisionalCreateCanisterWithCyclesArgs,
-    SchnorrAlgorithm, UpdateSettingsArgs,
+    CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions, EmptyBlob, InstallCodeArgs,
+    InstallCodeArgsV2, LogVisibilityV2, MasterPublicKeyId, Method, Payload,
+    ProvisionalCreateCanisterWithCyclesArgs, SchnorrAlgorithm, UpdateSettingsArgs,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -93,7 +92,7 @@ use ic_types_cycles::{
 };
 use ic_types_test_utils::ids::{node_test_id, subnet_test_id, user_test_id};
 use ic_universal_canister::{UNIVERSAL_CANISTER_SERIALIZED_MODULE, UNIVERSAL_CANISTER_WASM};
-use ic_wasm_types::{BinaryEncodedWasm, CanisterModule, WasmHash};
+use ic_wasm_types::BinaryEncodedWasm;
 use maplit::{btreemap, btreeset};
 use num_traits::ops::saturating::SaturatingAdd;
 use prometheus::IntCounter;
@@ -1581,69 +1580,19 @@ impl ExecutionTest {
         };
         let method = Method::from_str(message.method_name());
         match method {
-            Ok(Method::InstallCode) | Ok(Method::InstallChunkedCode) => {
-                let wasm_source = match method {
-                    Ok(Method::InstallCode) => {
-                        let wasm_module = InstallCodeArgsV2::decode(message.method_payload())
-                            .unwrap()
-                            .wasm_module;
-                        WasmSource::CanisterModule(CanisterModule::new(wasm_module))
-                    }
-                    Ok(Method::InstallChunkedCode) => {
-                        let payload =
-                            InstallChunkedCodeArgs::decode(message.method_payload()).unwrap();
-                        let store_canister_id: CanisterId = payload
-                            .store_canister
-                            .unwrap_or(payload.target_canister)
-                            .try_into()
-                            .unwrap();
-                        let wasm_chunk_store = self
-                            .state
-                            .as_ref()
-                            .unwrap()
-                            .canister_state(&store_canister_id)
-                            .unwrap()
-                            .system_state
-                            .wasm_chunk_store
-                            .clone();
-                        let chunk_hashes_list = payload
-                            .chunk_hashes_list
-                            .into_iter()
-                            .map(|chunk_hash| chunk_hash.hash)
-                            .collect();
-                        let wasm_module_hash =
-                            WasmHash::try_from(payload.wasm_module_hash).unwrap();
-                        WasmSource::ChunkStore {
-                            wasm_chunk_store,
-                            chunk_hashes_list,
-                            wasm_module_hash,
-                        }
-                    }
-                    _ => unreachable!(),
-                };
-                let execution_mode = wasm_execution_mode(wasm_source);
-                self.cycles_account_manager()
-                    .execution_cost(
-                        instructions_used,
-                        self.get_own_subnet_cycles_config(),
-                        execution_mode,
-                    )
-                    .nominal()
-            }
-            Ok(Method::LoadCanisterSnapshot) => {
-                let payload = LoadCanisterSnapshotArgs::decode(message.method_payload()).unwrap();
-                let snapshot = self.canister_state(payload.get_canister_id()).canister_snapshots.get(payload.snapshot_id()).expect("Loading a non-existing snapshot should fail during validation and no instructions should be used in that case!");
-                let wasm_module = snapshot.execution_snapshot().wasm_binary.clone();
-                let wasm_source = WasmSource::CanisterModule(wasm_module);
-                let execution_mode = wasm_execution_mode(wasm_source);
-                self.cycles_account_manager()
-                    .execution_cost(
-                        instructions_used,
-                        self.get_own_subnet_cycles_config(),
-                        execution_mode,
-                    )
-                    .nominal()
-            }
+            // Install and snapshot load messages are always charged at the
+            // Wasm32 rate: the actual Wasm execution mode of the module being
+            // installed is not known before compilation in the sandbox.
+            Ok(Method::InstallCode)
+            | Ok(Method::InstallChunkedCode)
+            | Ok(Method::LoadCanisterSnapshot) => self
+                .cycles_account_manager()
+                .execution_cost(
+                    instructions_used,
+                    self.get_own_subnet_cycles_config(),
+                    WasmExecutionMode::Wasm32,
+                )
+                .nominal(),
             Ok(Method::UpdateSettings)
             | Ok(Method::UploadChunk)
             | Ok(Method::TakeCanisterSnapshot)


### PR DESCRIPTION
The Wasm64 cost multiplier applies to executing Wasm code, not to compiling modules. 