### PR TITLE
chore: use new ic-cdk apis

### DIFF
--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 use candid::{CandidType, Nat, Principal, define_function};
-use ic_cdk::api::call::{RejectionCode, accept_message, arg_data_raw, reject};
+use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::ecdsa::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse, SignWithEcdsaArgument,
     SignWithEcdsaResponse, ecdsa_public_key as ic_cdk_ecdsa_public_key,
@@ -9,8 +9,10 @@ use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpMethod, HttpResponse, TransformArgs, TransformContext,
     TransformFunc, http_request as canister_http_outcall,
 };
-use ic_cdk::api::stable::{stable_grow, stable_size as raw_stable_size, stable_write};
-use ic_cdk::api::{canister_self, debug_print, instruction_counter};
+use ic_cdk::api::{
+    accept_message, canister_self, debug_print, instruction_counter, msg_arg_data, msg_reject,
+};
+use ic_cdk::stable::{stable_grow, stable_size as raw_stable_size, stable_write};
 use ic_cdk::{inspect_message, query, trap, update};
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::Memo;
@@ -478,7 +480,7 @@ fn time() -> u64 {
 
 #[inspect_message]
 fn inspect_message() {
-    let arg_data = arg_data_raw();
+    let arg_data = msg_arg_data();
     if arg_data == b"trap" {
         trap("trap in inspect message");
     } else if arg_data == b"skip" {
@@ -489,12 +491,12 @@ fn inspect_message() {
 
 #[query(manual_reply = true)]
 fn reject_query() {
-    reject("reject in query method");
+    msg_reject("reject in query method");
 }
 
 #[update(manual_reply = true)]
 fn reject_update() {
-    reject("reject in update method");
+    msg_reject("reject in update method");
 }
 
 #[query]

--- a/rs/boundary_node/rate_limits/canister/canister.rs
+++ b/rs/boundary_node/rate_limits/canister/canister.rs
@@ -16,7 +16,10 @@ use crate::state::{CanisterApi, init_version_and_config, with_canister_state};
 use candid::Principal;
 use ic_canister_log::{export as export_logs, log};
 use ic_cdk::api::call::call;
-use ic_cdk::{api::msg_caller, init, inspect_message, post_upgrade, query, update};
+use ic_cdk::{
+    api::{accept_message, msg_caller, msg_method_name},
+    init, inspect_message, post_upgrade, query, update,
+};
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_nns_constants::REGISTRY_CANISTER_ID;
 use rate_limits_api::{
@@ -35,7 +38,7 @@ const REPLICATED_QUERY_METHOD: &str = "get_config";
 fn inspect_message() {
     // In order for this hook to succeed, accept_message() must be invoked.
     let caller_id: Principal = msg_caller();
-    let called_method = ic_cdk::api::call::method_name();
+    let called_method = msg_method_name();
 
     let (has_full_access, has_full_read_access) = with_canister_state(|state| {
         let authorized_principal = state.get_authorized_principal();
@@ -47,7 +50,7 @@ fn inspect_message() {
 
     if called_method == REPLICATED_QUERY_METHOD {
         if has_full_access || has_full_read_access {
-            ic_cdk::api::call::accept_message();
+            accept_message();
         } else {
             ic_cdk::api::trap(
                 "message_inspection_failed: method call is prohibited in the current context",
@@ -55,7 +58,7 @@ fn inspect_message() {
         }
     } else if UPDATE_METHODS.contains(&called_method.as_str()) {
         if has_full_access {
-            ic_cdk::api::call::accept_message();
+            accept_message();
         } else {
             ic_cdk::api::trap("message_inspection_failed: unauthorized caller");
         }

--- a/rs/boundary_node/salt_sharing/canister/canister.rs
+++ b/rs/boundary_node/salt_sharing/canister/canister.rs
@@ -5,8 +5,7 @@ use crate::helpers::{init_async, is_api_boundary_node_principal};
 use crate::logs::export_logs_as_http_response;
 use crate::metrics::{METRICS, export_metrics_as_http_response};
 use crate::storage::SALT;
-use ic_cdk::api::call::{accept_message, method_name};
-use ic_cdk::api::{msg_caller, time};
+use ic_cdk::api::{accept_message, msg_caller, msg_method_name, time};
 use ic_cdk::trap;
 use ic_cdk::{init, inspect_message, post_upgrade, query};
 use ic_cdk_timers::set_timer;
@@ -20,7 +19,7 @@ const REPLICATED_QUERY_METHOD: &str = "get_salt";
 #[inspect_message]
 fn inspect_message() {
     let caller_id = msg_caller();
-    let called_method = method_name();
+    let called_method = msg_method_name();
 
     if called_method == REPLICATED_QUERY_METHOD && is_api_boundary_node_principal(&caller_id) {
         accept_message();

--- a/rs/nervous_system/common/src/lib.rs
+++ b/rs/nervous_system/common/src/lib.rs
@@ -73,7 +73,7 @@ pub const START_OF_2022_TIMESTAMP_SECONDS: u64 = 1641016800;
 pub const ONE_TRILLION: u64 = 1_000_000_000_000;
 
 /// The number of cycles required to create an SNS, charged by the SNS-W canister.
-pub const SNS_CREATION_FEE: u64 = 180 * ONE_TRILLION;
+pub const SNS_CREATION_FEE: u128 = 180 * ONE_TRILLION as u128;
 
 // The number of nanoseconds per second.
 pub const NANO_SECONDS_PER_SECOND: u64 = 1_000_000_000;

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -7,7 +7,8 @@ use exchange_rate_canister::{UpdateExchangeRateError, UpdateExchangeRateState};
 use ic_cdk::{
     api::{
         call::{CallResult, ManualReply},
-        canister_cycle_balance, canister_self, certified_data_set,
+        canister_cycle_balance, canister_self, certified_data_set, msg_cycles_accept,
+        msg_cycles_available,
     },
     heartbeat, init, post_upgrade, pre_upgrade, println, query, update,
 };
@@ -78,7 +79,7 @@ const MAX_MEMO_LENGTH: usize = 32;
 
 /// Calls to create_canister get rejected outright if they have obviously too few cycles attached.
 /// This is the minimum amount needed for creating a canister as of October 2023.
-const CREATE_CANISTER_MIN_CYCLES: u64 = 100_000_000_000;
+const CREATE_CANISTER_MIN_CYCLES: u128 = 100_000_000_000;
 
 /// Prior to 2024-12-10, we used 50e15, but legitimate users started running
 /// into this. At that time, prices had recently gone up, so we resolved to
@@ -1483,32 +1484,32 @@ async fn create_canister(
         subnet_type,
     }: CreateCanister,
 ) -> Result<CanisterId, CreateCanisterError> {
-    let cycles = ic_cdk::api::call::msg_cycles_available();
+    let cycles = msg_cycles_available();
 
     if cycles < CREATE_CANISTER_MIN_CYCLES {
         return Err(CreateCanisterError::Refunded {
-            refund_amount: cycles.into(),
+            refund_amount: cycles,
             create_error: "Insufficient cycles attached.".to_string(),
         });
     }
     let subnet_selection =
         get_subnet_selection(subnet_type, subnet_selection).map_err(|error_message| {
             CreateCanisterError::Refunded {
-                refund_amount: cycles.into(),
+                refund_amount: cycles,
                 create_error: error_message,
             }
         })?;
 
     match do_create_canister(caller(), cycles.into(), subnet_selection, settings).await {
         Ok(canister_id) => {
-            ic_cdk::api::call::msg_cycles_accept(cycles);
+            msg_cycles_accept(cycles);
             Ok(canister_id)
         }
         Err(create_error) => {
-            ic_cdk::api::call::msg_cycles_accept(BAD_REQUEST_CYCLES_PENALTY as u64);
-            let refund_amount = ic_cdk::api::call::msg_cycles_available();
+            msg_cycles_accept(BAD_REQUEST_CYCLES_PENALTY);
+            let refund_amount = msg_cycles_available();
             Err(CreateCanisterError::Refunded {
-                refund_amount: refund_amount.into(),
+                refund_amount,
                 create_error,
             })
         }

--- a/rs/nns/cmc/src/stable_utils.rs
+++ b/rs/nns/cmc/src/stable_utils.rs
@@ -1,4 +1,4 @@
-use ic_cdk::api::stable::{StableReader, StableWriter};
+use ic_cdk::stable::{StableReader, StableWriter};
 use std::io::{Read, Write};
 
 /// Writes `content` to stable memory.

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -35,7 +35,7 @@ use ic_sns_wasm::{
 };
 use ic_types::CanisterId;
 use ic_types_cycles::Cycles;
-use std::{cell::RefCell, collections::HashMap, convert::TryInto};
+use std::{cell::RefCell, collections::HashMap};
 
 use ic_cdk::{
     api::{
@@ -78,14 +78,14 @@ impl CanisterApi for CanisterApiImpl {
             .with_controllers(vec![controller_id])
             .with_wasm_memory_limit(wasm_memory_limit);
 
-        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment(
+        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment128(
             target_subnet.get().0,
             &Method::CreateCanister.to_string(),
             (CreateCanisterArgs {
                 settings: Some(settings.build()),
                 sender_canister_version: Some(ic_cdk::api::canister_version()),
             },),
-            cycles.get().try_into().unwrap(),
+            cycles.get(),
         )
         .await;
 
@@ -158,8 +158,8 @@ impl CanisterApi for CanisterApiImpl {
         )))
     }
 
-    fn this_canister_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String> {
-        let available = canister_cycle_balance() as u64;
+    fn this_canister_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String> {
+        let available = canister_cycle_balance();
 
         if available < required_cycles {
             return Err(format!(
@@ -169,8 +169,8 @@ impl CanisterApi for CanisterApiImpl {
         Ok(available)
     }
 
-    fn message_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String> {
-        let available = msg_cycles_available() as u64;
+    fn message_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String> {
+        let available = msg_cycles_available();
 
         if available < required_cycles {
             return Err(format!(
@@ -180,16 +180,20 @@ impl CanisterApi for CanisterApiImpl {
         Ok(available)
     }
 
-    fn accept_message_cycles(&self, cycles: Option<u64>) -> Result<u64, String> {
-        let cycles = cycles.unwrap_or_else(|| msg_cycles_available() as u64);
+    fn accept_message_cycles(&self, cycles: Option<u128>) -> Result<u128, String> {
+        let cycles = cycles.unwrap_or_else(msg_cycles_available);
         self.message_has_enough_cycles(cycles)?;
 
-        let accepted = msg_cycles_accept(cycles as u128) as u64;
+        let accepted = msg_cycles_accept(cycles);
         Ok(accepted)
     }
 
-    async fn send_cycles_to_canister(&self, target: CanisterId, cycles: u64) -> Result<(), String> {
-        let response: CallResult<()> = ic_cdk::api::call::call_with_payment(
+    async fn send_cycles_to_canister(
+        &self,
+        target: CanisterId,
+        cycles: u128,
+    ) -> Result<(), String> {
+        let response: CallResult<()> = ic_cdk::api::call::call_with_payment128(
             CanisterId::ic_00().get().0,
             "deposit_cycles",
             (CanisterIdRecord::from(target),),

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -38,7 +38,9 @@ use ic_types_cycles::Cycles;
 use std::{cell::RefCell, collections::HashMap, convert::TryInto};
 
 use ic_cdk::{
-    api::{canister_cycle_balance, canister_self, msg_caller},
+    api::{
+        canister_cycle_balance, canister_self, msg_caller, msg_cycles_accept, msg_cycles_available,
+    },
     init, post_upgrade, pre_upgrade, println, query, update,
 };
 use ic_nervous_system_common::serve_metrics;
@@ -168,7 +170,7 @@ impl CanisterApi for CanisterApiImpl {
     }
 
     fn message_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String> {
-        let available = ic_cdk::api::call::msg_cycles_available();
+        let available = msg_cycles_available() as u64;
 
         if available < required_cycles {
             return Err(format!(
@@ -179,10 +181,10 @@ impl CanisterApi for CanisterApiImpl {
     }
 
     fn accept_message_cycles(&self, cycles: Option<u64>) -> Result<u64, String> {
-        let cycles = cycles.unwrap_or_else(ic_cdk::api::call::msg_cycles_available);
+        let cycles = cycles.unwrap_or_else(|| msg_cycles_available() as u64);
         self.message_has_enough_cycles(cycles)?;
 
-        let accepted = ic_cdk::api::call::msg_cycles_accept(cycles);
+        let accepted = msg_cycles_accept(cycles as u128) as u64;
         Ok(accepted)
     }
 

--- a/rs/nns/sns-wasm/src/canister_api.rs
+++ b/rs/nns/sns-wasm/src/canister_api.rs
@@ -36,18 +36,18 @@ pub trait CanisterApi {
     ) -> Result<(), String>;
 
     /// Return cycles available from the canister's own balance, or error if not enough
-    fn this_canister_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String>;
+    fn this_canister_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String>;
 
     /// Return the cycles available, or fail if insufficient cycles are available.
-    fn message_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String>;
+    fn message_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String>;
 
     /// Accept Some(number) of cycles, or if no cycles are given (i.e. None), accept all available cycles in the message
-    fn accept_message_cycles(&self, cycles: Option<u64>) -> Result<u64, String>;
+    fn accept_message_cycles(&self, cycles: Option<u128>) -> Result<u128, String>;
 
     /// Send cycles to another canister
     async fn send_cycles_to_canister(
         &self,
         target_canister: CanisterId,
-        cycles: u64,
+        cycles: u128,
     ) -> Result<(), String>;
 }

--- a/rs/nns/sns-wasm/src/canister_stable_memory.rs
+++ b/rs/nns/sns-wasm/src/canister_stable_memory.rs
@@ -1,5 +1,4 @@
-#![allow(deprecated)]
-use ic_cdk::api::stable::{
+use ic_cdk::stable::{
     StableMemory, StableMemoryError, stable_grow, stable_read, stable_size, stable_write,
 };
 use std::sync::{Arc, Mutex};

--- a/rs/nns/sns-wasm/src/pb/mod.rs
+++ b/rs/nns/sns-wasm/src/pb/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     stable_memory::SnsWasmStableMemory,
 };
 use ic_base_types::CanisterId;
-use ic_cdk::api::stable::StableMemory;
+use ic_cdk::stable::StableMemory;
 use ic_crypto_sha2::Sha256;
 use ic_nervous_system_common::hash_to_hex_string;
 use std::{collections::HashMap, convert::TryFrom, str::FromStr};

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use candid::Encode;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_cdk::api::stable::StableMemory;
+use ic_cdk::stable::StableMemory;
 use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nervous_system_common::{ONE_TRILLION, SNS_CREATION_FEE, hash_to_hex_string};
 use ic_nervous_system_proto::pb::v1::Canister;

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -831,7 +831,7 @@ where
             .map_err(validation_deploy_error)?;
 
         canister_api
-            .this_canister_has_enough_cycles(SNS_CREATION_FEE)
+            .this_canister_has_enough_cycles(u128::from(SNS_CREATION_FEE))
             .map_err(validation_deploy_error)?;
 
         // Get the current controllers of each of the dapp_canisters in case of deployment errors.
@@ -1056,7 +1056,7 @@ where
                     cycles_per_canister
                 };
                 canister_api
-                    .send_cycles_to_canister(canister_id, cycles_to_provide)
+                    .send_cycles_to_canister(canister_id, u128::from(cycles_to_provide))
                     .await
                     .map_err(|e| format!("Could not fund {label} canister: {e}"))
             },
@@ -2089,14 +2089,14 @@ mod test {
         pub install_wasm_calls: Arc<Mutex<Vec<(CanisterId, Vec<u8>, Vec<u8>)>>>,
         #[allow(clippy::type_complexity)]
         pub set_controllers_calls: Arc<Mutex<Vec<(CanisterId, Vec<PrincipalId>)>>>,
-        pub cycles_accepted: Arc<Mutex<Vec<u64>>>,
+        pub cycles_accepted: Arc<Mutex<Vec<u128>>>,
         #[allow(clippy::type_complexity)]
-        pub cycles_sent: Arc<Mutex<Vec<(CanisterId, u64)>>>,
+        pub cycles_sent: Arc<Mutex<Vec<(CanisterId, u128)>>>,
         pub canisters_deleted: Arc<Mutex<Vec<CanisterId>>>,
         /// How many cycles the canister has.
-        pub canister_cycles_balance: Arc<Mutex<u64>>,
+        pub canister_cycles_balance: Arc<Mutex<u128>>,
         /// How many cycles does the pretend request contain.
-        pub cycles_found_in_request: Arc<Mutex<u64>>,
+        pub cycles_found_in_request: Arc<Mutex<u128>>,
         /// Errors that can be thrown at some nth function call.
         pub errors_on_create_canister: Arc<Mutex<Vec<Option<String>>>>,
         pub errors_on_set_controller: Arc<Mutex<Vec<Option<String>>>>,
@@ -2184,7 +2184,7 @@ mod test {
             Ok(())
         }
 
-        fn this_canister_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String> {
+        fn this_canister_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String> {
             let amount = *self.canister_cycles_balance.lock().unwrap();
             if amount < required_cycles {
                 return Err(format!(
@@ -2194,7 +2194,7 @@ mod test {
             Ok(amount)
         }
 
-        fn message_has_enough_cycles(&self, required_cycles: u64) -> Result<u64, String> {
+        fn message_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String> {
             let amount = *self.cycles_found_in_request.lock().unwrap();
             if amount < required_cycles {
                 return Err(format!(
@@ -2204,7 +2204,7 @@ mod test {
             Ok(amount)
         }
 
-        fn accept_message_cycles(&self, cycles: Option<u64>) -> Result<u64, String> {
+        fn accept_message_cycles(&self, cycles: Option<u128>) -> Result<u128, String> {
             let cycles = cycles.unwrap_or_else(|| *self.cycles_found_in_request.lock().unwrap());
             self.message_has_enough_cycles(cycles)?;
             self.cycles_accepted.lock().unwrap().push(cycles);
@@ -2217,7 +2217,7 @@ mod test {
         async fn send_cycles_to_canister(
             &self,
             target_canister: CanisterId,
-            cycles: u64,
+            cycles: u128,
         ) -> Result<(), String> {
             self.cycles_sent
                 .lock()
@@ -2235,8 +2235,8 @@ mod test {
             cycles_accepted: Arc::new(Mutex::new(vec![])),
             cycles_sent: Arc::new(Mutex::new(vec![])),
             canisters_deleted: Arc::new(Mutex::new(vec![])),
-            canister_cycles_balance: Arc::new(Mutex::new(SNS_CREATION_FEE)),
-            cycles_found_in_request: Arc::new(Mutex::new(SNS_CREATION_FEE)),
+            canister_cycles_balance: Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE))),
+            cycles_found_in_request: Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE))),
             errors_on_create_canister: Arc::new(Mutex::new(vec![])),
             errors_on_set_controller: Arc::new(Mutex::new(vec![])),
             errors_on_delete_canister: Arc::new(Mutex::new(vec![])),
@@ -3984,8 +3984,9 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles =
-            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
+        let sent_cycles = u128::from(
+            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
+        ) / 6;
 
         let sns_init_payload = SnsInitPayload {
             dapp_canisters: None,
@@ -4004,7 +4005,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
+                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4065,7 +4066,7 @@ mod test {
                 Some("Set controller fail".to_string()),
             ]);
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let this_id = canister_test_id(0);
 
@@ -4084,8 +4085,9 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles =
-            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
+        let sent_cycles = u128::from(
+            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
+        ) / 6;
 
         let mut sns_init_payload = SnsInitPayload::with_valid_values_for_testing_post_execution();
         add_dapp_canisters(&mut sns_init_payload, &[dapp_id]);
@@ -4115,7 +4117,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
+                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4247,7 +4249,7 @@ mod test {
     async fn test_governance_deploy_sends_cycles_but_not_from_request() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let this_id = canister_test_id(0);
 
@@ -4261,8 +4263,9 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles =
-            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
+        let sent_cycles = u128::from(
+            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
+        ) / 6;
 
         let sns_init_payload = SnsInitPayload {
             dapp_canisters: Some(DappCanisters::default()),
@@ -4281,7 +4284,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
+                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4327,8 +4330,8 @@ mod test {
         nns_root_canister_client: &SpyNnsRootCanisterClient,
         available_subnet: Option<SubnetId>,
         wasm_available: bool,
-        expected_accepted_cycles: Vec<u64>,
-        expected_sent_cycles: Vec<(CanisterId, u64)>,
+        expected_accepted_cycles: Vec<u128>,
+        expected_sent_cycles: Vec<(CanisterId, u128)>,
         expected_canisters_destroyed: Vec<CanisterId>,
         expected_set_controllers_calls: Vec<(CanisterId, Vec<PrincipalId>)>,
         expected_change_canister_controllers_calls: Vec<(PrincipalId, Vec<PrincipalId>)>,
@@ -4369,8 +4372,8 @@ mod test {
         available_subnet: Option<SubnetId>,
         wasm_available: bool,
         caller: PrincipalId,
-        expected_accepted_cycles: Vec<u64>,
-        expected_sent_cycles: Vec<(CanisterId, u64)>,
+        expected_accepted_cycles: Vec<u128>,
+        expected_sent_cycles: Vec<(CanisterId, u128)>,
         expected_canisters_destroyed: Vec<CanisterId>,
         expected_set_controllers_calls: Vec<(CanisterId, Vec<PrincipalId>)>,
         expected_change_canister_controllers_calls: Vec<(PrincipalId, Vec<PrincipalId>)>,
@@ -4481,7 +4484,7 @@ mod test {
     async fn test_deploy_new_sns_records_root_canisters() {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
-        canister_api.cycles_found_in_request = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.cycles_found_in_request = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4545,7 +4548,7 @@ mod test {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4624,7 +4627,8 @@ mod test {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE - 1));
+        canister_api.canister_cycles_balance =
+            Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE) - 1));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4701,7 +4705,7 @@ mod test {
     async fn fail_take_sole_control_of_dapps() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let dapp_ids = [
             canister_test_id(1000).get(),
@@ -4789,7 +4793,7 @@ mod test {
     async fn fail_transfer_all_dapps_to_sns_root() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let this_id = canister_test_id(0);
         let root_id = canister_test_id(1);
@@ -4846,8 +4850,9 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles =
-            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
+        let sent_cycles = u128::from(
+            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
+        ) / 6;
 
         test_deploy_new_sns_request_one_proposal(
             Some(sns_init_payload),
@@ -4861,7 +4866,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
+                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4926,7 +4931,7 @@ mod test {
     async fn fail_get_controllers_of_dapp_canisters() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let original_dapp_controller = PrincipalId::new_user_test_id(10);
 
@@ -4989,7 +4994,7 @@ mod test {
     async fn get_controllers_of_dapp_canisters_returns_empty_set() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let original_dapp_controller = PrincipalId::new_user_test_id(10);
 
@@ -5053,7 +5058,7 @@ mod test {
             .unwrap()
             .push(Some("Install WASM fail".to_string()));
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let root_id = canister_test_id(1);
         let governance_id = canister_test_id(2);
@@ -5166,7 +5171,7 @@ mod test {
     async fn fail_restore_dapp_canisters_partially_reversible_deployment() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
 
         let this_id = canister_test_id(0);
         let root_id = canister_test_id(1);
@@ -5227,8 +5232,9 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles =
-            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
+        let sent_cycles = u128::from(
+            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
+        ) / 6;
 
         test_deploy_new_sns_request_one_proposal(
             Some(sns_init_payload),
@@ -5242,7 +5248,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
+                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -53,7 +53,7 @@ use ic_cdk::println;
 
 const LOG_PREFIX: &str = "[SNS-WASM] ";
 
-const INITIAL_CANISTER_CREATION_CYCLES: u64 = 3 * ONE_TRILLION;
+const INITIAL_CANISTER_CREATION_CYCLES: u128 = 3 * ONE_TRILLION as u128;
 
 /// The number of canisters that the SNS-WASM canister will install when deploying
 /// an SNS. This constant is different than `SNS_CANISTER_COUNT` due to the Archive
@@ -64,7 +64,7 @@ const INITIAL_CANISTER_CREATION_CYCLES: u64 = 3 * ONE_TRILLION;
 ///   - SNS Swap Canister
 ///   - ICRC Ledger Canister
 ///   - ICRC Index Canister
-pub const SNS_CANISTER_COUNT_AT_INSTALL: u64 = 5;
+pub const SNS_CANISTER_COUNT_AT_INSTALL: u128 = 5;
 
 /// The total number of SNS canister types that make up an SNS. These are:
 ///   - SNS Governance Canister
@@ -73,7 +73,7 @@ pub const SNS_CANISTER_COUNT_AT_INSTALL: u64 = 5;
 ///   - ICRC Ledger Canister
 ///   - ICRC Index Canister
 ///   - ICRC Ledger Archive Canister
-pub const SNS_CANISTER_TYPE_COUNT: u64 = 6;
+pub const SNS_CANISTER_TYPE_COUNT: u128 = 6;
 
 impl From<SnsCanisterIds> for DeployedSns {
     fn from(src: SnsCanisterIds) -> Self {
@@ -831,7 +831,7 @@ where
             .map_err(validation_deploy_error)?;
 
         canister_api
-            .this_canister_has_enough_cycles(u128::from(SNS_CREATION_FEE))
+            .this_canister_has_enough_cycles(SNS_CREATION_FEE)
             .map_err(validation_deploy_error)?;
 
         // Get the current controllers of each of the dapp_canisters in case of deployment errors.
@@ -1056,7 +1056,7 @@ where
                     cycles_per_canister
                 };
                 canister_api
-                    .send_cycles_to_canister(canister_id, u128::from(cycles_to_provide))
+                    .send_cycles_to_canister(canister_id, cycles_to_provide)
                     .await
                     .map_err(|e| format!("Could not fund {label} canister: {e}"))
             },
@@ -1233,14 +1233,14 @@ where
     async fn create_sns_canisters(
         canister_api: &impl CanisterApi,
         subnet_id: SubnetId,
-        initial_cycles_per_canister: u64,
+        initial_cycles_per_canister: u128,
     ) -> Result<SnsCanisterIds, (String, Option<SnsCanisterIds>)> {
         let this_canister_id = canister_api.local_canister_id().get();
         let new_canister = |canister_type: SnsCanisterType| {
             canister_api.create_canister(
                 subnet_id,
                 this_canister_id,
-                Cycles::new(initial_cycles_per_canister.into()),
+                Cycles::new(initial_cycles_per_canister),
                 if canister_type == SnsCanisterType::Governance {
                     DEFAULT_SNS_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT
                 } else {
@@ -2080,7 +2080,7 @@ mod test {
         vec,
     };
 
-    const CANISTER_CREATION_CYCLES: u64 = INITIAL_CANISTER_CREATION_CYCLES * 5;
+    const CANISTER_CREATION_CYCLES: u128 = INITIAL_CANISTER_CREATION_CYCLES * 5;
 
     struct TestCanisterApi {
         canisters_created: Arc<Mutex<u64>>,
@@ -2235,8 +2235,8 @@ mod test {
             cycles_accepted: Arc::new(Mutex::new(vec![])),
             cycles_sent: Arc::new(Mutex::new(vec![])),
             canisters_deleted: Arc::new(Mutex::new(vec![])),
-            canister_cycles_balance: Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE))),
-            cycles_found_in_request: Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE))),
+            canister_cycles_balance: Arc::new(Mutex::new(SNS_CREATION_FEE)),
+            cycles_found_in_request: Arc::new(Mutex::new(SNS_CREATION_FEE)),
             errors_on_create_canister: Arc::new(Mutex::new(vec![])),
             errors_on_set_controller: Arc::new(Mutex::new(vec![])),
             errors_on_delete_canister: Arc::new(Mutex::new(vec![])),
@@ -3984,9 +3984,8 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles = u128::from(
-            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
-        ) / 6;
+        let sent_cycles =
+            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
 
         let sns_init_payload = SnsInitPayload {
             dapp_canisters: None,
@@ -4005,7 +4004,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
+                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4066,7 +4065,7 @@ mod test {
                 Some("Set controller fail".to_string()),
             ]);
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let this_id = canister_test_id(0);
 
@@ -4085,9 +4084,8 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles = u128::from(
-            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
-        ) / 6;
+        let sent_cycles =
+            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
 
         let mut sns_init_payload = SnsInitPayload::with_valid_values_for_testing_post_execution();
         add_dapp_canisters(&mut sns_init_payload, &[dapp_id]);
@@ -4117,7 +4115,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
+                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4249,7 +4247,7 @@ mod test {
     async fn test_governance_deploy_sends_cycles_but_not_from_request() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let this_id = canister_test_id(0);
 
@@ -4263,9 +4261,8 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles = u128::from(
-            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
-        ) / 6;
+        let sent_cycles =
+            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
 
         let sns_init_payload = SnsInitPayload {
             dapp_canisters: Some(DappCanisters::default()),
@@ -4284,7 +4281,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
+                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4484,7 +4481,7 @@ mod test {
     async fn test_deploy_new_sns_records_root_canisters() {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
-        canister_api.cycles_found_in_request = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.cycles_found_in_request = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4548,7 +4545,7 @@ mod test {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4627,8 +4624,7 @@ mod test {
         let test_id = subnet_test_id(1);
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance =
-            Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE) - 1));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE - 1));
 
         thread_local! {
             static CANISTER_WRAPPER: RefCell<SnsWasmCanister<TestCanisterStableMemory>> = RefCell::new(new_wasm_canister()) ;
@@ -4705,7 +4701,7 @@ mod test {
     async fn fail_take_sole_control_of_dapps() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let dapp_ids = [
             canister_test_id(1000).get(),
@@ -4793,7 +4789,7 @@ mod test {
     async fn fail_transfer_all_dapps_to_sns_root() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let this_id = canister_test_id(0);
         let root_id = canister_test_id(1);
@@ -4850,9 +4846,8 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles = u128::from(
-            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
-        ) / 6;
+        let sent_cycles =
+            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
 
         test_deploy_new_sns_request_one_proposal(
             Some(sns_init_payload),
@@ -4866,7 +4861,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
+                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),
@@ -4931,7 +4926,7 @@ mod test {
     async fn fail_get_controllers_of_dapp_canisters() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let original_dapp_controller = PrincipalId::new_user_test_id(10);
 
@@ -4994,7 +4989,7 @@ mod test {
     async fn get_controllers_of_dapp_canisters_returns_empty_set() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let original_dapp_controller = PrincipalId::new_user_test_id(10);
 
@@ -5058,7 +5053,7 @@ mod test {
             .unwrap()
             .push(Some("Install WASM fail".to_string()));
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let root_id = canister_test_id(1);
         let governance_id = canister_test_id(2);
@@ -5171,7 +5166,7 @@ mod test {
     async fn fail_restore_dapp_canisters_partially_reversible_deployment() {
         let mut canister_api = new_canister_api();
         canister_api.cycles_found_in_request = Arc::new(Mutex::new(0));
-        canister_api.canister_cycles_balance = Arc::new(Mutex::new(u128::from(SNS_CREATION_FEE)));
+        canister_api.canister_cycles_balance = Arc::new(Mutex::new(SNS_CREATION_FEE));
 
         let this_id = canister_test_id(0);
         let root_id = canister_test_id(1);
@@ -5232,9 +5227,8 @@ mod test {
         // used to create them, minus the INITIAL_CANISTER_CREATION_CYCLES that is allocated for
         // archive.  Also see below, ledger is given a double share, plus INITIAL_CANISTER_CREATION_CYCLES
         // to account for archive
-        let sent_cycles = u128::from(
-            SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES,
-        ) / 6;
+        let sent_cycles =
+            (SNS_CREATION_FEE - CANISTER_CREATION_CYCLES - INITIAL_CANISTER_CREATION_CYCLES) / 6;
 
         test_deploy_new_sns_request_one_proposal(
             Some(sns_init_payload),
@@ -5248,7 +5242,7 @@ mod test {
                 (governance_id, sent_cycles),
                 (
                     ledger_id,
-                    sent_cycles * 2 + u128::from(INITIAL_CANISTER_CREATION_CYCLES),
+                    sent_cycles * 2 + INITIAL_CANISTER_CREATION_CYCLES,
                 ),
                 (swap_id, sent_cycles),
                 (index_id, sent_cycles),

--- a/rs/nns/sns-wasm/src/stable_memory.rs
+++ b/rs/nns/sns-wasm/src/stable_memory.rs
@@ -21,10 +21,9 @@
 //! written bytes is written to "canister state size" in stable memory, so that in post-upgrade
 //! SNS-WASM can use "WASMs-end offset" and "canister state size" to read canister state from
 //! stable memory.
-#![allow(deprecated)]
 
 use crate::pb::v1::{SnsWasm, StableCanisterState};
-use ic_cdk::api::stable::{StableMemory, StableMemoryError, StableReader, StableWriter};
+use ic_cdk::stable::{StableMemory, StableMemoryError, StableReader, StableWriter};
 use prost::Message;
 use std::mem::size_of;
 

--- a/rs/nns/sns-wasm/tests/deploy_new_sns.rs
+++ b/rs/nns/sns-wasm/tests/deploy_new_sns.rs
@@ -244,7 +244,7 @@ fn test_deploy_cleanup_on_wasm_install_failure() {
     assert_eq!(
         machine.cycle_balance(SNS_WASM_CANISTER_ID),
         EXPECTED_SNS_CREATION_FEE
-            - SNS_CANISTER_COUNT_AT_INSTALL as u128 * initial_canister_creation_cycles,
+            - SNS_CANISTER_COUNT_AT_INSTALL * initial_canister_creation_cycles,
     );
 }
 

--- a/rs/rust_canisters/load_simulator/src/main.rs
+++ b/rs/rust_canisters/load_simulator/src/main.rs
@@ -1,5 +1,4 @@
-#![allow(deprecated)]
-use ic_cdk::api::stable;
+use ic_cdk::stable;
 use std::cell::RefCell;
 use std::time::Duration;
 

--- a/rs/rust_canisters/proxy_canister/src/main.rs
+++ b/rs/rust_canisters/proxy_canister/src/main.rs
@@ -10,7 +10,9 @@ use candid::Principal;
 use futures::future::join_all;
 use futures::stream::{FuturesUnordered, StreamExt};
 use ic_cdk::api::call::RejectionCode;
-use ic_cdk::api::{data_certificate, in_replicated_execution, msg_caller, time};
+use ic_cdk::api::{
+    data_certificate, in_replicated_execution, msg_caller, msg_cycles_refunded, time,
+};
 use ic_cdk::spawn;
 use ic_cdk::{query, update};
 use ic_management_canister_types_private::{
@@ -172,7 +174,9 @@ async fn send_request_with_refund_callback(
             Err((r, m))
         }
     };
-    let refunded_cycles = ic_cdk::api::call::msg_cycles_refunded();
+    // `ResponseWithRefundedCycles::refunded_cycles` is `nat64` on the wire, so keep the
+    // 64-bit width the Candid interface of this test canister already exposes.
+    let refunded_cycles = msg_cycles_refunded() as u64;
     ResponseWithRefundedCycles {
         result,
         refunded_cycles,

--- a/rs/rust_canisters/stable_memory_integrity/src/lib.rs
+++ b/rs/rust_canisters/stable_memory_integrity/src/lib.rs
@@ -1,6 +1,5 @@
-#![allow(deprecated)]
 use candid::CandidType;
-use ic_cdk::api::stable::{stable_grow, stable_read, stable_size, stable_write};
+use ic_cdk::stable::{stable_grow, stable_read, stable_size, stable_write};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug, CandidType, Deserialize, Serialize)]

--- a/rs/sns/governance/src/sns_root_types.rs
+++ b/rs/sns/governance/src/sns_root_types.rs
@@ -3,7 +3,7 @@
 ///
 /// When canister_init is called in the SNS root canister, it is expected that a
 /// serialized version of this was passed via ic_management_canister_types_private::InstallCodeArgs::args,
-/// which can be retrieved by the canister via ic_cdk::api::call::arg_data().
+/// which can be retrieved by the canister via ic_cdk::api::msg_arg_data().
 #[derive(
     candid::CandidType,
     candid::Deserialize,

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -9,7 +9,7 @@ import "ic_nervous_system/pb/v1/nervous_system.proto";
 //
 // When canister_init is called in the SNS root canister, it is expected that a
 // serialized version of this was passed via ic_management_canister_types_private::InstallCodeArgs::args,
-// which can be retrieved by the canister via ic_cdk::api::call::arg_data().
+// which can be retrieved by the canister via ic_cdk::api::msg_arg_data().
 message SnsRootCanister {
   // Required.
   //

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -3,7 +3,7 @@
 ///
 /// When canister_init is called in the SNS root canister, it is expected that a
 /// serialized version of this was passed via ic_management_canister_types_private::InstallCodeArgs::args,
-/// which can be retrieved by the canister via ic_cdk::api::call::arg_data().
+/// which can be retrieved by the canister via ic_cdk::api::msg_arg_data().
 #[derive(
     candid::CandidType,
     candid::Deserialize,


### PR DESCRIPTION
This migrates our code out of the 0.18-deprecated modules and into the new `ic_cdk::stable` and `api::*` system APIs.

This allows us to drop some explicit casts.