### PR TITLE
test(subnet-splitting): fix, extend and enable subnet splitting system test

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -210,8 +210,11 @@ thread_local! {
     static ENABLE_NEURON_FOLLOW_RESTRICTIONS: Cell<bool>
         = const { Cell::new(true) };
 
+    // Enabled in test builds (i.e. governance-canister-test) so that system
+    // tests can exercise subnet splitting end to end. Still off in the release
+    // build, until the feature is rolled out.
     static ENABLE_SUBNET_SPLITTING_PROPOSALS: Cell<bool>
-        = const { Cell::new(false) };
+        = const { Cell::new(cfg!(any(feature = "test"))) };
 
     // The planned effects of enabling this flag include
     //   1. Reduce max dissolve delay from 8 years to 2 years. This includes capping existing neurons via data migration.

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -211,8 +211,8 @@ fn canister_init() {
     {
         use registry_canister::flags::temporary_overrides::{
             test_set_blank_replica_version_id_for_cloud_engines_enabled,
-            test_set_swapping_enabled_subnets, test_set_swapping_status,
-            test_set_swapping_whitelisted_callers,
+            test_set_subnet_splitting_enabled, test_set_swapping_enabled_subnets,
+            test_set_swapping_status, test_set_swapping_whitelisted_callers,
         };
 
         println!("{LOG_PREFIX}canister_init: Overriding swapping flags");
@@ -245,6 +245,13 @@ fn canister_init() {
             init_payload
                 .is_blank_replica_version_id_for_cloud_engines_enabled
                 .unwrap_or_default(),
+        );
+        println!(
+            "{LOG_PREFIX}canister_init: Subnet Splitting enabled: {:?}",
+            init_payload.is_subnet_splitting_enabled
+        );
+        test_set_subnet_splitting_enabled(
+            init_payload.is_subnet_splitting_enabled.unwrap_or_default(),
         );
     }
 }

--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -106,6 +106,10 @@ pub mod temporary_overrides {
     pub fn test_set_blank_replica_version_id_for_cloud_engines_enabled(override_value: bool) {
         IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED.replace(override_value);
     }
+
+    pub fn test_set_subnet_splitting_enabled(override_value: bool) {
+        IS_SUBNET_SPLITTING_ENABLED.replace(override_value);
+    }
 }
 
 pub(crate) fn is_node_swapping_enabled_on_subnet(subnet_id: SubnetId) -> bool {

--- a/rs/registry/canister/src/init.rs
+++ b/rs/registry/canister/src/init.rs
@@ -25,6 +25,11 @@ pub struct RegistryCanisterInitPayload {
     // Same deal as the swapping flags above, but for the blank
     // replica_version_id (for Cloud Engines) feature.
     pub is_blank_replica_version_id_for_cloud_engines_enabled: Option<bool>,
+
+    // Same deal as above, but for the Subnet Splitting feature.
+    // Used by system tests which exercise subnet splitting, and will
+    // go away once the feature is fully rolled out.
+    pub is_subnet_splitting_enabled: Option<bool>,
 }
 
 impl fmt::Display for RegistryCanisterInitPayload {
@@ -50,6 +55,7 @@ pub struct RegistryCanisterInitPayloadBuilder {
     swapping_whitelisted_callers: BTreeSet<PrincipalId>,
     swapping_enabled_subnets: BTreeSet<SubnetId>,
     is_blank_replica_version_id_for_cloud_engines_enabled: bool,
+    is_subnet_splitting_enabled: bool,
 }
 
 #[allow(clippy::new_without_default)]
@@ -61,6 +67,7 @@ impl RegistryCanisterInitPayloadBuilder {
             swapping_whitelisted_callers: BTreeSet::new(),
             swapping_enabled_subnets: BTreeSet::new(),
             is_blank_replica_version_id_for_cloud_engines_enabled: false,
+            is_subnet_splitting_enabled: false,
         }
     }
 
@@ -88,6 +95,7 @@ impl RegistryCanisterInitPayloadBuilder {
             is_blank_replica_version_id_for_cloud_engines_enabled: Some(
                 self.is_blank_replica_version_id_for_cloud_engines_enabled,
             ),
+            is_subnet_splitting_enabled: Some(self.is_subnet_splitting_enabled),
         }
     }
 
@@ -108,6 +116,11 @@ impl RegistryCanisterInitPayloadBuilder {
 
     pub fn enable_blank_replica_version_id_for_cloud_engines(&mut self) -> &mut Self {
         self.is_blank_replica_version_id_for_cloud_engines_enabled = true;
+        self
+    }
+
+    pub fn enable_subnet_splitting(&mut self) -> &mut Self {
+        self.is_subnet_splitting_enabled = true;
         self
     }
 }

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -289,6 +289,8 @@ system_test_nns(
         "@crate_index//:anyhow",
         "@crate_index//:candid",
         "@crate_index//:futures",
+        "@crate_index//:ic-agent",
+        "@crate_index//:rand",
         "@crate_index//:slog",
         "@crate_index//:tokio",
     ],

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -261,6 +261,7 @@ system_test_nns(
 system_test_nns(
     name = "subnet_splitting_v2_test",
     cpus = MIN_LOCAL_CPUS + 11 * DEFAULT_VCPUS_PER_VM,  # 11 IC Node VMs (1+1 System + 8 Application + 1 VerifiedApplication) * 6 vCPUs.
+    enable_mainnet_nns_variant = False,  # This feature isn't in mainnet NNS yet.
     enable_metrics = True,
     tags = [
         "colocate",

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -288,6 +288,8 @@ system_test_nns(
         "@crate_index//:anyhow",
         "@crate_index//:candid",
         "@crate_index//:futures",
+        "@crate_index//:ic-agent",
+        "@crate_index//:rand",
         "@crate_index//:slog",
         "@crate_index//:tokio",
     ],

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -166,11 +166,16 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
     let source_subnet = get_source_subnet(&env);
     let original_source_subnet_canister_ranges = source_subnet.subnet_canister_ranges();
     let nns_canister_ranges = nns_subnet.subnet_canister_ranges();
+    let initial_dkg_canister_ranges = initial_dkg_subnet.subnet_canister_ranges();
 
     let mut source_subnet_nodes: Vec<_> = source_subnet.nodes().map(|node| node.node_id).collect();
     let destination_subnet_nodes: Vec<_> =
         source_subnet_nodes.split_off(INITIAL_SOURCE_SUBNET_NODES / 2);
     let nns_subnet_nodes: Vec<_> = nns_subnet.nodes().map(|node| node.node_id).collect();
+    let initial_dkg_subnet_nodes: Vec<_> = initial_dkg_subnet
+        .nodes()
+        .map(|node| node.node_id)
+        .collect();
 
     info!(env.logger(), "Proposing to split the source subnet.");
     propose_to_split_subnet(
@@ -191,6 +196,7 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
         source_subnet.subnet_id,
         &original_source_subnet_canister_ranges,
         &nns_canister_ranges,
+        &initial_dkg_canister_ranges,
         &test_params.canister_migration_list,
     );
     check_subnet_membership(
@@ -199,6 +205,7 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
         &source_subnet_nodes,
         &destination_subnet_nodes,
         &nns_subnet_nodes,
+        &initial_dkg_subnet_nodes,
     )
     .await;
     check_counter_canisters(&env, source_subnet.subnet_id, test_params).await;
@@ -626,6 +633,7 @@ async fn check_subnet_membership(
     source_subnet_nodes: &[NodeId],
     destination_subnet_nodes: &[NodeId],
     nns_subnet_nodes: &[NodeId],
+    initial_dkg_subnet_nodes: &[NodeId],
 ) {
     let topology = env.topology_snapshot();
 
@@ -637,10 +645,16 @@ async fn check_subnet_membership(
         let nodes: Vec<_> = subnet.nodes().map(|node| node.node_id).collect();
 
         match subnet.subnet_type() {
-            SubnetType::System => {
+            SubnetType::System if subnet.subnet_id == topology.root_subnet_id() => {
                 assert_eq!(
                     nodes, nns_subnet_nodes,
                     "The NNS subnet membership shouldn't change"
+                );
+            }
+            SubnetType::System => {
+                assert_eq!(
+                    nodes, initial_dkg_subnet_nodes,
+                    "The initial DKG subnet membership shouldn't change"
                 );
             }
             SubnetType::Application if subnet.subnet_id == source_subnet_id => {
@@ -678,8 +692,11 @@ async fn check_subnet_membership(
     );
     for subnet in topology.subnets() {
         match subnet.subnet_type() {
-            SubnetType::System => {
+            SubnetType::System if subnet.subnet_id == topology.root_subnet_id() => {
                 info!(env.logger(), "Checking the NNS subnet");
+            }
+            SubnetType::System => {
+                info!(env.logger(), "Checking the initial DKG subnet");
             }
             SubnetType::Application if subnet.subnet_id == source_subnet_id => {
                 info!(env.logger(), "Checking the source subnet");
@@ -728,6 +745,7 @@ fn check_routing_table(
     source_subnet_id: SubnetId,
     original_source_canister_ranges: &[CanisterIdRange],
     original_nns_canister_ranges: &[CanisterIdRange],
+    original_initial_dkg_canister_ranges: &[CanisterIdRange],
     migrated_canister_ranges: &[CanisterIdRange],
 ) {
     info!(
@@ -741,11 +759,20 @@ fn check_routing_table(
 
     for subnet in env.topology_snapshot().subnets() {
         match subnet.subnet_type() {
-            SubnetType::System => {
+            // NNS subnet
+            SubnetType::System if subnet.subnet_id == env.topology_snapshot().root_subnet_id() => {
                 assert_eq!(
                     subnet.subnet_canister_ranges(),
                     original_nns_canister_ranges,
                     "The NNS subnet canister id assignment shouldn't change"
+                );
+            }
+            // Initial DKG subnet
+            SubnetType::System => {
+                assert_eq!(
+                    subnet.subnet_canister_ranges(),
+                    original_initial_dkg_canister_ranges,
+                    "The initial DKG subnet canister id assignment shouldn't change"
                 );
             }
             // Source subnet

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -21,8 +21,7 @@ use anyhow::{Context, Result, bail};
 use canister_test::{Canister, Runtime, Wasm};
 use dfn_candid::candid;
 use ic_canister_client::Sender;
-use ic_consensus_system_test_utils::get_cup_from_node;
-use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
+use ic_consensus_system_test_utils::{get_cup_from_node, rw_message::install_nns_and_check_progress};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -32,20 +31,20 @@ use ic_registry_routing_table::{
     CANISTER_IDS_PER_SUBNET, CanisterIdRange, CanisterIdRanges, canister_id_into_u64, difference,
 };
 use ic_registry_subnet_type::SubnetType;
-use ic_system_test_driver::canister_agent::HasCanisterAgentCapability;
-use ic_system_test_driver::driver::test_env_api::{HasRegistryVersion, get_dependency_path};
-use ic_system_test_driver::nns::vote_and_execute_proposal;
-use ic_system_test_driver::retry_with_msg_async;
-use ic_system_test_driver::{driver::group::SystemTestGroup, systest};
 use ic_system_test_driver::{
+    canister_agent::HasCanisterAgentCapability,
     driver::{
+        group::SystemTestGroup,
         ic::{InternetComputer, Subnet},
         test_env::TestEnv,
         test_env_api::{
-            HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot, SubnetSnapshot,
+            HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot, SubnetSnapshot, HasRegistryVersion, get_dependency_path
         },
     },
     util::runtime_from_url,
+    nns::vote_and_execute_proposal,
+    retry_with_msg_async, retry_with_msg_async_quiet,
+    systest,
 };
 use ic_types::{CanisterId, Height, NodeId, PrincipalId, RegistryVersion, SubnetId};
 use registry_canister::mutations::do_split_subnet::SplitSubnetPayload;

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -74,6 +74,12 @@ fn main() -> Result<()> {
         .with_timeout_per_test(Duration::from_secs(30 * 60))
         .with_overall_timeout(Duration::from_secs(35 * 60))
         .add_test(systest!(subnet_splitting_test))
+        // When the subnet splits, it is expected that some messages are invalidated because the
+        // two new subnets are still connected through the same underlying p2p network.
+        .remove_metrics_to_check("consensus_invalidated_artifacts")
+        .remove_metrics_to_check("dkg_invalidated_artifacts")
+        // The destination replicas are restarted after the split
+        .update_orchestrator_metrics_to_check("orchestrator_processes_start_attempts_total", 2)
         .execute_from_args()
 }
 

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -23,7 +23,9 @@ use canister_test::{Canister, Runtime, Wasm};
 use dfn_candid::candid;
 use ic_agent::AgentError;
 use ic_canister_client::Sender;
-use ic_consensus_system_test_utils::{get_cup_from_node, rw_message::install_nns_and_check_progress};
+use ic_consensus_system_test_utils::{
+    get_cup_from_node, rw_message::install_nns_and_check_progress,
+};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -40,13 +42,13 @@ use ic_system_test_driver::{
         ic::{InternetComputer, Subnet},
         test_env::TestEnv,
         test_env_api::{
-            HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot, SubnetSnapshot, HasRegistryVersion, get_dependency_path
+            HasPublicApiUrl, HasRegistryVersion, HasTopologySnapshot, IcNodeContainer,
+            IcNodeSnapshot, SubnetSnapshot, get_dependency_path,
         },
     },
     nns::vote_and_execute_proposal,
+    retry_with_msg_async, retry_with_msg_async_quiet, systest,
     util::{create_agent, runtime_from_url},
-    retry_with_msg_async, retry_with_msg_async_quiet,
-    systest,
 };
 use ic_types::{CanisterId, Height, NodeId, PrincipalId, RegistryVersion, SubnetId};
 use registry_canister::mutations::do_split_subnet::SplitSubnetPayload;

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -24,7 +24,7 @@ use dfn_candid::candid;
 use ic_agent::AgentError;
 use ic_canister_client::Sender;
 use ic_consensus_system_test_utils::{
-    get_cup_from_node, rw_message::install_nns_and_check_progress,
+    get_cup_from_node, rw_message::install_nns_with_customizations_and_check_progress,
 };
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
 use ic_nns_common::types::NeuronId;
@@ -43,7 +43,7 @@ use ic_system_test_driver::{
         test_env::TestEnv,
         test_env_api::{
             HasPublicApiUrl, HasRegistryVersion, HasTopologySnapshot, IcNodeContainer,
-            IcNodeSnapshot, SubnetSnapshot, get_dependency_path,
+            IcNodeSnapshot, NnsCustomizations, SubnetSnapshot, get_dependency_path,
         },
     },
     nns::vote_and_execute_proposal,
@@ -51,7 +51,9 @@ use ic_system_test_driver::{
     util::{create_agent, runtime_from_url},
 };
 use ic_types::{CanisterId, Height, NodeId, PrincipalId, RegistryVersion, SubnetId};
-use registry_canister::mutations::do_split_subnet::SplitSubnetPayload;
+use registry_canister::{
+    init::RegistryCanisterInitPayload, mutations::do_split_subnet::SplitSubnetPayload,
+};
 use slog::info;
 use xnet_test::{Metrics, StartArgs};
 
@@ -72,8 +74,6 @@ const CHATTING_CANISTERS_ON_SOURCE_SUBNET_COUNT: usize = 10;
 const CHATTING_CANISTERS_ON_THIRD_SUBNET_COUNT: usize = 3;
 const FIRST_CHATTING_CANISTER_ID_TO_MIGRATE_OFFSET: usize = 3;
 const LAST_CHATTING_CANISTER_ID_TO_MIGRATE_OFFSET: usize = 8;
-
-const TEST_ENABLED: bool = false;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
@@ -120,7 +120,19 @@ fn setup(env: TestEnv) {
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
-    install_nns_and_check_progress(env.topology_snapshot());
+    // Subnet Splitting is still behind a feature flag in the Registry canister,
+    // so it has to be turned on explicitly. This only works because system
+    // tests install registry-canister-test, not the release build.
+    install_nns_with_customizations_and_check_progress(
+        env.topology_snapshot(),
+        NnsCustomizations {
+            registry_canister_init_payload: RegistryCanisterInitPayload {
+                is_subnet_splitting_enabled: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
 }
 
 fn subnet_splitting_test(env: TestEnv) {
@@ -132,15 +144,6 @@ fn subnet_splitting_test(env: TestEnv) {
             so the canisters have some time to chit chat"
         );
         tokio::time::sleep(Duration::from_secs(10)).await;
-
-        if !TEST_ENABLED {
-            info!(
-                env.logger(),
-                "Subnet splititing not enabled yet, skipping the test."
-            );
-
-            return;
-        }
 
         run_subnet_splitting_test(env.clone(), &test_params).await
     })

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use canister_test::{Canister, Runtime, Wasm};
 use dfn_candid::candid;
+use ic_agent::AgentError;
 use ic_canister_client::Sender;
 use ic_consensus_system_test_utils::{get_cup_from_node, rw_message::install_nns_and_check_progress};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
@@ -42,8 +43,8 @@ use ic_system_test_driver::{
             HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot, SubnetSnapshot, HasRegistryVersion, get_dependency_path
         },
     },
-    util::runtime_from_url,
     nns::vote_and_execute_proposal,
+    util::{create_agent, runtime_from_url},
     retry_with_msg_async, retry_with_msg_async_quiet,
     systest,
 };
@@ -54,6 +55,9 @@ use xnet_test::{Metrics, StartArgs};
 
 const DKG_INTERVAL: u64 = 99;
 const INITIAL_SOURCE_SUBNET_NODES: usize = 8;
+
+const ACCEPTABLE_SOURCE_DOWNTIME: Duration = Duration::from_secs(15);
+const ACCEPTABLE_DEST_DOWNTIME: Duration = Duration::from_secs(35);
 
 /// Number of counter canisters to install on the source subnet, before splitting it.
 const COUNTER_CANISTERS_COUNT: usize = 13;
@@ -178,17 +182,8 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
         .map(|node| node.node_id)
         .collect();
 
-    // All counter canisters, regardless of whether they stay on the source subnet or get
-    // migrated to the destination subnet.
-    let counter_canister_ids: Vec<CanisterId> = test_params
-        .source_subnet_counting_canister_ids
-        .iter()
-        .chain(&test_params.destination_subnet_counting_canister_ids)
-        .copied()
-        .collect();
-
-    // Flag used to stop the concurrent query probe (see below).
-    let stop_query_probe = AtomicBool::new(false);
+    // Flag used to stop the concurrent calls probe (see below).
+    let stop_calls_probe = AtomicBool::new(false);
 
     let split_and_check = async {
         info!(env.logger(), "Proposing to split the source subnet.");
@@ -224,43 +219,60 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
         .await;
         check_counter_canisters(&env, source_subnet.subnet_id, test_params).await;
 
-        // The split is done and all checks passed; stop the query probe just before the
+        // The split is done and all checks passed; stop the calls probe just before the
         // chatting canisters' metrics are measured and the canisters are stopped.
-        stop_query_probe.store(true, Ordering::Relaxed);
+        stop_calls_probe.store(true, Ordering::Relaxed);
     };
 
-    // Continuously make query calls to all the counter canisters for the entire duration of
-    // the split (starting before the split is proposed, stopping just before measuring the
-    // chatting canisters' metrics), asserting that every single one of them succeeds.
+    // Continuously make calls to all the counter canisters for the entire duration of the split
+    // (starting before the split is proposed, stopping just before measuring the chatting
+    // canisters' metrics), asserting that every single one of them succeeds.
     tokio::join!(
         split_and_check,
-        query_counter_canisters_until_stopped(&env, &counter_canister_ids, &stop_query_probe),
+        call_counter_canisters_until_stopped(
+            &env,
+            &test_params.source_subnet_counting_canister_ids,
+            &test_params.destination_subnet_counting_canister_ids,
+            &stop_calls_probe
+        ),
     );
 
     check_chatting_canisters(&env, test_params).await;
 }
 
-/// Continuously makes query calls to every counter canister — routing each call to whichever
-/// subnet currently hosts the canister — until `stop` is set, asserting that every single
-/// query call succeeds. Transient failures (e.g. while the destination subnet is still
-/// catching up right after the split, or while a node refreshes its cached NNS delegation)
-/// are retried.
+/// Continuously makes calls to every counter canister — routing each call to whichever subnet
+/// currently hosts the canister — until `stop` is set, asserting that every single call succeeds.
+/// Transient failures (e.g. while the destination subnet is still catching up right after the
+/// split, or while a node refreshes its cached NNS delegation) are retried.
 ///
 /// Run concurrently with the split, this verifies that the counter canisters remain available
 /// for the entire duration of the subnet split.
-async fn query_counter_canisters_until_stopped(
+async fn call_counter_canisters_until_stopped(
     env: &TestEnv,
-    counter_canister_ids: &[CanisterId],
+    source_counter_canister_ids: &[CanisterId],
+    dest_counter_canister_ids: &[CanisterId],
     stop: &AtomicBool,
 ) {
+    let counter_canister_ids: Vec<_> = source_counter_canister_ids
+        .iter()
+        .chain(dest_counter_canister_ids)
+        .copied()
+        .collect();
+    let timeout = |canister_id| {
+        if source_counter_canister_ids.contains(canister_id) {
+            ACCEPTABLE_SOURCE_DOWNTIME
+        } else if dest_counter_canister_ids.contains(canister_id) {
+            ACCEPTABLE_DEST_DOWNTIME
+        } else {
+            unreachable!()
+        }
+    };
     futures::future::join_all(counter_canister_ids.iter().map(|canister_id| async move {
         while !stop.load(Ordering::Relaxed) {
-            retry_with_msg_async!(
-                format!("Querying counter canister {canister_id} during the subnet split"),
+            retry_with_msg_async_quiet!(
+                format!("Calling counter canister {canister_id} during the subnet split"),
                 &env.logger(),
-                // Nodes should update their delegations within 15 seconds, so panic if the calls
-                // fails for longer than that.
-                Duration::from_secs(15),
+                timeout(canister_id),
                 Duration::from_secs(1),
                 || async {
                     // Re-resolve the host on every attempt: the migrated canisters move from
@@ -274,20 +286,42 @@ async fn query_counter_canisters_until_stopped(
                                 .iter()
                                 .any(|range| range.contains(canister_id))
                         })
-                        .and_then(|subnet| subnet.nodes().next())
+                        .and_then(|subnet| {
+                            subnet
+                                .nodes()
+                                .nth(rand::random::<usize>() % subnet.nodes().count())
+                        })
                         .expect("The counter canister is not hosted by any subnet");
 
-                    node.build_canister_agent()
-                        .await
-                        .get()
-                        .query(&canister_id.get().0, "read".to_string())
-                        .call()
-                        .await
-                        .context("Failed to make the query call")
+                    let agent = create_agent(node.get_public_url().as_str()).await?;
+                    match futures::future::try_join(
+                        agent.query(&canister_id.get().0, "read".to_string()).call(),
+                        agent
+                            .update(&canister_id.get().0, "read".to_string())
+                            .call(),
+                    )
+                    .await
+                    {
+                        Ok(_) => Ok(()),
+                        Err(err @ AgentError::CertificateNotAuthorized())
+                        | Err(err @ AgentError::CertificateVerificationFailed())
+                        | Err(err @ AgentError::CertificateOutdated(_)) => {
+                            // These errors could happen with an invalid/stale delegation.
+                            // Replicas could be able to detect this and refresh their delegations
+                            // before attempting to reply (and we could panic here to ensure we do
+                            // not observe those errors), but this is not yet implemented. So we
+                            // retry instead.
+                            Err(err.into())
+                        }
+                        Err(err) => {
+                            // Transient errors are expected during the subnet split, so we retry.
+                            Err(err.into())
+                        }
+                    }
                 }
             )
             .await
-            .expect("A query call to a counter canister failed during the subnet split");
+            .expect("A call to a counter canister failed during the subnet split");
 
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -360,8 +360,18 @@ async fn check_chatting_canisters_metrics(
     .into_iter()
     .for_each(|metrics_after| aggregated_metrics.merge(&metrics_after));
 
-    assert_eq!(aggregated_metrics.call_errors, 0);
-    assert_eq!(aggregated_metrics.reject_responses, 0);
+    let error_percentage = (aggregated_metrics.call_errors + aggregated_metrics.reject_responses)
+        as f64
+        / aggregated_metrics.calls_attempted as f64
+        * 100.0;
+    assert!(
+        error_percentage < 10.0,
+        "The percentage of failed calls ({error_percentage}%) is too high. \
+        {} calls were attempted, {} failed with call errors and {} failed with reject responses",
+        aggregated_metrics.calls_attempted,
+        aggregated_metrics.call_errors,
+        aggregated_metrics.reject_responses
+    );
     assert_eq!(aggregated_metrics.seq_errors, 0);
 }
 
@@ -408,7 +418,7 @@ async fn install_chatting_canisters(env: &TestEnv) -> (Vec<CanisterId>, Vec<Cani
 
     let canister_start_arguments = StartArgs {
         network_topology: canister_groups.clone(),
-        canister_to_subnet_rate: 10,
+        canister_to_subnet_rate: 1,
         request_payload_size_bytes: 1,
         call_timeouts_seconds: vec![None],
         response_payload_size_bytes: 1,

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -537,7 +537,7 @@ async fn install_chatting_canisters(env: &TestEnv) -> (Vec<CanisterId>, Vec<Cani
 
     let canister_start_arguments = StartArgs {
         network_topology: canister_groups.clone(),
-        canister_to_subnet_rate: 1,
+        canister_to_subnet_rate: 3,
         request_payload_size_bytes: 1,
         call_timeouts_seconds: vec![None],
         response_payload_size_bytes: 1,

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -15,6 +15,7 @@ Success::
 
 end::catalog[] */
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -51,7 +52,7 @@ use registry_canister::mutations::do_split_subnet::SplitSubnetPayload;
 use slog::info;
 use xnet_test::{Metrics, StartArgs};
 
-const DKG_INTERVAL: u64 = 49;
+const DKG_INTERVAL: u64 = 99;
 const INITIAL_SOURCE_SUBNET_NODES: usize = 8;
 
 /// Number of counter canisters to install on the source subnet, before splitting it.
@@ -177,39 +178,121 @@ async fn run_subnet_splitting_test(env: TestEnv, test_params: &TestParams) {
         .map(|node| node.node_id)
         .collect();
 
-    info!(env.logger(), "Proposing to split the source subnet.");
-    propose_to_split_subnet(
-        &env,
-        &source_subnet,
-        test_params.canister_migration_list.clone(),
-        destination_subnet_nodes.clone(),
-        Some(initial_dkg_subnet.subnet_id),
-    )
-    .await;
+    // All counter canisters, regardless of whether they stay on the source subnet or get
+    // migrated to the destination subnet.
+    let counter_canister_ids: Vec<CanisterId> = test_params
+        .source_subnet_counting_canister_ids
+        .iter()
+        .chain(&test_params.destination_subnet_counting_canister_ids)
+        .copied()
+        .collect();
 
-    info!(
-        env.logger(),
-        "Running checks to make sure the subnet was split correctly."
+    // Flag used to stop the concurrent query probe (see below).
+    let stop_query_probe = AtomicBool::new(false);
+
+    let split_and_check = async {
+        info!(env.logger(), "Proposing to split the source subnet.");
+        propose_to_split_subnet(
+            &env,
+            &source_subnet,
+            test_params.canister_migration_list.clone(),
+            destination_subnet_nodes.clone(),
+            Some(initial_dkg_subnet.subnet_id),
+        )
+        .await;
+
+        info!(
+            env.logger(),
+            "Running checks to make sure the subnet was split correctly."
+        );
+        check_routing_table(
+            &env,
+            source_subnet.subnet_id,
+            &original_source_subnet_canister_ranges,
+            &nns_canister_ranges,
+            &initial_dkg_canister_ranges,
+            &test_params.canister_migration_list,
+        );
+        check_subnet_membership(
+            &env,
+            source_subnet.subnet_id,
+            &source_subnet_nodes,
+            &destination_subnet_nodes,
+            &nns_subnet_nodes,
+            &initial_dkg_subnet_nodes,
+        )
+        .await;
+        check_counter_canisters(&env, source_subnet.subnet_id, test_params).await;
+
+        // The split is done and all checks passed; stop the query probe just before the
+        // chatting canisters' metrics are measured and the canisters are stopped.
+        stop_query_probe.store(true, Ordering::Relaxed);
+    };
+
+    // Continuously make query calls to all the counter canisters for the entire duration of
+    // the split (starting before the split is proposed, stopping just before measuring the
+    // chatting canisters' metrics), asserting that every single one of them succeeds.
+    tokio::join!(
+        split_and_check,
+        query_counter_canisters_until_stopped(&env, &counter_canister_ids, &stop_query_probe),
     );
-    check_routing_table(
-        &env,
-        source_subnet.subnet_id,
-        &original_source_subnet_canister_ranges,
-        &nns_canister_ranges,
-        &initial_dkg_canister_ranges,
-        &test_params.canister_migration_list,
-    );
-    check_subnet_membership(
-        &env,
-        source_subnet.subnet_id,
-        &source_subnet_nodes,
-        &destination_subnet_nodes,
-        &nns_subnet_nodes,
-        &initial_dkg_subnet_nodes,
-    )
-    .await;
-    check_counter_canisters(&env, source_subnet.subnet_id, test_params).await;
+
     check_chatting_canisters(&env, test_params).await;
+}
+
+/// Continuously makes query calls to every counter canister — routing each call to whichever
+/// subnet currently hosts the canister — until `stop` is set, asserting that every single
+/// query call succeeds. Transient failures (e.g. while the destination subnet is still
+/// catching up right after the split, or while a node refreshes its cached NNS delegation)
+/// are retried.
+///
+/// Run concurrently with the split, this verifies that the counter canisters remain available
+/// for the entire duration of the subnet split.
+async fn query_counter_canisters_until_stopped(
+    env: &TestEnv,
+    counter_canister_ids: &[CanisterId],
+    stop: &AtomicBool,
+) {
+    futures::future::join_all(counter_canister_ids.iter().map(|canister_id| async move {
+        while !stop.load(Ordering::Relaxed) {
+            retry_with_msg_async!(
+                format!("Querying counter canister {canister_id} during the subnet split"),
+                &env.logger(),
+                // Nodes should update their delegations within 15 seconds, so panic if the calls
+                // fails for longer than that.
+                Duration::from_secs(15),
+                Duration::from_secs(1),
+                || async {
+                    // Re-resolve the host on every attempt: the migrated canisters move from
+                    // the source to the destination subnet partway through the split.
+                    let node = env
+                        .topology_snapshot()
+                        .subnets()
+                        .find(|subnet| {
+                            subnet
+                                .subnet_canister_ranges()
+                                .iter()
+                                .any(|range| range.contains(canister_id))
+                        })
+                        .and_then(|subnet| subnet.nodes().next())
+                        .expect("The counter canister is not hosted by any subnet");
+
+                    node.build_canister_agent()
+                        .await
+                        .get()
+                        .query(&canister_id.get().0, "read".to_string())
+                        .call()
+                        .await
+                        .context("Failed to make the query call")
+                }
+            )
+            .await
+            .expect("A query call to a counter canister failed during the subnet split");
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }))
+    .await;
 }
 
 fn runtime_from_subnet(subnet: &SubnetSnapshot) -> Runtime {

--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -537,7 +537,7 @@ async fn install_chatting_canisters(env: &TestEnv) -> (Vec<CanisterId>, Vec<Cani
 
     let canister_start_arguments = StartArgs {
         network_topology: canister_groups.clone(),
-        canister_to_subnet_rate: 3,
+        canister_to_subnet_rate: 1,
         request_payload_size_bytes: 1,
         call_timeouts_seconds: vec![None],
         response_payload_size_bytes: 1,

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -2821,6 +2821,12 @@ pub async fn install_nns_canisters(
         {
             builder.enable_blank_replica_version_id_for_cloud_engines();
         }
+        if registry_canister_init_payload
+            .is_subnet_splitting_enabled
+            .unwrap_or_default()
+        {
+            builder.enable_subnet_splitting();
+        }
 
         builder
     };


### PR DESCRIPTION
As the subnet splitting system test is currently disabled because the feature itself is not merged in yet, the system test regressed because of other unrelated changes. This PR fixes it functionality by:
- Allowing critical metrics to increase:
  - We expect to observe invalidated artifacts as the two new subnets will share the same underlying P2P network for some short time after the split.
  - The replicas of the destination subnet restart.
- Handle the newly added initial-DKG subnet in the test logic.

Deflake it by reducing the number of exchanged messages between canisters and allowing an error percentage.

Extend it by bombarding the splitting subnet with query and update calls while ensuring that they only experience a small downtime (15 secs for source and 35 secs for destination for now, larger for destination because replicas restart in that case).