### PR TITLE
chore: migrate ic-cdk usage to new management canister API

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -130,7 +130,7 @@ impl From<bitcoin_canister::GetUtxosResponse> for GetUtxosResponse {
 }
 
 // Note that both [ic_btc_interface::Network] and
-// [ic_cdk::api::management_canister::bitcoin::BitcoinNetwork] from ic_cdk
+// [ic_cdk::bitcoin_canister::Network] from ic_cdk
 // would serialize to lowercase names, but here we keep uppercase names for
 // backward compatibility with the state of already deployed minter canister.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]

--- a/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
+++ b/rs/execution_environment/benches/management_canister/test_canister/src/main.rs
@@ -1,21 +1,16 @@
-#![allow(deprecated)]
 use candid::{CandidType, Principal};
 use futures::future::join_all;
-use ic_cdk::api::management_canister::ecdsa::{
-    EcdsaKeyId, EcdsaPublicKeyArgument, SignWithEcdsaArgument,
-    ecdsa_public_key as ic_cdk_ecdsa_public_key, sign_with_ecdsa as ic_cdk_sign_with_ecdsa,
-};
-use ic_cdk::api::management_canister::http_request::{
-    CanisterHttpRequestArgument, HttpHeader as IcCdkHttpHeader, HttpMethod,
-    http_request as ic_cdk_http_request,
-};
-use ic_cdk::api::management_canister::main::{
-    CanisterIdRecord, CanisterInstallMode, CanisterSettings, CreateCanisterArgument,
-    InstallCodeArgument, UpdateSettingsArgument, create_canister as ic_cdk_create_canister,
-    delete_canister as ic_cdk_delete_canister, install_code as ic_cdk_install_code,
+use ic_cdk::call::Call;
+use ic_cdk::management_canister::{
+    CanisterIdRecord, CanisterInstallMode, CanisterSettings, CreateCanisterArgs, EcdsaKeyId,
+    EcdsaPublicKeyArgs, HttpHeader as IcCdkHttpHeader, HttpMethod,
+    HttpRequestArgs as IcCdkHttpRequestArgs, InstallCodeArgs as IcCdkInstallCodeArgs,
+    SignWithEcdsaArgs, UpdateSettingsArgs as IcCdkUpdateSettingsArgs,
+    create_canister_with_extra_cycles as ic_cdk_create_canister,
+    delete_canister as ic_cdk_delete_canister, ecdsa_public_key as ic_cdk_ecdsa_public_key,
+    install_code as ic_cdk_install_code, sign_with_ecdsa as ic_cdk_sign_with_ecdsa,
     stop_canister as ic_cdk_stop_canister, update_settings as ic_cdk_update_settings,
 };
-use ic_cdk::call::Call;
 use ic_cdk::{api::canister_self, update};
 use serde::{Deserialize, Serialize};
 
@@ -34,15 +29,14 @@ async fn create_canisters(args: CreateCanistersArgs) -> Vec<Principal> {
         let batch_size = args.canisters_per_batch.min(remaining_canisters);
         let futures: Vec<_> = (0..batch_size)
             .map(|_| {
-                ic_cdk_create_canister(
-                    CreateCanisterArgument {
-                        settings: Some(CanisterSettings {
-                            controllers: Some(vec![canister_self()]),
-                            ..CanisterSettings::default()
-                        }),
-                    },
-                    args.initial_cycles,
-                )
+                let arg = CreateCanisterArgs {
+                    settings: Some(CanisterSettings {
+                        controllers: Some(vec![canister_self()]),
+                        ..CanisterSettings::default()
+                    }),
+                };
+                let initial_cycles = args.initial_cycles;
+                async move { ic_cdk_create_canister(&arg, initial_cycles).await }
             })
             .collect();
 
@@ -51,7 +45,7 @@ async fn create_canisters(args: CreateCanistersArgs) -> Vec<Principal> {
         let mut batch_ids: Vec<_> = batch_results
             .into_iter()
             .map(|r| {
-                let (canister_id_record,) = r.unwrap(); // Reject if there is an error.
+                let canister_id_record = r.unwrap(); // Reject if there is an error.
                 canister_id_record.canister_id
             })
             .collect();
@@ -92,9 +86,10 @@ async fn create_canisters_with_gaps(args: CreateCanistersArgs) -> u64 {
         let stop_futures: Vec<_> = batch
             .iter()
             .map(|canister_id| {
-                ic_cdk_stop_canister(CanisterIdRecord {
+                let arg = CanisterIdRecord {
                     canister_id: *canister_id,
-                })
+                };
+                async move { ic_cdk_stop_canister(&arg).await }
             })
             .collect();
         join_all(stop_futures).await.into_iter().for_each(|r| {
@@ -104,9 +99,10 @@ async fn create_canisters_with_gaps(args: CreateCanistersArgs) -> u64 {
         let delete_futures: Vec<_> = batch
             .iter()
             .map(|canister_id| {
-                ic_cdk_delete_canister(CanisterIdRecord {
+                let arg = CanisterIdRecord {
                     canister_id: *canister_id,
-                })
+                };
+                async move { ic_cdk_delete_canister(&arg).await }
             })
             .collect();
         join_all(delete_futures).await.into_iter().for_each(|r| {
@@ -135,12 +131,13 @@ async fn install_code(args: InstallCodeArgs) {
         .canister_ids
         .into_iter()
         .map(|canister_id| {
-            ic_cdk_install_code(InstallCodeArgument {
+            let install_arg = IcCdkInstallCodeArgs {
                 mode: CanisterInstallMode::Install,
                 canister_id,
                 wasm_module: wasm_module.clone(),
                 arg: arg.clone(),
-            })
+            };
+            async move { ic_cdk_install_code(&install_arg).await }
         })
         .collect();
 
@@ -164,13 +161,14 @@ async fn update_settings(args: UpdateSettingsArgs) {
         .canister_ids
         .into_iter()
         .map(|canister_id| {
-            ic_cdk_update_settings(UpdateSettingsArgument {
+            let arg = IcCdkUpdateSettingsArgs {
                 canister_id,
                 settings: CanisterSettings {
                     controllers: Some(controllers.clone()),
                     ..CanisterSettings::default()
                 },
-            })
+            };
+            async move { ic_cdk_update_settings(&arg).await }
         })
         .collect();
 
@@ -193,14 +191,15 @@ pub struct ECDSAArgs {
 async fn ecdsa_public_key(args: ECDSAArgs) {
     let futures: Vec<_> = (0..args.calls)
         .map(|_| {
-            ic_cdk_ecdsa_public_key(EcdsaPublicKeyArgument {
+            let arg = EcdsaPublicKeyArgs {
                 canister_id: None,
                 derivation_path: vec![
                     vec![0_u8; args.buf_size as usize];
                     args.derivation_paths as usize
                 ],
                 key_id: args.ecdsa_key.clone(),
-            })
+            };
+            async move { ic_cdk_ecdsa_public_key(&arg).await }
         })
         .collect();
 
@@ -215,14 +214,15 @@ async fn ecdsa_public_key(args: ECDSAArgs) {
 async fn sign_with_ecdsa(args: ECDSAArgs) {
     let futures: Vec<_> = (0..args.calls)
         .map(|_| {
-            ic_cdk_sign_with_ecdsa(SignWithEcdsaArgument {
+            let arg = SignWithEcdsaArgs {
                 message_hash: vec![0; 32],
                 derivation_path: vec![
                     vec![0_u8; args.buf_size as usize];
                     args.derivation_paths as usize
                 ],
                 key_id: args.ecdsa_key.clone(),
-            })
+            };
+            async move { ic_cdk_sign_with_ecdsa(&arg).await }
         })
         .collect();
 
@@ -251,23 +251,29 @@ pub struct HttpRequestArgs {
 async fn http_request(args: HttpRequestArgs) {
     let futures: Vec<_> = (0..args.calls)
         .map(|_| {
-            ic_cdk_http_request(
-                CanisterHttpRequestArgument {
-                    url: String::from("www.example.com"),
-                    max_response_bytes: None,
-                    method: HttpMethod::GET,
-                    headers: vec![
-                        IcCdkHttpHeader {
-                            name: args.header.name.clone(),
-                            value: args.header.value.clone(),
-                        };
-                        args.headers_number as usize
-                    ],
-                    body: None,
-                    transform: None,
-                },
-                args.cycles,
-            )
+            let arg = IcCdkHttpRequestArgs {
+                url: String::from("www.example.com"),
+                max_response_bytes: None,
+                method: HttpMethod::GET,
+                headers: vec![
+                    IcCdkHttpHeader {
+                        name: args.header.name.clone(),
+                        value: args.header.value.clone(),
+                    };
+                    args.headers_number as usize
+                ],
+                body: None,
+                transform: None,
+                is_replicated: None,
+            };
+            // `management_canister::http_request` computes the cycles itself, but this
+            // benchmark deliberately parameterizes them, so issue the call directly.
+            async move {
+                Call::unbounded_wait(Principal::management_canister(), "http_request")
+                    .with_arg(&arg)
+                    .with_cycles(args.cycles)
+                    .await
+            }
         })
         .collect();
 

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -2,8 +2,7 @@
 use crate::common::{send_signal_to_pic, start_server, start_server_helper};
 use candid::{Encode, Principal};
 use ic_agent::agent::CallResponse;
-use ic_cdk::api::management_canister::main::CanisterIdRecord;
-use ic_cdk::api::management_canister::provisional::ProvisionalCreateCanisterWithCyclesArgument;
+use ic_cdk::management_canister::CanisterIdRecord;
 use ic_management_canister_types_private::ProvisionalCreateCanisterWithCyclesArgs;
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_utils::interfaces::ManagementCanister;
@@ -1091,7 +1090,7 @@ fn provisional_create_canister_with_cycles() {
         .with_application_subnet()
         .build();
 
-    let arg = ProvisionalCreateCanisterWithCyclesArgument::default();
+    let arg = ic_cdk::management_canister::ProvisionalCreateCanisterWithCyclesArgs::default();
     let res: (CanisterIdRecord,) = update_candid(
         &pic,
         Principal::management_canister(),

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -2,7 +2,10 @@
 use crate::common::{send_signal_to_pic, start_server, start_server_helper};
 use candid::{Encode, Principal};
 use ic_agent::agent::CallResponse;
-use ic_cdk::management_canister::CanisterIdRecord;
+use ic_cdk::management_canister::{
+    CanisterIdRecord,
+    ProvisionalCreateCanisterWithCyclesArgs as IcCdkProvisionalCreateCanisterWithCyclesArgs,
+};
 use ic_management_canister_types_private::ProvisionalCreateCanisterWithCyclesArgs;
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_utils::interfaces::ManagementCanister;
@@ -1090,7 +1093,7 @@ fn provisional_create_canister_with_cycles() {
         .with_application_subnet()
         .build();
 
-    let arg = ic_cdk::management_canister::ProvisionalCreateCanisterWithCyclesArgs::default();
+    let arg = IcCdkProvisionalCreateCanisterWithCyclesArgs::default();
     let res: (CanisterIdRecord,) = update_candid(
         &pic,
         Principal::management_canister(),

--- a/rs/rust_canisters/canister_serve/src/lib.rs
+++ b/rs/rust_canisters/canister_serve/src/lib.rs
@@ -1,9 +1,6 @@
-#![allow(deprecated)]
 use by_address::ByAddress;
 use ic_canister_log::{GlobalBuffer, LogBuffer, LogEntry};
-use ic_cdk::api::management_canister::http_request::{
-    CanisterHttpRequestArgument, HttpHeader, HttpResponse,
-};
+use ic_cdk::management_canister::{HttpHeader, HttpRequestArgs, HttpRequestResult};
 use ic_metrics_encoder::MetricsEncoder;
 use maplit::hashmap;
 use priority_queue::PriorityQueue;
@@ -19,12 +16,12 @@ use std::{
 // 1 Mi. Approximately 10^6, 1 million (slightly more).
 const MAX_LOGS_RESPONSE_SIZE: usize = 1 << 20;
 
-/// Transforms an `ic_metrics_encoder::MetricsEncoder` into an HttpResponse that can be
+/// Transforms an `ic_metrics_encoder::MetricsEncoder` into an HttpRequestResult that can be
 /// served via a Canister's `http_request` query method.
 ///
 /// ```
 /// use ic_canister_serve::serve_metrics;
-/// use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument, HttpResponse};
+/// use ic_cdk::management_canister::{HttpRequestArgs, HttpRequestResult};
 /// use ic_metrics_encoder::MetricsEncoder;
 ///
 /// fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
@@ -33,7 +30,7 @@ const MAX_LOGS_RESPONSE_SIZE: usize = 1 << 20;
 /// }
 ///
 /// #[ic_cdk::query]
-/// fn http_request(request: CanisterHttpRequestArgument) -> HttpResponse {
+/// fn http_request(request: HttpRequestArgs) -> HttpRequestResult {
 ///     let path = match request.url.find('?') {
 ///         None => &request.url[..],
 ///         Some(index) => &request.url[..index],
@@ -41,7 +38,7 @@ const MAX_LOGS_RESPONSE_SIZE: usize = 1 << 20;
 ///
 ///     match path {
 ///         "/metrics" => serve_metrics(encode_metrics),
-///         _ => HttpResponse {
+///         _ => HttpRequestResult {
 ///                 status: 404_u32.into(),
 ///                 body: "not_found".into(),
 ///                 ..Default::default()
@@ -51,13 +48,13 @@ const MAX_LOGS_RESPONSE_SIZE: usize = 1 << 20;
 /// ```
 pub fn serve_metrics(
     encode_metrics: impl FnOnce(&mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()>,
-) -> HttpResponse {
+) -> HttpRequestResult {
     let mut writer = MetricsEncoder::new(vec![], now() as i64 / 1_000_000);
 
     match encode_metrics(&mut writer) {
         Ok(()) => {
             let content_body: Vec<u8> = writer.into_inner();
-            HttpResponse {
+            HttpRequestResult {
                 status: 200_u8.into(),
                 headers: vec![
                     HttpHeader {
@@ -76,7 +73,7 @@ pub fn serve_metrics(
                 body: content_body,
             }
         }
-        Err(err) => HttpResponse {
+        Err(err) => HttpRequestResult {
             status: 500_u16.into(),
             headers: vec![],
             body: format!("Failed to encode metrics: {err}").into(),
@@ -85,20 +82,20 @@ pub fn serve_metrics(
 }
 
 /// Given an INFO and ERROR `GlobalBuffer`, render the buffers into a json encoded body of an
-/// HttpResponse that can be served via a Canister's `http_request` query method. The method's
-/// `CanisterHttpRequestArgument` allows selecting the logs based on severity (INFO/ERROR) and
+/// HttpRequestResult that can be served via a Canister's `http_request` query method. The method's
+/// `HttpRequestArgs` allows selecting the logs based on severity (INFO/ERROR) and
 /// timestamp.
 ///
 /// ```
 /// use ic_canister_log::{declare_log_buffer, export, log};
 /// use ic_canister_serve::serve_logs;
-/// use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument, HttpResponse};
+/// use ic_cdk::management_canister::{HttpRequestArgs, HttpRequestResult};
 ///
 /// declare_log_buffer!(name = INFO, capacity = 100);
 /// declare_log_buffer!(name = ERROR, capacity = 100);
 ///
 /// #[ic_cdk::query]
-/// fn http_request(request: CanisterHttpRequestArgument) -> HttpResponse {
+/// fn http_request(request: HttpRequestArgs) -> HttpRequestResult {
 ///     log!(INFO, "This is an INFO log");
 ///     log!(ERROR, "This is an ERROR log");
 ///
@@ -109,7 +106,7 @@ pub fn serve_metrics(
 ///
 ///     match path {
 ///         "/logs" => serve_logs(request, &INFO, &ERROR),
-///         _ => HttpResponse {
+///         _ => HttpRequestResult {
 ///                 status: 404_u32.into(),
 ///                 body: "not_found".into(),
 ///                 ..Default::default()
@@ -118,10 +115,10 @@ pub fn serve_metrics(
 /// }
 /// ```
 pub fn serve_logs(
-    request: CanisterHttpRequestArgument,
+    request: HttpRequestArgs,
     info_logs: &'static GlobalBuffer,
     error_logs: &'static GlobalBuffer,
-) -> HttpResponse {
+) -> HttpRequestResult {
     // Convert from generic HTTP request to LogsRequest.
     let request = match LogsRequest::try_from(request) {
         Ok(request) => request,
@@ -130,7 +127,7 @@ pub fn serve_logs(
                 .unwrap_or_default()
                 .into_bytes();
 
-            return HttpResponse {
+            return HttpRequestResult {
                 status: 400_u16.into(),
                 headers: vec![
                     HttpHeader {
@@ -157,7 +154,7 @@ pub fn serve_logs(
     });
 
     let content_body: Vec<u8> = body.into_bytes();
-    HttpResponse {
+    HttpRequestResult {
         status: 200_u8.into(),
         headers: vec![
             HttpHeader {
@@ -177,8 +174,8 @@ pub fn serve_logs(
 ///
 /// This does two main things:
 ///
-/// 1. Tries to convert from a generic CanisterHttpRequestArgument
-///    (via impl From<CanisterHttpRequestArgument>).
+/// 1. Tries to convert from a generic HttpRequestArgs
+///    (via impl From<HttpRequestArgs>).
 ///
 ///2. Renders JSON (via LogsRequest::render_json). Of course, this needs to
 ///   be fed logs.
@@ -268,12 +265,10 @@ impl LogsRequest {
     }
 }
 
-impl TryFrom<CanisterHttpRequestArgument> for LogsRequest {
+impl TryFrom<HttpRequestArgs> for LogsRequest {
     type Error = String;
 
-    fn try_from(
-        http_request: CanisterHttpRequestArgument,
-    ) -> Result<Self, /* description */ String> {
+    fn try_from(http_request: HttpRequestArgs) -> Result<Self, /* description */ String> {
         // Parse query parameters.
         let query = query_parameters_map(&http_request.url);
 

--- a/rs/rust_canisters/canister_serve/tests/tests.rs
+++ b/rs/rust_canisters/canister_serve/tests/tests.rs
@@ -1,9 +1,7 @@
 #![allow(deprecated)]
 use ic_canister_log::{declare_log_buffer, log};
 use ic_canister_serve::serve_logs;
-use ic_cdk::api::management_canister::http_request::{
-    CanisterHttpRequestArgument, HttpMethod, HttpResponse,
-};
+use ic_cdk::management_canister::{HttpMethod, HttpRequestArgs, HttpRequestResult};
 use maplit::hashmap;
 use serde_json::json;
 use std::collections::HashMap;
@@ -41,15 +39,16 @@ fn test_serve_logs_no_frills() {
     log!(ERROR, "DA ROOF IS ON FAIYA");
 
     // Step 2: Call the code under test.
-    let http_request = CanisterHttpRequestArgument {
+    let http_request = HttpRequestArgs {
         method: HttpMethod::GET,
         url: "http://example.com/logs".to_string(),
         headers: vec![],
         body: Some(vec![]),
         max_response_bytes: None,
         transform: None,
+        is_replicated: None,
     };
-    let HttpResponse {
+    let HttpRequestResult {
         status,
         headers,
         body,
@@ -136,16 +135,17 @@ fn test_serve_logs_only_errors() {
     log!(ERROR, "BAR!");
 
     // Step 2: Call the code under test.
-    let http_request = CanisterHttpRequestArgument {
+    let http_request = HttpRequestArgs {
         method: HttpMethod::GET,
         url: "http://example.com/logs?severity=Error".to_string(),
         headers: vec![],
         body: Some(vec![]),
         max_response_bytes: None,
         transform: None,
+        is_replicated: None,
     };
 
-    let HttpResponse {
+    let HttpRequestResult {
         status,
         headers,
         body,
@@ -210,15 +210,16 @@ fn test_serve_logs_time_bound() {
     log!(INFO, "after");
 
     // Step 2: Call the code under test.
-    let http_request = CanisterHttpRequestArgument {
+    let http_request = HttpRequestArgs {
         method: HttpMethod::GET,
         url: format!("http://example.com/logs?time={between_timestamp_nanoseconds}"),
         headers: vec![],
         body: Some(vec![]),
         max_response_bytes: None,
         transform: None,
+        is_replicated: None,
     };
-    let HttpResponse {
+    let HttpRequestResult {
         status,
         headers,
         body,
@@ -278,15 +279,16 @@ fn test_serve_logs_malformed_request() {
     log!(ERROR, "BAZ!");
 
     // Step 2: Call the code under test.
-    let http_request = CanisterHttpRequestArgument {
+    let http_request = HttpRequestArgs {
         method: HttpMethod::GET,
         url: "http://example.com/logs?time=NONSENSE".to_string(),
         headers: vec![],
         body: Some(vec![]),
         max_response_bytes: None,
         transform: None,
+        is_replicated: None,
     };
-    let HttpResponse {
+    let HttpRequestResult {
         status,
         headers,
         body,

--- a/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
+++ b/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
@@ -102,7 +102,7 @@ pub fn create_canister_via_canister_succeeds(env: TestEnv) {
 
 pub fn update_settings_of_frozen_canister(env: TestEnv) {
     use ic_base_types::NumBytes;
-    use ic_cdk::api::management_canister::main::{CanisterSettings, UpdateSettingsArgument};
+    use ic_cdk::management_canister::{CanisterSettings, UpdateSettingsArgs};
     use ic_config::subnet_config::{
         CyclesAccountManagerConfig, DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig,
     };
@@ -135,7 +135,7 @@ pub fn update_settings_of_frozen_canister(env: TestEnv) {
                 controllers.push(PrincipalId::new_derived(&controllers[0].into(), &[i]).into());
             }
             let low_freezing_threshold = 30_u32 * 24 * 3600; // 30 days default
-            let arg = UpdateSettingsArgument {
+            let arg = UpdateSettingsArgs {
                 canister_id: canister.canister_id(),
                 settings: CanisterSettings {
                     controllers: Some(controllers),

--- a/rs/tests/execution/system_subnets_test.rs
+++ b/rs/tests/execution/system_subnets_test.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use candid::{Decode, Encode, Principal};
 use ic_agent::AgentError;
 use ic_agent::agent::RejectCode;
-use ic_cdk::api::management_canister::main::{CanisterIdRecord, CanisterStatusResponse};
+use ic_cdk::management_canister::{CanisterIdRecord, CanisterStatusResult};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::{GetFirstHealthyNodeSnapshot, HasPublicApiUrl};
@@ -117,7 +117,7 @@ pub fn ingress_message_to_subnet_id_fails(env: TestEnv) {
             let res = agent_call(&Principal::management_canister(), &canister_id)
                 .await
                 .unwrap();
-            let _ = Decode!(&res, CanisterStatusResponse).unwrap();
+            let _ = Decode!(&res, CanisterStatusResult).unwrap();
         }
     });
 }

--- a/rs/tests/networking/canisters/src/cloner_canister.rs
+++ b/rs/tests/networking/canisters/src/cloner_canister.rs
@@ -1,10 +1,10 @@
-#![allow(deprecated)]
 use candid::CandidType;
 use futures::future::join_all;
-use ic_cdk::api::call::CallResult;
-use ic_cdk::api::management_canister::main::{
+use ic_cdk::call::CallResult;
+use ic_cdk::management_canister::{
     CanisterId, CanisterIdRecord, CanisterInstallMode, CanisterSettings, CanisterStatusType,
-    CreateCanisterArgument, InstallCodeArgument, canister_status, create_canister, install_code,
+    CreateCanisterArgs, InstallCodeArgs, canister_status, create_canister_with_extra_cycles,
+    install_code,
 };
 use ic_cdk::{api::canister_self, update};
 use serde::{Deserialize, Serialize};
@@ -29,8 +29,8 @@ thread_local! {
 
 async fn spinup_canister(wasm_module: Vec<u8>) -> CallResult<()> {
     // Create canister.
-    let canister_id = create_canister(
-        CreateCanisterArgument {
+    let canister_id = create_canister_with_extra_cycles(
+        &CreateCanisterArgs {
             settings: Some(CanisterSettings {
                 controllers: Some(vec![canister_self()]),
                 ..CanisterSettings::default()
@@ -39,7 +39,6 @@ async fn spinup_canister(wasm_module: Vec<u8>) -> CallResult<()> {
         INITIAL_CYCLES_BALANCE,
     )
     .await?
-    .0
     .canister_id;
 
     // Store canister id.
@@ -48,7 +47,7 @@ async fn spinup_canister(wasm_module: Vec<u8>) -> CallResult<()> {
     // Install code if provided.
     let is_wasm_module_empty = wasm_module.is_empty();
     if !is_wasm_module_empty {
-        install_code(InstallCodeArgument {
+        install_code(&InstallCodeArgs {
             mode: CanisterInstallMode::Install,
             canister_id,
             wasm_module,
@@ -59,7 +58,7 @@ async fn spinup_canister(wasm_module: Vec<u8>) -> CallResult<()> {
 
     // Check the canister is properly running.
     for _ in 0..CHECK_STATUS_ATTEMPTS {
-        let (response,) = canister_status(CanisterIdRecord { canister_id }).await?;
+        let response = canister_status(&CanisterIdRecord { canister_id }).await?;
         // Stop checking status if the canister is running and if the wasm module
         // was provided, then also check that the module hash is not empty.
         if response.status == CanisterStatusType::Running


### PR DESCRIPTION
Continues the migration to ic-cdk 0.20, which removes the APIs deprecated in 0.18. `api::management_canister` was deprecated in favor of the root-level `management_canister` and `bitcoin_canister` modules.

Couple notes:

* `cloner_canister` used `create_canister(arg, INITIAL_CYCLES_BALANCE)`, which attached exactly that amount. The new API has no "attach exactly N" form, so this uses `create_canister_with_extra_cycles`, which attaches the creation fee *plus* that amount. Created canisters therefore end up with the full 1T rather than 1T minus the fee, which is what the constant's comment describes anyway.

* The management_canister benchmark canister deliberately parameterizes the cycles attached to `http_request` over its Candid interface, but `management_canister::http_request` computes them itself. That one call is issued via `Call::unbounded_wait(...).with_cycles(...)` instead, in keeping with the `Call` usage already in that file.

* `HttpRequestArgs` has a new `is_replicated` field; `None` is set everywhere to keep the existing replicated-outcall behavior.

* The benchmark canister defines its own `InstallCodeArgs`, `UpdateSettingsArgs` and `HttpRequestArgs` Candid types, which now collide with the new names, so the imports extend that file's existing `HttpHeader as IcCdkHttpHeader` aliasing convention rather than renaming the canister's public types.