### PR TITLE
fix: deflake //rs/execution_environment:memory_matrix_test

### DIFF
--- a/rs/canister_sandbox/src/process.rs
+++ b/rs/canister_sandbox/src/process.rs
@@ -43,13 +43,22 @@ pub fn spawn_socketed_process(
             }
             // `dup2()` clears `FD_CLOEXEC` on the new descriptor, *except* when
             // it is a self-copy (`newfd == oldfd`), where POSIX requires it to
-            // return `newfd` without touching it. `socket` can already be fd 3:
-            // the kernel hands out the lowest free descriptor, so under the fd
-            // churn of a process that creates and destroys many sandboxes, the
-            // socket pair created for this child can land there. Since
-            // `UnixStream::pair()` creates the sockets with `SOCK_CLOEXEC`,
-            // fd 3 then still has `FD_CLOEXEC` set, `execve()` closes it, and
-            // the child ends up talking to a closed descriptor. Clear the flag
+            // return `newfd` without touching it.
+            //
+            // `socket` can be fd 3, even though callers hand us the *second*
+            // descriptor of a freshly created pair: `socketpair()` allocates its
+            // two descriptors in two separate steps, each taking the lowest free
+            // slot at that moment. In a multi-threaded process another thread can
+            // free a lower slot in between, so the pair can come back out of
+            // order — e.g. `(9, 3)` once fd 3 was released between the two
+            // allocations. fd 3 is precisely such a slot in a process that
+            // creates and destroys many sandboxes: it is the lowest descriptor no
+            // long-lived object holds, so the socket ends that land there are
+            // constantly closed and the slot reused.
+            //
+            // Since `UnixStream::pair()` creates the sockets with `SOCK_CLOEXEC`,
+            // fd 3 then still has `FD_CLOEXEC` set, `execve()` closes it, and the
+            // child ends up talking to a closed descriptor. Clear the flag
             // unconditionally to cover both cases, leaving any other descriptor
             // flag untouched.
             let flags = libc::fcntl(3, libc::F_GETFD);

--- a/rs/canister_sandbox/src/process.rs
+++ b/rs/canister_sandbox/src/process.rs
@@ -41,6 +41,18 @@ pub fn spawn_socketed_process(
             if fd != 3 {
                 return Err(std::io::Error::last_os_error());
             }
+            // `dup2()` clears `FD_CLOEXEC` on the new descriptor, *except* when
+            // it is a self-copy (`newfd == oldfd`), where POSIX requires it to
+            // return `newfd` without touching it. `socket` can already be fd 3:
+            // the kernel hands out the lowest free descriptor, so under the fd
+            // churn of a process that creates and destroys many sandboxes, the
+            // socket pair created for this child can land there. In that case
+            // fd 3 keeps the `SOCK_CLOEXEC` that `UnixStream::pair()` set,
+            // `execve()` closes it, and the child ends up talking to a closed
+            // descriptor. Clear the flag unconditionally to cover both cases.
+            if libc::fcntl(3, libc::F_SETFD, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
             Ok(())
         })
     };

--- a/rs/canister_sandbox/src/process.rs
+++ b/rs/canister_sandbox/src/process.rs
@@ -46,11 +46,17 @@ pub fn spawn_socketed_process(
             // return `newfd` without touching it. `socket` can already be fd 3:
             // the kernel hands out the lowest free descriptor, so under the fd
             // churn of a process that creates and destroys many sandboxes, the
-            // socket pair created for this child can land there. In that case
-            // fd 3 keeps the `SOCK_CLOEXEC` that `UnixStream::pair()` set,
-            // `execve()` closes it, and the child ends up talking to a closed
-            // descriptor. Clear the flag unconditionally to cover both cases.
-            if libc::fcntl(3, libc::F_SETFD, 0) == -1 {
+            // socket pair created for this child can land there. Since
+            // `UnixStream::pair()` creates the sockets with `SOCK_CLOEXEC`,
+            // fd 3 then still has `FD_CLOEXEC` set, `execve()` closes it, and
+            // the child ends up talking to a closed descriptor. Clear the flag
+            // unconditionally to cover both cases, leaving any other descriptor
+            // flag untouched.
+            let flags = libc::fcntl(3, libc::F_GETFD);
+            if flags == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::fcntl(3, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
             Ok(())


### PR DESCRIPTION
`//rs/execution_environment:memory_matrix_test` flaked in 6 CI invocations (8 failed attempts) in the
last week. **Every** failed attempt was a bazel `size = "large"` 900s timeout — never an assertion —
while passing attempts finish all 28 tests in ~16s. So the test hangs; it is neither slow nor wrong.

This PR fixes the trigger. It is a product bug in the sandbox process launcher, not a test bug.

## Root cause

`spawn_socketed_process()` hands the child its end of the IPC socket pair on fd 3 with
`libc::dup2(socket, 3)` in a `pre_exec` closure, and assumes `socket` is never already fd 3.

`dup2()` clears `FD_CLOEXEC` on the new descriptor — *except* when it is a self-copy
(`newfd == oldfd`), where POSIX requires it to return `newfd` without touching it. Measured:

```
fresh socketpair fd 5   FD_CLOEXEC set? True      # Rust's UnixStream::pair() uses SOCK_CLOEXEC
dup2(fd, 20) -> 20      fd20 FD_CLOEXEC set? False    # normal case: cleared, survives execve
dup2(fd, fd) -> 5       fd   FD_CLOEXEC set? True     # self-copy: NOT cleared -> execve closes it
```

`socket` can be fd 3. `UnixStream::pair()` returns `(sv[0], sv[1])` and `spawn_launcher_process()`
passes the second element, which is *usually* the higher number — but the ordering is incidental, not
guaranteed: the kernel allocates each descriptor with `get_unused_fd_flags()`, and another thread
closing a lower fd between the two allocations lowers `files->next_fd`, so the second fd can come back
below the first. `memory_matrix_test` does nothing but churn low fds — `run()` builds a fresh
`ExecutionTest` per matrix point, ~1000 `SandboxedExecutionController`s each with two socket pairs
plus tempfiles and page-allocator files, created and torn down in ~15s across 2 libtest threads, with
fire-and-forget teardown that overlaps the next run's fresh sockets.

When that happens, `execve()` closes fd 3 and the `sandbox_launcher` starts up on a closed descriptor.

## Why a closed fd 3 becomes a silent 900s hang

1. The child's first `setsockopt()` fails with `EBADF` and prints the message we see in every failing
   log: `Failed to update sandbox IPC socket timeout: Bad file descriptor (os error 9)`
   (`transport.rs:357`). It prints exactly once per reader because `update_socket_timeout()` caches
   the last value and the reader always requests the same timeout.
2. Only `EWOULDBLOCK` maps to `None`, so the following `recvmsg()` returns `Some(-1)`,
   `num_bytes_received <= 0` breaks the reader loop (`transport.rs:480-482`), and
   `sandbox_launcher_main()` returns — the launcher exits **without ever serving a request**.
3. Replica side, that launcher's socket EOFs, so the `SandboxLauncherIPC` reader exits and runs its
   **one-shot** `reply_handler.flush_with_errors()` plus `out.stop()` (`launch_as_process.rs:64-67`).
4. Neither `ReplyManager` (`rpc.rs:223-259`) nor `ActiveExecutionStateRegistry`
   (`active_execution_state_registry.rs:81-105`) records that the channel is dead, so the next request
   is inserted into a map nobody will ever drain again. The stopped writer also swallows it silently:
   `write_frame()` discards `send_message()`'s return value and `start_execution()` is
   `.on_completion(|_| {})`.
5. Every wait on the RPC path is untimed — `ReplyBuffer::sync()`'s `Condvar::wait` (`rpc.rs:190-200`)
   and `rx.recv()` (`sandboxed_execution_controller.rs:1041-1043`) — with no watchdog. The
   `panic_..._reply_channel_closed()` branch is unreachable because `tx` is still alive inside the
   orphaned registry entry, so the thread blocks **forever, without a panic**.
6. libtest waits for that thread; the other 27 tests finish; bazel kills the test at 900s.

## Evidence

- **Reproduced locally**: 10 of 40 runs timed out at `--jobs=10`.
- **The EBADF message count equals the number of hung tests**, every time: 8/8 CI failed attempts
  (1 each), 10/10 local hangs (1 in eight runs, **2** in the two runs that hung two tests), and 0 in
  36 passing runs. A per-incident marker, not a correlation.
- **Live `/proc` dump of a hung process**: all 4 threads in `futex_wait_queue`, process state `S`, no
  `CanisterSandboxIPC`/`SandboxLauncherIPC`/`IPCBackgroundSend` threads left, zero children, zero
  zombies, no panic. The readers had already exited and flushed, so the blocked waiter must have
  registered *after* the flush. This also rules out CPU starvation and any busy-spin explanation.
- **Instrumented end-to-end.** With temporary diagnostics and `--nocapture` (libtest captures
  test-thread stderr, which is why CI logs only ever show child-process messages), in a run that hung:

  ```
  [DIAG parent-spawn] pid=1487750 exec=sandbox_launcher socket_fd=3 socket_cloexec=1
  [DIAG child-init]   pid=1675868 exe=Some("sandbox_launcher") fd3_fcntl=-1 errno=Some(9)
  Failed to update sandbox IPC socket timeout: Bad file descriptor (os error 9) \
      [pid=1675868 ppid=1487750 exe=.../sandbox_launcher thread=main fd=3 \
       requested=Some(50s) cached=None]
  ```

  Out of ~1000 launcher spawns in that run, `socket_fd=3` occurred **once**, `fd3_fcntl=-1` occurred
  **once**, the EBADF occurred **once** — all the same process — and the run hung. `cached=None`
  confirms it is the reader's first `setsockopt`; `fd3_fcntl=-1 errno=9` proves fd 3 was already
  closed before the launcher ran a single line of its own code, i.e. `execve()` closed it. Normal
  spawns show `socket_fd` in 4..13 and `fd3_fcntl=0`.

## Validation

40 runs of the test at `--jobs=10`, same machine, same command:

| | result | max | min | avg | dev |
|---|---|---|---|---|---|
| `master` | **TIMEOUT in 10 of 40** | 180.0s | 13.9s | 56.3s | 71.4s |
| this PR | **40 of 40 PASSED** | 15.9s | 15.1s | 15.6s | **0.2s** |

Re-run of the 40 on this branch as pushed reconfirms it: 40 of 40 passed, max 12.9s, min 12.0s,
avg 12.4s, dev 0.2s (a less loaded machine, hence the faster absolute times).

Also green: `//rs/canister_sandbox:backend_lib_test`, `//rs/replay:replay_test`,
`//rs/replay:player_integration_tests`, and `--runs_per_test=3` on the target.

This removes the trigger rather than widening a window, and it is not test-only: a replica whose
launcher socket happened to land on fd 3 would lose that launcher the same way.

## Deliberately out of scope

Points 3-5 above are independent latent defects that turned a one-off descriptor mistake into an
undiagnosable hang. They deserve their own PRs, and I have written them up separately:

1. Give `ReplyManager` / `ActiveExecutionStateRegistry` a `closed` flag so registering on a dead
   channel fails immediately instead of blocking forever.
2. Distinguish EOF (`0`) from error (`-1`) in the reader loop and log the errno — an `EBADF` on one's
   own IPC socket is a bug, not a shutdown.
3. Stop discarding `send_message()`'s result in `write_frame()`.
4. `background_sending_thread()` retries a failing `sendmsg()` forever at 100% CPU with no
   `quit_requested` check. A fix already exists but was never merged: `c2c74c471d` on
   `origin/ai/deflake-dts_test-2026-03-11`. It is *not* what caused these hangs (no spinning thread in
   the live dump), but it is a real bug on master.
5. `ReplyBuffer::post_result()` never invokes the `on_completion` closure; it only runs via `Drop`.

Once (1) lands, the `--test-threads=2` mitigation from #9647 can probably be dropped and parallelism
restored. Note that #9647's stated correlation ("always a memory-heavy `grow_memory_*` variant") no
longer holds — 6 of the 8 current hangs are not `grow_memory_*` — and the teardown explanation in
`82c76c1bb6` (EXC-1681) is also wrong, since the EBADF is provably the reader's *first* `setsockopt`,
before any message is read. The sibling targets `dts_test` and `storage_reservation_test` have the
same high-churn shape and should benefit from this fix too.

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
