### PR TITLE
feat(subnet-splitting): add subnet splitting status field to summary

### DIFF
--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -76,8 +76,8 @@ pub fn validate_payload(
             )?;
             if summary_payload.dkg != expected_summary {
                 return Err(InvalidDkgPayloadReason::MismatchedDkgSummary(
-                    expected_summary,
-                    summary_payload.dkg.clone(),
+                    Box::new(expected_summary),
+                    Box::new(summary_payload.dkg.clone()),
                 )
                 .into());
             }

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -96,6 +96,7 @@ enum ValidationFailure {
 // The fields are only read by the `Debug` implementation.
 // The `dead_code` lint ignores `Debug` impls, see: https://github.com/rust-lang/rust/issues/88900.
 #[allow(dead_code)]
+#[allow(clippy::large_enum_variant)]
 enum InvalidArtifactReason {
     CryptoError(CryptoError),
     MismatchedRank(Rank, Option<Rank>),

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -96,7 +96,6 @@ enum ValidationFailure {
 // The fields are only read by the `Debug` implementation.
 // The `dead_code` lint ignores `Debug` impls, see: https://github.com/rust-lang/rust/issues/88900.
 #[allow(dead_code)]
-#[allow(clippy::large_enum_variant)]
 enum InvalidArtifactReason {
     CryptoError(CryptoError),
     MismatchedRank(Rank, Option<Rank>),

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package types.v1;
 
+import "google/protobuf/empty.proto";
 import "types/v1/types.proto";
 
 message DkgMessage {
@@ -28,6 +29,16 @@ message DkgDataPayload {
   repeated CallbackIdedNiDkgTranscript transcripts_for_remote_subnets = 3;
 }
 
+message SplittingArgs {
+  SubnetId destination_subnet_id = 1;
+  SubnetId source_subnet_id = 2;
+}
+
+message PostSplitArgs {
+  SubnetId new_subnet_id = 1;
+}
+
+// next id: 16
 message Summary {
   reserved 5, 6, 8;
   reserved "transcripts_for_new_subnets";
@@ -40,6 +51,11 @@ message Summary {
   repeated CallbackIdedNiDkgTranscript transcripts_for_remote_subnets = 10;
   repeated NiDkgTranscript current_transcripts = 11;
   repeated NiDkgTranscript next_transcripts = 12;
+  oneof subnet_splitting_status {
+    google.protobuf.Empty not_scheduled = 13;
+    SplittingArgs scheduled = 14;
+    PostSplitArgs post_split = 15;
+  }
 }
 
 message CallbackIdedNiDkgTranscript {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -369,6 +369,19 @@ pub struct DkgDataPayload {
     #[prost(message, repeated, tag = "3")]
     pub transcripts_for_remote_subnets: ::prost::alloc::vec::Vec<CallbackIdedNiDkgTranscript>,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SplittingArgs {
+    #[prost(message, optional, tag = "1")]
+    pub destination_subnet_id: ::core::option::Option<SubnetId>,
+    #[prost(message, optional, tag = "2")]
+    pub source_subnet_id: ::core::option::Option<SubnetId>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PostSplitArgs {
+    #[prost(message, optional, tag = "1")]
+    pub new_subnet_id: ::core::option::Option<SubnetId>,
+}
+/// next id: 16
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Summary {
     #[prost(uint64, tag = "1")]
@@ -389,6 +402,20 @@ pub struct Summary {
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]
     pub next_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
+    #[prost(oneof = "summary::SubnetSplittingStatus", tags = "13, 14, 15")]
+    pub subnet_splitting_status: ::core::option::Option<summary::SubnetSplittingStatus>,
+}
+/// Nested message and enum types in `Summary`.
+pub mod summary {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum SubnetSplittingStatus {
+        #[prost(message, tag = "13")]
+        NotScheduled(()),
+        #[prost(message, tag = "14")]
+        Scheduled(super::SplittingArgs),
+        #[prost(message, tag = "15")]
+        PostSplit(super::PostSplitArgs),
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CallbackIdedNiDkgTranscript {

--- a/rs/types/types/src/consensus/catchup.rs
+++ b/rs/types/types/src/consensus/catchup.rs
@@ -5,12 +5,15 @@ use crate::{
     consensus::{
         Block, Committee, ConsensusMessageHashable, HasCommittee, HasHeight, HasVersion,
         HashedBlock, HashedRandomBeacon, ThresholdSignature, ThresholdSignatureShare,
+        dkg::SubnetSplittingStatus,
     },
     crypto::*,
     node_id_into_protobuf, node_id_try_from_option,
 };
+use ic_base_types::{SubnetId, subnet_id_try_from_option};
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
+    registry::subnet::v1 as subnet_pb,
     types::v1 as pb,
 };
 use prost::Message;
@@ -178,6 +181,18 @@ impl CatchUpPackage {
     /// This is `false` for Genesis and recovery CUPs.
     pub fn is_signed(&self) -> bool {
         !self.signature.signature.as_ref().0.is_empty()
+    }
+
+    /// Returns the [`SubnetSplittingStatus`] of the summary block contained in this CUP.
+    pub fn subnet_splitting_status(&self) -> SubnetSplittingStatus {
+        self.content
+            .block
+            .get_value()
+            .payload
+            .as_ref()
+            .as_summary()
+            .dkg
+            .subnet_splitting_status()
     }
 
     /// Return the oldest registry version that is still referenced by

--- a/rs/types/types/src/consensus/catchup.rs
+++ b/rs/types/types/src/consensus/catchup.rs
@@ -10,10 +10,8 @@ use crate::{
     crypto::*,
     node_id_into_protobuf, node_id_try_from_option,
 };
-use ic_base_types::{SubnetId, subnet_id_try_from_option};
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
-    registry::subnet::v1 as subnet_pb,
     types::v1 as pb,
 };
 use prost::Message;

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -792,6 +792,7 @@ pub enum DkgPayloadCreationError {
 }
 
 /// Reasons for why a dkg payload might be invalid.
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Debug)]
 pub enum InvalidDkgPayloadReason {
     CryptoError(CryptoError),

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -241,7 +241,6 @@ pub enum SubnetSplittingStatus {
     #[default]
     NotScheduled,
     /// The subnet is requested to be split at the height of the summary block.
-    /// Contains all the information necessary to determine the new subnet of the replica
     Scheduled(SplittingArgs),
     /// The subnet was split at the previous summary block.
     PostSplit(PostSplitArgs),

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -294,7 +294,6 @@ impl DkgSummary {
         next_interval_length: Height,
         height: Height,
         remote_dkg_attempts: BTreeMap<NiDkgTargetId, RemoteDkgAttempts>,
-        subnet_splitting_status: SubnetSplittingStatus,
     ) -> Self {
         Self {
             configs: configs

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -551,53 +551,6 @@ fn build_transcript_result(
     }
 }
 
-impl From<SplittingArgs> for pb::SplittingArgs {
-    fn from(args: SplittingArgs) -> Self {
-        Self {
-            destination_subnet_id: Some(subnet_id_into_protobuf(args.destination_subnet_id)),
-            source_subnet_id: Some(subnet_id_into_protobuf(args.source_subnet_id)),
-        }
-    }
-}
-
-impl TryFrom<pb::SplittingArgs> for SplittingArgs {
-    type Error = ProxyDecodeError;
-
-    fn try_from(args: pb::SplittingArgs) -> Result<Self, Self::Error> {
-        Ok(Self {
-            destination_subnet_id: subnet_id_try_from_option(
-                args.destination_subnet_id,
-                "SplittingArgs::destination_subnet_id",
-            )?,
-            source_subnet_id: subnet_id_try_from_option(
-                args.source_subnet_id,
-                "SplittingArgs::source_subnet_id",
-            )?,
-        })
-    }
-}
-
-impl From<PostSplitArgs> for pb::PostSplitArgs {
-    fn from(args: PostSplitArgs) -> Self {
-        Self {
-            new_subnet_id: Some(subnet_id_into_protobuf(args.new_subnet_id)),
-        }
-    }
-}
-
-impl TryFrom<pb::PostSplitArgs> for PostSplitArgs {
-    type Error = ProxyDecodeError;
-
-    fn try_from(args: pb::PostSplitArgs) -> Result<Self, Self::Error> {
-        Ok(Self {
-            new_subnet_id: subnet_id_try_from_option(
-                args.new_subnet_id,
-                "PostSplitArgs::new_subnet_id",
-            )?,
-        })
-    }
-}
-
 impl From<&SubnetSplittingStatus> for pb::summary::SubnetSplittingStatus {
     fn from(status: &SubnetSplittingStatus) -> Self {
         match status {
@@ -605,14 +558,21 @@ impl From<&SubnetSplittingStatus> for pb::summary::SubnetSplittingStatus {
                 pb::summary::SubnetSplittingStatus::NotScheduled(())
             }
             SubnetSplittingStatus::Scheduled(splitting_args) => {
-                pb::summary::SubnetSplittingStatus::Scheduled(pb::SplittingArgs::from(
-                    *splitting_args,
-                ))
+                pb::summary::SubnetSplittingStatus::Scheduled(pb::SplittingArgs {
+                    destination_subnet_id: Some(subnet_id_into_protobuf(
+                        *splitting_args.destination_subnet_id,
+                    )),
+                    source_subnet_id: Some(subnet_id_into_protobuf(
+                        *splitting_args.source_subnet_id,
+                    )),
+                })
             }
             SubnetSplittingStatus::PostSplit(post_split_args) => {
-                pb::summary::SubnetSplittingStatus::PostSplit(pb::PostSplitArgs::from(
-                    *post_split_args,
-                ))
+                pb::summary::SubnetSplittingStatus::PostSplit(pb::PostSplitArgs {
+                    new_subnet_id: Some(subnet_id_into_protobuf(
+                        *post_split_args.new_subnet_id,
+                    )),
+                })
             }
         }
     }
@@ -627,10 +587,24 @@ impl TryFrom<pb::summary::SubnetSplittingStatus> for SubnetSplittingStatus {
                 Ok(SubnetSplittingStatus::NotScheduled)
             }
             pb::summary::SubnetSplittingStatus::Scheduled(splitting_args) => {
-                Ok(SubnetSplittingStatus::Scheduled(splitting_args.try_into()?))
+                Ok(SubnetSplittingStatus::Scheduled(SplittingArgs {
+                    destination_subnet_id: subnet_id_try_from_option(
+                        splitting_args.destination_subnet_id,
+                        "SplittingArgs::destination_subnet_id",
+                    )?,
+                    source_subnet_id: subnet_id_try_from_option(
+                        splitting_args.source_subnet_id,
+                        "SplittingArgs::source_subnet_id",
+                    )?,
+                }))
             }
             pb::summary::SubnetSplittingStatus::PostSplit(post_split_args) => Ok(
-                SubnetSplittingStatus::PostSplit(post_split_args.try_into()?),
+                SubnetSplittingStatus::PostSplit(PostSplitArgs {
+                    new_subnet_id: subnet_id_try_from_option(
+                        post_split_args.new_subnet_id,
+                        "PostSplitArgs::new_subnet_id",
+                    )?,
+                })
             ),
         }
     }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -468,7 +468,8 @@ impl From<&DkgSummary> for pb::Summary {
                 summary.transcripts_for_remote_subnets.as_slice(),
             ),
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
-            subnet_splitting_status: summary.subnet_splitting_status
+            subnet_splitting_status: summary
+                .subnet_splitting_status
                 .as_ref()
                 .map(pb::summary::SubnetSplittingStatus::from),
         }
@@ -569,9 +570,7 @@ impl From<&SubnetSplittingStatus> for pb::summary::SubnetSplittingStatus {
             }
             SubnetSplittingStatus::PostSplit(post_split_args) => {
                 pb::summary::SubnetSplittingStatus::PostSplit(pb::PostSplitArgs {
-                    new_subnet_id: Some(subnet_id_into_protobuf(
-                        *post_split_args.new_subnet_id,
-                    )),
+                    new_subnet_id: Some(subnet_id_into_protobuf(*post_split_args.new_subnet_id)),
                 })
             }
         }
@@ -598,14 +597,14 @@ impl TryFrom<pb::summary::SubnetSplittingStatus> for SubnetSplittingStatus {
                     )?,
                 }))
             }
-            pb::summary::SubnetSplittingStatus::PostSplit(post_split_args) => Ok(
-                SubnetSplittingStatus::PostSplit(PostSplitArgs {
+            pb::summary::SubnetSplittingStatus::PostSplit(post_split_args) => {
+                Ok(SubnetSplittingStatus::PostSplit(PostSplitArgs {
                     new_subnet_id: subnet_id_try_from_option(
                         post_split_args.new_subnet_id,
                         "PostSplitArgs::new_subnet_id",
                     )?,
-                })
-            ),
+                }))
+            }
         }
     }
 }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::{
     ReplicaVersion,
     artifact::PbArtifact,
+    backwards_compatibility::BackwardsCompatible,
     crypto::threshold_sig::ni_dkg::{
         NiDkgDealing, NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTranscript,
         config::NiDkgConfig,
@@ -215,6 +216,35 @@ impl std::hash::Hash for RemoteDkgAttempts {
     }
 }
 
+#[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+pub struct SplittingArgs {
+    pub destination_subnet_id: SubnetId,
+    pub source_subnet_id: SubnetId,
+}
+
+/// The subnet-splitting-related information available once the subnet has been
+/// split at the previous summary block.
+#[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+pub struct PostSplitArgs {
+    pub new_subnet_id: SubnetId,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug, Default)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+/// Represents the status of subnet splitting at the given summary height.
+pub enum SubnetSplittingStatus {
+    /// The subnet hasn't been requested to be split.
+    #[default]
+    NotScheduled,
+    /// The subnet is requested to be split at the height of the summary block.
+    /// Contains all the information necessary to determine the new subnet of the replica
+    Scheduled(SplittingArgs),
+    /// The subnet was split at the previous summary block.
+    PostSplit(PostSplitArgs),
+}
+
 /// The DKG summary will be present as the DKG payload at every block,
 /// corresponding to the start of a new DKG interval.
 #[serde_as]
@@ -247,6 +277,8 @@ pub struct DkgSummary {
     pub height: Height,
     /// The number of intervals a DKG for the given remote target was attempted.
     pub remote_dkg_attempts: BTreeMap<NiDkgTargetId, RemoteDkgAttempts>,
+    /// Status of the subnet splitting.
+    pub subnet_splitting_status: BackwardsCompatible<SubnetSplittingStatus, false>,
 }
 
 impl DkgSummary {
@@ -260,6 +292,7 @@ impl DkgSummary {
         next_interval_length: Height,
         height: Height,
         remote_dkg_attempts: BTreeMap<NiDkgTargetId, RemoteDkgAttempts>,
+        subnet_splitting_status: SubnetSplittingStatus,
     ) -> Self {
         Self {
             configs: configs
@@ -274,6 +307,7 @@ impl DkgSummary {
             next_interval_length,
             height,
             remote_dkg_attempts,
+            subnet_splitting_status: BackwardsCompatible::empty(),
         }
     }
 
@@ -356,6 +390,13 @@ impl DkgSummary {
             .min()
             .expect("No current transcripts available")
     }
+
+    pub fn subnet_splitting_status(&self) -> SubnetSplittingStatus {
+        self.subnet_splitting_status
+            .as_ref()
+            .copied()
+            .unwrap_or_default()
+    }
 }
 
 fn build_transcripts_vec(
@@ -409,23 +450,35 @@ fn build_remote_dkg_attempts_vec(
 }
 
 impl From<&DkgSummary> for pb::Summary {
-    fn from(summary: &DkgSummary) -> Self {
+    fn from(
+        DkgSummary {
+            registry_version,
+            configs,
+            current_transcripts,
+            next_transcripts,
+            transcripts_for_remote_subnets,
+            interval_length,
+            next_interval_length,
+            height,
+            remote_dkg_attempts,
+            subnet_splitting_status,
+        }: &DkgSummary,
+    ) -> Self {
         Self {
-            registry_version: summary.registry_version.get(),
-            configs: summary
-                .configs
-                .values()
-                .map(pb::NiDkgConfig::from)
-                .collect(),
-            current_transcripts: build_transcripts_vec(&summary.current_transcripts),
-            next_transcripts: build_transcripts_vec(&summary.next_transcripts),
-            interval_length: summary.interval_length.get(),
-            next_interval_length: summary.next_interval_length.get(),
-            height: summary.height.get(),
+            registry_version: registry_version.get(),
+            configs: configs.values().map(pb::NiDkgConfig::from).collect(),
+            current_transcripts: build_transcripts_vec(current_transcripts),
+            next_transcripts: build_transcripts_vec(next_transcripts),
+            interval_length: interval_length.get(),
+            next_interval_length: next_interval_length.get(),
+            height: height.get(),
             transcripts_for_remote_subnets: build_callback_ided_transcripts_vec(
-                summary.transcripts_for_remote_subnets.as_slice(),
+                transcripts_for_remote_subnets,
             ),
-            remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
+            remote_dkg_attempts: build_remote_dkg_attempts_vec(remote_dkg_attempts),
+            subnet_splitting_status: subnet_splitting_status
+                .as_ref()
+                .map(pb::summary::SubnetSplittingStatus::from),
         }
     }
 }
@@ -506,6 +559,91 @@ fn build_transcript_result(
     }
 }
 
+impl From<SplittingArgs> for pb::SplittingArgs {
+    fn from(args: SplittingArgs) -> Self {
+        Self {
+            destination_subnet_id: Some(subnet_id_into_protobuf(args.destination_subnet_id)),
+            source_subnet_id: Some(subnet_id_into_protobuf(args.source_subnet_id)),
+        }
+    }
+}
+
+impl TryFrom<pb::SplittingArgs> for SplittingArgs {
+    type Error = ProxyDecodeError;
+
+    fn try_from(args: pb::SplittingArgs) -> Result<Self, Self::Error> {
+        Ok(Self {
+            destination_subnet_id: subnet_id_try_from_option(
+                args.destination_subnet_id,
+                "SplittingArgs::destination_subnet_id",
+            )?,
+            source_subnet_id: subnet_id_try_from_option(
+                args.source_subnet_id,
+                "SplittingArgs::source_subnet_id",
+            )?,
+        })
+    }
+}
+
+impl From<PostSplitArgs> for pb::PostSplitArgs {
+    fn from(args: PostSplitArgs) -> Self {
+        Self {
+            new_subnet_id: Some(subnet_id_into_protobuf(args.new_subnet_id)),
+        }
+    }
+}
+
+impl TryFrom<pb::PostSplitArgs> for PostSplitArgs {
+    type Error = ProxyDecodeError;
+
+    fn try_from(args: pb::PostSplitArgs) -> Result<Self, Self::Error> {
+        Ok(Self {
+            new_subnet_id: subnet_id_try_from_option(
+                args.new_subnet_id,
+                "PostSplitArgs::new_subnet_id",
+            )?,
+        })
+    }
+}
+
+impl From<&SubnetSplittingStatus> for pb::summary::SubnetSplittingStatus {
+    fn from(status: &SubnetSplittingStatus) -> Self {
+        match status {
+            SubnetSplittingStatus::NotScheduled => {
+                pb::summary::SubnetSplittingStatus::NotScheduled(())
+            }
+            SubnetSplittingStatus::Scheduled(splitting_args) => {
+                pb::summary::SubnetSplittingStatus::Scheduled(pb::SplittingArgs::from(
+                    *splitting_args,
+                ))
+            }
+            SubnetSplittingStatus::PostSplit(post_split_args) => {
+                pb::summary::SubnetSplittingStatus::PostSplit(pb::PostSplitArgs::from(
+                    *post_split_args,
+                ))
+            }
+        }
+    }
+}
+
+impl TryFrom<pb::summary::SubnetSplittingStatus> for SubnetSplittingStatus {
+    type Error = ProxyDecodeError;
+
+    fn try_from(status: pb::summary::SubnetSplittingStatus) -> Result<Self, Self::Error> {
+        match status {
+            pb::summary::SubnetSplittingStatus::NotScheduled(()) => {
+                Ok(SubnetSplittingStatus::NotScheduled)
+            }
+            pb::summary::SubnetSplittingStatus::Scheduled(splitting_args) => {
+                Ok(SubnetSplittingStatus::Scheduled(splitting_args.try_into()?))
+            }
+            pb::summary::SubnetSplittingStatus::PostSplit(post_split_args) => Ok(
+                SubnetSplittingStatus::PostSplit(post_split_args.try_into()?),
+            ),
+        }
+    }
+}
+
 impl TryFrom<pb::Summary> for DkgSummary {
     type Error = ProxyDecodeError;
 
@@ -527,6 +665,9 @@ impl TryFrom<pb::Summary> for DkgSummary {
             )
             .map_err(ProxyDecodeError::Other)?,
             remote_dkg_attempts: build_remote_dkg_attempts_map(&summary.remote_dkg_attempts),
+            subnet_splitting_status: BackwardsCompatible::try_from_proto(
+                summary.subnet_splitting_status,
+            )?,
         })
     }
 }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -451,33 +451,24 @@ fn build_remote_dkg_attempts_vec(
 }
 
 impl From<&DkgSummary> for pb::Summary {
-    fn from(
-        DkgSummary {
-            registry_version,
-            configs,
-            current_transcripts,
-            next_transcripts,
-            transcripts_for_remote_subnets,
-            interval_length,
-            next_interval_length,
-            height,
-            remote_dkg_attempts,
-            subnet_splitting_status,
-        }: &DkgSummary,
-    ) -> Self {
+    fn from(summary: &DkgSummary) -> Self {
         Self {
-            registry_version: registry_version.get(),
-            configs: configs.values().map(pb::NiDkgConfig::from).collect(),
-            current_transcripts: build_transcripts_vec(current_transcripts),
-            next_transcripts: build_transcripts_vec(next_transcripts),
-            interval_length: interval_length.get(),
-            next_interval_length: next_interval_length.get(),
-            height: height.get(),
+            registry_version: summary.registry_version.get(),
+            configs: summary
+                .configs
+                .values()
+                .map(pb::NiDkgConfig::from)
+                .collect(),
+            current_transcripts: build_transcripts_vec(&summary.current_transcripts),
+            next_transcripts: build_transcripts_vec(&summary.next_transcripts),
+            interval_length: summary.interval_length.get(),
+            next_interval_length: summary.next_interval_length.get(),
+            height: summary.height.get(),
             transcripts_for_remote_subnets: build_callback_ided_transcripts_vec(
-                transcripts_for_remote_subnets,
+                summary.transcripts_for_remote_subnets.as_slice(),
             ),
-            remote_dkg_attempts: build_remote_dkg_attempts_vec(remote_dkg_attempts),
-            subnet_splitting_status: subnet_splitting_status
+            remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
+            subnet_splitting_status: summary.subnet_splitting_status
                 .as_ref()
                 .map(pb::summary::SubnetSplittingStatus::from),
         }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -792,12 +792,11 @@ pub enum DkgPayloadCreationError {
 }
 
 /// Reasons for why a dkg payload might be invalid.
-#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Debug)]
 pub enum InvalidDkgPayloadReason {
     CryptoError(CryptoError),
     DkgVerifyDealingError(DkgVerifyDealingError),
-    MismatchedDkgSummary(DkgSummary, DkgSummary),
+    MismatchedDkgSummary(Box<DkgSummary>, Box<DkgSummary>),
     MissingDkgConfigForDealing,
     DkgStartHeightDoesNotMatchParentBlock,
     DkgSummaryAtNonStartHeight(Height),

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -561,16 +561,16 @@ impl From<&SubnetSplittingStatus> for pb::summary::SubnetSplittingStatus {
             SubnetSplittingStatus::Scheduled(splitting_args) => {
                 pb::summary::SubnetSplittingStatus::Scheduled(pb::SplittingArgs {
                     destination_subnet_id: Some(subnet_id_into_protobuf(
-                        *splitting_args.destination_subnet_id,
+                        splitting_args.destination_subnet_id,
                     )),
                     source_subnet_id: Some(subnet_id_into_protobuf(
-                        *splitting_args.source_subnet_id,
+                        splitting_args.source_subnet_id,
                     )),
                 })
             }
             SubnetSplittingStatus::PostSplit(post_split_args) => {
                 pb::summary::SubnetSplittingStatus::PostSplit(pb::PostSplitArgs {
-                    new_subnet_id: Some(subnet_id_into_protobuf(*post_split_args.new_subnet_id)),
+                    new_subnet_id: Some(subnet_id_into_protobuf(post_split_args.new_subnet_id)),
                 })
             }
         }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -216,6 +216,8 @@ impl std::hash::Hash for RemoteDkgAttempts {
     }
 }
 
+/// The subnet-splitting-related information available when the subnet is splitting at the summary
+/// block.
 #[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct SplittingArgs {
@@ -223,17 +225,17 @@ pub struct SplittingArgs {
     pub source_subnet_id: SubnetId,
 }
 
-/// The subnet-splitting-related information available once the subnet has been
-/// split at the previous summary block.
+/// The subnet-splitting-related information available once the subnet has been split at the
+/// previous summary block.
 #[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct PostSplitArgs {
     pub new_subnet_id: SubnetId,
 }
 
+/// Represents the status of subnet splitting at the given summary height.
 #[derive(Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, Debug, Default)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
-/// Represents the status of subnet splitting at the given summary height.
 pub enum SubnetSplittingStatus {
     /// The subnet hasn't been requested to be split.
     #[default]


### PR DESCRIPTION
To prepare for subnet splitting, this PR adds a new field to summary blocks, empty for the moment for backwards compatibility purposes. This field indicates the status of a potential subnet split. 
- In most cases, this will be `NotScheduled`.
- The summary at which the subnet split happens (the summary height following the registry change, call it `H`) will have `Scheduled` together with the two new subnet IDs (the source being the current one, and the destination which will be taken [from the registry](https://sourcegraph.com/r/github.com/dfinity/ic@0f3c60f6a7ba51e3306c2305072a2959b00718ef/-/blob/rs/registry/canister/src/mutations/do_split_subnet.rs?L170)).
- At that point, replicas will skip CUP for height `H` and will instead create two CUPs for `H + 500` (one for each subnet) each containing a new summary block created on the fly that contain the respective DKG transcripts created by the NNS and will have status `PostSplit` with the respective `new_subnet_id` they are part of (derived by looking at the registry).