### PR TITLE
fix: resolve uninstall_code effective canister id with UninstallCodeArgs

### DIFF
--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -20,8 +20,8 @@ use ic_management_canister_types_private::{
     ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, IC_00, InstallChunkedCodeArgs,
     InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload,
     ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
-    StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    StoredChunksArgs, TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_protobuf::{
     log::ingress_message_log_entry::v1::IngressMessageLogEntry,
@@ -588,9 +588,15 @@ pub fn extract_effective_canister_id(
         Ok(Method::StartCanister)
         | Ok(Method::CanisterStatus)
         | Ok(Method::DeleteCanister)
-        | Ok(Method::UninstallCode)
         | Ok(Method::StopCanister) => match CanisterIdRecord::decode(ingress.arg()) {
             Ok(record) => Ok(Some(record.get_canister_id())),
+            Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
+        },
+        // `uninstall_code` is executed with `UninstallCodeArgs`; resolve the
+        // effective canister id with the same type (see the matching comment in
+        // `Request::extract_effective_canister_id`).
+        Ok(Method::UninstallCode) => match UninstallCodeArgs::decode(ingress.arg()) {
+            Ok(args) => Ok(Some(args.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },
         Ok(Method::CanisterInfo) => match CanisterInfoRequest::decode(ingress.arg()) {

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -592,9 +592,6 @@ pub fn extract_effective_canister_id(
             Ok(record) => Ok(Some(record.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },
-        // `uninstall_code` is executed with `UninstallCodeArgs`; resolve the
-        // effective canister id with the same type (see the matching comment in
-        // `Request::extract_effective_canister_id`).
         Ok(Method::UninstallCode) => match UninstallCodeArgs::decode(ingress.arg()) {
             Ok(args) => Ok(Some(args.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -160,9 +160,6 @@ impl Request {
                 Ok(record) => Some(record.get_canister_id()),
                 Err(_) => None,
             },
-            // `uninstall_code` is executed with `UninstallCodeArgs`. Decode
-            // with the same type here, consistent with the other management
-            // methods.
             Ok(Method::UninstallCode) => match UninstallCodeArgs::decode(&self.method_payload) {
                 Ok(args) => Some(args.get_canister_id()),
                 Err(_) => None,

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -12,8 +12,8 @@ use ic_management_canister_types_private::{
     InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
     Method, Payload as _, ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs,
     ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs, StoredChunksArgs,
-    TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
@@ -155,10 +155,16 @@ impl Request {
             Ok(Method::StartCanister)
             | Ok(Method::CanisterStatus)
             | Ok(Method::DeleteCanister)
-            | Ok(Method::UninstallCode)
             | Ok(Method::DepositCycles)
             | Ok(Method::StopCanister) => match CanisterIdRecord::decode(&self.method_payload) {
                 Ok(record) => Some(record.get_canister_id()),
+                Err(_) => None,
+            },
+            // `uninstall_code` is executed with `UninstallCodeArgs`. Decode
+            // with the same type here, consistent with the other management
+            // methods.
+            Ok(Method::UninstallCode) => match UninstallCodeArgs::decode(&self.method_payload) {
+                Ok(args) => Some(args.get_canister_id()),
                 Err(_) => None,
             },
             Ok(Method::CanisterInfo) => match CanisterInfoRequest::decode(&self.method_payload) {


### PR DESCRIPTION
The effective canister id of an `uninstall_code` message was resolved with `CanisterIdRecord`, whereas the handler executes the call with `UninstallCodeArgs`. Decode `uninstall_code` with `UninstallCodeArgs` in both the inter-canister and ingress effective-canister-id resolvers, consistently with the other management methods.