### PR TITLE
chore: Remove migration and remnants of blessed versions

### DIFF
--- a/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
+++ b/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
@@ -52,12 +52,3 @@ message GuestLaunchMeasurementMetadata {
   // Supported values can be found in ic-os/defs.bzl under `vcpu_types`.
   optional string vcpu_type = 2;
 }
-
-// A list of blessed versions of the IC Replica
-//
-// New versions are added here after a vote has been accepted by token
-// holders. Subnetworks can then be upgraded to any of those version.
-message BlessedReplicaVersions {
-  // A list of version information ids.
-  repeated string blessed_version_ids = 1;
-}

--- a/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
+++ b/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
@@ -45,12 +45,3 @@ message GuestLaunchMeasurementMetadata {
   // Supported values can be found in ic-os/defs.bzl under `vcpu_types`.
   optional string vcpu_type = 2;
 }
-
-// A list of blessed versions of the IC Replica
-//
-// New versions are added here after a vote has been accepted by token
-// holders. Subnetworks can then be upgraded to any of those version.
-message BlessedReplicaVersions {
-  // A list of version information ids.
-  repeated string blessed_version_ids = 1;
-}

--- a/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
@@ -78,13 +78,3 @@ pub struct GuestLaunchMeasurementMetadata {
     #[prost(string, optional, tag = "2")]
     pub vcpu_type: ::core::option::Option<::prost::alloc::string::String>,
 }
-/// A list of blessed versions of the IC Replica
-///
-/// New versions are added here after a vote has been accepted by token
-/// holders. Subnetworks can then be upgraded to any of those version.
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct BlessedReplicaVersions {
-    /// A list of version information ids.
-    #[prost(string, repeated, tag = "1")]
-    pub blessed_version_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}

--- a/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
@@ -71,13 +71,3 @@ pub struct GuestLaunchMeasurementMetadata {
     #[prost(string, optional, tag = "2")]
     pub vcpu_type: ::core::option::Option<::prost::alloc::string::String>,
 }
-/// A list of blessed versions of the IC Replica
-///
-/// New versions are added here after a vote has been accepted by token
-/// holders. Subnetworks can then be upgraded to any of those version.
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct BlessedReplicaVersions {
-    /// A list of version information ids.
-    #[prost(string, repeated, tag = "1")]
-    pub blessed_version_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -11,7 +11,7 @@ use ic_registry_keys::{
     REPLICA_VERSION_KEY_PREFIX, make_node_operator_record_key, make_node_record_key,
     make_replica_version_key, make_subnet_list_record_key,
 };
-use ic_registry_transport::{delete, pb::v1::RegistryMutation, update};
+use ic_registry_transport::{pb::v1::RegistryMutation, update};
 use ic_types::NodeId;
 use maplit::btreemap;
 use prost::Message;
@@ -48,12 +48,6 @@ pub fn canister_post_upgrade(
         }
 
         let mutations = add_version_id_to_replica_versions(registry);
-        if !mutations.is_empty() {
-            registry.maybe_apply_mutation_internal(mutations);
-            total_batches += 1;
-        }
-
-        let mutations = remove_blessed_version_list_record(registry);
         if !mutations.is_empty() {
             registry.maybe_apply_mutation_internal(mutations);
             total_batches += 1;
@@ -409,22 +403,6 @@ fn add_version_id_to_replica_versions(registry: &Registry) -> Vec<RegistryMutati
     }
 
     mutations
-}
-
-/// The blessed version list record is no longer used.
-/// If it still exists, delete it.
-fn remove_blessed_version_list_record(registry: &Registry) -> Vec<RegistryMutation> {
-    if registry
-        .get(
-            "blessed_replica_versions".as_bytes(),
-            registry.latest_version(),
-        )
-        .is_some()
-    {
-        vec![delete("blessed_replica_versions".as_bytes())]
-    } else {
-        Vec::new()
-    }
 }
 
 #[cfg(test)]

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -8,7 +8,7 @@ use ic_protobuf::registry::subnet::v1::SubnetListRecord;
 use ic_registry_keys::{
     make_node_operator_record_key, make_node_record_key, make_subnet_list_record_key,
 };
-use ic_registry_transport::{delete, pb::v1::RegistryMutation, update};
+use ic_registry_transport::{pb::v1::RegistryMutation, update};
 use ic_types::NodeId;
 use maplit::btreemap;
 use prost::Message;
@@ -39,12 +39,6 @@ pub fn canister_post_upgrade(
         }
 
         let mutations = convert_type1dot1_nodes_to_type4dot5(registry);
-        if !mutations.is_empty() {
-            registry.maybe_apply_mutation_internal(mutations);
-            total_batches += 1;
-        }
-
-        let mutations = remove_blessed_version_list_record(registry);
         if !mutations.is_empty() {
             registry.maybe_apply_mutation_internal(mutations);
             total_batches += 1;
@@ -370,22 +364,6 @@ fn convert_type1dot1_nodes_to_type4dot5(registry: &Registry) -> Vec<RegistryMuta
     }
 
     mutations
-}
-
-/// The blessed version list record is no longer used.
-/// If it still exists, delete it.
-fn remove_blessed_version_list_record(registry: &Registry) -> Vec<RegistryMutation> {
-    if registry
-        .get(
-            "blessed_replica_versions".as_bytes(),
-            registry.latest_version(),
-        )
-        .is_some()
-    {
-        vec![delete("blessed_replica_versions".as_bytes())]
-    } else {
-        Vec::new()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Now that the record has been removed with https://github.com/dfinity/ic/pull/10940, drop the migration and the record type itself.

---

Long ago, we stopped requiring an extra proposal to add versions to the `blessed_replica_versions` list. The code continued to depend on this record for much longer, until the `eero/blessed-versions-*` saga of PRs moved everything to use `replica_version_*` records directly, instead. The record is now gone, and the last remaining reference can be removed.