### PR TITLE
feat: Make the ReplicaVersionRecord version_id mandatory

### DIFF
--- a/rs/ic_os/guest_upgrade/tests/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/tests/src/lib.rs
@@ -125,7 +125,7 @@ impl DiskEncryptionKeyExchangeTestFixture {
             1,
             REPLICA_VERSION,
             ReplicaVersionRecord {
-                replica_version_id: Some(REPLICA_VERSION.to_string()),
+                replica_version_id: REPLICA_VERSION.to_string(),
                 release_package_sha256_hex: "abc".to_string(),
                 guest_launch_measurements: Some(GuestLaunchMeasurements {
                     guest_launch_measurements: vec![

--- a/rs/ic_os/guest_upgrade/tests/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/tests/src/lib.rs
@@ -123,7 +123,7 @@ impl DiskEncryptionKeyExchangeTestFixture {
             1,
             REPLICA_VERSION,
             ReplicaVersionRecord {
-                version_id: Some(REPLICA_VERSION.to_string()),
+                version_id: REPLICA_VERSION.to_string(),
                 release_package_sha256_hex: "abc".to_string(),
                 guest_launch_measurements: Some(GuestLaunchMeasurements {
                     guest_launch_measurements: vec![

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -348,9 +348,8 @@ pub fn invariant_compliant_mutation_with_subnet_id(
     };
     const MOCK_HASH: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     let release_package_url = "http://release_package.tar.zst".to_string();
-    let replica_version_id = test_replica_version().to_string();
     let replica_version = ReplicaVersionRecord {
-        replica_version_id: Some(replica_version_id.clone()),
+        replica_version_id: test_replica_version().to_string(),
         release_package_sha256_hex: MOCK_HASH.into(),
         release_package_urls: vec![release_package_url],
         guest_launch_measurements: None,
@@ -362,7 +361,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
     let system_subnet = SubnetRecord {
         membership: vec![node_id.get().to_vec()],
         subnet_type: i32::from(SubnetType::System),
-        replica_version_id: replica_version_id.clone(),
+        replica_version_id: replica_version.replica_version_id.clone(),
         unit_delay_millis: 600,
         chain_key_config,
         ..Default::default()
@@ -381,7 +380,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
             system_subnet.encode_to_vec(),
         ),
         insert(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.replica_version_id).as_bytes(),
             replica_version.encode_to_vec(),
         ),
         insert(
@@ -608,7 +607,6 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
         add_node_mutations.append(&mut mutations);
     }
 
-    let replica_version_id = test_replica_version().to_string();
     const MOCK_HASH: &str = "abbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba";
     let release_package_url = "http://release_package.tar.zst".to_string();
     let guest_launch_measurements = Some(GuestLaunchMeasurements {
@@ -621,7 +619,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
         }],
     });
     let replica_version = ReplicaVersionRecord {
-        replica_version_id: Some(replica_version_id.clone()),
+        replica_version_id: test_replica_version().to_string(),
         release_package_sha256_hex: MOCK_HASH.into(),
         release_package_urls: vec![release_package_url],
         guest_launch_measurements,
@@ -632,7 +630,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
     let system_subnet = SubnetRecord {
         membership: node_id.iter().map(|id| id.get().to_vec()).collect(),
         subnet_type: i32::from(SubnetType::System),
-        replica_version_id: replica_version_id.clone(),
+        replica_version_id: replica_version.replica_version_id.clone(),
         unit_delay_millis: 600,
         ..Default::default()
     };
@@ -659,7 +657,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
             RoutingTablePB::from(routing_table).encode_to_vec(),
         ),
         insert(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.replica_version_id).as_bytes(),
             replica_version.encode_to_vec(),
         ),
     ];

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -347,9 +347,8 @@ pub fn invariant_compliant_mutation_with_subnet_id(
     };
     const MOCK_HASH: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     let release_package_url = "http://release_package.tar.zst".to_string();
-    let replica_version_id = ReplicaVersion::default().to_string();
     let replica_version = ReplicaVersionRecord {
-        version_id: Some(replica_version_id.clone()),
+        version_id: ReplicaVersion::default().to_string(),
         release_package_sha256_hex: MOCK_HASH.into(),
         release_package_urls: vec![release_package_url],
         guest_launch_measurements: None,
@@ -361,7 +360,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
     let system_subnet = SubnetRecord {
         membership: vec![node_id.get().to_vec()],
         subnet_type: i32::from(SubnetType::System),
-        replica_version_id: replica_version_id.clone(),
+        replica_version_id: replica_version.version_id.clone(),
         unit_delay_millis: 600,
         chain_key_config,
         ..Default::default()
@@ -380,7 +379,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
             system_subnet.encode_to_vec(),
         ),
         insert(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.version_id).as_bytes(),
             replica_version.encode_to_vec(),
         ),
         insert(
@@ -607,7 +606,6 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
         add_node_mutations.append(&mut mutations);
     }
 
-    let replica_version_id = ReplicaVersion::default().to_string();
     const MOCK_HASH: &str = "abbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba";
     let release_package_url = "http://release_package.tar.zst".to_string();
     let guest_launch_measurements = Some(GuestLaunchMeasurements {
@@ -620,7 +618,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
         }],
     });
     let replica_version = ReplicaVersionRecord {
-        version_id: Some(replica_version_id.clone()),
+        version_id: ReplicaVersion::default().to_string(),
         release_package_sha256_hex: MOCK_HASH.into(),
         release_package_urls: vec![release_package_url],
         guest_launch_measurements,
@@ -631,7 +629,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
     let system_subnet = SubnetRecord {
         membership: node_id.iter().map(|id| id.get().to_vec()).collect(),
         subnet_type: i32::from(SubnetType::System),
-        replica_version_id: replica_version_id.clone(),
+        replica_version_id: replica_version.version_id.clone(),
         unit_delay_millis: 600,
         ..Default::default()
     };
@@ -658,7 +656,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
             RoutingTablePB::from(routing_table).encode_to_vec(),
         ),
         insert(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.version_id).as_bytes(),
             replica_version.encode_to_vec(),
         ),
     ];

--- a/rs/orchestrator/src/upgrade.rs
+++ b/rs/orchestrator/src/upgrade.rs
@@ -1359,7 +1359,7 @@ mod tests {
                 &make_replica_version_key(replica_version),
                 registry_version,
                 Some(ReplicaVersionRecord {
-                    replica_version_id: Some(replica_version.to_string()),
+                    replica_version_id: replica_version.to_string(),
                     release_package_sha256_hex: "sha256".to_string(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/orchestrator/src/upgrade.rs
+++ b/rs/orchestrator/src/upgrade.rs
@@ -1355,7 +1355,7 @@ mod tests {
                 &make_replica_version_key(replica_version),
                 registry_version,
                 Some(ReplicaVersionRecord {
-                    version_id: Some(replica_version.to_string()),
+                    version_id: replica_version.to_string(),
                     release_package_sha256_hex: "sha256".to_string(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -647,7 +647,7 @@ impl IcConfig {
         }
 
         let replica_version_record = ReplicaVersionRecord {
-            replica_version_id: Some(self.initial_replica_version_id.to_string()),
+            replica_version_id: self.initial_replica_version_id.to_string(),
             release_package_sha256_hex: self.initial_release_package_sha256_hex.unwrap_or_default(),
             release_package_urls: opturl_to_string_vec(self.initial_release_package_url),
             guest_launch_measurements: self.guest_launch_measurements,
@@ -656,7 +656,7 @@ impl IcConfig {
         write_registry_entry(
             &data_provider,
             self.target_dir.as_path(),
-            make_replica_version_key(self.initial_replica_version_id.clone()).as_ref(),
+            make_replica_version_key(&replica_version_record.replica_version_id).as_ref(),
             version,
             replica_version_record,
         );

--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -647,7 +647,7 @@ impl IcConfig {
         }
 
         let replica_version_record = ReplicaVersionRecord {
-            version_id: Some(self.initial_replica_version_id.to_string()),
+            version_id: self.initial_replica_version_id.to_string(),
             release_package_sha256_hex: self.initial_release_package_sha256_hex.unwrap_or_default(),
             release_package_urls: opturl_to_string_vec(self.initial_release_package_url),
             guest_launch_measurements: self.guest_launch_measurements,
@@ -656,7 +656,7 @@ impl IcConfig {
         write_registry_entry(
             &data_provider,
             self.target_dir.as_path(),
-            make_replica_version_key(self.initial_replica_version_id.clone()).as_ref(),
+            make_replica_version_key(&replica_version_record.version_id).as_ref(),
             version,
             replica_version_record,
         );

--- a/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
+++ b/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
@@ -18,7 +18,7 @@ message ReplicaVersionRecord {
   // matches the suffix of the key for this record in the registry, and is
   // included here to make it easier to work with the generated Rust types. A
   // ReplicaVersionRecord almost always travels with its ID String.
-  optional string replica_version_id = 10;
+  string replica_version_id = 10;
 
   reserved 1, 2, 3, 4, 5, 8;
   reserved "binary_url";

--- a/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
+++ b/rs/protobuf/def/registry/replica_version/v1/replica_version.proto
@@ -14,7 +14,7 @@ message ReplicaVersionRecord {
   GuestLaunchMeasurements guest_launch_measurements = 9;
 
   // The ID used to reference this version.
-  optional string version_id = 10;
+  string version_id = 10;
 
   reserved 1, 2, 3, 4, 5, 8;
   reserved "binary_url";

--- a/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
@@ -17,8 +17,8 @@ pub struct ReplicaVersionRecord {
     /// matches the suffix of the key for this record in the registry, and is
     /// included here to make it easier to work with the generated Rust types. A
     /// ReplicaVersionRecord almost always travels with its ID String.
-    #[prost(string, optional, tag = "10")]
-    pub replica_version_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "10")]
+    pub replica_version_id: ::prost::alloc::string::String,
 }
 #[derive(
     serde::Serialize,

--- a/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.replica_version.v1.rs
@@ -13,8 +13,8 @@ pub struct ReplicaVersionRecord {
     #[prost(message, optional, tag = "9")]
     pub guest_launch_measurements: ::core::option::Option<GuestLaunchMeasurements>,
     /// The ID used to reference this version.
-    #[prost(string, optional, tag = "10")]
-    pub version_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "10")]
+    pub version_id: ::prost::alloc::string::String,
 }
 #[derive(
     serde::Serialize,

--- a/rs/recovery/src/lib.rs
+++ b/rs/recovery/src/lib.rs
@@ -563,7 +563,7 @@ impl Recovery {
         skip_prompts: bool,
     ) -> RecoveryResult<impl Step + use<>> {
         let version_record = ReplicaVersionRecord {
-            replica_version_id: Some(upgrade_version.to_string()),
+            replica_version_id: upgrade_version.to_string(),
             release_package_sha256_hex: sha256,
             release_package_urls: vec![upgrade_url.to_string()],
             guest_launch_measurements: Some(guest_launch_measurements),

--- a/rs/recovery/src/lib.rs
+++ b/rs/recovery/src/lib.rs
@@ -563,7 +563,7 @@ impl Recovery {
         skip_prompts: bool,
     ) -> RecoveryResult<impl Step + use<>> {
         let version_record = ReplicaVersionRecord {
-            version_id: Some(upgrade_version.to_string()),
+            version_id: upgrade_version.to_string(),
             release_package_sha256_hex: sha256,
             release_package_urls: vec![upgrade_url.to_string()],
             guest_launch_measurements: Some(guest_launch_measurements),

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -5043,12 +5043,12 @@ async fn main() {
             if opts.json {
                 let version_ids: Vec<String> = guestos_versions
                     .into_iter()
-                    .map(|(version, _)| version)
+                    .map(|record| record.replica_version_id)
                     .collect();
                 println!("{}", serde_json::to_string_pretty(&version_ids).unwrap());
             } else {
-                for (version, _) in guestos_versions {
-                    println!("{}", version);
+                for version in guestos_versions {
+                    println!("{}", version.replica_version_id);
                 }
             }
         }

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -4976,12 +4976,12 @@ async fn main() {
             if opts.json {
                 let version_ids: Vec<String> = guestos_versions
                     .into_iter()
-                    .map(|(version, _)| version)
+                    .map(|record| record.version_id)
                     .collect();
                 println!("{}", serde_json::to_string_pretty(&version_ids).unwrap());
             } else {
-                for (version, _) in guestos_versions {
-                    println!("{}", version);
+                for version in guestos_versions {
+                    println!("{}", version.version_id);
                 }
             }
         }

--- a/rs/registry/canister/src/invariants/replica_version.rs
+++ b/rs/registry/canister/src/invariants/replica_version.rs
@@ -90,9 +90,7 @@ pub(crate) fn check_replica_version_invariants(
         }
 
         // Enforce that the stored version always matches the key
-        if let Some(replica_version_id) = r.replica_version_id {
-            assert_eq!(replica_version_id, version);
-        }
+        assert_eq!(r.replica_version_id, version);
     }
 
     Ok(())
@@ -219,8 +217,9 @@ mod tests {
             .into_iter()
             .map(|v| {
                 insert(
-                    make_replica_version_key(v).as_bytes(),
+                    make_replica_version_key(&v).as_bytes(),
                     ReplicaVersionRecord {
+                        replica_version_id: v,
                         // Versions referenced by the StandardEngineReplicaVersionRecord
                         // must have launch measurements.
                         guest_launch_measurements: Some(GUEST_LAUNCH_MEASUREMENTS.clone()),
@@ -568,21 +567,20 @@ mod tests {
     fn panic_when_retiring_unassigned_nodes_version() {
         let mut registry = invariant_compliant_registry(0);
 
-        let replica_version_id = "unassigned_version".to_string();
         let replica_version = ReplicaVersionRecord {
-            replica_version_id: Some(replica_version_id.clone()),
+            replica_version_id: "unassigned_version".to_string(),
             release_package_sha256_hex: "".to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: None,
         };
         let unassigned_nodes_config = UnassignedNodesConfigRecord {
             ssh_readonly_access: vec![],
-            replica_version: replica_version_id.clone(),
+            replica_version: replica_version.replica_version_id.clone(),
         };
 
         let init = vec![
             insert(
-                make_replica_version_key(&replica_version_id).as_bytes(),
+                make_replica_version_key(&replica_version.replica_version_id).as_bytes(),
                 replica_version.encode_to_vec(),
             ),
             insert(
@@ -593,7 +591,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(init);
 
         let mutation = vec![delete(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.replica_version_id).as_bytes(),
         )];
         registry.check_global_state_invariants(&mutation);
     }
@@ -637,7 +635,7 @@ mod tests {
         let replica_version = test_replica_version().to_string();
         let key = make_replica_version_key(&replica_version);
         let value = ReplicaVersionRecord {
-            replica_version_id: Some(replica_version),
+            replica_version_id: replica_version,
             release_package_sha256_hex: hash.into(),
             release_package_urls: urls,
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -688,7 +686,7 @@ mod tests {
         let replica_version = test_replica_version().to_string();
         let key = make_replica_version_key(&replica_version);
         let value = ReplicaVersionRecord {
-            replica_version_id: Some(replica_version),
+            replica_version_id: replica_version,
             release_package_sha256_hex: MOCK_HASH.into(),
             release_package_urls: vec![MOCK_URL.into()],
             guest_launch_measurements: Some(GuestLaunchMeasurements {

--- a/rs/registry/canister/src/invariants/replica_version.rs
+++ b/rs/registry/canister/src/invariants/replica_version.rs
@@ -517,21 +517,20 @@ mod tests {
     fn panic_when_retiring_unassigned_nodes_version() {
         let mut registry = invariant_compliant_registry(0);
 
-        let replica_version_id = "unassigned_version".to_string();
         let replica_version = ReplicaVersionRecord {
-            version_id: Some(replica_version_id.clone()),
+            version_id: "unassigned_version".to_string(),
             release_package_sha256_hex: "".to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: None,
         };
         let unassigned_nodes_config = UnassignedNodesConfigRecord {
             ssh_readonly_access: vec![],
-            replica_version: replica_version_id.clone(),
+            replica_version: replica_version.version_id.clone(),
         };
 
         let init = vec![
             insert(
-                make_replica_version_key(&replica_version_id).as_bytes(),
+                make_replica_version_key(&replica_version.version_id).as_bytes(),
                 replica_version.encode_to_vec(),
             ),
             insert(
@@ -542,7 +541,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(init);
 
         let mutation = vec![delete(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.version_id).as_bytes(),
         )];
         registry.check_global_state_invariants(&mutation);
     }
@@ -585,7 +584,7 @@ mod tests {
 
         let key = make_replica_version_key(ReplicaVersion::default());
         let value = ReplicaVersionRecord {
-            version_id: Some(ReplicaVersion::default().to_string()),
+            version_id: ReplicaVersion::default().to_string(),
             release_package_sha256_hex: hash.into(),
             release_package_urls: urls,
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -635,7 +634,7 @@ mod tests {
 
         let key = make_replica_version_key(ReplicaVersion::default());
         let value = ReplicaVersionRecord {
-            version_id: Some(ReplicaVersion::default().to_string()),
+            version_id: ReplicaVersion::default().to_string(),
             release_package_sha256_hex: MOCK_HASH.into(),
             release_package_urls: vec![MOCK_URL.into()],
             guest_launch_measurements: Some(GuestLaunchMeasurements {

--- a/rs/registry/canister/src/invariants/standard_engine_replica_version.rs
+++ b/rs/registry/canister/src/invariants/standard_engine_replica_version.rs
@@ -105,8 +105,9 @@ mod tests {
             .into_iter()
             .map(|v| {
                 insert(
-                    make_replica_version_key(v).as_bytes(),
+                    make_replica_version_key(&v).as_bytes(),
                     ReplicaVersionRecord {
+                        replica_version_id: v,
                         // Versions of the StandardEngineReplicaVersionRecord must
                         // have launch measurements.
                         guest_launch_measurements: Some(GUEST_LAUNCH_MEASUREMENTS.clone()),
@@ -175,7 +176,11 @@ mod tests {
         let replica_version_id_without_measurements = "b4f14b18a1b4a3d3ba31c1b0a3c53e35a1e1b0dc";
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key(replica_version_id_without_measurements).as_bytes(),
-            ReplicaVersionRecord::default().encode_to_vec(),
+            ReplicaVersionRecord {
+                replica_version_id: replica_version_id_without_measurements.to_string(),
+                ..Default::default()
+            }
+            .encode_to_vec(),
         )]);
 
         // Step 2: Run the code under test. Start upgrading the engines to that

--- a/rs/registry/canister/src/invariants/subnet/tests.rs
+++ b/rs/registry/canister/src/invariants/subnet/tests.rs
@@ -217,7 +217,7 @@ fn elect_replica_version(
     snapshot.insert(
         make_replica_version_key(replica_version_id).into_bytes(),
         ReplicaVersionRecord {
-            replica_version_id: Some(replica_version_id.to_string()),
+            replica_version_id: replica_version_id.to_string(),
             release_package_sha256_hex:
                 "C0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEEC0FFEED00D".to_string(),
             release_package_urls: vec!["https://example.com/release_package.tar.zst".to_string()],

--- a/rs/registry/canister/src/mutations/do_add_api_boundary_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_add_api_boundary_nodes.rs
@@ -256,7 +256,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                replica_version_id: Some("version".to_string()),
+                replica_version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -304,7 +304,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                replica_version_id: Some("version".to_string()),
+                replica_version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -343,7 +343,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                replica_version_id: Some("version".to_string()),
+                replica_version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -379,7 +379,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                replica_version_id: Some("version".to_string()),
+                replica_version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -424,7 +424,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                replica_version_id: Some("version".to_string()),
+                replica_version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_add_api_boundary_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_add_api_boundary_nodes.rs
@@ -257,7 +257,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                version_id: Some("version".to_string()),
+                version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -305,7 +305,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                version_id: Some("version".to_string()),
+                version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -344,7 +344,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                version_id: Some("version".to_string()),
+                version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -380,7 +380,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                version_id: Some("version".to_string()),
+                version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,
@@ -425,7 +425,7 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![insert(
             make_replica_version_key("version"), // key
             ReplicaVersionRecord {
-                version_id: Some("version".to_string()),
+                version_id: "version".to_string(),
                 release_package_sha256_hex: "".into(),
                 release_package_urls: vec![],
                 guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
@@ -195,11 +195,19 @@ mod tests {
         registry.maybe_apply_mutation_internal(vec![
             insert(
                 make_replica_version_key(OLD_REPLICA_VERSION_ID).as_bytes(),
-                ReplicaVersionRecord::default().encode_to_vec(),
+                ReplicaVersionRecord {
+                    replica_version_id: OLD_REPLICA_VERSION_ID.to_string(),
+                    ..Default::default()
+                }
+                .encode_to_vec(),
             ),
             insert(
                 make_replica_version_key(NEW_REPLICA_VERSION_ID).as_bytes(),
-                ReplicaVersionRecord::default().encode_to_vec(),
+                ReplicaVersionRecord {
+                    replica_version_id: NEW_REPLICA_VERSION_ID.to_string(),
+                    ..Default::default()
+                }
+                .encode_to_vec(),
             ),
         ]);
         add_guest_launch_measurements_to_replica_version(registry, OLD_REPLICA_VERSION_ID);

--- a/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs
@@ -71,7 +71,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    replica_version_id: Some("version".to_string()),
+                    replica_version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs
@@ -71,7 +71,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    version_id: Some("version".to_string()),
+                    version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
+++ b/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
@@ -54,7 +54,7 @@ impl Registry {
                     mutation_type: registry_mutation::Type::Insert as i32,
                     key: make_replica_version_key(&version).as_bytes().to_vec(),
                     value: ReplicaVersionRecord {
-                        replica_version_id: Some(version),
+                        replica_version_id: version,
                         release_package_sha256_hex: payload
                             .release_package_sha256_hex
                             .unwrap_or_else(|| {

--- a/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
+++ b/rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs
@@ -54,7 +54,7 @@ impl Registry {
                     mutation_type: registry_mutation::Type::Insert as i32,
                     key: make_replica_version_key(&version).as_bytes().to_vec(),
                     value: ReplicaVersionRecord {
-                        version_id: Some(version),
+                        version_id: version,
                         release_package_sha256_hex: payload
                             .release_package_sha256_hex
                             .unwrap_or_else(|| {

--- a/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
@@ -167,7 +167,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    replica_version_id: Some("version".to_string()),
+                    replica_version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs
@@ -167,7 +167,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    version_id: Some("version".to_string()),
+                    version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_ssh_readonly_access_for_all_unassigned_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_update_ssh_readonly_access_for_all_unassigned_nodes.rs
@@ -74,7 +74,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    replica_version_id: Some("version".to_string()),
+                    replica_version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_ssh_readonly_access_for_all_unassigned_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_update_ssh_readonly_access_for_all_unassigned_nodes.rs
@@ -74,7 +74,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    version_id: Some("version".to_string()),
+                    version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_standard_engine_replica_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_standard_engine_replica_version.rs
@@ -182,7 +182,7 @@ mod tests {
                 result.maybe_apply_mutation_internal(vec![insert(
                     make_replica_version_key(version),
                     ReplicaVersionRecord {
-                        replica_version_id: Some(version.to_string()),
+                        replica_version_id: version.to_string(),
                         release_package_sha256_hex: "".into(),
                         release_package_urls: vec![],
                         // Versions of the StandardEngineReplicaVersionRecord must

--- a/rs/registry/canister/src/mutations/do_update_standard_engine_replica_version.rs
+++ b/rs/registry/canister/src/mutations/do_update_standard_engine_replica_version.rs
@@ -182,7 +182,7 @@ mod tests {
                 result.maybe_apply_mutation_internal(vec![insert(
                     make_replica_version_key(version),
                     ReplicaVersionRecord {
-                        version_id: Some(version.to_string()),
+                        version_id: version.to_string(),
                         release_package_sha256_hex: "".into(),
                         release_package_urls: vec![],
                         guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_unassigned_nodes_config.rs
+++ b/rs/registry/canister/src/mutations/do_update_unassigned_nodes_config.rs
@@ -102,7 +102,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    replica_version_id: Some("version".to_string()),
+                    replica_version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/do_update_unassigned_nodes_config.rs
+++ b/rs/registry/canister/src/mutations/do_update_unassigned_nodes_config.rs
@@ -102,7 +102,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    version_id: Some("version".to_string()),
+                    version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -1504,9 +1504,8 @@ mod tests {
     }
 
     fn add_elected_measurement_to_registry(registry: &mut Registry, measurement: &[u8]) {
-        let replica_version_id = test_replica_version().to_string();
         let replica_version = ReplicaVersionRecord {
-            replica_version_id: Some(replica_version_id.clone()),
+            replica_version_id: test_replica_version().to_string(),
             release_package_sha256_hex: "".to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -1517,7 +1516,7 @@ mod tests {
             }),
         };
         registry.maybe_apply_mutation_internal(vec![update(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.replica_version_id).as_bytes(),
             replica_version.encode_to_vec(),
         )]);
     }

--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -1501,9 +1501,8 @@ mod tests {
     }
 
     fn add_elected_measurement_to_registry(registry: &mut Registry, measurement: &[u8]) {
-        let replica_version_id = ReplicaVersion::default().to_string();
         let replica_version = ReplicaVersionRecord {
-            version_id: Some(replica_version_id.clone()),
+            version_id: ReplicaVersion::default().to_string(),
             release_package_sha256_hex: "".to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -1514,7 +1513,7 @@ mod tests {
             }),
         };
         registry.maybe_apply_mutation_internal(vec![update(
-            make_replica_version_key(replica_version_id).as_bytes(),
+            make_replica_version_key(&replica_version.version_id).as_bytes(),
             replica_version.encode_to_vec(),
         )]);
     }

--- a/rs/registry/canister/src/mutations/node_management/do_update_node_domain_directly.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_update_node_domain_directly.rs
@@ -247,7 +247,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    replica_version_id: Some("version".to_string()),
+                    replica_version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/mutations/node_management/do_update_node_domain_directly.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_update_node_domain_directly.rs
@@ -247,7 +247,7 @@ mod tests {
             insert(
                 make_replica_version_key("version"), // key
                 ReplicaVersionRecord {
-                    version_id: Some("version".to_string()),
+                    version_id: "version".to_string(),
                     release_package_sha256_hex: "".into(),
                     release_package_urls: vec![],
                     guest_launch_measurements: None,

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -1,15 +1,12 @@
 use crate::certification::recertify_registry;
-use crate::common::key_family::get_key_family_iter;
 use crate::mutations::node_management::common::find_subnet_for_node;
 use crate::{pb::v1::RegistryCanisterStableStorage, registry::Registry};
 use ic_base_types::PrincipalId;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
-use ic_protobuf::registry::replica_version::v1::ReplicaVersionRecord;
 use ic_protobuf::registry::subnet::v1::SubnetListRecord;
 use ic_registry_keys::{
-    REPLICA_VERSION_KEY_PREFIX, make_node_operator_record_key, make_node_record_key,
-    make_replica_version_key, make_subnet_list_record_key,
+    make_node_operator_record_key, make_node_record_key, make_subnet_list_record_key,
 };
 use ic_registry_transport::{pb::v1::RegistryMutation, update};
 use ic_types::NodeId;
@@ -42,12 +39,6 @@ pub fn canister_post_upgrade(
         }
 
         let mutations = convert_type1dot1_nodes_to_type4dot5(registry);
-        if !mutations.is_empty() {
-            registry.maybe_apply_mutation_internal(mutations);
-            total_batches += 1;
-        }
-
-        let mutations = add_version_id_to_replica_versions(registry);
         if !mutations.is_empty() {
             registry.maybe_apply_mutation_internal(mutations);
             total_batches += 1;
@@ -370,36 +361,6 @@ fn convert_type1dot1_nodes_to_type4dot5(registry: &Registry) -> Vec<RegistryMuta
 
         node_record.node_reward_type = Some(NodeRewardType::Type4dot5 as i32);
         mutations.push(update(node_key, node_record.encode_to_vec()));
-    }
-
-    mutations
-}
-
-/// Backfill a new `replica_version_id` field on `ReplicaVersionRecord`s.
-/// This ID is also used in the registry key. Adding it to the record is more
-/// convenient, as only a `ReplicaVersionRecord` needs to be passed around.
-fn add_version_id_to_replica_versions(registry: &Registry) -> Vec<RegistryMutation> {
-    let mut mutations = Vec::new();
-
-    for (id, mut version) in
-        get_key_family_iter::<ReplicaVersionRecord>(registry, REPLICA_VERSION_KEY_PREFIX)
-    {
-        if version.replica_version_id.is_some() {
-            continue;
-        }
-
-        version.replica_version_id = Some(id.clone());
-        mutations.push(update(
-            make_replica_version_key(id),
-            version.encode_to_vec(),
-        ))
-    }
-
-    if mutations.len() > 10 {
-        ic_cdk::println!(
-            "Trying to update ReplicaVersionRecords generated too many mutations. Aborting."
-        );
-        return Vec::new();
     }
 
     mutations

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -1,15 +1,12 @@
 use crate::certification::recertify_registry;
-use crate::common::key_family::get_key_family_iter;
 use crate::mutations::node_management::common::find_subnet_for_node;
 use crate::{pb::v1::RegistryCanisterStableStorage, registry::Registry};
 use ic_base_types::PrincipalId;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
-use ic_protobuf::registry::replica_version::v1::ReplicaVersionRecord;
 use ic_protobuf::registry::subnet::v1::SubnetListRecord;
 use ic_registry_keys::{
-    REPLICA_VERSION_KEY_PREFIX, make_node_operator_record_key, make_node_record_key,
-    make_replica_version_key, make_subnet_list_record_key,
+    make_node_operator_record_key, make_node_record_key, make_subnet_list_record_key,
 };
 use ic_registry_transport::{pb::v1::RegistryMutation, update};
 use ic_types::NodeId;
@@ -42,12 +39,6 @@ pub fn canister_post_upgrade(
         }
 
         let mutations = convert_type1dot1_nodes_to_type4dot5(registry);
-        if !mutations.is_empty() {
-            registry.maybe_apply_mutation_internal(mutations);
-            total_batches += 1;
-        }
-
-        let mutations = add_version_id_to_replica_versions(registry);
         if !mutations.is_empty() {
             registry.maybe_apply_mutation_internal(mutations);
             total_batches += 1;
@@ -370,27 +361,6 @@ fn convert_type1dot1_nodes_to_type4dot5(registry: &Registry) -> Vec<RegistryMuta
 
         node_record.node_reward_type = Some(NodeRewardType::Type4dot5 as i32);
         mutations.push(update(node_key, node_record.encode_to_vec()));
-    }
-
-    mutations
-}
-
-/// Backfill a new `version_id` field on `ReplicaVersionRecord`s.
-/// This ID is also used in the registry key. Adding it to the record is more
-/// convenient, as only a `ReplicaVersionRecord` needs to be passed around.
-fn add_version_id_to_replica_versions(registry: &Registry) -> Vec<RegistryMutation> {
-    let mut mutations = Vec::new();
-
-    for (id, mut version) in
-        get_key_family_iter::<ReplicaVersionRecord>(registry, REPLICA_VERSION_KEY_PREFIX)
-    {
-        if version.version_id.is_none() {
-            version.version_id = Some(id.clone());
-            mutations.push(update(
-                make_replica_version_key(id),
-                version.encode_to_vec(),
-            ))
-        }
     }
 
     mutations

--- a/rs/registry/canister/tests/update_subnet_and_elect_replica_version.rs
+++ b/rs/registry/canister/tests/update_subnet_and_elect_replica_version.rs
@@ -228,7 +228,7 @@ fn test_accepted_proposal_mutates_the_registry() {
             )
             .await,
             ReplicaVersionRecord {
-                replica_version_id: Some(replica_version_id.to_string()),
+                replica_version_id: replica_version_id.to_string(),
                 release_package_sha256_hex: MOCK_HASH.into(),
                 release_package_urls: vec![release_package_url.clone()],
                 guest_launch_measurements: Some(GUEST_LAUNCH_MEASUREMENTS.clone()),

--- a/rs/registry/canister/tests/update_subnet_and_elect_replica_version.rs
+++ b/rs/registry/canister/tests/update_subnet_and_elect_replica_version.rs
@@ -235,7 +235,7 @@ fn test_accepted_proposal_mutates_the_registry() {
             )
             .await,
             ReplicaVersionRecord {
-                version_id: Some(replica_version_id.to_string()),
+                version_id: replica_version_id.to_string(),
                 release_package_sha256_hex: MOCK_HASH.into(),
                 release_package_urls: vec![release_package_url.clone()],
                 guest_launch_measurements: guest_launch_measurements_for_test(),

--- a/rs/registry/helpers/src/replica_version.rs
+++ b/rs/registry/helpers/src/replica_version.rs
@@ -8,7 +8,6 @@ use ic_registry_keys::{
     REPLICA_VERSION_KEY_PREFIX, make_replica_version_key,
     make_standard_engine_replica_version_record_key,
 };
-use ic_types::registry::RegistryClientError;
 pub use ic_types::replica_version::ReplicaVersion;
 pub use ic_types::{NodeId, RegistryVersion, SubnetId};
 
@@ -16,7 +15,7 @@ pub trait ReplicaVersionRegistry {
     fn get_all_replica_version_records(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<Vec<(String, ReplicaVersionRecord)>>;
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>>;
 
     fn get_replica_version_record(
         &self,
@@ -44,8 +43,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
     fn get_all_replica_version_records(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<Vec<(String, ReplicaVersionRecord)>> {
-        // Note this `get_key_family` impl does not strip the prefix from keys. The impl in the registry canister, does.
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>> {
         let keys = self.get_key_family(REPLICA_VERSION_KEY_PREFIX, version)?;
 
         let mut records = Vec::new();
@@ -53,13 +51,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
             let bytes = self.get_value(&key, version);
             let replica_version_proto =
                 deserialize_registry_value::<ReplicaVersionRecord>(bytes)?.unwrap_or_default();
-            let id = key
-                .strip_prefix(REPLICA_VERSION_KEY_PREFIX)
-                .ok_or_else(|| RegistryClientError::DecodeError {
-                    error: format!("Replica Version Record key {key} does not start with prefix {REPLICA_VERSION_KEY_PREFIX}"),
-                })?
-                .to_string();
-            records.push((id, replica_version_proto))
+            records.push(replica_version_proto)
         }
 
         Ok(Some(records))
@@ -93,7 +85,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
 
         let measurements = replica_versions
             .into_iter()
-            .flat_map(|(_, record)| {
+            .flat_map(|record| {
                 record
                     .guest_launch_measurements
                     .unwrap_or_default()
@@ -123,7 +115,7 @@ mod tests {
         measurements: &[impl AsRef<[u8]>],
     ) -> ReplicaVersionRecord {
         ReplicaVersionRecord {
-            replica_version_id: Some(replica_version_id.to_string()),
+            replica_version_id: replica_version_id.to_string(),
             release_package_sha256_hex: package_hash.to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -143,7 +135,7 @@ mod tests {
         package_hash: &str,
     ) -> ReplicaVersionRecord {
         ReplicaVersionRecord {
-            replica_version_id: Some(replica_version_id.to_string()),
+            replica_version_id: replica_version_id.to_string(),
             release_package_sha256_hex: package_hash.to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: None,
@@ -159,33 +151,21 @@ mod tests {
         let measurement3 = [11, 12, 13, 14, 15];
         let measurement4 = [16, 17, 18, 19, 20]; // From removed version
 
-        let replica_versions_and_records = vec![
-            (
-                "version1",
-                create_replica_record("version1", "12345", &[measurement1, measurement2]),
-            ),
-            (
-                "version2",
-                create_replica_record("version2", "abcde", &[measurement3]),
-            ),
-            (
-                "version3",
-                create_replica_record("version3", "99999", &[measurement4]),
-            ),
-            (
-                "version4",
-                create_replica_record_without_measurements("version4", "424242"),
-            ),
+        let replica_records = vec![
+            create_replica_record("version1", "12345", &[measurement1, measurement2]),
+            create_replica_record("version2", "abcde", &[measurement3]),
+            create_replica_record("version3", "99999", &[measurement4]),
+            create_replica_record_without_measurements("version4", "424242"),
         ];
 
         // Set up registry data provider
         let data_provider = ProtoRegistryDataProvider::new();
 
         // Add replica version records
-        for (replica_version_id, record) in &replica_versions_and_records {
+        for record in &replica_records {
             data_provider
                 .add(
-                    &make_replica_version_key(replica_version_id),
+                    &make_replica_version_key(&record.replica_version_id),
                     registry_version,
                     Some(record.clone()),
                 )

--- a/rs/registry/helpers/src/replica_version.rs
+++ b/rs/registry/helpers/src/replica_version.rs
@@ -2,7 +2,6 @@ use crate::deserialize_registry_value;
 use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
 use ic_protobuf::registry::replica_version::v1::ReplicaVersionRecord;
 use ic_registry_keys::{REPLICA_VERSION_KEY_PREFIX, make_replica_version_key};
-use ic_types::registry::RegistryClientError;
 pub use ic_types::replica_version::ReplicaVersion;
 pub use ic_types::{NodeId, RegistryVersion, SubnetId};
 
@@ -10,7 +9,7 @@ pub trait ReplicaVersionRegistry {
     fn get_all_replica_version_records(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<Vec<(String, ReplicaVersionRecord)>>;
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>>;
 
     fn get_replica_version_record(
         &self,
@@ -33,8 +32,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
     fn get_all_replica_version_records(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<Vec<(String, ReplicaVersionRecord)>> {
-        // Note this `get_key_family` impl does not strip the prefix from keys. The impl in the registry canister, does.
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>> {
         let keys = self.get_key_family(REPLICA_VERSION_KEY_PREFIX, version)?;
 
         let mut records = Vec::new();
@@ -42,13 +40,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
             let bytes = self.get_value(&key, version);
             let replica_version_proto =
                 deserialize_registry_value::<ReplicaVersionRecord>(bytes)?.unwrap_or_default();
-            let id = key
-                .strip_prefix(REPLICA_VERSION_KEY_PREFIX)
-                .ok_or_else(|| RegistryClientError::DecodeError {
-                    error: format!("Replica Version Record key {key} does not start with prefix {REPLICA_VERSION_KEY_PREFIX}"),
-                })?
-                .to_string();
-            records.push((id, replica_version_proto))
+            records.push(replica_version_proto)
         }
 
         Ok(Some(records))
@@ -74,7 +66,7 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
 
         let measurements = replica_versions
             .into_iter()
-            .flat_map(|(_, record)| {
+            .flat_map(|record| {
                 record
                     .guest_launch_measurements
                     .unwrap_or_default()
@@ -104,7 +96,7 @@ mod tests {
         measurements: &[impl AsRef<[u8]>],
     ) -> ReplicaVersionRecord {
         ReplicaVersionRecord {
-            version_id: Some(version_id.to_string()),
+            version_id: version_id.to_string(),
             release_package_sha256_hex: package_hash.to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: Some(GuestLaunchMeasurements {
@@ -124,7 +116,7 @@ mod tests {
         package_hash: &str,
     ) -> ReplicaVersionRecord {
         ReplicaVersionRecord {
-            version_id: Some(version_id.to_string()),
+            version_id: version_id.to_string(),
             release_package_sha256_hex: package_hash.to_string(),
             release_package_urls: vec![],
             guest_launch_measurements: None,
@@ -141,32 +133,20 @@ mod tests {
         let measurement4 = [16, 17, 18, 19, 20]; // From removed version
 
         let replica_versions_and_records = vec![
-            (
-                "version1",
-                create_replica_record("version1", "12345", &[measurement1, measurement2]),
-            ),
-            (
-                "version2",
-                create_replica_record("version2", "abcde", &[measurement3]),
-            ),
-            (
-                "version3",
-                create_replica_record("version3", "99999", &[measurement4]),
-            ),
-            (
-                "version4",
-                create_replica_record_without_measurements("version4", "424242"),
-            ),
+            create_replica_record("version1", "12345", &[measurement1, measurement2]),
+            create_replica_record("version2", "abcde", &[measurement3]),
+            create_replica_record("version3", "99999", &[measurement4]),
+            create_replica_record_without_measurements("version4", "424242"),
         ];
 
         // Set up registry data provider
         let data_provider = ProtoRegistryDataProvider::new();
 
         // Add replica version records
-        for (version_id, record) in &replica_versions_and_records {
+        for record in &replica_versions_and_records {
             data_provider
                 .add(
-                    &make_replica_version_key(version_id),
+                    &make_replica_version_key(&record.version_id),
                     registry_version,
                     Some(record.clone()),
                 )

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -353,16 +353,15 @@ pub fn add_initial_registry_records(registry_data_provider: Arc<ProtoRegistryDat
         .unwrap();
 
     // replica version record
-    let replica_version = test_replica_version();
     let replica_version_record = ReplicaVersionRecord {
-        replica_version_id: Some(replica_version.to_string()),
+        replica_version_id: test_replica_version().to_string(),
         release_package_sha256_hex: "".to_string(),
         release_package_urls: vec![],
         guest_launch_measurements: None,
     };
     registry_data_provider
         .add(
-            &make_replica_version_key(replica_version),
+            &make_replica_version_key(&replica_version_record.replica_version_id),
             registry_version,
             Some(replica_version_record),
         )

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -352,16 +352,15 @@ pub fn add_initial_registry_records(registry_data_provider: Arc<ProtoRegistryDat
         .unwrap();
 
     // replica version record
-    let replica_version = ReplicaVersion::default();
     let replica_version_record = ReplicaVersionRecord {
-        version_id: Some(replica_version.to_string()),
+        version_id: ReplicaVersion::default().to_string(),
         release_package_sha256_hex: "".to_string(),
         release_package_urls: vec![],
         guest_launch_measurements: None,
     };
     registry_data_provider
         .add(
-            &make_replica_version_key(replica_version),
+            &make_replica_version_key(&replica_version_record.version_id),
             registry_version,
             Some(replica_version_record),
         )

--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -21,7 +21,7 @@ pub async fn get_elected_replica_versions(topology: &TopologySnapshot) -> Vec<St
         .replica_version_records()
         .unwrap()
         .into_iter()
-        .map(|(k, _)| k)
+        .map(|v| v.replica_version_id)
         .collect()
 }
 

--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -21,7 +21,7 @@ pub async fn get_elected_replica_versions(topology: &TopologySnapshot) -> Vec<St
         .replica_version_records()
         .unwrap()
         .into_iter()
-        .map(|(k, _)| k)
+        .map(|v| v.version_id)
         .collect()
 }
 

--- a/rs/tests/dre/utils/steps/ensure_elected_version.rs
+++ b/rs/tests/dre/utils/steps/ensure_elected_version.rs
@@ -29,7 +29,7 @@ impl Step for EnsureElectedVersion {
         let elected_versions = env.topology_snapshot().replica_version_records()?;
         if elected_versions
             .iter()
-            .any(|(k, _)| k == self.version.as_ref())
+            .any(|v| v.replica_version_id == self.version.as_ref())
         {
             info!(env.logger(), "Version `{}` already elected", self.version);
             return Ok(());
@@ -62,7 +62,7 @@ impl Step for EnsureElectedVersion {
 
         match elected_versions
             .iter()
-            .any(|(k, _)| k == self.version.as_ref())
+            .any(|v| v.replica_version_id == self.version.as_ref())
         {
             true => Ok(()),
             false => Err(anyhow::anyhow!("Version not found in the registry")),

--- a/rs/tests/dre/utils/steps/ensure_elected_version.rs
+++ b/rs/tests/dre/utils/steps/ensure_elected_version.rs
@@ -29,7 +29,7 @@ impl Step for EnsureElectedVersion {
         let elected_versions = env.topology_snapshot().replica_version_records()?;
         if elected_versions
             .iter()
-            .any(|(k, _)| k == self.version.as_ref())
+            .any(|v| v.version_id == self.version.as_ref())
         {
             info!(env.logger(), "Version `{}` already elected", self.version);
             return Ok(());
@@ -62,7 +62,7 @@ impl Step for EnsureElectedVersion {
 
         match elected_versions
             .iter()
-            .any(|(k, _)| k == self.version.as_ref())
+            .any(|v| v.version_id == self.version.as_ref())
         {
             true => Ok(()),
             false => Err(anyhow::anyhow!("Version not found in the registry")),

--- a/rs/tests/dre/utils/steps/retire_elected_version.rs
+++ b/rs/tests/dre/utils/steps/retire_elected_version.rs
@@ -33,7 +33,11 @@ impl Step for RetireElectedVersions {
         let mut versions_to_unelect = self
             .versions
             .iter()
-            .filter(|version| replica_versions.iter().any(|(k, _)| k == version.as_ref()))
+            .filter(|version| {
+                replica_versions
+                    .iter()
+                    .any(|v| v.replica_version_id == version.as_ref())
+            })
             .cloned()
             .collect_vec();
 
@@ -57,17 +61,15 @@ impl Step for RetireElectedVersions {
         versions_to_unelect.retain(|r| {
             let record = replica_versions
                 .iter()
-                .find_map(|(key, rec)| {
-                    if key == r.as_ref() {
-                        return Some(rec);
-                    }
-                    None
-                })
+                .find(|rec| rec.replica_version_id == r.as_ref())
                 .unwrap_or_else(|| {
                     panic!(
                         "Elected replica version with key {} not found in records: {}",
                         r,
-                        replica_versions.iter().map(|(k, _)| k).join(", ")
+                        replica_versions
+                            .iter()
+                            .map(|v| &v.replica_version_id)
+                            .join(", ")
                     )
                 });
 

--- a/rs/tests/dre/utils/steps/retire_elected_version.rs
+++ b/rs/tests/dre/utils/steps/retire_elected_version.rs
@@ -33,7 +33,11 @@ impl Step for RetireElectedVersions {
         let mut versions_to_unelect = self
             .versions
             .iter()
-            .filter(|version| replica_versions.iter().any(|(k, _)| k == version.as_ref()))
+            .filter(|version| {
+                replica_versions
+                    .iter()
+                    .any(|v| v.version_id == version.as_ref())
+            })
             .cloned()
             .collect_vec();
 
@@ -57,17 +61,12 @@ impl Step for RetireElectedVersions {
         versions_to_unelect.retain(|r| {
             let record = replica_versions
                 .iter()
-                .find_map(|(key, rec)| {
-                    if key == r.as_ref() {
-                        return Some(rec);
-                    }
-                    None
-                })
+                .find(|rec| rec.version_id == r.as_ref())
                 .unwrap_or_else(|| {
                     panic!(
                         "Elected replica version with key {} not found in records: {}",
                         r,
-                        replica_versions.iter().map(|(k, _)| k).join(", ")
+                        replica_versions.iter().map(|v| &v.version_id).join(", ")
                     )
                 });
 

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -522,7 +522,7 @@ impl TopologySnapshot {
         )
     }
 
-    pub fn replica_version_records(&self) -> Result<Vec<(String, ReplicaVersionRecord)>> {
+    pub fn replica_version_records(&self) -> Result<Vec<ReplicaVersionRecord>> {
         self.local_registry
             .get_all_replica_version_records(self.registry_version)?
             .context("get_all_replica_version_records always returns Some (and it did not)")

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -520,7 +520,7 @@ impl TopologySnapshot {
         )
     }
 
-    pub fn replica_version_records(&self) -> Result<Vec<(String, ReplicaVersionRecord)>> {
+    pub fn replica_version_records(&self) -> Result<Vec<ReplicaVersionRecord>> {
         self.local_registry
             .get_all_replica_version_records(self.registry_version)?
             .context("get_all_replica_version_records always returns Some (and it did not)")

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -125,7 +125,7 @@ pub fn get_elected_guestos_versions(topology: &TopologySnapshot) -> Vec<String> 
         .replica_version_records()
         .unwrap()
         .into_iter()
-        .map(|(k, _)| k)
+        .map(|v| v.replica_version_id)
         .collect()
 }
 

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -125,7 +125,7 @@ pub fn get_elected_guestos_versions(topology: &TopologySnapshot) -> Vec<String> 
         .replica_version_records()
         .unwrap()
         .into_iter()
-        .map(|(k, _)| k)
+        .map(|v| v.version_id)
         .collect()
 }
 


### PR DESCRIPTION
Now that the `version_id` is filled everywhere after https://github.com/dfinity/ic/pull/10942, make the field mandatory, so that we can simplify code.