### PR TITLE
feat(nns/root): Support upgrade options.

### DIFF
--- a/rs/nervous_system/integration_tests/tests/deploy_fresh_sns_test.rs
+++ b/rs/nervous_system/integration_tests/tests/deploy_fresh_sns_test.rs
@@ -9,7 +9,7 @@ use ic_nervous_system_integration_tests::{
         upgrade_nns_canister_to_tip_of_master_or_panic,
     },
 };
-use ic_nns_constants::{self, GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
+use ic_nns_constants::{self, GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use ic_nns_test_utils::sns_wasm::{
     build_archive_sns_wasm, build_index_ng_sns_wasm, build_ledger_sns_wasm,
 };
@@ -51,8 +51,8 @@ async fn test_deploy_fresh_sns() {
     }
 
     eprintln!("Step 1. Upgrade NNS Governance and SNS-W to the latest version ...");
+    upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, ROOT_CANISTER_ID).await;
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, GOVERNANCE_CANISTER_ID).await;
-
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;
 
     eprintln!("Test upgrading SNS Ledger via proposals. First, add all the WASMs to SNS-W ...");

--- a/rs/nervous_system/integration_tests/tests/deploy_fresh_sns_test.rs
+++ b/rs/nervous_system/integration_tests/tests/deploy_fresh_sns_test.rs
@@ -50,7 +50,10 @@ async fn test_deploy_fresh_sns() {
         .await;
     }
 
-    eprintln!("Step 1. Upgrade NNS Governance and SNS-W to the latest version ...");
+    // Two chunks of code prior, the production WASMs were installed into the
+    // NNS canisters. But what we want in this test is to exercise the latest
+    // NNS code. To achieve that end, we upgrade NNS here.
+    eprintln!("Step 1. Upgrade NNS to the latest version ...");
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, ROOT_CANISTER_ID).await;
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, GOVERNANCE_CANISTER_ID).await;
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;

--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -7,7 +7,7 @@ use ic_nervous_system_integration_tests::{
         add_wasm_via_nns_proposal, nns, sns, upgrade_nns_canister_to_tip_of_master_or_panic,
     },
 };
-use ic_nns_constants::{GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
+use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use ic_nns_test_utils::sns_wasm::{
     build_governance_sns_wasm, build_index_ng_sns_wasm, build_ledger_sns_wasm, build_root_sns_wasm,
     build_swap_sns_wasm, ensure_sns_wasm_gzipped,
@@ -37,7 +37,11 @@ use sns_upgrade_test_utils::test_sns_upgrade;
 #[tokio::test]
 async fn test_deployment_all_upgrades() {
     test_sns_deployment(
-        vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID],
+        vec![
+            ROOT_CANISTER_ID,
+            GOVERNANCE_CANISTER_ID,
+            SNS_WASM_CANISTER_ID,
+        ],
         vec![
             SnsCanisterType::Governance,
             SnsCanisterType::Ledger,
@@ -51,7 +55,15 @@ async fn test_deployment_all_upgrades() {
 
 #[tokio::test]
 async fn test_deployment_with_only_nns_upgrades() {
-    test_sns_deployment(vec![GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID], vec![]).await;
+    test_sns_deployment(
+        vec![
+            ROOT_CANISTER_ID,
+            GOVERNANCE_CANISTER_ID,
+            SNS_WASM_CANISTER_ID,
+        ],
+        vec![],
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_existing_sns_test.rs
@@ -11,7 +11,7 @@ use ic_nervous_system_integration_tests::{
         upgrade_nns_canister_to_tip_of_master_or_panic,
     },
 };
-use ic_nns_constants::{self, GOVERNANCE_CANISTER_ID, SNS_WASM_CANISTER_ID};
+use ic_nns_constants::{self, GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use ic_nns_test_utils::sns_wasm::{
     build_archive_sns_wasm, build_index_ng_sns_wasm, build_ledger_sns_wasm,
     create_modified_sns_wasm,
@@ -137,7 +137,8 @@ async fn test_upgrade_existing_sns() {
     )
     .await;
 
-    eprintln!("Step 3. Upgrade NNS Governance and SNS-W to the latest version ...");
+    eprintln!("Step 3. Upgrade NNS Root, Governance, and SNS-W to the latest version ...");
+    upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, ROOT_CANISTER_ID).await;
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, GOVERNANCE_CANISTER_ID).await;
     upgrade_nns_canister_to_tip_of_master_or_panic(&pocket_ic, SNS_WASM_CANISTER_ID).await;
 

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -18,8 +18,7 @@ use dfn_core::api::CanisterId;
 use dfn_core::println;
 use ic_crypto_sha2::Sha256;
 use ic_management_canister_types_private::{
-    CanisterInstallMode, CanisterInstallModeV2, ChunkHash, IC_00, InstallChunkedCodeArgs,
-    InstallCodeArgs,
+    CanisterInstallModeV2, ChunkHash, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
 };
 use ic_nervous_system_clients::canister_id_record::CanisterIdRecord;
 use ic_nervous_system_runtime::Runtime;
@@ -63,7 +62,7 @@ pub struct ChangeCanisterRequest {
     /// Using mode `Reinstall` on a stateful canister is very dangerous;
     /// however, this field is provided so that repairing a nervous system
     /// (e.g. NNS) is possible even under extreme circumstances.
-    pub mode: CanisterInstallMode,
+    pub mode: CanisterInstallModeV2,
 
     /// The id of the canister to change.
     pub canister_id: CanisterId,
@@ -116,7 +115,7 @@ impl std::fmt::Display for ChangeCanisterRequest {
 impl ChangeCanisterRequest {
     pub fn new(
         stop_before_installing: bool,
-        mode: CanisterInstallMode,
+        mode: CanisterInstallModeV2,
         canister_id: CanisterId,
     ) -> Self {
         Self {
@@ -153,7 +152,7 @@ impl ChangeCanisterRequest {
         self
     }
 
-    pub fn with_mode(mut self, mode: CanisterInstallMode) -> Self {
+    pub fn with_mode(mut self, mode: CanisterInstallModeV2) -> Self {
         self.mode = mode;
         self
     }
@@ -300,7 +299,6 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
             .into_iter()
             .map(|hash| ChunkHash { hash })
             .collect();
-        let mode = CanisterInstallModeV2::from(mode);
         let argument = InstallChunkedCodeArgs {
             mode,
             target_canister,
@@ -317,7 +315,7 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
         )
         .await
     } else {
-        let argument = InstallCodeArgs {
+        let argument = InstallCodeArgsV2 {
             mode,
             canister_id,
             wasm_module,

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -399,7 +399,7 @@ mod tests {
         let conflicting_request = ChangeCanisterRequest {
             stop_before_installing: false,
             canister_id,
-            mode: CanisterInstallMode::Install,
+            mode: CanisterInstallModeV2::Install,
             wasm_module: vec![1, 2, 3],
             chunked_canister_wasm: None,
             arg: vec![7, 8, 9],
@@ -417,7 +417,7 @@ mod tests {
         let new_request = ChangeCanisterRequest {
             stop_before_installing: true,
             canister_id,
-            mode: CanisterInstallMode::Upgrade,
+            mode: CanisterInstallModeV2::Upgrade(None),
             wasm_module: vec![10, 11, 12],
             chunked_canister_wasm: None,
             arg: vec![16, 17, 18],

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -373,7 +373,7 @@ mod tests {
             decoded_payload,
             ChangeCanisterRequest {
                 stop_before_installing: true,
-                mode: RootCanisterInstallMode::Upgrade,
+                mode: CanisterInstallModeV2::Upgrade(None),
                 canister_id: REGISTRY_CANISTER_ID,
                 wasm_module: vec![1, 2, 3],
                 arg: vec![4, 5, 6],
@@ -444,7 +444,7 @@ mod tests {
             decoded_payload,
             ChangeCanisterRequest {
                 stop_before_installing: false,
-                mode: RootCanisterInstallMode::Reinstall,
+                mode: CanisterInstallModeV2::Reinstall,
                 canister_id: SNS_WASM_CANISTER_ID,
                 wasm_module: vec![1, 2, 3],
                 arg: vec![],

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -12,7 +12,9 @@ use crate::{
 
 use candid::{CandidType, Deserialize, Encode};
 use ic_base_types::CanisterId;
-use ic_management_canister_types_private::CanisterInstallMode as RootCanisterInstallMode;
+use ic_management_canister_types_private::{
+    CanisterInstallMode as RootCanisterInstallMode, CanisterInstallModeV2,
+};
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_constants::{LIFELINE_CANISTER_ID, ROOT_CANISTER_ID};
 use serde::Serialize;
@@ -134,7 +136,7 @@ impl InstallCode {
 
         Encode!(&ChangeCanisterRequest {
             stop_before_installing,
-            mode,
+            mode: CanisterInstallModeV2::from(mode),
             canister_id,
             wasm_module,
             arg,

--- a/rs/nns/handlers/root/impl/canister/root.did
+++ b/rs/nns/handlers/root/impl/canister/root.did
@@ -18,8 +18,18 @@ type CanisterIdRecord = record {
 
 type CanisterInstallMode = variant {
   reinstall;
-  upgrade;
+  upgrade : opt CanisterUpgradeOptions;
   install;
+};
+
+type CanisterUpgradeOptions = record {
+  skip_pre_upgrade : opt bool;
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+};
+
+type WasmMemoryPersistence = variant {
+  keep;
+  replace;
 };
 
 type CanisterSettings = record {

--- a/rs/nns/handlers/root/impl/src/root_proposals.rs
+++ b/rs/nns/handlers/root/impl/src/root_proposals.rs
@@ -2,7 +2,7 @@
 use candid::{CandidType, Deserialize};
 use ic_base_types::{CanisterId, NodeId, PrincipalId, SubnetId};
 use ic_cdk::call;
-use ic_management_canister_types_private::CanisterInstallMode;
+use ic_management_canister_types_private::CanisterInstallModeV2;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::CanisterStatusResultFromManagementCanister,
@@ -186,7 +186,7 @@ pub async fn submit_root_proposal_to_upgrade_governance_canister(
     // - That it is an upgrade (reinstall is not supported).
     if request.wasm_module.is_empty()
         || request.canister_id != GOVERNANCE_CANISTER_ID
-        || request.mode != CanisterInstallMode::Upgrade
+        || !matches!(request.mode, CanisterInstallModeV2::Upgrade(_))
     {
         let message = format!(
             "{LOG_PREFIX}Invalid proposal. Proposal must be an upgrade proposal \

--- a/rs/nns/handlers/root/impl/tests/test.rs
+++ b/rs/nns/handlers/root/impl/tests/test.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use candid::Encode;
 use dfn_candid::candid;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_management_canister_types_private::CanisterInstallMode::Upgrade;
+use ic_management_canister_types_private::CanisterInstallModeV2::Upgrade;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord, canister_status::CanisterStatusResult,
 };
@@ -99,7 +99,7 @@ fn test_the_anonymous_user_cannot_change_an_nns_canister() {
             .unwrap();
 
         let change_canister_request =
-            ChangeCanisterRequest::new(false, Upgrade, universal.canister_id())
+            ChangeCanisterRequest::new(false, Upgrade(None), universal.canister_id())
                 .with_wasm(UNIVERSAL_CANISTER_WASM.to_vec());
 
         // The anonymous end-user tries to upgrade an NNS canister a subnet, bypassing
@@ -152,7 +152,7 @@ fn test_a_canister_other_than_the_governance_canister_cannot_change_an_nns_canis
             ic_nns_constants::GOVERNANCE_CANISTER_ID
         );
         let change_canister_request =
-            ChangeCanisterRequest::new(false, Upgrade, universal.canister_id())
+            ChangeCanisterRequest::new(false, Upgrade(None), universal.canister_id())
                 .with_wasm(UNIVERSAL_CANISTER_WASM.to_vec());
 
         assert!(

--- a/rs/nns/handlers/root/impl/tests/test_bad_wasm.rs
+++ b/rs/nns/handlers/root/impl/tests/test_bad_wasm.rs
@@ -3,7 +3,7 @@
 use candid::Encode;
 use canister_test::Runtime;
 use dfn_candid::candid;
-use ic_management_canister_types_private::CanisterInstallMode::{self, Reinstall, Upgrade};
+use ic_management_canister_types_private::CanisterInstallModeV2::{self, Reinstall, Upgrade};
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::{CanisterStatusResult, CanisterStatusType},
@@ -36,7 +36,7 @@ fn assert_is_running_universal_canister(status: &CanisterStatusResult) {
 /// unchanged, still running.
 async fn install_invalid_wasm(
     runtime: &'_ Runtime,
-    mode: CanisterInstallMode,
+    mode: CanisterInstallModeV2,
     stop_before_installing: bool,
 ) {
     let root = set_up_root_canister(runtime, RootCanisterInitPayloadBuilder::new().build()).await;
@@ -100,7 +100,7 @@ fn test_try_to_upgrade_to_invalid_does_nothing_reinstall_dont_stop() {
 #[test]
 fn test_try_to_upgrade_to_invalid_does_nothing_upgrade_dont_stop() {
     state_machine_test_on_nns_subnet(|runtime| async move {
-        install_invalid_wasm(&runtime, Upgrade, false).await;
+        install_invalid_wasm(&runtime, Upgrade(None), false).await;
         Ok(())
     });
 }
@@ -116,7 +116,7 @@ fn test_try_to_upgrade_to_invalid_does_nothing_reinstall_stop() {
 #[test]
 fn test_try_to_upgrade_to_invalid_does_nothing_upgrade_stop() {
     state_machine_test_on_nns_subnet(|runtime| async move {
-        install_invalid_wasm(&runtime, Upgrade, true).await;
+        install_invalid_wasm(&runtime, Upgrade(None), true).await;
         Ok(())
     });
 }

--- a/rs/nns/handlers/root/impl/tests/test_reinstall_and_upgrade.rs
+++ b/rs/nns/handlers/root/impl/tests/test_reinstall_and_upgrade.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use candid::Encode;
 use canister_test::{Project, Runtime};
 use dfn_candid::{candid, candid_one};
-use ic_management_canister_types_private::CanisterInstallMode::{
+use ic_management_canister_types_private::CanisterInstallModeV2::{
     self, Install, Reinstall, Upgrade,
 };
 use ic_nervous_system_clients::{
@@ -31,7 +31,7 @@ const MSG: &[u8] = b"Oh my, what a beautiful test";
 /// stable memory if it was an upgrade.
 async fn install_stable_memory_reader(
     runtime: &'_ Runtime,
-    mode: CanisterInstallMode,
+    mode: CanisterInstallModeV2,
     stop_before_installing: bool,
 ) {
     let root = set_up_root_canister(runtime, RootCanisterInitPayload {}).await;
@@ -98,7 +98,7 @@ async fn install_stable_memory_reader(
 
     match mode {
         Install => panic!("There should be a test for Install"),
-        Upgrade =>
+        Upgrade(_) =>
         // The stable memory should have ben preserved
         {
             assert_eq!(
@@ -122,7 +122,7 @@ async fn install_stable_memory_reader(
 #[test]
 fn test_upgrade_preserves_stable_memory_dont_stop() {
     state_machine_test_on_nns_subnet(|runtime| async move {
-        install_stable_memory_reader(&runtime, Upgrade, false).await;
+        install_stable_memory_reader(&runtime, Upgrade(None), false).await;
         Ok(())
     });
 }
@@ -130,7 +130,7 @@ fn test_upgrade_preserves_stable_memory_dont_stop() {
 #[test]
 fn test_upgrade_preserves_stable_memory_stop() {
     state_machine_test_on_nns_subnet(|runtime| async move {
-        install_stable_memory_reader(&runtime, Upgrade, true).await;
+        install_stable_memory_reader(&runtime, Upgrade(None), true).await;
         Ok(())
     });
 }
@@ -178,7 +178,7 @@ fn test_init_payload_is_passed_through_upgrades() {
             .unwrap();
 
         let change_canister_request =
-            ChangeCanisterRequest::new(false, Upgrade, universal.canister_id())
+            ChangeCanisterRequest::new(false, Upgrade(None), universal.canister_id())
                 .with_wasm(test_wasm)
                 .with_arg(test_byte_array.to_vec());
 

--- a/rs/nns/handlers/root/impl/tests/test_upgrade_proposals_canister.rs
+++ b/rs/nns/handlers/root/impl/tests/test_upgrade_proposals_canister.rs
@@ -1,6 +1,6 @@
 use candid::Encode;
 use dfn_candid::candid;
-use ic_management_canister_types_private::CanisterInstallMode::Upgrade;
+use ic_management_canister_types_private::CanisterInstallModeV2::Upgrade;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::{CanisterStatusResult, CanisterStatusType::Running},
@@ -62,7 +62,7 @@ fn test_upgrade_governance_canister() {
             .unwrap();
 
         let change_canister_request =
-            ChangeCanisterRequest::new(true, Upgrade, fake_governance_canister.canister_id())
+            ChangeCanisterRequest::new(true, Upgrade(None), fake_governance_canister.canister_id())
                 .with_wasm(STABLE_MEMORY_READER_WASM.clone());
 
         // The upgrade should work

--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -9,6 +9,10 @@ on the process that this file is part of, see
 
 ## Added
 
+* Support for upgrade options. We are mostly interested in
+  wasm_memory_persistence, since that is needed to upgrade modern Motoko
+  canisters that use Enhanced Orthogonal Persistence.
+
 ## Changed
 
 ## Deprecated

--- a/rs/nns/integration_tests/src/governance_upgrade.rs
+++ b/rs/nns/integration_tests/src/governance_upgrade.rs
@@ -9,7 +9,7 @@ use dfn_candid::candid_one;
 use ic_base_types::PrincipalId;
 use ic_canister_client_sender::Sender;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInstallMode, CanisterSettingsArgsBuilder,
+    CanisterIdRecord, CanisterInstallMode, CanisterInstallModeV2, CanisterSettingsArgsBuilder,
 };
 use ic_nervous_system_clients::canister_status::{CanisterStatusResult, CanisterStatusType};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
@@ -124,7 +124,7 @@ fn test_root_restarts_canister_during_upgrade_canister_with_stop_canister_timeou
 
     let proposal = ChangeCanisterRequest {
         stop_before_installing: true,
-        mode: CanisterInstallMode::Upgrade,
+        mode: CanisterInstallModeV2::Upgrade(None),
         canister_id: GOVERNANCE_CANISTER_ID,
         wasm_module,
         arg: vec![],

--- a/rs/nns/integration_tests/src/root_proposals.rs
+++ b/rs/nns/integration_tests/src/root_proposals.rs
@@ -1,7 +1,7 @@
 use canister_test::{Canister, Project};
 use ic_base_types::PrincipalId;
 use ic_canister_client_sender::Sender;
-use ic_management_canister_types_private::CanisterInstallMode;
+use ic_management_canister_types_private::CanisterInstallModeV2;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord, canister_status::CanisterStatusResult,
 };
@@ -89,12 +89,15 @@ fn test_upgrade_governance_through_root_proposal() {
         let proposer_pid = *TEST_USER1_PRINCIPAL;
 
         // Build and submit a root proposal
-        let change_canister_request =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                // Note that we upgrade the governance canister to the universal
-                // canister (effectively breaking governance). This is needed so
-                // that we can be sure that the upgrade actually went through.
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        // As long as this is not what Governance is currently running, if
+        // Governance ends up with this, then, we have demonstrated that
+        // upgrading (Governance) via "root proposals" works.
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
             &ic_crypto_sha2::Sha256::hash(ic_test_utilities::empty_wasm::EMPTY_WASM);
@@ -188,9 +191,12 @@ fn test_unauthorized_user_cant_submit_on_root_proposals() {
         let proposer = Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR);
 
         // Build and submit a root proposal
-        let change_canister_request =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters
             .root
@@ -227,9 +233,12 @@ fn test_cant_submit_root_proposal_with_wrong_sha() {
         let proposer = Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR);
 
         // Build and submit a root proposal
-        let change_canister_request =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
             &ic_crypto_sha2::Sha256::hash(ic_test_utilities::empty_wasm::EMPTY_WASM);
@@ -272,12 +281,12 @@ fn test_enough_no_votes_rejects_the_proposal() {
         let proposer_pid = *TEST_USER1_PRINCIPAL;
 
         // Build and submit a root proposal
-        let change_canister_request =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                // Note that we upgrade the governance canister to the universal
-                // canister (effectively breaking governance). This is needed so
-                // that we can be sure that the upgrade actually went through.
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
             &ic_crypto_sha2::Sha256::hash(ic_test_utilities::empty_wasm::EMPTY_WASM);
@@ -348,12 +357,12 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         let proposer1_pid = *TEST_USER1_PRINCIPAL;
 
         // Build and submit a root proposal
-        let change_canister_request1 =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                // Note that we upgrade the governance canister to the empty
-                // canister (effectively breaking governance). This is needed so
-                // that we can be sure that the upgrade actually went through.
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request1 = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
             &ic_crypto_sha2::Sha256::hash(ic_test_utilities::empty_wasm::EMPTY_WASM);
@@ -379,9 +388,12 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         let proposer2_pid = *TEST_USER2_PRINCIPAL;
 
         // Build and submit a second root proposal
-        let change_canister_request2 =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
+        let change_canister_request2 = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters
             .root

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -22,7 +22,7 @@ use ic_crypto_utils_threshold_sig_der::{
 };
 use ic_http_utils::file_downloader::{FileDownloader, check_file_hash};
 use ic_interfaces_registry::{RegistryClient, RegistryDataProvider};
-use ic_management_canister_types_private::CanisterInstallMode;
+use ic_management_canister_types_private::{CanisterInstallMode, CanisterInstallModeV2};
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord, canister_status::CanisterStatusResult,
 };
@@ -1491,7 +1491,7 @@ impl ProposalPayload<ChangeCanisterRequest> for ProposeToChangeNnsCanisterCmd {
         let arg = read_arg(&self.arg, &self.arg_sha256);
         ChangeCanisterRequest {
             stop_before_installing: !self.skip_stopping_before_installing,
-            mode: self.mode,
+            mode: CanisterInstallModeV2::from(self.mode),
             canister_id: self.canister_id,
             wasm_module,
             arg,
@@ -7394,9 +7394,12 @@ impl RootCanisterClient {
             &cmd.wasm_module_sha256,
         )
         .await;
-        let change_canister_request =
-            ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_wasm(wasm_module);
+        let change_canister_request = ChangeCanisterRequest::new(
+            true, // Stop before installing.
+            CanisterInstallModeV2::Upgrade(None),
+            GOVERNANCE_CANISTER_ID,
+        )
+        .with_wasm(wasm_module);
 
         let serialized = Encode!(&CanisterIdRecord::from(GOVERNANCE_CANISTER_ID)).unwrap();
         let response = self

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -97,6 +97,7 @@ use ic_canister_profiler::SpanStats;
 use ic_ledger_core::Tokens;
 use ic_management_canister_types_private::{
     CanisterChangeDetails, CanisterInfoRequest, CanisterInfoResponse, CanisterInstallMode,
+    CanisterInstallModeV2,
 };
 use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
@@ -2708,6 +2709,7 @@ impl Governance {
             // For more details, please refer to the comments above the (definition of the)
             // stop_before_installing field in ChangeCanisterRequest.
             let stop_before_installing = true;
+            let mode = CanisterInstallModeV2::from(mode);
 
             let mut change_canister_arg =
                 ChangeCanisterRequest::new(stop_before_installing, mode, canister_id)

--- a/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
+++ b/rs/sns/governance/src/governance/advance_target_sns_version_tests.rs
@@ -1059,9 +1059,13 @@ fn add_environment_mock_calls_for_initiate_upgrade(
                 root_canister_id,
                 "change_canister",
                 Encode!(
-                    &ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, canister_id)
-                        .with_wasm(vec![9, 8, 7, 6, 5, 4, 3, 2])
-                        .with_arg(Encode!().unwrap())
+                    &ChangeCanisterRequest::new(
+                        true, // Stop before installing.
+                        CanisterInstallModeV2::Upgrade(None),
+                        canister_id
+                    )
+                    .with_wasm(vec![9, 8, 7, 6, 5, 4, 3, 2])
+                    .with_arg(Encode!().unwrap())
                 )
                 .unwrap(),
                 // We don't actually look at the response from this call anywhere

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -1525,9 +1525,13 @@ fn setup_env_for_sns_upgrade_to_next_version_test(
                 root_canister_id,
                 "change_canister",
                 Encode!(
-                    &ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, canister_id)
-                        .with_wasm(vec![9, 8, 7, 6, 5, 4, 3, 2])
-                        .with_arg(Encode!().unwrap())
+                    &ChangeCanisterRequest::new(
+                        true, // Stop before installing.
+                        CanisterInstallModeV2::Upgrade(None),
+                        canister_id
+                    )
+                    .with_wasm(vec![9, 8, 7, 6, 5, 4, 3, 2])
+                    .with_arg(Encode!().unwrap())
                 )
                 .unwrap(),
                 // We don't actually look at the response from this call anywhere

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -3,7 +3,7 @@ use canister_test::Project;
 use dfn_candid::candid;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::Tokens;
-use ic_management_canister_types_private::CanisterInstallMode;
+use ic_management_canister_types_private::{CanisterInstallMode, CanisterInstallModeV2};
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::{CanisterStatusResult, CanisterStatusType},
@@ -315,7 +315,7 @@ fn test_root_restarts_governance_on_stop_canister_timeout() {
 
     let proposal = ChangeCanisterRequest {
         stop_before_installing: true,
-        mode: CanisterInstallMode::Upgrade,
+        mode: CanisterInstallModeV2::Upgrade(None),
         canister_id: GOVERNANCE_CANISTER_ID,
         wasm_module,
         arg: vec![],

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -9,8 +9,18 @@ type CanisterIdRecord = record {
 
 type CanisterInstallMode = variant {
   reinstall;
-  upgrade;
+  upgrade : opt CanisterUpgradeOptions;
   install;
+};
+
+type CanisterUpgradeOptions = record {
+  skip_pre_upgrade : opt bool;
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+};
+
+type WasmMemoryPersistence = variant {
+  keep;
+  replace;
 };
 
 type MemoryMetrics = record {

--- a/rs/sns/root/unreleased_changelog.md
+++ b/rs/sns/root/unreleased_changelog.md
@@ -11,6 +11,10 @@ on the process that this file is part of, see
 
 - Support for `snapshot_visibility` in `ManageDappCanisterSettingsRequest`.
 
+- Support for upgrade options. The one of greatest interest is
+  wasm_memory_persistence, which is needed for modern Motoko canisters that use
+  Enhanced Orthogonal Persistence.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Motivation

We want to support modern Motoko canisters that use [Enhanced Orthogonal Persistence][eop]. To upgrade such canisters, we have to use the `wasm_memory_persistence` option when upgrading such canisters.

[eop]: https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/orthogonal-persistence/enhanced/

# Future Work

Make NNS Proposals support this.

# References

[Next PR 👉][next]

[next]: https://github.com/dfinity/ic/pull/10979