### PR TITLE
fix(node-rewards): give each execution exactly one successor

### DIFF
--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -14,6 +14,12 @@ use std::collections::{BTreeMap, HashMap};
 
 pub type RetryCount = u64;
 
+/// How many failing subnets to name in the aggregated error log line. Failures
+/// are correlated (an unreachable subnet fails on every retry, and exhausted
+/// call capacity fails all of them at once), so naming a handful is enough to
+/// diagnose without emitting one line per subnet per retry forever.
+const MAX_LOGGED_FAILURES: usize = 5;
+
 #[async_trait]
 pub trait ManagementCanisterClient {
     async fn node_metrics_history(
@@ -103,7 +109,7 @@ where
         &self,
         subnets: Vec<SubnetId>,
     ) -> Result<NaiveDate, String> {
-        let mut success = true;
+        let mut failures: Vec<(SubnetId, String)> = Vec::new();
         let last_timestamp_per_subnet = self.last_timestamp_per_subnet(subnets.clone());
         let subnets_metrics = self.fetch_subnets_metrics(&last_timestamp_per_subnet).await;
         for (subnet_id, call_result) in subnets_metrics {
@@ -147,17 +153,31 @@ where
                     }
                 }
                 Err(e) => {
-                    success = false;
-                    ic_cdk::println!(
-                        "Error fetching metrics for subnet {}: ERROR: {}",
-                        subnet_id,
-                        e
-                    );
+                    failures.push((subnet_id, e.to_string()));
                 }
             }
         }
 
-        if success {
+        // One line per sync rather than one per failing subnet: a subnet that
+        // is unreachable fails on every retry, and when the canister runs out
+        // of call capacity every subnet fails at once, so per-subnet logging
+        // turns a single stuck subnet into millions of NNS log lines an hour.
+        if !failures.is_empty() {
+            let sample = failures
+                .iter()
+                .take(MAX_LOGGED_FAILURES)
+                .map(|(subnet_id, e)| format!("{subnet_id}: {e}"))
+                .join(", ");
+            ic_cdk::println!(
+                "Error fetching metrics for {} of {} subnets (showing up to {}): {}",
+                failures.len(),
+                last_timestamp_per_subnet.len(),
+                MAX_LOGGED_FAILURES,
+                sample,
+            );
+        }
+
+        if failures.is_empty() {
             let max_ts_update = self
                 .last_timestamp_per_subnet(subnets)
                 .into_values()

--- a/rs/node_rewards/canister/src/timer_tasks.rs
+++ b/rs/node_rewards/canister/src/timer_tasks.rs
@@ -11,8 +11,9 @@ use ic_nervous_system_common::ONE_DAY_SECONDS;
 use ic_nervous_system_timer_task::set_timer;
 use ic_node_rewards_canister_api::DateUtc;
 use ic_node_rewards_canister_api::providers_rewards::GetNodeProvidersRewardsRequest;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::future::Future;
+use std::rc::Rc;
 use std::thread::LocalKey;
 use std::time::Duration;
 
@@ -23,6 +24,47 @@ const SECS_PER_HOUR: u64 = 3600;
 const SYNC_OFFSET: u64 = 5 * 60; // 5 minutes in seconds
 
 const RETRY_FAILED_SYNC_SECS: u64 = 5 * 60; // 5 minutes in seconds
+
+/// How long after starting an execution the recovery timer presumes it trapped.
+///
+/// Should stay well above the longest a legitimate execution can take,
+/// including the timeouts of every call it awaits — the sync awaits calls that
+/// give up after the CDK's default 300s, so this is comfortably above that.
+/// Kept separate from [`RETRY_FAILED_SYNC_SECS`]: sharing one number left the
+/// deadline exactly equal to those call timeouts, so a single unresponsive
+/// callee was guaranteed to trip it.
+///
+/// Tripping it is no longer harmful — see [`RescheduleOnce`] — so this value
+/// only decides how eagerly a trapped execution is replaced, not whether the
+/// task can fork. That matters, because the registry-sync phase is a loop of
+/// sequential calls whose length is not bounded in code: no constant here can
+/// be *proven* to exceed the worst case.
+const RECOVERY_DELAY_SECS: u64 = 30 * 60; // 30 minutes in seconds
+
+/// Guards the two paths that can reschedule a task — normal completion and the
+/// recovery timer — so that an execution always has exactly one successor.
+/// Whichever path claims it first wins; the other stands down.
+///
+/// This is what keeps a slow execution from forking the chain. The recovery
+/// timer cannot distinguish "trapped" from "still awaiting responses", and with
+/// this it does not need to: it takes over the chain, and the execution it gave
+/// up on quietly declines to reschedule when it eventually finishes. Without
+/// it, an execution that outlived its recovery delay produced *two*
+/// successors, each of which forked again — enough forks and every call the
+/// canister makes fails to be enqueued.
+#[derive(Clone)]
+struct RescheduleOnce(Rc<Cell<bool>>);
+
+impl RescheduleOnce {
+    fn new() -> Self {
+        Self(Rc::new(Cell::new(false)))
+    }
+
+    /// Returns `true` for the first caller only.
+    fn claim(&self) -> bool {
+        !self.0.replace(true)
+    }
+}
 
 fn spawn_in_canister_env(future: impl Future<Output = ()> + Sized + 'static) {
     #[cfg(target_arch = "wasm32")]
@@ -46,24 +88,40 @@ pub trait RecurringAsyncTaskNonSend: Clone + Sized + 'static {
 
     fn schedule_with_delay(self, delay: Duration) {
         set_timer(delay, async move {
+            // Exactly one successor per execution, whichever path gets there
+            // first. See [`RescheduleOnce`].
+            let reschedule = RescheduleOnce::new();
+
             // Set a recovery timer before spawning the task. The timer callback
             // and the spawned future run in different IC messages, so if the
             // spawned future traps, the recovery timer survives and will reschedule the task.
             let recovery = self.clone();
             let recovery_delay = recovery.recovery_delay();
+            let recovery_reschedule = reschedule.clone();
             let recovery_timer_id = set_timer(recovery_delay, async move {
-                ic_cdk::println!(
-                    "Task {} recovery timer fired — rescheduling after suspected trap.",
-                    Self::NAME,
-                );
-                recovery.schedule_with_delay(recovery_delay);
+                if recovery_reschedule.claim() {
+                    ic_cdk::println!(
+                        "Task {} recovery timer fired — rescheduling after suspected trap.",
+                        Self::NAME,
+                    );
+                    recovery.schedule_with_delay(recovery_delay);
+                }
             });
 
             spawn_in_canister_env(async move {
                 let (new_delay, new_task) = self.execute().await;
 
                 clear_timer(recovery_timer_id);
-                new_task.schedule_with_delay(new_delay);
+                if reschedule.claim() {
+                    new_task.schedule_with_delay(new_delay);
+                } else {
+                    // The recovery timer already took over the chain; forking a
+                    // second one here is what multiplied concurrent syncs.
+                    ic_cdk::println!(
+                        "Task {} finished after its recovery timer rescheduled it; not scheduling a second successor.",
+                        Self::NAME,
+                    );
+                }
             });
         });
     }
@@ -139,7 +197,7 @@ impl RecurringAsyncTaskNonSend for HourlySyncTask {
     }
 
     fn recovery_delay(&self) -> Duration {
-        Duration::from_secs(RETRY_FAILED_SYNC_SECS)
+        Duration::from_secs(RECOVERY_DELAY_SECS)
     }
 
     const NAME: &'static str = "hourly_sync";
@@ -198,7 +256,7 @@ impl RecurringAsyncTaskNonSend for GetNodeProvidersRewardsInstructionsExporter {
         Duration::from_secs(0)
     }
     fn recovery_delay(&self) -> Duration {
-        Duration::from_secs(RETRY_FAILED_SYNC_SECS)
+        Duration::from_secs(RECOVERY_DELAY_SECS)
     }
     const NAME: &'static str = "get_node_providers_rewards_metrics";
 }
@@ -215,7 +273,7 @@ pub mod test_tasks {
     use super::*;
     use std::cell::Cell;
 
-    const RECOVERY_DELAY_SECS: u64 = 10;
+    const TEST_RECOVERY_DELAY_SECS: u64 = 10;
     const SUCCESS_TASK_DELAY_SECS: u64 = 5;
 
     thread_local! {
@@ -251,7 +309,7 @@ pub mod test_tasks {
         }
 
         fn recovery_delay(&self) -> Duration {
-            Duration::from_secs(RECOVERY_DELAY_SECS)
+            Duration::from_secs(TEST_RECOVERY_DELAY_SECS)
         }
 
         const NAME: &'static str = "panicking_recovery_task";
@@ -277,9 +335,44 @@ pub mod test_tasks {
         }
 
         fn recovery_delay(&self) -> Duration {
-            Duration::from_secs(RECOVERY_DELAY_SECS)
+            Duration::from_secs(TEST_RECOVERY_DELAY_SECS)
         }
 
         const NAME: &'static str = "success_recovery_task";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An execution and its recovery timer share one token, so exactly one of
+    /// them schedules the successor. Both scheduling means the chain forks, and
+    /// forks multiply until the canister runs out of call capacity.
+    #[test]
+    fn only_the_first_claimant_reschedules() {
+        let reschedule = RescheduleOnce::new();
+        let recovery = reschedule.clone();
+
+        assert!(
+            recovery.claim(),
+            "the recovery timer claims an unclaimed token"
+        );
+        assert!(
+            !reschedule.claim(),
+            "the execution must stand down once the recovery timer has taken over"
+        );
+        assert!(!recovery.claim(), "a token cannot be claimed twice");
+    }
+
+    /// The common case: the execution finishes first, so it reschedules and the
+    /// recovery timer does not, even if it somehow fires afterwards.
+    #[test]
+    fn execution_claims_before_recovery() {
+        let reschedule = RescheduleOnce::new();
+        let recovery = reschedule.clone();
+
+        assert!(reschedule.claim());
+        assert!(!recovery.claim());
     }
 }


### PR DESCRIPTION
## Problem

`RecurringAsyncTaskNonSend::schedule_with_delay` has two paths that reschedule the task:

- the recovery timer added in #9352 (SECFIND-2110), which reschedules if the execution appears to have trapped
- the normal completion path, which reschedules after `execute()` returns

Which of them runs is decided by a race, and `recovery_delay()` was wired to `RETRY_FAILED_SYNC_SECS` (300s) — exactly the CDK's default bounded-wait timeout for the calls the sync awaits (`ic-cdk/src/call.rs`: `timeout_seconds: Some(300)`).

So any callee that stopped responding guaranteed the collision: the call burned its full 300s, the recovery timer fired and rescheduled, and then the still-running execution finished and rescheduled as well. **One chain became two, and each fork forked again.**

## What it caused on mainnet, 2026-07-24/25

The SEV subnet `re2t4…` halted at an upgrade CUP (separate bug, `dre` PR dfinity/dre#2099). From then:

| time (UTC) | |
|---|---|
| 00:20 | first `recovery timer fired` — the 00:05 sync outlived its deadline |
| 01:00 → 03:00 | recovery firings per hour: 288 → 1,902 (doubling) |
| 02:15 | `call_perform` starts failing for **every** subnet |
| 03:00 → 10:42 | NNS finalization pinned at **0.15-0.25 blocks/s**, down from ~2.0 |

At peak, ~2,000 concurrent executions each fanned out ~37 calls against `CANISTER_GUARANTEED_CALLBACK_QUOTA = 50`, so almost every call was refused before leaving the canister, and the NNS logged ~2M lines/hour per replica.

The population is also **conserved** once saturated: each fast-failing run schedules exactly one successor, so the canister stayed wedged for three hours after `re2t4` recovered. Only a canister upgrade (which discards the heap-resident timer queue) cleared it.

## Fix

The invariant that matters is not "one execution at a time" but **each execution schedules at most one successor**. The two paths now share one token:

```rust
#[derive(Clone)]
struct RescheduleOnce(Rc<Cell<bool>>);

impl RescheduleOnce {
    fn claim(&self) -> bool { !self.0.replace(true) }   // true for the first caller only
}
```

Whichever path claims it first schedules the successor; the other stands down. The recovery timer therefore no longer needs to distinguish "trapped" from "still awaiting responses" — it takes over the chain, and the execution it gave up on declines to fork when it eventually finishes. **#9352's guarantee is unchanged**: a trapped execution is still rescheduled.

Alongside that:

- `RECOVERY_DELAY_SECS` split out from `RETRY_FAILED_SYNC_SECS` and set to **30 minutes**, so the supervision deadline is no longer equal to the timeout of the calls it supervises. Since tripping the deadline is no longer harmful, this value only decides how eagerly a trapped execution is replaced — worth noting that no constant here can be *proven* to exceed the worst case, because the registry-sync phase (`stable_canister_client.rs:203`) is a loop of sequential calls whose length is not bounded in code. The token is what carries correctness; the constant only reduces needless reschedules.
- Failures log **one aggregated line per sync** instead of one per subnet. Not part of the forking fix, but it is what turned this bug into ~2M log lines/hour per NNS replica (37 subnets x ~2000 chains x 12 retries/hour).

Call timeouts are left at the CDK's 300s default: with the token in place, a slow sync no longer forks, so shortening them would only trade a little latency for a little headroom.

## Tests

- Two unit tests on the token's claim semantics (either path may win; a token cannot be claimed twice).
- `recovery_timer_test.rs` is unchanged and still asserts a panicking task is rescheduled — the property #9352 added. **This is the test to watch in CI**; it could not be run locally (no pocket-ic binary).
- `cargo test -p ic-node-rewards-canister --lib`: 29 passed. Clippy clean with `--all-features`.

## Follow-up, not in this PR

The hand-rolled `RecurringAsyncTaskNonSend` exists because `MetricsManager` and `StableCanisterRegistryClient` are not `Send` (there's a TODO to that effect). In copying `ic_nervous_system_timer_task::RecurringAsyncTask` it dropped that crate's `record_start`/`record_finish` metrics — which count async tasks started but not finished. Had those been wired up, 2,000 in-flight syncs would have been visible on a dashboard instead of inferred from log volume. Worth adopting separately.
