### PR TITLE
chore: migrate to ic-cdk's new print, spawn and reply

### DIFF
--- a/rs/nervous_system/runtime/src/lib.rs
+++ b/rs/nervous_system/runtime/src/lib.rs
@@ -148,7 +148,7 @@ impl Runtime for CdkRuntime {
     }
 
     fn spawn_future<F: 'static + Future<Output = ()>>(future: F) {
-        ic_cdk::spawn(future);
+        ic_cdk::futures::spawn_017_compat(future);
     }
 
     fn canister_version() -> u64 {

--- a/rs/nervous_system/timer_task/src/lib.rs
+++ b/rs/nervous_system/timer_task/src/lib.rs
@@ -113,7 +113,6 @@
 //! }
 //! ```
 
-#![allow(deprecated)]
 
 mod metrics;
 
@@ -123,7 +122,7 @@ use async_trait::async_trait;
 #[cfg(not(target_arch = "wasm32"))]
 use futures::FutureExt;
 #[cfg(target_arch = "wasm32")]
-use ic_cdk::spawn;
+use ic_cdk::futures::spawn_017_compat;
 use ic_nervous_system_time_helpers::now_seconds;
 pub use ic_nervous_system_timers::{TimerId, set_timer, set_timer_interval};
 use metrics::{MetricsRegistryRef, with_async_metrics, with_sync_metrics};
@@ -137,7 +136,7 @@ use std::time::Duration;
 fn spawn_in_canister_env(future: impl Future<Output = ()> + Sized + 'static) {
     #[cfg(target_arch = "wasm32")]
     {
-        spawn(future);
+        spawn_017_compat(future);
     }
     // This is needed for tests
     #[cfg(not(target_arch = "wasm32"))]

--- a/rs/nervous_system/timer_task/src/lib.rs
+++ b/rs/nervous_system/timer_task/src/lib.rs
@@ -113,7 +113,6 @@
 //! }
 //! ```
 
-
 mod metrics;
 
 pub use metrics::MetricsRegistry as TimerTaskMetricsRegistry;

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -6,9 +6,8 @@ use environment::Environment;
 use exchange_rate_canister::{UpdateExchangeRateError, UpdateExchangeRateState};
 use ic_cdk::{
     api::{
-        call::{CallResult, ManualReply},
-        canister_cycle_balance, canister_self, certified_data_set, msg_cycles_accept,
-        msg_cycles_available,
+        call::CallResult, canister_cycle_balance, canister_self, certified_data_set,
+        msg_cycles_accept, msg_cycles_available, msg_reject, msg_reply,
     },
     heartbeat, init, post_upgrade, pre_upgrade, println, query, update,
 };
@@ -543,9 +542,11 @@ fn set_authorized_subnetwork_list(arg: SetAuthorizedSubnetworkListArgs) {
 #[update(manual_reply = true)]
 fn update_subnet_type(args: UpdateSubnetTypeArgs) {
     match do_update_subnet_type(args) {
-        Ok(response) => ManualReply::<()>::one(response),
-        Err(err) => ManualReply::reject(err.to_string()),
-    };
+        Ok(response) => {
+            msg_reply(candid::encode_one(response).expect("Failed to encode the reply."))
+        }
+        Err(err) => msg_reject(err.to_string()),
+    }
 }
 
 /// Updates the set of available subnet types.
@@ -614,9 +615,11 @@ fn remove_subnet_type(subnet_type: String) -> UpdateSubnetTypeResult {
 #[update(manual_reply = true)]
 fn change_subnet_type_assignment(args: ChangeSubnetTypeAssignmentArgs) {
     match do_change_subnet_type_assignment(args) {
-        Ok(response) => ManualReply::<()>::one(response),
-        Err(err) => ManualReply::reject(err.to_string()),
-    };
+        Ok(response) => {
+            msg_reply(candid::encode_one(response).expect("Failed to encode the reply."))
+        }
+        Err(err) => msg_reject(err.to_string()),
+    }
 }
 
 /// Changes the assignment of provided subnets to subnet types.

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -90,9 +90,9 @@ use disburse_maturity::initiate_maturity_disbursement;
 #[cfg(not(target_arch = "wasm32"))]
 use futures::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_cdk::println;
 #[cfg(target_arch = "wasm32")]
-use ic_cdk::spawn;
+use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::println;
 use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::{
@@ -1250,7 +1250,7 @@ impl TryFrom<SettleNeuronsFundParticipationRequest>
 fn spawn_in_canister_env(future: impl Future<Output = ()> + Sized + 'static) {
     #[cfg(target_arch = "wasm32")]
     {
-        spawn(future);
+        spawn_017_compat(future);
     }
     // This is needed for tests
     #[cfg(not(target_arch = "wasm32"))]

--- a/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
+++ b/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
@@ -28,7 +28,7 @@ async fn test_() {
 // #[update]
 // async fn test() {
 //     println!("Playground test was called");
-//     ic_cdk::spawn(async move {
+//     ic_cdk::futures::spawn_017_compat(async move {
 //         let _: () = ic_cdk::call(ic_cdk::api::id(), "test_2", ()).await.unwrap();
 //     });
 //     ic_cdk_timers::set_timer(Duration::from_millis(0), || {

--- a/rs/rust_canisters/ecdsa/src/main.rs
+++ b/rs/rust_canisters/ecdsa/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 use candid::{CandidType, Encode, candid_method};
-use ic_cdk::api::{call::call_raw, print};
+use ic_cdk::api::{call::call_raw, debug_print};
 use ic_cdk::update;
 use ic_management_canister_types_private::{
     DerivationPath, EcdsaCurve, EcdsaKeyId, IC_00, Method as Ic00Method, SignWithECDSAArgs,
@@ -26,7 +26,7 @@ impl Default for Options {
 #[candid_method(update)]
 #[update]
 async fn get_sig(options: Options) {
-    print(format!(
+    debug_print(format!(
         "calling get sig with key {} and derivation path {:?}",
         options.key_name, options.derivation_path,
     ));
@@ -51,7 +51,7 @@ async fn get_sig(options: Options) {
         1_000_000_000_000,
     )
     .await;
-    print(format!("got result {response:?}"));
+    debug_print(format!("got result {response:?}"));
 }
 
 // When run on native this prints the candid service definition of this

--- a/rs/rust_canisters/proxy_canister/src/main.rs
+++ b/rs/rust_canisters/proxy_canister/src/main.rs
@@ -5,7 +5,6 @@
 //! as a canister message to client if the call was successful and agreed by majority nodes,
 //! otherwise errors out.
 //!
-#![allow(deprecated)]
 use candid::Principal;
 use futures::future::join_all;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -13,7 +12,7 @@ use ic_cdk::api::{
     data_certificate, in_replicated_execution, msg_caller, msg_cycles_refunded, time,
 };
 use ic_cdk::call::{Call, CallFailed};
-use ic_cdk::spawn;
+use ic_cdk::futures::spawn_017_compat;
 use ic_cdk::{query, update};
 use ic_management_canister_types_private::{
     CanisterHttpResponsePayload, HttpHeader, Payload, TransformArgs,
@@ -108,7 +107,7 @@ pub async fn start_continuous_requests(
     // This request establishes the session to the target server.
     let _ = send_request(request.clone()).await;
 
-    spawn(async move {
+    spawn_017_compat(async move {
         run_continuous_request_loop(request).await;
     });
 

--- a/rs/tests/test_canisters/message/src/main.rs
+++ b/rs/tests/test_canisters/message/src/main.rs
@@ -1,7 +1,8 @@
 #![allow(deprecated)]
-use ic_cdk::api::call::ManualReply;
+use ic_cdk::api::{msg_reject, msg_reply};
 use ic_message::ForwardParams;
 use std::cell::RefCell;
+use std::marker::PhantomData;
 
 thread_local! {
     static MSG: RefCell<Option<String>> = const { RefCell::new(None) };
@@ -26,11 +27,13 @@ pub async fn forward(
         cycles,
         payload,
     }: ForwardParams,
-) -> ManualReply<Vec<u8>> {
+) -> PhantomData<Vec<u8>> {
     match ic_cdk::api::call::call_raw128(receiver, &method, &payload, cycles).await {
-        Ok(res) => ManualReply::one(res),
-        Err((_, err)) => ManualReply::reject(err),
+        Ok(res) => msg_reply(candid::encode_one(res).expect("Failed to encode the reply.")),
+        Err((_, err)) => msg_reject(err),
     }
+
+    PhantomData
 }
 
 #[ic_cdk::pre_upgrade]


### PR DESCRIPTION
This migrates to the new ic-cdk interfaces for `print` (`debug_print`) and `ManualReply` (`msg_reply` & friends). The `spawn` call sites are migrated to the `_017` compat (follows the pattern from elsewhere in the repo).