### PR TITLE
test: drop test failed_stable_memory_grow_cost_and_time_multiple_canisters

### DIFF
--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -2530,54 +2530,6 @@ fn no_critical_error_on_empty_data_segment() {
     );
 }
 
-#[test]
-fn failed_stable_memory_grow_cost_and_time_multiple_canisters() {
-    let num_wasm_pages = 116 * GIB / WASM_PAGE_SIZE_IN_BYTES;
-    let num_canisters = 128;
-
-    let env = StateMachineBuilder::new()
-        .with_subnet_type(SubnetType::Application)
-        .build();
-
-    let mut canister_ids = vec![];
-    for _ in 0..num_canisters {
-        let canister_id = create_universal_canister_with_cycles(&env, None, INITIAL_CYCLES_BALANCE);
-        canister_ids.push(canister_id);
-    }
-
-    let timer = std::time::Instant::now();
-    let mut total_initial_balance = 0;
-    let mut payload = ic_state_machine_tests::PayloadBuilder::new();
-    for canister_id in &canister_ids {
-        let balance = env.cycle_balance(*canister_id);
-        total_initial_balance += balance;
-        payload = payload.ingress(
-            PrincipalId::new_anonymous(),
-            *canister_id,
-            "update",
-            wasm()
-                .stable64_grow(num_wasm_pages)
-                .stable64_write(0, &[42])
-                .trap()
-                .build(),
-        );
-    }
-    env.execute_payload(payload);
-    let elapsed_ms = timer.elapsed().as_millis();
-    let mut total_balance = 0;
-    for canister_id in &canister_ids {
-        let balance = env.cycle_balance(*canister_id);
-        total_balance += balance;
-    }
-    let cycles_m = (total_initial_balance - total_balance) / 1000 / 1000;
-    assert_lt!(
-        elapsed_ms,
-        10_000,
-        "Test timed out after {elapsed_ms} ms and {cycles_m} M cycles"
-    );
-    assert_gt!(cycles_m, 800);
-}
-
 /// Verifies that canister liquid cycle balance can be used to transfer as many cycles as possible.
 #[test]
 fn test_canister_liquid_cycle_balance() {


### PR DESCRIPTION
Companion to #10968, which dropped the single-canister variant of this test. Both tests were added in #3932 and make a wall-clock time assertion (`elapsed_ms < 10_000`), which is fragile and flaky on CI: the assertion measures how long the test process happened to take rather than any property of the replica, so unrelated load on the CI machine fails it.