### PR TITLE
chore: enable bazel-test-all-rbe again but allow it to fail

### DIFF
--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -61,10 +61,8 @@ jobs:
   ci-rbe-evaluation:
     name: CI RBE Evaluation
     # for dfinity/ic: run on all events except for forked PRs
-    # NOTE: currently disabled due to the following error:
-    #
-    # > No available targets are compatible with triple “x86_64-unknown-linux5.10.0-gnu2.31.0”
-    if: false
+    if: |
+      github.repository == 'dfinity/ic' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/ci-rbe-evaluation.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-rbe-evaluation.yml
+++ b/.github/workflows/ci-rbe-evaluation.yml
@@ -168,6 +168,7 @@ jobs:
 
   bazel-test-all-rbe:
     name: Bazel Test All on RBE
+    continue-on-error: true
     needs: [config, infer-bazel-targets]
     runs-on: namespace-profile-rbe-driver-amd64-linux-16x32
     container:


### PR DESCRIPTION
Reverts https://github.com/dfinity/ic/commit/c7ae711733440409618605018bbc5785b946b65c such that the `bazel-test-all-rbe` job is enabled again but configures it as `continue-on-error: true` to not get red checkmarks and slack notifications when the job fails on `master`. 