### PR TITLE
fix(sns-wasm): rotate SNS deployments across all subnets instead of always picking the first one

### DIFF
--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -1628,14 +1628,19 @@ where
         Ok(canister_status_result.settings.controllers)
     }
 
-    /// Get an available subnet to create canisters on
+    /// Get an available subnet to create canisters on.
+    ///
+    /// Distributes deployments across all configured SNS subnets by rotating on
+    /// the number of SNSs already deployed, instead of always using the first
+    /// subnet.
     fn get_available_sns_subnet(&self) -> Result<SubnetId, String> {
-        // TODO We need a way to find "available" subnets based on SNS deployments (limiting numbers per Subnet)
-        if !self.sns_subnet_ids.is_empty() {
-            Ok(self.sns_subnet_ids[0])
-        } else {
-            Err("No SNS Subnet is available".to_string())
+        if self.sns_subnet_ids.is_empty() {
+            return Err("No SNS Subnet is available".to_string());
         }
+
+        let index = self.deployed_sns_list.len() % self.sns_subnet_ids.len();
+
+        Ok(self.sns_subnet_ids[index])
     }
 
     /// Given the SnsVersion of an SNS instance, returns the SnsVersion that this SNS instance
@@ -2457,6 +2462,66 @@ mod test {
 
         let response3 = canister.get_sns_subnet_ids();
         assert_eq!(response3.sns_subnet_ids, vec![principal2]);
+    }
+
+    // Appends `count` placeholder deployments so that `deployed_sns_list.len()`
+    // reflects the number of SNSs already deployed.
+    fn push_dummy_deployments(
+        canister: &mut SnsWasmCanister<TestCanisterStableMemory>,
+        count: u64,
+    ) {
+        for i in 0..count {
+            let base = 1_000 + i * 10;
+            canister.deployed_sns_list.push(DeployedSns {
+                root_canister_id: Some(CanisterId::from_u64(base).into()),
+                governance_canister_id: Some(CanisterId::from_u64(base + 1).into()),
+                ledger_canister_id: Some(CanisterId::from_u64(base + 2).into()),
+                swap_canister_id: Some(CanisterId::from_u64(base + 3).into()),
+                index_canister_id: Some(CanisterId::from_u64(base + 4).into()),
+            });
+        }
+    }
+
+    #[test]
+    fn test_get_available_sns_subnet_errors_when_no_subnets_configured() {
+        // Step 1: Prepare the world.
+        let canister = new_wasm_canister();
+
+        // Step 2: Run the code under test.
+        let result = canister.get_available_sns_subnet();
+
+        // Step 3: Verify result.
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+
+    #[test]
+    fn test_get_available_sns_subnet_returns_only_subnet() {
+        // Step 1: Prepare the world.
+        let mut canister = new_wasm_canister();
+        let only_subnet = subnet_test_id(1);
+        canister.set_sns_subnets(vec![only_subnet]);
+
+        // Step 2 & 3: With a single subnet, every deployment count maps to it.
+        for _ in 0..5 {
+            push_dummy_deployments(&mut canister, 1);
+            assert_eq!(canister.get_available_sns_subnet(), Ok(only_subnet));
+        }
+    }
+
+    #[test]
+    fn test_get_available_sns_subnet_rotates_across_subnets() {
+        // Step 1: Prepare the world.
+        let mut canister = new_wasm_canister();
+        let subnets = vec![subnet_test_id(1), subnet_test_id(2), subnet_test_id(3)];
+        canister.set_sns_subnets(subnets.clone());
+
+        // Step 2 & 3: Selection rotates by the number of deployments so far.
+        // deployed_sns_list lengths 0,1,2,3,4 -> subnets 0,1,2,0,1.
+        let expected_order = vec![subnets[0], subnets[1], subnets[2], subnets[0], subnets[1]];
+        for expected_subnet in expected_order {
+            assert_eq!(canister.get_available_sns_subnet(), Ok(expected_subnet));
+            push_dummy_deployments(&mut canister, 1);
+        }
     }
 
     #[test]

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -17,7 +17,8 @@ on the process that this file is part of, see
 
 ## Fixed
 
-* SNS deployments are now distributed across all configured subnets using
-  round-robin, instead of always deploying to the first subnet.
+* `get_available_sns_subnet` now rotates through all configured SNS subnets
+  (round-robin, based on the number of SNSs already deployed) instead of
+  always deploying new SNSes to the first subnet in `sns_subnet_ids`.
 
 ## Security

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -17,4 +17,7 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* SNS deployments are now distributed across all configured subnets using
+  round-robin, instead of always deploying to the first subnet.
+
 ## Security


### PR DESCRIPTION
## Bug

The `get_available_sns_subnet()` function always returned the first subnet in the list (`sns_subnet_ids[0]`). This means every SNS ever deployed goes to the same subnet, while all other configured subnets are never used.

## Fix

Use `deployed_sns_list.len() % sns_subnet_ids.len()` to rotate through all subnets in round-robin order. No schema change or data migration needed.

## Tests

Added 3 unit tests:
- Returns error when no subnets are configured
- Always returns the only subnet when there is just one
- Rotates correctly across multiple subnets