### PR TITLE
feat: migrate non-governance canisters to new ic_cdk call interface

### DIFF
--- a/packages/icrc-ledger-client-cdk/src/lib.rs
+++ b/packages/icrc-ledger-client-cdk/src/lib.rs
@@ -3,7 +3,23 @@ use candid::{
     Principal,
     utils::{ArgumentDecoder, ArgumentEncoder},
 };
+use ic_cdk::call::{Call, Error, RejectCode};
 pub use icrc_ledger_client::{ICRC1Client, Runtime};
+
+/// Translates a failed call into the `(reject code, message)` pair that
+/// [`Runtime`] reports to its callers.
+fn map_call_error(err: Error) -> (i32, String) {
+    match err {
+        Error::CallRejected(rejected) => (
+            rejected.raw_reject_code() as i32,
+            rejected.reject_message().to_string(),
+        ),
+        // A response that cannot be decoded means the callee misbehaved.
+        Error::CandidDecodeFailed(err) => (RejectCode::CanisterError as i32, err.to_string()),
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient as i32, err.to_string()),
+    }
+}
 
 /// ICRC1Client runtime that uses the ic-cdk.
 pub struct CdkRuntime;
@@ -20,9 +36,11 @@ impl Runtime for CdkRuntime {
         In: ArgumentEncoder + Send,
         Out: for<'a> ArgumentDecoder<'a>,
     {
-        #[allow(deprecated)]
-        ic_cdk::call(id, method, args)
+        Call::unbounded_wait(id, method)
+            .with_args(&args)
             .await
-            .map_err(|(code, msg)| (code as i32, msg))
+            .map_err(Error::from)
+            .and_then(|response| response.candid_tuple().map_err(Error::from))
+            .map_err(map_call_error)
     }
 }

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -1,9 +1,8 @@
-#![allow(deprecated)]
 use candid::{CandidType, Nat, Principal, define_function};
 use ic_cdk::api::{
     accept_message, canister_self, debug_print, instruction_counter, msg_arg_data, msg_reject,
 };
-use ic_cdk::call::Error as CallError;
+use ic_cdk::call::{Call, Error as CallError, RejectCode};
 use ic_cdk::management_canister::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, EcdsaPublicKeyResult, HttpMethod, HttpRequestArgs,
     HttpRequestResult, SignWithEcdsaArgs, SignWithEcdsaResult, TransformArgs, TransformContext,
@@ -189,13 +188,13 @@ async fn schnorr_public_key(
         key_id,
     };
 
-    let (res,): (SchnorrPublicKeyResponse,) = ic_cdk::call(
-        Principal::management_canister(),
-        "schnorr_public_key",
-        (request,),
-    )
-    .await
-    .map_err(|e| format!("schnorr_public_key failed {}", e.1))?;
+    let res: SchnorrPublicKeyResponse =
+        Call::unbounded_wait(Principal::management_canister(), "schnorr_public_key")
+            .with_arg(&request)
+            .await
+            .map_err(|err| format!("schnorr_public_key failed: {err}"))?
+            .candid()
+            .map_err(|err| format!("could not decode the schnorr_public_key reply: {err}"))?;
 
     Ok(res)
 }
@@ -219,14 +218,14 @@ async fn sign_with_schnorr(
         aux,
     };
 
-    let (reply,): (SignWithSchnorrResponse,) = ic_cdk::api::call::call_with_payment(
-        Principal::management_canister(),
-        "sign_with_schnorr",
-        (request,),
-        fee,
-    )
-    .await
-    .map_err(|e| format!("sign_with_schnorr failed {e:?}"))?;
+    let reply: SignWithSchnorrResponse =
+        Call::unbounded_wait(Principal::management_canister(), "sign_with_schnorr")
+            .with_arg(&request)
+            .with_cycles(fee)
+            .await
+            .map_err(|err| format!("sign_with_schnorr failed: {err}"))?
+            .candid()
+            .map_err(|err| format!("could not decode the sign_with_schnorr reply: {err}"))?;
 
     Ok(reply.signature)
 }
@@ -271,14 +270,15 @@ async fn sign_with_ecdsa(
             name,
         },
     };
-    let (res,): (SignWithEcdsaResult,) = ic_cdk::api::call::call_with_payment128(
-        Principal::management_canister(),
-        "sign_with_ecdsa",
-        (arg,),
-        fee,
-    )
-    .await
-    .map_err(|(code, msg)| format!("Reject code: {code:?}; Reject message: {msg}"))?;
+    let res: SignWithEcdsaResult =
+        Call::unbounded_wait(Principal::management_canister(), "sign_with_ecdsa")
+            .with_arg(&arg)
+            .with_cycles(fee)
+            .await
+            .map_err(|err| format!("sign_with_ecdsa failed: {err}"))?
+            .candid()
+            .map_err(|err| format!("could not decode the sign_with_ecdsa reply: {err}"))?;
+
     Ok(res.signature)
 }
 
@@ -337,13 +337,13 @@ async fn vetkd_public_key(
         },
     };
 
-    let (res,): (VetKdPublicKeyResponse,) = ic_cdk::call(
-        Principal::management_canister(),
-        "vetkd_public_key",
-        (request,),
-    )
-    .await
-    .map_err(|e| format!("vetkd_public_key failed {}", e.1))?;
+    let res: VetKdPublicKeyResponse =
+        Call::unbounded_wait(Principal::management_canister(), "vetkd_public_key")
+            .with_arg(&request)
+            .await
+            .map_err(|err| format!("vetkd_public_key failed: {err}"))?
+            .candid()
+            .map_err(|err| format!("could not decode the vetkd_public_key reply: {err}"))?;
 
     Ok(res.public_key)
 }
@@ -370,14 +370,14 @@ async fn vetkd_derive_key(
         transport_public_key,
     };
 
-    let (reply,): (VetKdDeriveKeyResponse,) = ic_cdk::api::call::call_with_payment(
-        Principal::management_canister(),
-        "vetkd_derive_key",
-        (request,),
-        fee,
-    )
-    .await
-    .map_err(|e| format!("vetkd_derive_key failed {e:?}"))?;
+    let reply: VetKdDeriveKeyResponse =
+        Call::unbounded_wait(Principal::management_canister(), "vetkd_derive_key")
+            .with_arg(&request)
+            .with_cycles(fee)
+            .await
+            .map_err(|err| format!("vetkd_derive_key failed: {err}"))?
+            .candid()
+            .map_err(|err| format!("could not decode the vetkd_derive_key reply: {err}"))?;
 
     Ok(reply.encrypted_key)
 }
@@ -438,17 +438,28 @@ async fn whoami() -> String {
 
 #[update]
 async fn whois(canister: Principal) -> String {
-    ic_cdk::call::<_, (String,)>(canister, "whoami", ((),))
+    Call::unbounded_wait(canister, "whoami")
+        .with_arg(())
         .await
         .unwrap()
-        .0
+        .candid()
+        .unwrap()
 }
 
 #[update]
 async fn call_and_get_rejection_code(canister: Principal) -> u32 {
-    match ic_cdk::call::<_, (String,)>(canister, "whoami", ((),)).await {
+    let result = Call::unbounded_wait(canister, "whoami")
+        .with_arg(())
+        .await
+        .map_err(CallError::from)
+        .and_then(|response| response.candid::<String>().map_err(CallError::from));
+
+    match result {
         Ok(_) => 0,
-        Err((code, _)) => code as u32,
+        Err(CallError::CallRejected(rejected)) => rejected.raw_reject_code(),
+        Err(CallError::CandidDecodeFailed(_)) => RejectCode::CanisterError as u32,
+        // The call never left this canister, so it may well succeed if retried.
+        Err(_) => RejectCode::SysTransient as u32,
     }
 }
 
@@ -459,10 +470,12 @@ async fn blob_len(blob: Vec<u8>) -> usize {
 
 #[update]
 async fn call_with_large_blob(canister: Principal, blob_len: usize) -> usize {
-    ic_cdk::call::<_, (usize,)>(canister, "blob_len", (vec![42_u8; blob_len],))
+    Call::unbounded_wait(canister, "blob_len")
+        .with_arg(vec![42_u8; blob_len])
         .await
         .unwrap()
-        .0
+        .candid()
+        .unwrap()
 }
 
 #[derive(CandidType, Deserialize)]
@@ -488,15 +501,15 @@ pub struct NodeMetricsHistoryArgs {
 async fn node_metrics_history_proxy(
     args: NodeMetricsHistoryArgs,
 ) -> Vec<NodeMetricsHistoryResponse> {
-    ic_cdk::api::call::call_with_payment128::<_, (Vec<NodeMetricsHistoryResponse>,)>(
+    Call::unbounded_wait(
         candid::Principal::management_canister(),
         "node_metrics_history",
-        (args,),
-        0_u128,
     )
+    .with_arg(&args)
     .await
     .unwrap()
-    .0
+    .candid()
+    .unwrap()
 }
 
 // executing many instructions
@@ -576,14 +589,13 @@ async fn deposit_cycles_to_cycles_ledger(beneficiary: Principal, cycles: u128) {
         },
         memo: None,
     };
-    ic_cdk::api::call::call_with_payment128::<_, (DepositResult,)>(
-        cycles_ledger_id,
-        "deposit",
-        (deposit_arg,),
-        cycles,
-    )
-    .await
-    .unwrap();
+    let _deposit_result: DepositResult = Call::unbounded_wait(cycles_ledger_id, "deposit")
+        .with_arg(&deposit_arg)
+        .with_cycles(cycles)
+        .await
+        .unwrap()
+        .candid()
+        .unwrap();
 }
 
 #[query]

--- a/rs/bitcoin/ckbtc/minter/canbench/results.yml
+++ b/rs/bitcoin/ckbtc/minter/canbench/results.yml
@@ -2,185 +2,185 @@ benches:
   build_estimate_retrieve_btc_fee_1_50k_sats:
     total:
       calls: 1
-      instructions: 255974
+      instructions: 255870
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4382
+        instructions: 4374
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250033
+        instructions: 250029
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_1_50k_sats:
     total:
       calls: 1
-      instructions: 258018
+      instructions: 257878
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255473
+        instructions: 255367
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4382
+        instructions: 4374
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250033
+        instructions: 250029
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_2_100k_sats:
     total:
       calls: 1
-      instructions: 258064
+      instructions: 257924
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255519
+        instructions: 255413
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4428
+        instructions: 4420
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250079
+        instructions: 250075
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_3_1m_sats:
     total:
       calls: 1
-      instructions: 258140
+      instructions: 257971
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255595
+        instructions: 255460
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 3065
+        instructions: 3032
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250155
+        instructions: 250122
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_4_10m_sats:
     total:
       calls: 1
-      instructions: 259103
+      instructions: 258963
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 256558
+        instructions: 256452
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4078
+        instructions: 4074
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 251118
+        instructions: 251114
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_5_1_btc:
     total:
       calls: 1
-      instructions: 259103
+      instructions: 258963
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 256558
+        instructions: 256452
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3263
+        instructions: 3159
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4078
+        instructions: 4074
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 251118
+        instructions: 251114
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_6_10_btc:
     total:
       calls: 1
-      instructions: 264479
+      instructions: 264334
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 261934
+        instructions: 261823
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3698
+        instructions: 3593
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 11848
+        instructions: 11840
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 256059
+        instructions: 256051
         heap_increase: 0
         stable_memory_increase: 0
 version: 0.6.0

--- a/rs/boundary_node/salt_sharing/canister/helpers.rs
+++ b/rs/boundary_node/salt_sharing/canister/helpers.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::{collections::HashSet, time::Duration};
 
 use crate::{
@@ -9,7 +8,8 @@ use crate::{
 };
 use candid::Principal;
 use ic_canister_log::log;
-use ic_cdk::{api::time, call};
+use ic_cdk::api::time;
+use ic_cdk::call::Call;
 use ic_cdk_timers::{set_timer, set_timer_interval};
 use ic_nns_constants::REGISTRY_CANISTER_ID;
 use salt_sharing_api::{
@@ -53,15 +53,11 @@ pub fn is_salt_init() -> bool {
 // Regenerate salt and store it in the stable memory
 // Can only fail, if the call to management canister fails.
 pub async fn try_regenerate_salt() -> Result<(), String> {
-    let (salt,): ([u8; SALT_SIZE],) =
-        ic_cdk::call(Principal::management_canister(), "raw_rand", ())
-            .await
-            .map_err(|err| {
-                format!(
-                    "Call to `raw_rand` of management canister failed: code={:?}, err={}",
-                    err.0, err.1
-                )
-            })?;
+    let salt: [u8; SALT_SIZE] = Call::unbounded_wait(Principal::management_canister(), "raw_rand")
+        .await
+        .map_err(|err| format!("Call to `raw_rand` of management canister failed: {err}"))?
+        .candid()
+        .map_err(|err| format!("Could not decode the `raw_rand` response: {err}"))?;
 
     let stored_salt = StorableSalt {
         salt: salt.to_vec(),
@@ -78,14 +74,18 @@ pub async fn try_regenerate_salt() -> Result<(), String> {
 pub async fn poll_api_boundary_nodes() {
     let canister_id = Principal::from(REGISTRY_CANISTER_ID);
 
-    let (call_status, message) = match call::<_, (Result<Vec<ApiBoundaryNodeIdRecord>, String>,)>(
-        canister_id,
-        REGISTRY_CANISTER_METHOD,
-        (&GetApiBoundaryNodeIdsRequest {},),
-    )
-    .await
-    {
-        Ok((Ok(api_bn_records),)) => {
+    let response = Call::unbounded_wait(canister_id, REGISTRY_CANISTER_METHOD)
+        .with_arg(GetApiBoundaryNodeIdsRequest {})
+        .await
+        .map_err(|err| err.to_string())
+        .and_then(|response| {
+            response
+                .candid::<Result<Vec<ApiBoundaryNodeIdRecord>, String>>()
+                .map_err(|err| err.to_string())
+        });
+
+    let (call_status, message) = match response {
+        Ok(Ok(api_bn_records)) => {
             // Set authorized readers of salt.
             let principals: HashSet<_> = api_bn_records.into_iter().filter_map(|n| n.id).collect();
             API_BOUNDARY_NODE_PRINCIPALS.with(|cell| *cell.borrow_mut() = principals);
@@ -98,7 +98,7 @@ pub async fn poll_api_boundary_nodes() {
             });
             ("success", "")
         }
-        Ok((Err(err),)) => {
+        Ok(Err(err)) => {
             log!(
                 P0,
                 "[poll_api_boundary_nodes]: failed to fetch nodes from registry {err:?}",

--- a/rs/nervous_system/timer_task/tests/test_canisters/timer_task_canister.rs
+++ b/rs/nervous_system/timer_task/tests/test_canisters/timer_task_canister.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use async_trait::async_trait;
 use ic_cdk::{api::canister_self, init, query};
 use ic_metrics_encoder::MetricsEncoder;
@@ -86,7 +85,7 @@ fn get_metrics() -> String {
 fn __self_call() {}
 
 async fn invoke_self_call() {
-    let () = ic_cdk::call(canister_self(), "__self_call", ())
+    ic_cdk::call::Call::unbounded_wait(canister_self(), "__self_call")
         .await
         .unwrap();
 }

--- a/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
+++ b/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
@@ -29,7 +29,7 @@ async fn test_() {
 // async fn test() {
 //     println!("Playground test was called");
 //     ic_cdk::futures::spawn_017_compat(async move {
-//         let _: () = ic_cdk::call(ic_cdk::api::id(), "test_2", ()).await.unwrap();
+//         ic_cdk::call::Call::unbounded_wait(ic_cdk::api::canister_self(), "test_2").await.unwrap();
 //     });
 //     ic_cdk_timers::set_timer(Duration::from_millis(0), || {
 //         println!("Timer call worked!");

--- a/rs/tests/test_canisters/message/src/main.rs
+++ b/rs/tests/test_canisters/message/src/main.rs
@@ -1,5 +1,5 @@
-#![allow(deprecated)]
 use ic_cdk::api::{msg_reject, msg_reply};
+use ic_cdk::call::Call;
 use ic_message::ForwardParams;
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -28,9 +28,15 @@ pub async fn forward(
         payload,
     }: ForwardParams,
 ) -> PhantomData<Vec<u8>> {
-    match ic_cdk::api::call::call_raw128(receiver, &method, &payload, cycles).await {
-        Ok(res) => msg_reply(candid::encode_one(res).expect("Failed to encode the reply.")),
-        Err((_, err)) => msg_reject(err),
+    match Call::unbounded_wait(receiver, &method)
+        .with_raw_args(&payload)
+        .with_cycles(cycles)
+        .await
+    {
+        Ok(response) => msg_reply(
+            candid::encode_one(response.into_bytes()).expect("Failed to encode the reply."),
+        ),
+        Err(err) => msg_reject(err.to_string()),
     }
 
     PhantomData


### PR DESCRIPTION
This migrates most canisters outside of the production NNS/governance canisters to the new ic-cdk cross-canister call interface introduced in 0.18. This tries to keep the old behavior wherever possible.