### PR TITLE
refactor(state_manager): stop checking the legacy canister log index on checkpoint load

### DIFF
--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -881,15 +881,6 @@ pub fn load_canister_state(
         metrics,
     );
 
-    let lms_next_idx = system_state.log_memory_store.next_idx();
-    let log_next_idx = system_state.canister_log.next_idx();
-    if lms_next_idx != log_next_idx {
-        metrics.observe_broken_soft_invariant(format!(
-            "canister {canister_id}: log_memory_store.next_idx ({lms_next_idx}) \
-             != canister_log.next_idx ({log_next_idx})",
-        ));
-    }
-
     let canister_state = CanisterState {
         system_state,
         execution_state,


### PR DESCRIPTION
`load_canister_state` compared `log_memory_store.next_idx()` against the `canister_log.next_idx()` decoded from `next_canister_log_record_idx`, and reported a `state_manager_checkpoint_soft_invariant_broken` critical error on mismatch.

That check is what makes dropping the legacy `canister_log` fields from `CanisterStateBits` a downgrade-breaking change: a replica that no longer writes `next_canister_log_record_idx` produces checkpoints on which every older replica reports one critical error per canister that has ever logged.

Removing the check here first means that once this version is on mainnet, the legacy fields can be dropped from the checkpoint without tripping the downgrade path.

The log memory store is authoritative for `fetch_canister_logs` and the delta log index is seeded from `log_memory_store.next_idx()`, so nothing on the read path depends on the legacy index; after this change it is only written, in `tip.rs`, for backward compatibility.