### PR TITLE
fix: adapt II init args to new mainnet candid

### DIFF
--- a/rs/pocket_ic_server/src/external_canister_types.rs
+++ b/rs/pocket_ic_server/src/external_canister_types.rs
@@ -186,4 +186,6 @@ pub struct InternetIdentityInit {
     pub enable_dnssec_email_recovery: Option<bool>,
     pub dnssec_config: Option<Option<DnssecConfig>>,
     pub doh_config: Option<Option<DohConfig>>,
+    pub mcp_official_url: Option<Option<String>>,
+    pub mcp_config_migration: Option<bool>,
 }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2102,6 +2102,7 @@ impl PocketIcSubnets {
             //       };
             //       sso_credential_migration = null;
             //       is_production = opt true;
+            //       mcp_config_migration = null;
             //       backend_canister_id = opt principal "rdmx6-jaaaa-aaaaa-aaadq-cai";
             //       enable_dapps_explorer = opt false;
             //       assigned_user_number_range = opt record {
@@ -2191,6 +2192,7 @@ impl PocketIcSubnets {
             //         max_unsolved_captchas = 500 : nat64;
             //         captcha_trigger = variant { Static = variant { CaptchaDisabled } };
             //       };
+            //       mcp_official_url = opt opt "https://mcp.internetcomputer.org/mcp";
             //       dummy_auth = opt null;
             //       sso_allow_insecure_discovery = null;
             //       register_rate_limit = opt record {
@@ -2249,6 +2251,8 @@ impl PocketIcSubnets {
                 enable_dnssec_email_recovery: None, // DIFFERENT FROM ICP MAINNET
                 dnssec_config: None,                // DIFFERENT FROM ICP MAINNET
                 doh_config: None,                   // DIFFERENT FROM ICP MAINNET
+                mcp_official_url: None,             // DIFFERENT FROM ICP MAINNET
+                mcp_config_migration: None,
             });
             ii_subnet
                 .state_machine


### PR DESCRIPTION
The latest mainnet Internet Identity backend (`release-2026-07-31`) added two init fields, `mcp_official_url : opt opt text` and `mcp_config_migration : opt bool`, breaking the strict candid equality check in `//rs/pocket_ic_server:external_types_tests`.

Add both fields to `InternetIdentityInit` and the PocketIC II installation. Mainnet returns `mcp_config_migration = null`, so `None` matches mainnet; `mcp_official_url` is left as `None` because PocketIC ships no official MCP connector. Also refresh the mainnet-config reference comment from a fresh `dfx canister call
rdmx6-jaaaa-aaaaa-aaadq-cai config --ic`.