### PR TITLE
feat: bump ic-wasm and drop syn 3

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "feb8067e63073c430e7775025ee4ae3c2dba8c0253491bdbffbdcca3d938923c",
+  "checksum": "7715396b0cb71a6d82b810c1643994794f30ce0ebab5f668467709f25216961e",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -95685,6 +95685,7 @@
     "dyn-clone 1.0.20",
     "ed25519-dalek 2.2.0",
     "educe 0.5.11",
+    "enum-ordinalize-derive 4.4.1",
     "erased-serde 0.3.28",
     "escargot 0.5.7",
     "ethers-core 2.0.8",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1849,7 +1849,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -3401,7 +3401,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -11015,7 +11015,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -13613,7 +13613,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -20925,7 +20925,7 @@
               "target": "ic_vetkeys"
             },
             {
-              "id": "ic-wasm 0.10.0",
+              "id": "ic-wasm 0.11.1",
               "target": "ic_wasm"
             },
             {
@@ -21599,7 +21599,7 @@
               "target": "textplots"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -21871,6 +21871,10 @@
             {
               "id": "educe 0.5.11",
               "target": "educe"
+            },
+            {
+              "id": "enum-ordinalize-derive 4.4.1",
+              "target": "enum_ordinalize_derive"
             },
             {
               "id": "indoc 1.0.9",
@@ -23669,7 +23673,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "enum-ordinalize-derive 4.4.2",
+              "id": "enum-ordinalize-derive 4.4.1",
               "target": "enum_ordinalize_derive"
             }
           ],
@@ -23683,14 +23687,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "enum-ordinalize-derive 4.4.2": {
+    "enum-ordinalize-derive 4.4.1": {
       "name": "enum-ordinalize-derive",
-      "version": "4.4.2",
+      "version": "4.4.1",
       "package_url": "https://github.com/magiclen/enum-ordinalize",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/enum-ordinalize-derive/4.4.2/download",
-          "sha256": "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+          "url": "https://static.crates.io/crates/enum-ordinalize-derive/4.4.1/download",
+          "sha256": "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
         }
       },
       "targets": [
@@ -23712,6 +23716,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -23723,14 +23733,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 3.0.2",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2024",
-        "version": "4.4.2"
+        "version": "4.4.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -25252,7 +25262,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -29631,7 +29641,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -29710,7 +29720,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -31025,7 +31035,7 @@
               "target": "rustls_pki_types"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -31163,7 +31173,7 @@
               "target": "rustls_pki_types"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -31297,7 +31307,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -33387,7 +33397,7 @@
               "target": "stop_token"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -33731,7 +33741,7 @@
               "target": "tempfile"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -33989,7 +33999,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -34087,7 +34097,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -34233,7 +34243,7 @@
               "target": "slotmap"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -34313,7 +34323,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -34598,7 +34608,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -34957,7 +34967,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -35107,7 +35117,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -35364,7 +35374,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -35667,7 +35677,7 @@
               "target": "simple_asn1"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -36357,7 +36367,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -36459,7 +36469,7 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -36709,14 +36719,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-wasm 0.10.0": {
+    "ic-wasm 0.11.1": {
       "name": "ic-wasm",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "package_url": "https://github.com/dfinity/ic-wasm",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-wasm/0.10.0/download",
-          "sha256": "44ab14c3676c8881fc1a8bad7a2c19cc6f7511584008f777c12cd42a70f380ab"
+          "url": "https://static.crates.io/crates/ic-wasm/0.11.1/download",
+          "sha256": "62beb934ad93d6cab235018e6b2ad15c72a54cd2148885f7b83dc8f5362806b7"
         }
       },
       "targets": [
@@ -36796,7 +36806,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -36811,7 +36821,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.10.0"
+        "version": "0.11.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -39372,7 +39382,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -40584,7 +40594,7 @@
               "target": "simd_cesu8"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -45841,7 +45851,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -51703,7 +51713,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -51793,7 +51803,7 @@
               "target": "prost"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -52198,7 +52208,7 @@
               "target": "rand"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -55921,7 +55931,7 @@
               "target": "tempfile"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -57858,7 +57868,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -59653,7 +59663,7 @@
               "target": "rustls"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -59778,7 +59788,7 @@
               "target": "slab"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -61547,7 +61557,7 @@
               "target": "libredox"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -63318,7 +63328,7 @@
               "target": "tempfile"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -66055,7 +66065,7 @@
               "target": "serde_json"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -69512,7 +69522,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -72974,7 +72984,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -74999,73 +75009,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "syn 3.0.2": {
-      "name": "syn",
-      "version": "3.0.2",
-      "package_url": "https://github.com/dtolnay/syn",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/syn/3.0.2/download",
-          "sha256": "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "syn",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "syn",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "parsing",
-            "printing",
-            "proc-macro"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "unicode-ident 1.0.22",
-              "target": "unicode_ident"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "3.0.2"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "sync_wrapper 0.1.2": {
       "name": "sync_wrapper",
       "version": "0.1.2",
@@ -76402,7 +76345,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -77230,14 +77173,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror 2.0.19": {
+    "thiserror 2.0.18": {
       "name": "thiserror",
-      "version": "2.0.19",
+      "version": "2.0.18",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/2.0.19/download",
-          "sha256": "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+          "url": "https://static.crates.io/crates/thiserror/2.0.18/download",
+          "sha256": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
         }
       },
       "targets": [
@@ -77281,7 +77224,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "build_script_build"
             }
           ],
@@ -77291,13 +77234,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 2.0.19",
+              "id": "thiserror-impl 2.0.18",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "2.0.19"
+        "version": "2.0.18"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -77373,14 +77316,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 2.0.19": {
+    "thiserror-impl 2.0.18": {
       "name": "thiserror-impl",
-      "version": "2.0.19",
+      "version": "2.0.18",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/2.0.19/download",
-          "sha256": "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+          "url": "https://static.crates.io/crates/thiserror-impl/2.0.18/download",
+          "sha256": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
         }
       },
       "targets": [
@@ -77413,14 +77356,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 3.0.2",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.19"
+        "version": "2.0.18"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -81210,7 +81153,7 @@
               "target": "pin_project"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -82644,7 +82587,7 @@
               "target": "sha1"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -82734,7 +82677,7 @@
               "target": "sha1"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             }
           ],
@@ -87496,7 +87439,7 @@
               "target": "target_lexicon"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -94045,7 +93988,7 @@
               "target": "rusticata_macros"
             },
             {
-              "id": "thiserror 2.0.19",
+              "id": "thiserror 2.0.18",
               "target": "thiserror"
             },
             {
@@ -95348,7 +95291,7 @@
   },
   "binary_crates": [
     "ic-gateway 0.2.0",
-    "ic-wasm 0.10.0",
+    "ic-wasm 0.11.1",
     "metrics-proxy 0.1.0"
   ],
   "workspace_members": {
@@ -95807,7 +95750,7 @@
     "ic-utils 0.49.1",
     "ic-verify-bls-signature 0.6.0",
     "ic-vetkeys 0.7.0",
-    "ic-wasm 0.10.0",
+    "ic-wasm 0.11.1",
     "ic-xrc-types 1.2.0",
     "ic0 1.1.0",
     "ic_bls12_381 0.10.1",
@@ -95983,7 +95926,7 @@
     "tempfile 3.23.0",
     "test-strategy 0.3.1",
     "textplots 0.8.4",
-    "thiserror 2.0.19",
+    "thiserror 2.0.18",
     "thousands 0.2.0",
     "threadpool 1.8.1",
     "tikv-jemalloc-ctl 0.7.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "dyn-clone",
  "ed25519-dalek",
  "educe",
+ "enum-ordinalize-derive",
  "erased-serde",
  "escargot",
  "ethers-core",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -331,7 +331,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -585,7 +585,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1856,7 +1856,7 @@ dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.15.2",
  "once_cell",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -2273,7 +2273,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3710,7 +3710,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "textplots",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "thousands",
  "threadpool",
  "tikv-jemalloc-ctl",
@@ -4074,13 +4074,13 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4334,7 +4334,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -5034,7 +5034,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36fca164ea873ea6d164c3b9e6bc59a70e172d28a57b8513528ed4f5ec127c9f"
 dependencies = [
  "paste",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5273,7 +5273,7 @@ dependencies = [
  "rand 0.10.1",
  "rustls 0.23.27",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tinyvec",
  "tokio",
@@ -5300,7 +5300,7 @@ dependencies = [
  "rand 0.10.1",
  "ring 0.17.14",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tinyvec",
  "tracing",
@@ -5329,7 +5329,7 @@ dependencies = [
  "rustls 0.23.27",
  "smallvec",
  "system-configuration 0.7.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.0",
  "tracing",
@@ -5712,7 +5712,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.9",
  "stop-token",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower-service",
@@ -5790,7 +5790,7 @@ dependencies = [
  "systemstat",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.0",
@@ -5842,7 +5842,7 @@ dependencies = [
  "ic-cdk 0.19.0",
  "ic-error-types",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5860,7 +5860,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5892,7 +5892,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "slotmap",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5908,7 +5908,7 @@ dependencies = [
  "ic0",
  "pin-project-lite",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5959,7 +5959,7 @@ dependencies = [
  "ic-management-canister-types 0.7.1",
  "serde",
  "serde_bytes",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6025,7 +6025,7 @@ dependencies = [
  "derive-new",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6053,7 +6053,7 @@ dependencies = [
  "ic_principal",
  "pem",
  "rand 0.8.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -6108,7 +6108,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "time",
@@ -6171,7 +6171,7 @@ dependencies = [
  "pkcs11",
  "sha2 0.10.9",
  "simple_asn1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6301,7 +6301,7 @@ dependencies = [
  "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6322,7 +6322,7 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -6373,9 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ab14c3676c8881fc1a8bad7a2c19cc6f7511584008f777c12cd42a70f380ab"
+checksum = "62beb934ad93d6cab235018e6b2ad15c72a54cd2148885f7b83dc8f5362806b7"
 dependencies = [
  "anyhow",
  "candid",
@@ -6386,7 +6386,7 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walrus",
  "wasmparser 0.253.0",
 ]
@@ -6843,7 +6843,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -7042,7 +7042,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -7841,7 +7841,7 @@ dependencies = [
  "log",
  "memchr",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8747,7 +8747,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -8762,7 +8762,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk 0.32.1",
  "prost",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-types",
@@ -8838,7 +8838,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9462,7 +9462,7 @@ dependencies = [
  "spin 0.10.1",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9749,7 +9749,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "procfs 0.17.0",
  "protobuf 3.7.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10049,7 +10049,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.27",
  "socket2 0.6.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -10071,7 +10071,7 @@ dependencies = [
  "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -10362,7 +10362,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.10",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10625,7 +10625,7 @@ dependencies = [
  "nix 0.30.1",
  "regex",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11033,7 +11033,7 @@ dependencies = [
  "rcgen 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "webpki-roots 1.0.6",
  "x509-parser 0.16.0",
 ]
@@ -11599,7 +11599,7 @@ dependencies = [
  "futures",
  "percent-encoding",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12183,7 +12183,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "percent-encoding",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -12520,17 +12520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12738,7 +12727,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -12877,11 +12866,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12897,13 +12886,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13541,7 +13530,7 @@ dependencies = [
  "governor",
  "http 1.3.1",
  "pin-project",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tonic",
  "tower 0.5.2",
  "tracing",
@@ -13807,7 +13796,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -13824,7 +13813,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -14596,7 +14585,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -15498,7 +15487,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -606,7 +606,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -865,7 +865,7 @@ dependencies = [
  "sev",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ dependencies = [
  "rexpect",
  "rust-ini",
  "ssh2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1806,7 +1806,7 @@ dependencies = [
  "ahash 0.8.12",
  "hashbrown 0.15.5",
  "once_cell",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -2309,7 +2309,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2494,7 +2494,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum 0.26.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -3814,7 +3814,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -4193,13 +4193,13 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -5177,7 +5177,7 @@ dependencies = [
  "regex",
  "strum 0.26.3",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5259,7 +5259,7 @@ dependencies = [
  "rustls 0.23.37",
  "sev",
  "sev_guest",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -5339,7 +5339,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "systemd",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5427,7 +5427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36fca164ea873ea6d164c3b9e6bc59a70e172d28a57b8513528ed4f5ec127c9f"
 dependencies = [
  "paste",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5643,7 +5643,7 @@ dependencies = [
  "rand 0.10.1",
  "rustls 0.23.37",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tinyvec",
  "tokio",
@@ -5670,7 +5670,7 @@ dependencies = [
  "rand 0.10.1",
  "ring",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tinyvec",
  "tracing",
@@ -5699,7 +5699,7 @@ dependencies = [
  "rustls 0.23.37",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tracing",
@@ -6229,7 +6229,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.9",
  "stop-token",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower-service",
@@ -6265,7 +6265,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.6",
  "slog",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -6499,7 +6499,7 @@ dependencies = [
  "systemstat",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.4",
@@ -6586,7 +6586,7 @@ dependencies = [
  "simple_moving_average",
  "strum 0.26.3",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -6704,7 +6704,7 @@ dependencies = [
  "slog-async",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-socks",
  "tonic",
@@ -6812,7 +6812,7 @@ dependencies = [
  "proptest",
  "prost",
  "slog",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6943,7 +6943,7 @@ dependencies = [
  "ic-cdk 0.19.0",
  "ic-error-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7028,7 +7028,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7089,7 +7089,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scoped_threadpool",
  "test-strategy 0.4.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7131,7 +7131,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "slotmap",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7147,7 +7147,7 @@ dependencies = [
  "ic0",
  "pin-project-lite",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7198,7 +7198,7 @@ dependencies = [
  "ic-management-canister-types 0.7.1",
  "serde",
  "serde_bytes",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7499,7 +7499,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "thousands",
  "time",
  "tokio",
@@ -7989,7 +7989,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -8267,7 +8267,7 @@ dependencies = [
  "stubborn-io",
  "tarpc",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-serde",
@@ -8502,7 +8502,7 @@ dependencies = [
  "serde_cbor",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -8844,7 +8844,7 @@ version = "0.9.0"
 dependencies = [
  "ic-types",
  "mockall",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8917,7 +8917,7 @@ dependencies = [
  "maplit",
  "rustls 0.23.37",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "x509-parser 0.18.1",
 ]
 
@@ -8950,7 +8950,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "test-strategy 0.4.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8963,7 +8963,7 @@ dependencies = [
  "proptest",
  "rand 0.8.6",
  "test-strategy 0.4.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9022,7 +9022,7 @@ dependencies = [
  "pem",
  "simple_asn1",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9030,7 +9030,7 @@ name = "ic-crypto-utils-tls"
 version = "0.9.0"
 dependencies = [
  "ic-base-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "x509-parser 0.18.1",
 ]
 
@@ -9070,7 +9070,7 @@ dependencies = [
  "derive-new",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9179,7 +9179,7 @@ dependencies = [
  "pem",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "wycheproof",
  "zeroize",
 ]
@@ -9197,7 +9197,7 @@ dependencies = [
  "ic_principal",
  "pem",
  "rand 0.8.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -9486,7 +9486,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "time",
@@ -9802,7 +9802,7 @@ dependencies = [
  "slog",
  "socks5-impl",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
  "tonic",
@@ -10166,7 +10166,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "test-strategy 0.4.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10374,7 +10374,7 @@ dependencies = [
  "pkcs11",
  "sha2 0.10.9",
  "simple_asn1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10453,7 +10453,7 @@ dependencies = [
  "serde",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tower",
 ]
 
@@ -10462,7 +10462,7 @@ name = "ic-interfaces-adapter-client"
 version = "0.9.0"
 dependencies = [
  "strum_macros 0.26.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10518,7 +10518,7 @@ dependencies = [
  "ic-crypto-tree-hash",
  "ic-types",
  "phantom_newtype",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11095,7 +11095,7 @@ dependencies = [
  "serde_cbor",
  "sns-treasury-manager",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -12447,7 +12447,7 @@ dependencies = [
  "pprof",
  "prost",
  "regex",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -12494,7 +12494,7 @@ dependencies = [
  "serde_json",
  "slog",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
  "x509-cert",
@@ -12613,7 +12613,7 @@ dependencies = [
  "slog",
  "socket2 0.5.10",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-metrics",
  "tokio-util",
@@ -12707,7 +12707,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -12724,7 +12724,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-utils 0.9.0",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12801,7 +12801,7 @@ dependencies = [
  "ic-registry-subnet-features",
  "ic-types",
  "serde_cbor",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12863,7 +12863,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-test-utilities-registry",
  "ic-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -12952,7 +12952,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-sys",
  "ic-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13624,7 +13624,7 @@ dependencies = [
  "serde",
  "serde_json",
  "textplots",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -13670,7 +13670,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -13756,7 +13756,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
 ]
@@ -14160,7 +14160,7 @@ dependencies = [
  "serde",
  "slog",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -14452,7 +14452,7 @@ dependencies = [
  "prost",
  "rand 0.8.6",
  "slog",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-metrics",
  "tokio-util",
@@ -14537,7 +14537,7 @@ dependencies = [
  "prost",
  "rand 0.8.6",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "wsl",
 ]
@@ -14647,7 +14647,7 @@ dependencies = [
  "slog-term",
  "ssh2",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -15176,7 +15176,7 @@ dependencies = [
  "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -15228,7 +15228,7 @@ dependencies = [
  "serde_with",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "thousands",
 ]
 
@@ -15297,7 +15297,7 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -15369,7 +15369,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "simple_asn1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -15496,9 +15496,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ab14c3676c8881fc1a8bad7a2c19cc6f7511584008f777c12cd42a70f380ab"
+checksum = "62beb934ad93d6cab235018e6b2ad15c72a54cd2148885f7b83dc8f5362806b7"
 dependencies = [
  "anyhow",
  "candid",
@@ -15506,7 +15506,7 @@ dependencies = [
  "libflate",
  "rustc-demangle",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walrus",
  "wasmparser 0.253.0",
 ]
@@ -15594,7 +15594,7 @@ dependencies = [
  "slog",
  "tempfile",
  "test-strategy 0.4.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -16523,7 +16523,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -16756,7 +16756,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -17624,7 +17624,7 @@ dependencies = [
  "log",
  "memchr",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -18795,7 +18795,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -18810,7 +18810,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-types",
@@ -18842,7 +18842,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -19534,7 +19534,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -19776,7 +19776,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -19993,7 +19993,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -20272,7 +20272,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "socket2 0.6.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -20294,7 +20294,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -20561,7 +20561,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "strum 0.26.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -20671,7 +20671,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -21074,7 +21074,7 @@ dependencies = [
  "nix 0.30.1",
  "regex",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -21576,7 +21576,7 @@ dependencies = [
  "rcgen 0.13.2",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "webpki-roots 1.0.6",
  "x509-parser 0.16.0",
 ]
@@ -22186,7 +22186,7 @@ dependencies = [
  "futures",
  "percent-encoding",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -22610,7 +22610,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -22899,7 +22899,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "percent-encoding",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -23242,17 +23242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync-with-released-nervous-system-wasms"
 version = "0.9.0"
 dependencies = [
@@ -23424,7 +23413,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -23585,11 +23574,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -23605,13 +23594,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -24199,7 +24188,7 @@ dependencies = [
  "governor",
  "http 1.4.0",
  "pin-project",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tonic",
  "tower",
  "tracing",
@@ -24224,7 +24213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -24422,7 +24411,7 @@ dependencies = [
  "log",
  "rand 0.9.3",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -24439,7 +24428,7 @@ dependencies = [
  "log",
  "rand 0.9.3",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -25262,7 +25251,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -26047,7 +26036,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -915,7 +915,9 @@ systemd = "0.10"
 tar = "0.4.39"
 tempfile = "3.20"
 textplots = "^0.8"
-thiserror = "2.0.18"
+# DO NOT upgrade to >=2.0.19 as it pulls in syn 3 whereas the rest of the
+# codebase uses syn 2.
+thiserror = "=2.0.18"
 thousands = "^0.2.0"
 threadpool = "1.8.1"
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
@@ -987,4 +989,4 @@ zstd = "0.13.2"
 [workspace.dependencies.ic-wasm]
 default-features = false
 features = ["exe"]
-version = "^0.10.0"
+version = "^0.11.1"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -426,6 +426,15 @@ crate.spec(
     package = "educe",
     version = "^0.5",
 )
+
+# Not used directly; spec'd only to constrain the version resolved for `educe`'s
+# transitive `enum-ordinalize` -> `enum-ordinalize-derive` chain.
+# DO NOT upgrade to >=4.4.2 as it pulls in syn 3 whereas the rest of the
+# codebase uses syn 2.
+crate.spec(
+    package = "enum-ordinalize-derive",
+    version = "=4.4.1",
+)
 crate.spec(
     package = "erased-serde",
     version = "^0.3.11",
@@ -817,7 +826,9 @@ crate.spec(
         "exe",
     ],
     package = "ic-wasm",
-    version = "^0.10.0",
+    # 0.11.1 relaxed the `thiserror` requirement to "2"; anything older forces
+    # thiserror >=2.0.19, which pulls in syn 3. See the `thiserror` spec below.
+    version = "^0.11.1",
 )
 crate.spec(
     package = "ic-xrc-types",
@@ -1720,9 +1731,12 @@ crate.spec(
     package = "tui-textarea",
     version = "^0.7",
 )
+
+# DO NOT upgrade to >=2.0.19 as it pulls in syn 3 whereas the rest of the
+# codebase uses syn 2.
 crate.spec(
     package = "thiserror",
-    version = "^2.0.18",
+    version = "=2.0.18",
 )
 crate.spec(
     package = "thousands",


### PR DESCRIPTION
This bumps to ic-wasm 0.11.1 which relaxes the bounds on `syn`, which (with some more pinning gymnastics) allows us to drop the recently released syn v3 crate. We already depend on syn v1 & v2, and we'll update everything to v3 later.