### PR TITLE
feat: add engine-controller-canister to GH artifacts

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -62,6 +62,7 @@ jobs:
           CANISTERS=(
             "canister-creator-canister.wasm"
             "cycles-minting-canister.wasm"
+            "engine-controller-canister.wasm"
             "genesis-token-canister.wasm"
             "governance-canister.wasm"
             "governance-canister_test.wasm"


### PR DESCRIPTION
This adds the `engine-controller-canister` to the list of artifacts uploaded to GitHub releases:
https://github.com/dfinity/ic/releases/tag/release-2026-07-31_04-23-reverts-deterministic-tracker