### PR TITLE
feat: bump paramiko

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ mypy
 nested_lookup>=0.2.25
 node_semver>=0.9.0
 packaging>=21.3
-paramiko>=2.11.0
+paramiko>=5.0.0
 parse>=1.19.0
 pyjwt>=2.13.0
 pynacl>=1.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -472,6 +472,7 @@ invoke==2.2.0 \
     # via
     #   -r requirements.in
     #   fabric
+    #   paramiko
 jira==3.10.5 \
     --hash=sha256:2d09ae3bf4741a2787dd889dfea5926a5d509aac3b28ab3b98c098709e6ee72d \
     --hash=sha256:d4da1385c924ee693d6cc9838e56a34e31d74f0d6899934ef35bbd0d2d33997f
@@ -671,9 +672,9 @@ pandas==2.3.3 \
     --hash=sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c \
     --hash=sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee
     # via -r requirements.in
-paramiko==3.5.1 \
-    --hash=sha256:43b9a0501fc2b5e70680388d9346cf252cfb7d00b0667c39e80eb43a408b8f61 \
-    --hash=sha256:b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822
+paramiko==5.0.0 \
+    --hash=sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79 \
+    --hash=sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c
     # via
     #   -r requirements.in
     #   fabric


### PR DESCRIPTION
In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm.

https://github.com/advisories/GHSA-r374-rxx8-8654