### PR TITLE
fix: use correct error messages in tecdsa test asserts

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
@@ -72,7 +72,7 @@ fn test(env: TestEnv) {
             let expected_reject = RejectResponse {
                 reject_code: RejectCode::CanisterReject,
                 reject_message: format!(
-                    "{} request sent with {} cycles, but {} cycles are required.",
+                    "call rejected: 4 - {} request sent with {} cycles, but {} cycles are required.",
                     method_name,
                     scale_cycles(ECDSA_SIGNATURE_FEE) - Cycles::from(1_u64),
                     scale_cycles(ECDSA_SIGNATURE_FEE),

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
@@ -128,7 +128,7 @@ fn test(env: TestEnv) {
             let expected_reject = RejectResponse {
                 reject_code: RejectCode::CanisterReject,
                 reject_message: format!(
-                    "Unable to route management canister request {method_name}: \
+                    "call rejected: 3 - Unable to route management canister request {method_name}: \
                         ChainKeyError(\"Requested unknown threshold key: {key_id}, existing keys: {initial_key_ids_as_string}\")",
                 ),
                 error_code: Some("IC0406".to_string()),
@@ -150,7 +150,7 @@ fn test(env: TestEnv) {
             let expected_reject = RejectResponse {
                 reject_code: RejectCode::CanisterReject,
                 reject_message: format!(
-                    "Unable to route management canister request {method_name}: \
+                    "call rejected: 3 - Unable to route management canister request {method_name}: \
                         ChainKeyError(\"Requested unknown or disabled threshold key: {key_id}, \
                         existing enabled keys: {initial_key_ids_as_string}\")",
                 ),
@@ -256,7 +256,7 @@ fn test(env: TestEnv) {
                     let expected_reject = RejectResponse {
                         reject_code: RejectCode::CanisterReject,
                         reject_message: format!(
-                            "Unable to route management canister request {method_name}: \
+                            "call rejected: 3 - Unable to route management canister request {method_name}: \
                                 ChainKeyError(\"Requested unknown or disabled threshold key: {key_id}, \
                                 existing enabled keys: []\")",
                         ),

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_timeout_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_timeout_test.rs
@@ -65,7 +65,7 @@ fn test(env: TestEnv) {
             .unwrap_err();
             let expected_reject = RejectResponse {
                 reject_code: RejectCode::CanisterReject,
-                reject_message: "Chain key request expired".to_string(),
+                reject_message: "call rejected: 2 - Chain key request expired".to_string(),
                 error_code: Some("IC0406".to_string()),
             };
             match error {


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/10995 caused the error messages returned by the IC to change slightly, and some `long_test`s (which do not run on PRs) started failing.