### PR TITLE
refactor: Restrict which CompoundCycles specializations can be consumed directly

### DIFF
--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -17,9 +17,9 @@ use ic_types::{
 };
 use ic_types_cycles::{
     CanisterCreation, CanisterCyclesCostSchedule, CompoundCycles, Cycles,
-    CyclesAccountManagerSubnetConfig, CyclesUseCase, CyclesUseCaseKind, DeletedCanisters,
-    ECDSAOutcalls, HTTPOutcalls, IngressInduction, Instructions, Memory,
-    RequestAndResponseTransmission, SchnorrOutcalls, VetKd,
+    CyclesAccountManagerSubnetConfig, CyclesUseCase, CyclesUseCaseKind,
+    CyclesUseCaseNonRefundableKind, DeletedCanisters, ECDSAOutcalls, HTTPOutcalls,
+    IngressInduction, Instructions, Memory, RequestAndResponseTransmission, SchnorrOutcalls, VetKd,
 };
 use prometheus::IntCounter;
 use serde::{Deserialize, Serialize};
@@ -356,11 +356,38 @@ impl CyclesAccountManager {
     ///       For withdrawals where cycles are not consumed, such as the case
     ///       for inter-canister transfers, use `withdraw_cycles_for_transfer`.
     ///
+    /// Only non-refundable use cases can be consumed this way: refundable ones
+    /// are prepaid and must go through the dedicated methods that pair the
+    /// prepayment with its refund (e.g. `prepay_execution_cycles` or
+    /// `consume_cycles_for_final_instructions`).
+    ///
     /// # Errors
     ///
     /// Returns a `CanisterOutOfCyclesError` if the
     /// requested amount is greater than the currently available.
-    pub fn consume_cycles<T: CyclesUseCaseKind>(
+    pub fn consume_cycles<T: CyclesUseCaseNonRefundableKind>(
+        &self,
+        system_state: &mut SystemState,
+        canister_current_memory_usage: NumBytes,
+        canister_current_message_memory_usage: MessageMemoryUsage,
+        cycles: CompoundCycles<T>,
+        subnet_cycles_config: CyclesAccountManagerSubnetConfig,
+        reveal_top_up: bool,
+    ) -> Result<(), CanisterOutOfCyclesError> {
+        self.consume_cycles_impl(
+            system_state,
+            canister_current_memory_usage,
+            canister_current_message_memory_usage,
+            cycles,
+            subnet_cycles_config,
+            reveal_top_up,
+        )
+    }
+
+    /// Same as `consume_cycles` but without the restriction to non-refundable
+    /// use cases, so that this crate can also consume prepayments for
+    /// refundable use cases.
+    fn consume_cycles_impl<T: CyclesUseCaseKind>(
         &self,
         system_state: &mut SystemState,
         canister_current_memory_usage: NumBytes,
@@ -378,7 +405,7 @@ impl CyclesAccountManager {
             subnet_cycles_config,
             system_state.reserved_balance(),
         );
-        self.consume_with_threshold(system_state, cycles, threshold, reveal_top_up)
+        self.consume_with_threshold_impl(system_state, cycles, threshold, reveal_top_up)
     }
 
     /// Consumes a direct, final `Instructions` charge (e.g. the cost of
@@ -398,7 +425,7 @@ impl CyclesAccountManager {
         subnet_cycles_config: CyclesAccountManagerSubnetConfig,
         reveal_top_up: bool,
     ) -> Result<(), CanisterOutOfCyclesError> {
-        self.consume_cycles(
+        self.consume_cycles_impl(
             system_state,
             canister_current_memory_usage,
             canister_current_message_memory_usage,
@@ -457,7 +484,7 @@ impl CyclesAccountManager {
         execution_mode: WasmExecutionMode,
     ) -> Result<CompoundCycles<Instructions>, CanisterOutOfCyclesError> {
         let cost = self.execution_cost(num_instructions, subnet_cycles_config, execution_mode);
-        self.consume_with_threshold(
+        self.consume_with_threshold_impl(
             system_state,
             cost,
             self.freeze_threshold_cycles(
@@ -916,7 +943,25 @@ impl CyclesAccountManager {
 
     /// Subtracts and consumes the cycles. This call should be used when the
     /// cycles are not being sent somewhere else.
-    pub fn consume_with_threshold<T: CyclesUseCaseKind>(
+    ///
+    /// Only non-refundable use cases can be consumed this way: refundable ones
+    /// are prepaid and must go through the dedicated methods that pair the
+    /// prepayment with its refund (e.g. `prepay_execution_cycles` or
+    /// `consume_cycles_for_final_instructions`).
+    pub fn consume_with_threshold<T: CyclesUseCaseNonRefundableKind>(
+        &self,
+        system_state: &mut SystemState,
+        cycles: CompoundCycles<T>,
+        threshold: Cycles,
+        reveal_top_up: bool,
+    ) -> Result<(), CanisterOutOfCyclesError> {
+        self.consume_with_threshold_impl(system_state, cycles, threshold, reveal_top_up)
+    }
+
+    /// Same as `consume_with_threshold` but without the restriction to
+    /// non-refundable use cases, so that this crate can also consume
+    /// prepayments for refundable use cases.
+    fn consume_with_threshold_impl<T: CyclesUseCaseKind>(
         &self,
         system_state: &mut SystemState,
         cycles: CompoundCycles<T>,
@@ -1148,7 +1193,7 @@ impl CyclesAccountManager {
         )
     }
 
-    fn charge_canister_for_single_resource<T: CyclesUseCaseKind>(
+    fn charge_canister_for_single_resource<T: CyclesUseCaseNonRefundableKind>(
         &self,
         rate: CompoundCycles<T>,
         log: &ReplicaLogger,

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -357,9 +357,8 @@ impl CyclesAccountManager {
     ///       for inter-canister transfers, use `withdraw_cycles_for_transfer`.
     ///
     /// Only non-refundable use cases can be consumed this way: refundable ones
-    /// are prepaid and must go through the dedicated methods that pair the
-    /// prepayment with its refund (e.g. `prepay_execution_cycles` or
-    /// `consume_cycles_for_final_instructions`).
+    /// are prepaid and must go through a dedicated method (e.g.
+    /// `prepay_execution_cycles` or `consume_cycles_for_final_instructions`).
     ///
     /// # Errors
     ///
@@ -945,9 +944,8 @@ impl CyclesAccountManager {
     /// cycles are not being sent somewhere else.
     ///
     /// Only non-refundable use cases can be consumed this way: refundable ones
-    /// are prepaid and must go through the dedicated methods that pair the
-    /// prepayment with its refund (e.g. `prepay_execution_cycles` or
-    /// `consume_cycles_for_final_instructions`).
+    /// are prepaid and must go through a dedicated method (e.g.
+    /// `prepay_execution_cycles` or `consume_cycles_for_final_instructions`).
     pub fn consume_with_threshold<T: CyclesUseCaseNonRefundableKind>(
         &self,
         system_state: &mut SystemState,

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -1233,29 +1233,61 @@ fn consume_cycles_for_uninstall_drains_reserved_balance() {
 #[test]
 fn consume_cycles_for_execution_does_not_drain_reserved_balance() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let cam = CyclesAccountManagerBuilder::new()
         .with_subnet_type(SubnetType::Application)
         .build();
+    let reserved = Cycles::new(10_000_000);
+    let main = Cycles::new(30_000_000);
     let mut system_state = SystemStateBuilder::new()
         .initial_cycles(Cycles::zero())
         .build();
-    system_state.add_cycles(Cycles::new(4_000_000));
-    system_state.reserve_cycles(Cycles::new(1_000_000)).unwrap();
-    cam.consume_cycles_for_final_instructions(
+    system_state.add_cycles(main + reserved);
+    system_state.reserve_cycles(reserved).unwrap();
+
+    let n_max = NumInstructions::from(1_000_000);
+    let n_refund = NumInstructions::from(600_000);
+
+    // Prepaying the execution cost only draws from the main balance.
+    let prepaid = cam
+        .prepay_execution_cycles(
+            &mut system_state,
+            NumBytes::from(0),
+            MessageMemoryUsage::ZERO,
+            ComputeAllocation::default(),
+            n_max,
+            subnet_cycles_config,
+            false,
+            WASM_EXECUTION_MODE,
+        )
+        .unwrap();
+    assert_ne!(prepaid.real(), Cycles::zero());
+    assert_eq!(system_state.reserved_balance(), reserved);
+    assert_eq!(system_state.balance(), main - prepaid.real());
+
+    // Refunding the unused instructions returns the cycles to the main balance,
+    // again leaving the reserved balance untouched.
+    let no_op_counter = IntCounter::new("no_op", "no_op").unwrap();
+    cam.refund_unused_execution_cycles(
         &mut system_state,
-        NumBytes::from(0),
-        MessageMemoryUsage::ZERO,
-        CompoundCycles::<Instructions>::new(Cycles::new(2_000_000), cost_schedule),
-        CyclesAccountManagerSubnetConfig::new(
-            SMALL_APP_SUBNET_MAX_SIZE,
-            cost_schedule,
-            DEFAULT_REFERENCE_SUBNET_SIZE,
-        ),
-        false,
-    )
-    .unwrap();
-    assert_eq!(system_state.reserved_balance(), Cycles::new(1_000_000));
-    assert_eq!(system_state.balance(), Cycles::new(1_000_000));
+        n_refund,
+        n_max,
+        prepaid,
+        &no_op_counter,
+        subnet_cycles_config,
+        WASM_EXECUTION_MODE,
+        &no_op_logger(),
+    );
+    let refund = cam
+        .variable_execution_cost(n_refund, subnet_cycles_config, WASM_EXECUTION_MODE)
+        .real();
+    assert_ne!(refund, Cycles::zero());
+    assert_eq!(system_state.reserved_balance(), reserved);
+    assert_eq!(system_state.balance(), main - prepaid.real() + refund);
 }
 
 #[test]

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -872,7 +872,7 @@ fn cycles_withdraw_for_execution() {
         CompoundCycles::<Instructions>::new(Cycles::from(initial_amount / 2), cost_schedule);
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -885,7 +885,7 @@ fn cycles_withdraw_for_execution() {
     assert_eq!(system_state.balance(), initial_cycles - amount.real());
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -915,7 +915,7 @@ fn cycles_withdraw_for_execution() {
     );
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -948,7 +948,7 @@ fn cycles_withdraw_for_execution() {
     // no more cycles can be withdrawn, the rest is reserved for storage
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -960,7 +960,7 @@ fn cycles_withdraw_for_execution() {
     );
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -972,7 +972,7 @@ fn cycles_withdraw_for_execution() {
     );
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -984,7 +984,7 @@ fn cycles_withdraw_for_execution() {
     );
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -1038,7 +1038,7 @@ fn do_not_withdraw_cycles_for_execution_free_schedule() {
         CompoundCycles::<Instructions>::new(Cycles::from(initial_amount / 2), cost_schedule);
     assert!(
         cycles_account_manager
-            .consume_cycles(
+            .consume_cycles_for_final_instructions(
                 &mut system_state,
                 memory_usage,
                 message_memory_usage,
@@ -1241,10 +1241,16 @@ fn consume_cycles_for_execution_does_not_drain_reserved_balance() {
         .build();
     system_state.add_cycles(Cycles::new(4_000_000));
     system_state.reserve_cycles(Cycles::new(1_000_000)).unwrap();
-    cam.consume_with_threshold(
+    cam.consume_cycles_for_final_instructions(
         &mut system_state,
+        NumBytes::from(0),
+        MessageMemoryUsage::ZERO,
         CompoundCycles::<Instructions>::new(Cycles::new(2_000_000), cost_schedule),
-        Cycles::new(0),
+        CyclesAccountManagerSubnetConfig::new(
+            SMALL_APP_SUBNET_MAX_SIZE,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        ),
         false,
     )
     .unwrap();

--- a/rs/types/cycles/src/cycles_use_case.rs
+++ b/rs/types/cycles/src/cycles_use_case.rs
@@ -113,8 +113,8 @@ pub trait CyclesUseCaseRefundableKind: CyclesUseCaseKind {}
 /// i.e. the ones that are charged directly, without a prepayment that would later
 /// be refunded via a call to `SystemState::refund_cycles`.
 ///
-/// This trait is disjoint from `CyclesUseCaseRefundableKind`: every use case
-/// implements exactly one of the two.
+/// Intended to be disjoint from `CyclesUseCaseRefundableKind`: each built-in use case
+/// in this crate implements exactly one of the two traits.
 pub trait CyclesUseCaseNonRefundableKind: CyclesUseCaseKind {}
 
 /*

--- a/rs/types/cycles/src/cycles_use_case.rs
+++ b/rs/types/cycles/src/cycles_use_case.rs
@@ -109,6 +109,14 @@ pub trait CyclesUseCaseKind: Copy + Clone + Debug {
 /// i.e. the ones that are prepaid and expected to be refunded if not fully consumed.
 pub trait CyclesUseCaseRefundableKind: CyclesUseCaseKind {}
 
+/// Marker trait to identify which use cases of `CyclesUseCase` are non-refundable,
+/// i.e. the ones that are charged directly, without a prepayment that would later
+/// be refunded via a call to `SystemState::refund_cycles`.
+///
+/// This trait is disjoint from `CyclesUseCaseRefundableKind`: every use case
+/// implements exactly one of the two.
+pub trait CyclesUseCaseNonRefundableKind: CyclesUseCaseKind {}
+
 /*
  * Empty structs are added for each use case to act like tags that can be used
  * to allow the compiler to enforce type-safe operations on `CompoundCycles`
@@ -125,6 +133,8 @@ impl CyclesUseCaseKind for Memory {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for Memory {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct ComputeAllocation;
 
@@ -134,6 +144,8 @@ impl CyclesUseCaseKind for ComputeAllocation {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for ComputeAllocation {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct IngressInduction;
 
@@ -142,6 +154,8 @@ impl CyclesUseCaseKind for IngressInduction {
         CyclesUseCase::IngressInduction
     }
 }
+
+impl CyclesUseCaseNonRefundableKind for IngressInduction {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct Instructions;
@@ -174,6 +188,8 @@ impl CyclesUseCaseKind for Uninstall {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for Uninstall {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct CanisterCreation;
 
@@ -182,6 +198,8 @@ impl CyclesUseCaseKind for CanisterCreation {
         CyclesUseCase::CanisterCreation
     }
 }
+
+impl CyclesUseCaseNonRefundableKind for CanisterCreation {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct ECDSAOutcalls;
@@ -192,6 +210,8 @@ impl CyclesUseCaseKind for ECDSAOutcalls {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for ECDSAOutcalls {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct HTTPOutcalls;
 
@@ -200,6 +220,8 @@ impl CyclesUseCaseKind for HTTPOutcalls {
         CyclesUseCase::HTTPOutcalls
     }
 }
+
+impl CyclesUseCaseNonRefundableKind for HTTPOutcalls {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct DeletedCanisters;
@@ -210,6 +232,8 @@ impl CyclesUseCaseKind for DeletedCanisters {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for DeletedCanisters {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct BurnedCycles;
 
@@ -218,6 +242,8 @@ impl CyclesUseCaseKind for BurnedCycles {
         CyclesUseCase::BurnedCycles
     }
 }
+
+impl CyclesUseCaseNonRefundableKind for BurnedCycles {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct SchnorrOutcalls;
@@ -228,6 +254,8 @@ impl CyclesUseCaseKind for SchnorrOutcalls {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for SchnorrOutcalls {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct VetKd;
 
@@ -237,6 +265,8 @@ impl CyclesUseCaseKind for VetKd {
     }
 }
 
+impl CyclesUseCaseNonRefundableKind for VetKd {}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct DroppedMessages;
 
@@ -245,3 +275,5 @@ impl CyclesUseCaseKind for DroppedMessages {
         CyclesUseCase::DroppedMessages
     }
 }
+
+impl CyclesUseCaseNonRefundableKind for DroppedMessages {}

--- a/rs/types/cycles/src/lib.rs
+++ b/rs/types/cycles/src/lib.rs
@@ -11,8 +11,8 @@ pub use cycles_account_manager_subnet_config::CyclesAccountManagerSubnetConfig;
 pub use cycles_cost_schedule::CanisterCyclesCostSchedule;
 pub use cycles_use_case::{
     BurnedCycles, CanisterCreation, ComputeAllocation, CyclesUseCase, CyclesUseCaseKind,
-    CyclesUseCaseRefundableKind, DeletedCanisters, DroppedMessages, ECDSAOutcalls, HTTPOutcalls,
-    IngressInduction, Instructions, Memory, RequestAndResponseTransmission, SchnorrOutcalls,
-    Uninstall, VetKd,
+    CyclesUseCaseNonRefundableKind, CyclesUseCaseRefundableKind, DeletedCanisters, DroppedMessages,
+    ECDSAOutcalls, HTTPOutcalls, IngressInduction, Instructions, Memory,
+    RequestAndResponseTransmission, SchnorrOutcalls, Uninstall, VetKd,
 };
 pub use nominal_cycles::{NominalCycles, testing::NominalCyclesTesting};


### PR DESCRIPTION
Introduce the marker trait `CyclesUseCaseNonRefundableKind`, the counterpart of `CyclesUseCaseRefundableKind`, and implement it for every use case that is charged directly rather than prepaid.

Restrict the public `CyclesAccountManager::consume_cycles` and `CyclesAccountManager::consume_with_threshold` to that trait, so refundable use cases can no longer be consumed through the generic API and instead have to go through a dedicated method (e.g. `prepay_execution_cycles` or `consume_cycles_for_final_instructions`). This makes it an explicit choice of the code author whether a charge is prepaid or final.

Both methods now delegate to private `*_impl` counterparts that keep the unrestricted `CyclesUseCaseKind` bound.