### PR TITLE
feat: add node-rewards-canister to GH artifacts

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -72,6 +72,7 @@ jobs:
             "ledger-canister_notify-method.wasm"
             "lifeline_canister.wasm"
             "nns-ui-canister.wasm"
+            "node-rewards-canister.wasm"
             "registry-canister.wasm"
             "root-canister.wasm"
             "sns-governance-canister.wasm"


### PR DESCRIPTION
This adds the `node-rewards-canister` to the list of artifacts uploaded to GitHub releases, following the same approach as #11017.