### PR TITLE
feat: introduce SystemMetadata::subnet_merged

### DIFF
--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -448,3 +448,10 @@ message SplitFrom {
   // subnet that this was split from.
   types.v1.SubnetId subnet_id = 1;
 }
+
+message SubnetMerged {
+  // Whether the subnet is the result of a subnet merge. Because `false` is
+  // encoded as an empty message, the enclosing file is not written at all in
+  // that case.
+  bool merged = 1;
+}

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -652,6 +652,14 @@ pub struct SplitFrom {
     #[prost(message, optional, tag = "1")]
     pub subnet_id: ::core::option::Option<super::super::super::types::v1::SubnetId>,
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SubnetMerged {
+    /// Whether the subnet is the result of a subnet merge. Because `false` is
+    /// encoded as an empty message, the enclosing file is not written at all in
+    /// that case.
+    #[prost(bool, tag = "1")]
+    pub merged: bool,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum HttpMethod {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -111,6 +111,14 @@ pub struct SystemMetadata {
     /// exported.
     pub subnet_split_from: Option<SubnetId>,
 
+    /// "Subnet was merged" marker: `true` if this subnet is the result of a subnet
+    /// merge.
+    ///
+    /// Like `split_from`, persisted in its own `subnet_merged.pbuf` file rather than
+    /// as a `SystemMetadata` proto field. A `false` flag encodes to an empty message,
+    /// so the file is absent in that case.
+    pub subnet_merged: bool,
+
     /// Asynchronously handled subnet messages.
     pub subnet_call_context_manager: SubnetCallContextManager,
 
@@ -738,6 +746,7 @@ impl SystemMetadata {
             own_subnet_info: Default::default(),
             split_from: None,
             subnet_split_from: None,
+            subnet_merged: false,
 
             // StateManager populates proper values of these fields before
             // committing each state.
@@ -968,6 +977,7 @@ impl SystemMetadata {
     ) -> Result<Self, String> {
         assert_eq!(None, self.split_from);
         assert_eq!(None, self.subnet_split_from);
+        assert!(!self.subnet_merged);
         assert_eq!(0, self.heap_delta_estimate.get());
         assert!(self.expected_compiled_wasms.is_empty());
 
@@ -1071,6 +1081,7 @@ impl SystemMetadata {
             own_subnet_info: _,
             ref mut split_from,
             subnet_split_from,
+            subnet_merged,
             subnet_call_context_manager: _,
             // Set by `commit_and_certify()` at the end of the round. Not used before.
             state_sync_version: _,
@@ -1088,6 +1099,7 @@ impl SystemMetadata {
         let split_from_subnet = split_from.expect("Not a state resulting from a subnet split");
 
         assert_eq!(None, subnet_split_from);
+        assert!(!subnet_merged);
         assert_eq!(0, heap_delta_estimate.get());
         assert!(expected_compiled_wasms.is_empty());
 
@@ -1175,6 +1187,7 @@ impl SystemMetadata {
             own_subnet_info,
             split_from,
             mut subnet_split_from,
+            subnet_merged,
             mut subnet_call_context_manager,
             state_sync_version,
             certification_version,
@@ -1189,6 +1202,7 @@ impl SystemMetadata {
 
         assert_eq!(None, split_from);
         assert_eq!(None, subnet_split_from);
+        assert!(!subnet_merged);
         assert_eq!(0, heap_delta_estimate.get());
         assert!(expected_compiled_wasms.is_empty());
 
@@ -1278,6 +1292,8 @@ impl SystemMetadata {
             own_subnet_info,
             split_from,
             subnet_split_from,
+            // Just asserted to be `false`; a subnet split does not set it.
+            subnet_merged,
             subnet_call_context_manager,
             state_sync_version,
             certification_version,
@@ -2409,6 +2425,7 @@ pub mod testing {
             own_subnet_info: Default::default(),
             split_from: None,
             subnet_split_from: None,
+            subnet_merged: false,
             prev_state_hash: Default::default(),
             state_sync_version: CURRENT_STATE_SYNC_VERSION,
             certification_version: CURRENT_CERTIFICATION_VERSION,

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -615,6 +615,9 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
                 .subnet_split_from
                 .map(subnet_id_try_from_protobuf)
                 .transpose()?,
+            // Note: `load_checkpoint()` will set this based on the presence of
+            // `subnet_merged.pbuf`.
+            subnet_merged: false,
             canister_allocation_ranges,
             last_generated_canister_id,
             prev_state_hash: item.prev_state_hash.map(|b| CryptoHash(b).into()),

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -65,6 +65,7 @@ pub const QUEUES_FILE: &str = "queues.pbuf";
 pub const CANISTER_FILE: &str = "canister.pbuf";
 pub const INGRESS_HISTORY_FILE: &str = "ingress_history.pbuf";
 pub const SPLIT_MARKER_FILE: &str = "split_from.pbuf";
+pub const SUBNET_MERGED_FILE: &str = "subnet_merged.pbuf";
 pub const SUBNET_QUEUES_FILE: &str = "subnet_queues.pbuf";
 pub const REFUNDS_FILE: &str = "refunds.pbuf";
 pub const SYSTEM_METADATA_FILE: &str = "system_metadata.pbuf";
@@ -319,6 +320,7 @@ struct CheckpointRefData {
 /// │   │           └── vmemory_0.bin
 /// │   ├── ingress_history.pbuf
 /// │   ├── split_from.pbuf
+/// │   ├── subnet_merged.pbuf
 /// │   ├── subnet_queues.pbuf
 /// │   └── system_metadata.pbuf
 /// │
@@ -342,6 +344,7 @@ struct CheckpointRefData {
 /// │      │           └── vmemory_0.bin
 /// │      ├── ingress_history.pbuf
 /// │      ├── split_from.pbuf
+/// │      ├── subnet_merged.pbuf
 /// │      ├── subnet_queues.pbuf
 /// │      └── system_metadata.pbuf
 /// │
@@ -1762,6 +1765,14 @@ impl<Permissions: AccessPolicy> CheckpointLayout<Permissions> {
 
     pub fn split_marker(&self) -> ProtoFileWith<pb_metadata::SplitFrom, Permissions> {
         self.0.root.join(SPLIT_MARKER_FILE).into()
+    }
+
+    /// The "subnet was merged" marker, backing `SystemMetadata::subnet_merged`.
+    ///
+    /// A `false` flag encodes to an empty message, so (as with all other empty
+    /// protos) the file is not written at all in that case.
+    pub fn subnet_merged_marker(&self) -> ProtoFileWith<pb_metadata::SubnetMerged, Permissions> {
+        self.0.root.join(SUBNET_MERGED_FILE).into()
     }
 
     pub fn stats(&self) -> ProtoFileWith<pb_stats::Stats, Permissions> {

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -441,7 +441,8 @@ impl CheckpointLoader {
             );
         }
 
-        // Same for the "subnet was merged" marker.
+        // Like the split marker, the "subnet was merged" marker is persisted
+        // separately from `SystemMetadata`.
         metadata.subnet_merged = self
             .checkpoint_layout
             .subnet_merged_marker()

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -441,6 +441,13 @@ impl CheckpointLoader {
             );
         }
 
+        // Same for the "subnet was merged" marker.
+        metadata.subnet_merged = self
+            .checkpoint_layout
+            .subnet_merged_marker()
+            .deserialize()?
+            .merged;
+
         Ok(metadata)
     }
 

--- a/rs/state_manager/src/checkpoint/tests.rs
+++ b/rs/state_manager/src/checkpoint/tests.rs
@@ -616,6 +616,53 @@ fn can_recover_refunds() {
     });
 }
 
+/// Checkpoints a state with the given `SystemMetadata::subnet_merged` value and
+/// asserts that the `subnet_merged.pbuf` marker file is present iff
+/// `subnet_merged`; and that the value is derived from the checkpoint.
+fn test_can_derive_subnet_merged(subnet_merged: bool) {
+    with_test_replica_logger(|log| {
+        let tmp = tmpdir("checkpoint");
+        let root = tmp.path().to_path_buf();
+        let (_tip_handler, tip_channel, layout, state_manager_metrics) = init(&root, &log);
+
+        const HEIGHT: Height = Height::new(42);
+
+        let own_subnet_type = SubnetType::Application;
+        let subnet_id = subnet_test_id(1);
+        let mut state = ReplicatedState::new(subnet_id, own_subnet_type);
+        state.metadata.subnet_merged = subnet_merged;
+
+        let _state = make_checkpoint_and_get_state(&mut state, HEIGHT, &tip_channel, &log);
+
+        let checkpoint_layout = layout.checkpoint_verified(HEIGHT).unwrap();
+        let marker = checkpoint_layout.subnet_merged_marker();
+        // A `false` flag encodes to an empty message, i.e. to no file at all.
+        assert_eq!(subnet_merged, marker.raw_path().exists());
+        assert_eq!(subnet_merged, marker.deserialize().unwrap().merged);
+
+        let derived_state = load_checkpoint(
+            &checkpoint_layout,
+            own_subnet_type,
+            &state_manager_metrics.checkpoint_metrics,
+            Some(&mut thread_pool()),
+            Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
+        )
+        .unwrap();
+
+        assert_eq!(subnet_merged, derived_state.metadata.subnet_merged);
+    });
+}
+
+#[test]
+fn can_derive_subnet_merged() {
+    test_can_derive_subnet_merged(true);
+}
+
+#[test]
+fn can_derive_not_subnet_merged() {
+    test_can_derive_subnet_merged(false);
+}
+
 #[test]
 fn empty_protobufs_are_loaded_correctly() {
     with_test_replica_logger(|log| {
@@ -655,6 +702,11 @@ fn empty_protobufs_are_loaded_correctly() {
             checkpoint_layout.subnet_queues().raw_path().to_owned(),
             checkpoint_layout.ingress_history().raw_path().to_owned(),
             checkpoint_layout.refunds().raw_path().to_owned(),
+            checkpoint_layout.split_marker().raw_path().to_owned(),
+            checkpoint_layout
+                .subnet_merged_marker()
+                .raw_path()
+                .to_owned(),
             canister_layout.queues().raw_path().to_owned(),
         ];
 

--- a/rs/state_manager/src/manifest/split.rs
+++ b/rs/state_manager/src/manifest/split.rs
@@ -10,8 +10,8 @@ use ic_registry_routing_table::RoutingTable;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::SystemMetadata;
 use ic_state_layout::{
-    INGRESS_HISTORY_FILE, SPLIT_MARKER_FILE, STATS_FILE, SUBNET_QUEUES_FILE, SYSTEM_METADATA_FILE,
-    canister_id_from_path,
+    INGRESS_HISTORY_FILE, SPLIT_MARKER_FILE, STATS_FILE, SUBNET_MERGED_FILE, SUBNET_QUEUES_FILE,
+    SYSTEM_METADATA_FILE, canister_id_from_path,
 };
 use ic_types::Time;
 use ic_types::state_sync::StateSyncVersion;
@@ -106,6 +106,13 @@ pub fn split_manifest(
                 Some(SPLIT_MARKER_FILE) => {
                     return Err(ManifestValidationError::InconsistentManifest {
                         reason: "state is already undergoing a split".into(),
+                    });
+                }
+                Some(SUBNET_MERGED_FILE) => {
+                    // `SystemMetadata::split()` asserts that the state was not just
+                    // merged, so this manifest cannot be the input of a split.
+                    return Err(ManifestValidationError::InconsistentManifest {
+                        reason: "state was just merged".into(),
                     });
                 }
                 Some(SUBNET_QUEUES_FILE) => {

--- a/rs/state_manager/src/manifest/split/tests.rs
+++ b/rs/state_manager/src/manifest/split/tests.rs
@@ -123,8 +123,9 @@ fn split_manifest_unassigned_canister() {
     );
 }
 
-/// Every split / merge marker file is a precondition of `SystemMetadata::split()`,
-/// so a manifest containing one cannot be the input of a split.
+/// `SystemMetadata::split()` requires the absence of both the split and the
+/// "subnet was merged" markers, so a manifest containing either marker file
+/// cannot be the input of a split.
 #[test]
 fn split_manifest_marked_state() {
     for (marker_file, reason) in [

--- a/rs/state_manager/src/manifest/split/tests.rs
+++ b/rs/state_manager/src/manifest/split/tests.rs
@@ -123,27 +123,35 @@ fn split_manifest_unassigned_canister() {
     );
 }
 
+/// Every split / merge marker file is a precondition of `SystemMetadata::split()`,
+/// so a manifest containing one cannot be the input of a split.
 #[test]
-fn split_manifest_state_already_splitting() {
-    let manifest = Manifest::new(
-        CURRENT_STATE_SYNC_VERSION,
-        vec![empty_file_info(SPLIT_MARKER_FILE)],
-        vec![],
-    );
+fn split_manifest_marked_state() {
+    for (marker_file, reason) in [
+        (SPLIT_MARKER_FILE, "state is already undergoing a split"),
+        (SUBNET_MERGED_FILE, "state was just merged"),
+    ] {
+        let manifest = Manifest::new(
+            CURRENT_STATE_SYNC_VERSION,
+            vec![empty_file_info(marker_file)],
+            vec![],
+        );
 
-    assert_eq!(
-        Err(ManifestValidationError::InconsistentManifest {
-            reason: "state is already undergoing a split".into()
-        }),
-        split_manifest(
-            &manifest,
-            SUBNET_0,
-            SUBNET_1,
-            SubnetType::Application,
-            BATCH_TIME,
-            &RoutingTable::default(),
-        )
-    );
+        assert_eq!(
+            Err(ManifestValidationError::InconsistentManifest {
+                reason: reason.into()
+            }),
+            split_manifest(
+                &manifest,
+                SUBNET_0,
+                SUBNET_1,
+                SubnetType::Application,
+                BATCH_TIME,
+                &RoutingTable::default(),
+            ),
+            "unexpected result for {marker_file}"
+        );
+    }
 }
 
 #[test]

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1197,7 +1197,8 @@ fn serialize_protos_to_checkpoint_readwrite(
         }
     }
 
-    // Same for the "subnet was merged" marker.
+    // Like the split marker, the "subnet was merged" marker is serialized
+    // separately from `SystemMetadata`.
     checkpoint_readwrite
         .subnet_merged_marker()
         .serialize(SubnetMerged {

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -15,7 +15,7 @@ use ic_config::state_manager::LsmtConfig;
 use ic_logger::{ReplicaLogger, error, fatal, info, warn};
 use ic_protobuf::state::{
     stats::v1::Stats,
-    system_metadata::v1::{SplitFrom, SystemMetadata},
+    system_metadata::v1::{SplitFrom, SubnetMerged, SystemMetadata},
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::canister_snapshots::CanisterSnapshot;
@@ -1196,6 +1196,13 @@ fn serialize_protos_to_checkpoint_readwrite(
             checkpoint_readwrite.split_marker().try_remove_file()?;
         }
     }
+
+    // Same for the "subnet was merged" marker.
+    checkpoint_readwrite
+        .subnet_merged_marker()
+        .serialize(SubnetMerged {
+            merged: state.system_metadata().subnet_merged,
+        })?;
 
     checkpoint_readwrite
         .subnet_queues()


### PR DESCRIPTION
Add a Boolean `subnet_merged` field to `SystemMetadata`, backed by its own `subnet_merged.pbuf` file in the checkpoint (rather than by a `SystemMetadata` proto field), following the `split_from.pbuf` blueprint: `CheckpointLayout::subnet_merged_marker()` is a `ProtoFileWith`, the tip serializes it every round and `load_checkpoint()` derives the field from it. A `false` flag encodes to an empty message, so the file is only written when the flag is set.

Splitting a manifest of a just-merged state is rejected.