### PR TITLE
test: exercise every ingress state in the `test_backward_compatibility` fixture

### DIFF
--- a/rs/state_manager/src/tree_hash.rs
+++ b/rs/state_manager/src/tree_hash.rs
@@ -94,7 +94,7 @@ mod tests {
     use ic_types::{
         CanisterId, CryptoHashOfPartialState, Height, Time,
         crypto::CryptoHash,
-        ingress::{IngressState, IngressStatus},
+        ingress::{IngressState, IngressStatus, WasmResult},
         messages::{NO_DEADLINE, Refund, RequestMetadata},
         time::CoarseTime,
         xnet::{RejectReason, StreamFlags, StreamIndex, StreamIndexedQueue},
@@ -268,29 +268,32 @@ mod tests {
                 streams.insert(other_subnet_id, stream);
             });
 
-            for i in 1..6 {
+            // Exercise every ingress state. (`IngressStatus::Unknown` stands for the
+            // absence of an ingress history entry, so it is never recorded.)
+            let ingress_states = [
+                IngressState::Received,
+                IngressState::Processing,
+                IngressState::Completed(WasmResult::Reply(vec![1, 2, 3])),
+                IngressState::Completed(WasmResult::Reject("rejected".into())),
+                IngressState::Done,
+                IngressState::Failed(UserError::new(
+                    ErrorCode::CanisterNotFound,
+                    "canister not found",
+                )),
+            ];
+            for (i, ingress_state) in ingress_states.into_iter().enumerate() {
                 state.set_ingress_status(
-                    message_test_id(i),
-                    IngressStatus::Unknown,
+                    message_test_id(i as u64 + 1),
+                    IngressStatus::Known {
+                        state: ingress_state,
+                        receiver: canister_id.into(),
+                        user_id: user_test_id(1),
+                        time: Time::from_nanos_since_unix_epoch(12345),
+                    },
                     NumBytes::from(u64::MAX),
                     |_| {},
                 );
             }
-
-            state.set_ingress_status(
-                message_test_id(7),
-                IngressStatus::Known {
-                    state: IngressState::Failed(UserError::new(
-                        ErrorCode::CanisterNotFound,
-                        "canister not found",
-                    )),
-                    receiver: canister_id.into(),
-                    user_id: user_test_id(1),
-                    time: Time::from_nanos_since_unix_epoch(12345),
-                },
-                NumBytes::from(u64::MAX),
-                |_| {},
-            );
 
             std::sync::Arc::make_mut(&mut state.metadata.own_subnet_info).node_public_keys = btreemap! {
                 node_test_id(1) => vec![1; 44],
@@ -397,17 +400,17 @@ mod tests {
         // BACKWARD COMPATIBILITY CODE FOR OLD CERTIFICATION VERSIONS THAT
         // NEED TO BE SUPPORTED.
         let expected_hashes = [
-            "47C3A071B293B4723FCACB17F2FD2FD75F68C010E333007ACC0EF425D92765FB",
-            "3F9441CBAC0A00718BA6CB2D4D1B6FF7FF96F42051567365B670ACFC08AB96EA",
-            "9D9C8D991198BCD0BCAA627F409181D08ADD8CA442730393D5A27FA1042D2477",
-            "7FA3E764326968A311F7FE760CE7B6D29978BC9165DCDA332B4350EBEEC6D90C",
-            "07797459A2F82D6F64628C0668C5BDB7F83447680DDB178208A40C2256409E8D",
-            "F80B2659485C03F68935F214E4CB5D8CCAC02913DCA88E913C4B497F2120DA50",
-            "416172D9AFD573236F1CDE2459756736EEB25028D64FB8D7192AAF33AFC0DA6F",
-            "057FA1842C06C958F79C6394C54E12F9C9DCF5036D186EBBB9A49CDB4E3683BF",
-            "70D1FCB311A682DAB0350E075806E0A37985456D7BD171750C41A735CF8077F3",
-            "995B6CAFE481325EF08A84A0F1DA4DEE0E3C352B5F44998B20D021A044FD3AF2",
-            "5F80A3CCB57843D07CF77CBA08AD2ECE0B0C8C92F308569EC76DF341085E5C44",
+            "A58A2CE65A1EF1F32AA1B46E884B52FDBF14C4A8A01100C78401F958F5BE04E4",
+            "D23410333D985C91C2BE540D7282BCB28C356D6B587F7ABCEFC8BE2C4D7DE454",
+            "1090ACD6B66270816569DD4AEC2B315EAFB0AF7F00D6C4801BE88979765C67C5",
+            "5FB827932CC4FF419E47869F1AB37473311B81DFD10A7090FABB90E55B6495BE",
+            "3FFC2919D08408B3C9D582AE2BEE4D806707179B1D110E113EFEF3D709A62E24",
+            "BCD87ECE333D4F1C132EDE0F820EA717A6BD63F14544526FBBAF5BAA69A45C5A",
+            "DB79E2779240264D24194A0FA3609F1369F6C98800DEC23DEF69D2B395C0D2E1",
+            "0EC99B2AA159C259010B02E8568077959506C4153594338E9A69450F326CEE38",
+            "3EE82452CD7712A87BC313F6AD0BBEEC7F264A4699BEBD324A961080D96F5FD1",
+            "512D8886C4E68D75AA1EE4AFC26A67F2BA00E56FB75FE5C9FB7E69DDA25026EB",
+            "A15A37BD9A0454C39D6B9A4234001D19B02433D8F0CD790664027145790B06B3",
         ];
         assert_eq!(expected_hashes.len(), all_supported_versions().count());
 


### PR DESCRIPTION
The state fixture recorded five `IngressStatus::Unknown` entries. `Unknown` stands for the absence of an ingress history entry, so it is never recorded as the status of a message; and the canonical encoding of the fixture's single `Known` entry only covered `Failed`.

Record the six ingress states that actually can be recorded instead, which also covers the `reply` and `Completed(Reject)` canonical encodings that the fixture was missing. The partial state hashes change accordingly: the fixture changed, the hashing did not.