### PR TITLE
feat: Make snapshots immutable after loading

### DIFF
--- a/rs/execution_environment/src/canister_logs.rs
+++ b/rs/execution_environment/src/canister_logs.rs
@@ -29,6 +29,7 @@ pub(crate) fn fetch_canister_logs(
         deleted_call_context_responses: vec![],
         stop_call_id_to_remove: None,
         stop_contexts_to_reject: vec![],
+        snapshot_to_make_immutable: None,
     })
 }
 

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -778,6 +778,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1043,6 +1044,7 @@ impl CanisterManager {
             deleted_call_context_responses: rejects,
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1087,6 +1089,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1120,6 +1123,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject,
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1659,6 +1663,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1690,6 +1695,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         }
     }
 
@@ -1804,6 +1810,7 @@ impl CanisterManager {
                     deleted_call_context_responses: vec![],
                     stop_call_id_to_remove: None,
                     stop_contexts_to_reject: vec![],
+                    snapshot_to_make_immutable: None,
                 });
             }
             ChunkValidationResult::ValidationError(err) => {
@@ -1851,6 +1858,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -1892,6 +1900,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -2171,6 +2180,7 @@ impl CanisterManager {
             deleted_call_context_responses,
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -2526,6 +2536,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: Some(snapshot_id),
         })
     }
 
@@ -2598,6 +2609,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -2727,6 +2739,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -2848,6 +2861,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 
@@ -2872,8 +2886,11 @@ impl CanisterManager {
 
         let snapshot = self.get_snapshot(canister, snapshot_id)?;
 
-        // Ensure the snapshot was created via metadata upload, not from the canister.
-        if snapshot.source() != SnapshotSource::MetadataUpload(candid::Reserved) {
+        // Ensure the snapshot was created via metadata upload, not from the
+        // canister, and has not been restored onto a canister.
+        if snapshot.source() != SnapshotSource::MetadataUpload(candid::Reserved)
+            || snapshot.restored()
+        {
             return Err(CanisterManagerError::CanisterSnapshotImmutable);
         }
 
@@ -2966,6 +2983,7 @@ impl CanisterManager {
                             deleted_call_context_responses: vec![],
                             stop_call_id_to_remove: None,
                             stop_contexts_to_reject: vec![],
+                            snapshot_to_make_immutable: None,
                         });
                     }
                     ChunkValidationResult::ValidationError(err) => {
@@ -3008,6 +3026,7 @@ impl CanisterManager {
             deleted_call_context_responses: vec![],
             stop_call_id_to_remove: None,
             stop_contexts_to_reject: vec![],
+            snapshot_to_make_immutable: None,
         })
     }
 

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -328,6 +328,10 @@ pub(crate) struct CanisterManagerResponse {
     /// Stop canister request contexts (for requests other than the current request)
     /// that must be rejected (because the canister was restarted by the current request).
     pub stop_contexts_to_reject: Vec<StopCanisterContext>,
+    /// A snapshot that must be marked as immutable (because it was loaded onto
+    /// a canister by the current request). The snapshot may belong to a canister
+    /// other than the target canister of the current request.
+    pub snapshot_to_make_immutable: Option<SnapshotId>,
 }
 
 #[derive(Eq, PartialEq, Debug)]
@@ -680,7 +684,7 @@ impl AsErrorHelp for CanisterManagerError {
                 doc_link: "not-enough-cycles".to_string(),
             },
             CanisterManagerError::CanisterSnapshotImmutable => ErrorHelp::UserError {
-                suggestion: "Only canister snapshots created by metadata upload can be mutated.".to_string(),
+                suggestion: "Only canister snapshots created by metadata upload can be mutated, and only until they are loaded onto a canister.".to_string(),
                 doc_link: "".to_string(),
             },
             CanisterManagerError::LongExecutionAlreadyInProgress { .. } => ErrorHelp::UserError {
@@ -1082,7 +1086,7 @@ impl From<CanisterManagerError> for UserError {
             ),
             CanisterSnapshotImmutable => Self::new(
                 ErrorCode::CanisterSnapshotImmutable,
-                "Only canister snapshots created by metadata upload can be mutated.".to_string(),
+                "Only canister snapshots created by metadata upload can be mutated, and only until they are loaded onto a canister.".to_string(),
             ),
             CanisterSnapshotNotController {
                 sender,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -2136,6 +2136,13 @@ impl ExecutionEnvironment {
                         .unflushed_checkpoint_ops
                         .push(unflushed_checkpoint_op);
                 }
+                if let Some(snapshot_id) = response.snapshot_to_make_immutable
+                    && let Some(canister) =
+                        state.canister_state_make_mut(&snapshot_id.get_canister_id())
+                    && let Some(snapshot) = canister.canister_snapshots.get_mut(snapshot_id)
+                {
+                    Arc::make_mut(snapshot).set_restored();
+                }
                 crate::util::process_responses(
                     response.deleted_call_context_responses,
                     state,

--- a/rs/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/tests/canister_snapshots.rs
@@ -548,6 +548,80 @@ fn upload_and_load_snapshot_with_wasm_memory() {
     ));
 }
 
+// Once a metadata-upload snapshot has been loaded onto a canister it becomes
+// immutable and rejects further `upload_canister_snapshot_data`, no matter
+// whether it was loaded onto the canister owning it or onto another one.
+fn upload_snapshot_data_rejected_after_load(load_onto_other_canister: bool) {
+    let env = StateMachineBuilder::new().build();
+
+    let canister_id = env.create_canister(None);
+
+    // The canister is never executed, so the module only has to be loadable:
+    // it declares no globals, matching the `globals` of the uploaded metadata.
+    const PAGES: u64 = 32;
+    const HEAP_SIZE: u64 = PAGES * 64 * 1024;
+    let wasm = wat::parse_str(format!("(module (memory {PAGES} {PAGES}))")).unwrap();
+    let heap = vec![7_u8; HEAP_SIZE as usize];
+
+    let upload_args = UploadCanisterSnapshotMetadataArgs::new(
+        canister_id,
+        None,              /* replace_snapshot */
+        wasm.len() as u64, /* wasm_module_size */
+        vec![],            /* globals */
+        HEAP_SIZE,         /* wasm_memory_size */
+        0,                 /* stable_memory_size */
+        vec![],            /* certified_data */
+        None,              /* global_timer */
+        None,              /* on_low_wasm_memory_hook_status */
+    );
+    let snapshot_id = env
+        .upload_canister_snapshot_metadata(&upload_args)
+        .unwrap()
+        .snapshot_id;
+
+    env.upload_snapshot_module(canister_id, snapshot_id, &wasm, None, None)
+        .unwrap();
+
+    // Before the snapshot is loaded it is mutable: uploading wasm memory succeeds.
+    let write_memory =
+        |env: &StateMachine| env.upload_snapshot_heap(canister_id, snapshot_id, &heap, None, None);
+    write_memory(&env).unwrap();
+
+    let target_canister_id = if load_onto_other_canister {
+        // Loading onto another canister copies the snapshot's memories, which
+        // requires them to have been flushed to disk first.
+        env.checkpointed_tick();
+        env.create_canister(None)
+    } else {
+        canister_id
+    };
+    let load_args = LoadCanisterSnapshotArgs::new(target_canister_id, snapshot_id, None);
+    env.load_canister_snapshot(load_args).unwrap();
+
+    // The snapshot is now immutable: the same upload is rejected.
+    let err = write_memory(&env).unwrap_err();
+    assert_eq!(err.code(), ErrorCode::CanisterSnapshotImmutable);
+    assert_eq!(
+        err.description(),
+        "Only canister snapshots created by metadata upload can be mutated, and only until they are loaded onto a canister."
+    );
+
+    // The `restored` flag persists across a checkpoint, so the rejection holds.
+    env.checkpointed_tick();
+    let err = write_memory(&env).unwrap_err();
+    assert_eq!(err.code(), ErrorCode::CanisterSnapshotImmutable);
+}
+
+#[test]
+fn upload_snapshot_data_rejected_after_load_onto_own_canister() {
+    upload_snapshot_data_rejected_after_load(false);
+}
+
+#[test]
+fn upload_snapshot_data_rejected_after_load_onto_other_canister() {
+    upload_snapshot_data_rejected_after_load(true);
+}
+
 #[test]
 fn upgrade_with_keep_heap_exceeds_module_max_fails_gracefully() {
     // The custom section marks the module as supporting enhanced orthogonal

--- a/rs/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/tests/canister_snapshots.rs
@@ -551,6 +551,7 @@ fn upload_and_load_snapshot_with_wasm_memory() {
 // Once a metadata-upload snapshot has been loaded onto a canister it becomes
 // immutable and rejects further `upload_canister_snapshot_data`, no matter
 // whether it was loaded onto the canister owning it or onto another one.
+// Being immutable does not prevent it from being loaded again, though.
 fn upload_snapshot_data_rejected_after_load(load_onto_other_canister: bool) {
     let env = StateMachineBuilder::new().build();
 
@@ -610,6 +611,14 @@ fn upload_snapshot_data_rejected_after_load(load_onto_other_canister: bool) {
     env.checkpointed_tick();
     let err = write_memory(&env).unwrap_err();
     assert_eq!(err.code(), ErrorCode::CanisterSnapshotImmutable);
+
+    // The snapshot can still be loaded again, onto the canister it was already
+    // loaded onto as well as onto a canister that has never seen it.
+    let another_canister_id = env.create_canister(None);
+    for target_canister_id in [target_canister_id, another_canister_id] {
+        let load_args = LoadCanisterSnapshotArgs::new(target_canister_id, snapshot_id, None);
+        env.load_canister_snapshot(load_args).unwrap();
+    }
 }
 
 #[test]

--- a/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
+++ b/rs/protobuf/def/state/canister_snapshot_bits/v1/canister_snapshot_bits.proto
@@ -25,4 +25,5 @@ message CanisterSnapshotBits {
   CanisterTimer global_timer = 12;
   optional canister_state_bits.v1.OnLowWasmMemoryHookStatus on_low_wasm_memory_hook_status = 13;
   canister_state_bits.v1.SnapshotSource source = 14;
+  bool restored = 15;
 }

--- a/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_snapshot_bits.v1.rs
@@ -44,4 +44,6 @@ pub struct CanisterSnapshotBits {
         tag = "14"
     )]
     pub source: i32,
+    #[prost(bool, tag = "15")]
+    pub restored: bool,
 }

--- a/rs/replicated_state/src/canister_state/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_state/canister_snapshots.rs
@@ -238,6 +238,9 @@ pub struct CanisterSnapshot {
     size: NumBytes,
     /// The certified data blob belonging to the canister.
     certified_data: Vec<u8>,
+    /// Whether this snapshot has been loaded onto a canister. Restored snapshots
+    /// are immutable and cannot be modified via `upload_canister_snapshot_data`.
+    restored: bool,
     /// Snapshot of chunked store.
     #[validate_eq(CompareWithValidateEq)]
     chunk_store: WasmChunkStore,
@@ -254,12 +257,14 @@ impl CanisterSnapshot {
         chunk_store: WasmChunkStore,
         execution_snapshot: ExecutionStateSnapshot,
         size: NumBytes,
+        restored: bool,
     ) -> CanisterSnapshot {
         Self {
             source,
             taken_at_timestamp,
             canister_version,
             certified_data,
+            restored,
             chunk_store,
             execution_snapshot,
             size,
@@ -316,6 +321,7 @@ impl CanisterSnapshot {
             taken_at_timestamp,
             canister_version: canister.system_state.canister_version(),
             certified_data: canister.system_state.certified_data.clone(),
+            restored: false,
             chunk_store: canister.system_state.wasm_chunk_store.clone(),
             execution_snapshot,
             size: canister.snapshot_size_bytes(),
@@ -360,6 +366,7 @@ impl CanisterSnapshot {
             canister_version,
             size: metadata.snapshot_size_bytes(),
             certified_data: metadata.certified_data.clone(),
+            restored: false,
             chunk_store,
             execution_snapshot,
         }
@@ -367,6 +374,14 @@ impl CanisterSnapshot {
 
     pub fn source(&self) -> SnapshotSource {
         self.source
+    }
+
+    pub fn restored(&self) -> bool {
+        self.restored
+    }
+
+    pub fn set_restored(&mut self) {
+        self.restored = true;
     }
 
     pub fn canister_version(&self) -> u64 {
@@ -642,6 +657,7 @@ mod tests {
             WasmChunkStore::new_for_testing(),
             execution_snapshot,
             NumBytes::from(0),
+            false,
         );
 
         let snapshot_id = SnapshotId::from((canister_id, local_id));

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -251,6 +251,9 @@ pub struct CanisterSnapshotBits {
     pub global_timer: Option<CanisterTimer>,
     /// The state of the low memory hook.
     pub on_low_wasm_memory_hook_status: Option<OnLowWasmMemoryHookStatus>,
+    /// Whether this snapshot has been loaded onto a canister and is therefore
+    /// immutable.
+    pub restored: bool,
 }
 
 #[derive(Clone)]

--- a/rs/state_layout/src/state_layout/proto.rs
+++ b/rs/state_layout/src/state_layout/proto.rs
@@ -351,6 +351,7 @@ impl From<CanisterSnapshotBits> for pb_canister_snapshot_bits::CanisterSnapshotB
                 .on_low_wasm_memory_hook_status
                 .map(|x| pb_canister_state_bits::OnLowWasmMemoryHookStatus::from(&x).into()),
             source: pb_canister_state_bits::SnapshotSource::from(item.source).into(),
+            restored: item.restored,
         }
     }
 }
@@ -405,6 +406,7 @@ impl TryFrom<pb_canister_snapshot_bits::CanisterSnapshotBits> for CanisterSnapsh
             global_timer,
             on_low_wasm_memory_hook_status,
             source,
+            restored: item.restored,
         })
     }
 }

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -262,6 +262,7 @@ fn test_canister_snapshots_decode() {
         source: SnapshotSource::taken_from_canister(),
         global_timer: Some(CanisterTimer::Inactive),
         on_low_wasm_memory_hook_status: Some(OnLowWasmMemoryHookStatus::ConditionNotSatisfied),
+        restored: true,
     };
 
     let pb_bits =

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -1004,6 +1004,7 @@ pub fn load_snapshot(
         wasm_chunk_store,
         execution_snapshot,
         canister_snapshot_bits.total_size,
+        canister_snapshot_bits.restored,
     );
 
     let metrics = LoadCanisterMetrics { durations };

--- a/rs/state_manager/src/checkpoint/tests.rs
+++ b/rs/state_manager/src/checkpoint/tests.rs
@@ -739,6 +739,7 @@ fn make_test_snapshot(
         chunk_store,
         execution_snapshot,
         NumBytes::from(0),
+        false,
     )
 }
 

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1475,6 +1475,7 @@ fn serialize_snapshot_protos_to_checkpoint_readwrite(
             on_low_wasm_memory_hook_status: canister_snapshot
                 .execution_snapshot()
                 .on_low_wasm_memory_hook_status,
+            restored: canister_snapshot.restored(),
         }
         .into(),
     )?;


### PR DESCRIPTION
This is done for consistency with snapshots that have been taken directly on-chain, which are also immutable, and separates the (comparably short) upload phase from the phase where the snapshot is usable.