### PR TITLE
fix(devcontainer): mount /tmp/containers as tmpfs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,12 @@
     "--cgroupns",
     "host",
     "--add-host",
-    "devenv-container:127.0.0.1"
+    "devenv-container:127.0.0.1",
+    // expected by ic-os build (same as ci/container/container-run.sh and the CI
+    // workflows); declared here rather than in "mounts" because the
+    // devcontainer mount schema only covers bind & volume mounts.
+    "--mount",
+    "type=tmpfs,target=/tmp/containers"
   ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/ic,type=bind",
   "workspaceFolder": "/ic",


### PR DESCRIPTION
Both `ci/container/container-run.sh` and the CI workflows (`.github/workflows/ci-main.yml` and friends) mount `/tmp/containers` as a tmpfs, since the IC-OS build expects it there: `toolchains/sysimage/proc_wrapper.sh` creates its podman storage dir under `/tmp/containers` and notes it should be a tmpfs for best performance.

The dev container (`.devcontainer/devcontainer.json`) was missing this, which was likely an oversight. This adds it.

The mount is declared via `runArgs` rather than the `mounts` array because the devcontainer mount schema only covers `bind` & `volume` mounts; passing it as a raw runtime arg matches exactly what `container-run.sh` and the CI workflows do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)