### PR TITLE
chore: Remove impl_hash and REPLICA_BINARY_HASH

### DIFF
--- a/rs/boundary_node/ic_boundary/src/http/handlers.rs
+++ b/rs/boundary_node/ic_boundary/src/http/handlers.rs
@@ -206,7 +206,6 @@ pub async fn status(
     let status = HttpStatusResponse {
         root_key: rk.root_key().map(|x| x.into()),
         impl_version: None,
-        impl_hash: None,
         replica_health_status: Some(health),
         certified_height: None,
     };

--- a/rs/http_endpoints/public/src/status.rs
+++ b/rs/http_endpoints/public/src/status.rs
@@ -11,7 +11,6 @@ use ic_replicated_state::ReplicatedState;
 use ic_types::{
     ReplicaVersion, SubnetId,
     messages::{Blob, HttpStatusResponse, ReplicaHealthStatus},
-    replica_version::REPLICA_BINARY_HASH,
 };
 use std::sync::Arc;
 
@@ -76,7 +75,6 @@ pub(crate) async fn status(State(state): State<StatusService>) -> Cbor<HttpStatu
         // USE WITH EXTREME CAUTION.
         root_key: root_key.map(Blob),
         impl_version: Some(ReplicaVersion::default().to_string()),
-        impl_hash: REPLICA_BINARY_HASH.get().map(|s| s.to_string()),
         replica_health_status: Some(state.replica_health_status.load()),
         certified_height: Some(state.state_reader.latest_certified_height()),
     };

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -898,8 +898,6 @@ pub enum ReplicaHealthStatus {
 #[serde(rename_all = "snake_case")]
 pub struct HttpStatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub impl_hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_key: Option<Blob>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub impl_version: Option<String>,

--- a/rs/types/types/src/messages/http/tests.rs
+++ b/rs/types/types/src/messages/http/tests.rs
@@ -844,7 +844,6 @@ mod cbor_serialization {
             &HttpStatusResponse {
                 root_key: None,
                 impl_version: Some("0.0".to_string()),
-                impl_hash: None,
                 replica_health_status: Some(ReplicaHealthStatus::Starting),
                 certified_height: None,
             },
@@ -861,7 +860,6 @@ mod cbor_serialization {
             &HttpStatusResponse {
                 root_key: Some(Blob(vec![1, 2, 3])),
                 impl_version: Some("0.0".to_string()),
-                impl_hash: None,
                 replica_health_status: Some(ReplicaHealthStatus::Healthy),
                 certified_height: None,
             },
@@ -879,7 +877,6 @@ mod cbor_serialization {
             &HttpStatusResponse {
                 root_key: Some(Blob(vec![1, 2, 3])),
                 impl_version: Some("0.0".to_string()),
-                impl_hash: None,
                 replica_health_status: None,
                 certified_height: None,
             },
@@ -896,7 +893,6 @@ mod cbor_serialization {
             &HttpStatusResponse {
                 root_key: Some(Blob(vec![1, 2, 3])),
                 impl_version: Some("0.0".to_string()),
-                impl_hash: None,
                 replica_health_status: Some(ReplicaHealthStatus::Healthy),
                 certified_height: Some(AmountOf::new(1)),
             },

--- a/rs/types/types/src/replica_version.rs
+++ b/rs/types/types/src/replica_version.rs
@@ -12,7 +12,6 @@ pub struct ReplicaVersion {
 }
 
 static DEFAULT_VERSION_ID: OnceCell<String> = OnceCell::new();
-pub static REPLICA_BINARY_HASH: OnceCell<String> = OnceCell::new();
 
 /// The default replica version can be initialized only once to prevent
 /// accidental mistakes. Otherwise its value is taken from environment


### PR DESCRIPTION
These fields were never populated, nor read. `impl_hash` was marked with `skip_serializing_if = "Option::is_none"` so it didn't even show up in the serialized output.