### PR TITLE
fix: Subnet splitting for new HTTP outcalls pricing

### DIFF
--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -8,6 +8,7 @@ use self::subnet_call_context_manager::SubnetCallContextManager;
 use self::subnet_schedule::SubnetSchedule;
 use crate::CanisterQueues;
 use crate::CheckpointLoadingMetrics;
+use crate::RefundPool;
 use ic_base_types::{CanisterId, SnapshotId};
 use ic_btc_replica_types::BlockBlob;
 use ic_certification_version::{CURRENT_CERTIFICATION_VERSION, CertificationVersion};
@@ -26,6 +27,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_types::{
     CountBytes, CryptoHashOfPartialState, NodeId, NumBytes, PrincipalId, SubnetId,
     batch::BlockmakerMetrics,
+    canister_http::{CanisterHttpRequestContext, PricingVersion},
     crypto::CryptoHash,
     ingress::{IngressState, IngressStatus},
     messages::{CanisterCall, MessageId, Payload, RejectContext, Response, StreamMessage},
@@ -38,7 +40,7 @@ use ic_types::{
         StreamSlice,
     },
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, CyclesUseCase, NominalCycles};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles, CyclesUseCase, NominalCycles};
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
 use ic_wasm_types::WasmHash;
@@ -1029,8 +1031,9 @@ impl SystemMetadata {
     /// in terminal states and messages addressed to local canisters. Additionally,
     /// on subnet A' we reject all management canister calls whose execution is in
     /// progress on one of the canisters migrated to subnet B (hence the
-    /// `subnet_queues` argument); and silently discard the corresponding tasks and
-    /// roll back `Stopping` states on all subnet B canisters.
+    /// `subnet_queues` and `refunds` arguments); and silently discard the
+    /// corresponding tasks and roll back `Stopping` states on all subnet B
+    /// canisters.
     ///
     /// Notes:
     ///  * `own_subnet_type` has just been set during `load_checkpoint()`, based on
@@ -1045,6 +1048,7 @@ impl SystemMetadata {
         &mut self,
         is_local_canister: F,
         subnet_queues: &mut CanisterQueues,
+        refunds: &mut RefundPool,
     ) where
         F: Fn(CanisterId) -> bool,
     {
@@ -1114,6 +1118,7 @@ impl SystemMetadata {
             time,
             subnet_queues,
             &mut self.ingress_history,
+            refunds,
         );
     }
 
@@ -1131,6 +1136,9 @@ impl SystemMetadata {
     ///  * Rejects management canister calls targeting canisters that have migrated
     ///    (subnet B will silently drop the corresponding executions from its
     ///    canisters).
+    ///  * Rejects the in-progress HTTP outcalls of migrated canisters and drops
+    ///    their already responded to (delivered) contexts, refunding the cycles
+    ///    still owed for either.
     ///
     /// On subnet B:
     ///  * Updates `own_subnet_id` to `subnet_id`.
@@ -1156,6 +1164,7 @@ impl SystemMetadata {
         self,
         subnet_id: SubnetId,
         subnet_queues: &mut CanisterQueues,
+        refunds: &mut RefundPool,
     ) -> Result<Self, String> {
         // Destructure `self` in order for the compiler to enforce an explicit decision
         // whenever new fields are added.
@@ -1224,6 +1233,7 @@ impl SystemMetadata {
                 batch_time,
                 subnet_queues,
                 &mut ingress_history,
+                refunds,
             );
         } else {
             //
@@ -1316,13 +1326,14 @@ impl SystemMetadata {
     ///    only a response from *subnet A'* could be inducted.
     ///
     ///  * Specific requests that must be entirely handled by the local subnet where
-    ///    the originator canister exists (e.g. `raw_rand`).
+    ///    the originator canister exists (e.g. `raw_rand` and HTTP outcalls).
     fn reject_in_progress_management_calls_after_split<F>(
         subnet_call_context_manager: &mut SubnetCallContextManager,
         is_local_canister: F,
         time: Time,
         subnet_queues: &mut CanisterQueues,
         ingress_history: &mut IngressHistoryState,
+        refunds: &mut RefundPool,
     ) where
         F: Fn(CanisterId) -> bool,
     {
@@ -1362,6 +1373,73 @@ impl SystemMetadata {
                 subnet_queues,
                 ingress_history,
             );
+        }
+
+        // In-progress HTTP outcalls are rejected if the sender has migrated to another
+        // subnet.
+        for context in
+            subnet_call_context_manager.remove_non_local_canister_http_calls(&is_local_canister)
+        {
+            Self::reject_canister_http_call_after_split(context, subnet_queues);
+        }
+
+        // Delivered HTTP outcall contexts are only retained in order to apply late
+        // per-replica refunds. This can no longer happen for a canister that this subnet
+        // no longer hosts: the refund could only be credited on the canister's new subnet.
+        // Instead, we settle the outcall now, refunding everything it still owes.
+        for context in subnet_call_context_manager
+            .remove_non_local_delivered_canister_http_calls(&is_local_canister)
+        {
+            // Only pay-as-you-go contexts are ever retained as delivered.
+            debug_assert_eq!(PricingVersion::PayAsYouGo, context.pricing_version);
+            refunds.add(
+                context.request.sender,
+                Self::unrefunded_canister_http_cycles(&context),
+            );
+        }
+    }
+
+    /// Rejects an in-progress HTTP outcall made by a canister that has migrated to a
+    /// new subnet following a subnet split. Enqueues an output reject response on behalf
+    /// of the subnet into the provided `subnet_queues`.
+    ///
+    /// Unlike other management calls, an HTTP outcall may hold cycles beyond
+    /// `Request::payment`, so the reject refunds both (see
+    /// [`Self::unrefunded_canister_http_cycles()`]).
+    fn reject_canister_http_call_after_split(
+        context: CanisterHttpRequestContext,
+        subnet_queues: &mut CanisterQueues,
+    ) {
+        let refund = context.request.payment + Self::unrefunded_canister_http_cycles(&context);
+        let request = context.request;
+        let migrated_canister_id = request.sender;
+        subnet_queues.push_output_response(
+            Response {
+                originator: migrated_canister_id,
+                respondent: request.receiver,
+                originator_reply_callback: request.sender_reply_callback,
+                refund,
+                response_payload: Payload::Reject(RejectContext::new(
+                    RejectCode::SysTransient,
+                    format!("Canister {migrated_canister_id} migrated during a subnet split"),
+                )),
+                deadline: request.deadline,
+            }
+            .into(),
+        );
+    }
+
+    /// The part of an HTTP outcall's refundable cycles that has not been refunded to
+    /// the calling canister yet.
+    ///
+    /// Always zero under legacy pricing: there the caller is refunded through
+    /// `Request::payment` when the response is delivered.
+    fn unrefunded_canister_http_cycles(context: &CanisterHttpRequestContext) -> Cycles {
+        match context.pricing_version {
+            PricingVersion::Legacy => Cycles::zero(),
+            PricingVersion::PayAsYouGo => {
+                context.refund_status.refundable_cycles - context.refund_status.refunded_cycles
+            }
         }
     }
 

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -385,6 +385,47 @@ impl SubnetCallContextManager {
             .collect()
     }
 
+    /// Removes and returns all in-flight `CanisterHttpRequestContext`s made by
+    /// canisters that are not local.
+    ///
+    /// Used for rejecting the outcalls of migrated canisters after a subnet split.
+    pub fn remove_non_local_canister_http_calls(
+        &mut self,
+        is_local_canister: impl Fn(CanisterId) -> bool,
+    ) -> Vec<CanisterHttpRequestContext> {
+        Self::remove_non_local_contexts(&mut self.canister_http_request_contexts, is_local_canister)
+    }
+
+    /// Removes and returns all delivered `CanisterHttpRequestContext`s made by
+    /// canisters that are not local.
+    ///
+    /// Used for settling the outcalls of migrated canisters after a subnet split: no
+    /// further spend report for them can be applied on this subnet and any refund
+    /// resulting from one could not be credited to the migrated canister anyway.
+    pub fn remove_non_local_delivered_canister_http_calls(
+        &mut self,
+        is_local_canister: impl Fn(CanisterId) -> bool,
+    ) -> Vec<CanisterHttpRequestContext> {
+        Self::remove_non_local_contexts(
+            &mut self.delivered_canister_http_request_contexts,
+            is_local_canister,
+        )
+    }
+
+    /// Removes and returns all `CanisterHttpRequestContext`s in `contexts` whose
+    /// calling canister is not local.
+    fn remove_non_local_canister_http_contexts(
+        contexts: &mut BTreeMap<CallbackId, CanisterHttpRequestContext>,
+        is_local_canister: impl Fn(CanisterId) -> bool,
+    ) -> Vec<CanisterHttpRequestContext> {
+        contexts
+            .extract_if(.., |_callback_id, context| {
+                !is_local_canister(context.request.sender)
+            })
+            .map(|(_callback_id, context)| context)
+            .collect()
+    }
+
     pub fn push_install_code_call(&mut self, call: InstallCodeCall) -> InstallCodeCallId {
         self.canister_management_calls.push_install_code_call(call)
     }

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -393,7 +393,10 @@ impl SubnetCallContextManager {
         &mut self,
         is_local_canister: impl Fn(CanisterId) -> bool,
     ) -> Vec<CanisterHttpRequestContext> {
-        Self::remove_non_local_contexts(&mut self.canister_http_request_contexts, is_local_canister)
+        Self::remove_non_local_canister_http_contexts(
+            &mut self.canister_http_request_contexts,
+            is_local_canister,
+        )
     }
 
     /// Removes and returns all delivered `CanisterHttpRequestContext`s made by
@@ -406,7 +409,7 @@ impl SubnetCallContextManager {
         &mut self,
         is_local_canister: impl Fn(CanisterId) -> bool,
     ) -> Vec<CanisterHttpRequestContext> {
-        Self::remove_non_local_contexts(
+        Self::remove_non_local_canister_http_contexts(
             &mut self.delivered_canister_http_request_contexts,
             is_local_canister,
         )

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -43,7 +43,9 @@ use ic_types::crypto::AlgorithmId;
 use ic_types::crypto::canister_threshold_sig::SchnorrPreSignatureTranscript;
 use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealers, IDkgReceivers, IDkgTranscript};
 use ic_types::ingress::WasmResult;
-use ic_types::messages::{CallbackId, CanisterCall, Payload, Refund, Request, RequestMetadata};
+use ic_types::messages::{
+    CallbackId, CanisterCall, Payload, Refund, Request, RequestMetadata, RequestOrResponse,
+};
 use ic_types::time::{CoarseTime, current_time};
 use ic_types::{ExecutionRound, Height, NumberOfNodes, RegistryVersion};
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles, NominalCyclesTesting};
@@ -609,7 +611,11 @@ fn system_metadata_split() {
     // Technically some parts of the `SystemMetadata` (such as `prev_state_hash` and
     // `own_subnet_type`) would be replaced during loading. However, we only care
     // that `after_split()` does not touch them.
-    metadata_a.after_split(is_canister_on_subnet_a, &mut subnet_queues);
+    metadata_a.after_split(
+        is_canister_on_subnet_a,
+        &mut subnet_queues,
+        &mut RefundPool::default(),
+    );
 
     // Expect same metadata, but with pruned ingress history and no split marker.
     expected.ingress_history.split(is_receiver_on_subnet_a);
@@ -632,7 +638,11 @@ fn system_metadata_split() {
     // Technically some parts of the `SystemMetadata` (such as `prev_state_hash` and
     // `own_subnet_type`) would be replaced during loading. However, we only care
     // that `after_split()` does not touch them.
-    metadata_b.after_split(is_canister_on_subnet_b, &mut subnet_queues);
+    metadata_b.after_split(
+        is_canister_on_subnet_b,
+        &mut subnet_queues,
+        &mut RefundPool::default(),
+    );
 
     // Expect pruned ingress history and no split marker.
     expected.split_from = None;
@@ -798,7 +808,7 @@ fn system_metadata_online_split() {
     // Split off subnet A'.
     let metadata_a = system_metadata
         .clone()
-        .online_split(SUBNET_A, &mut subnet_queues)
+        .online_split(SUBNET_A, &mut subnet_queues, &mut RefundPool::default())
         .unwrap();
 
     // Expect a pruned ingress history.
@@ -831,7 +841,7 @@ fn system_metadata_online_split() {
     // Split off subnet B.
     let metadata_b = system_metadata
         .clone()
-        .online_split(SUBNET_B, &mut subnet_queues)
+        .online_split(SUBNET_B, &mut subnet_queues, &mut RefundPool::default())
         .unwrap();
 
     // Start off with the original metadata state.
@@ -1099,6 +1109,312 @@ fn time_out_delivered_canister_http_request_contexts() {
         manager.time_out_delivered_canister_http_request_contexts(at_second_timeout)
     );
     assert!(manager.delivered_canister_http_request_contexts.is_empty());
+}
+
+/// Cycles that had already been refunded for each of the HTTP outcalls below. A
+/// refund produced by a subnet split must not hand them out a second time.
+const ALREADY_REFUNDED: Cycles = Cycles::new(3_000);
+
+/// An HTTP outcall context from `sender` to the management canister of `subnet_id`,
+/// with `payment` cycles left on the request and `unrefunded` refundable cycles not
+/// refunded yet (on top of the [`ALREADY_REFUNDED`] ones that were).
+fn canister_http_context_for_split(
+    sender: CanisterId,
+    subnet_id: SubnetId,
+    callback_id: CallbackId,
+    pricing_version: PricingVersion,
+    payment: Cycles,
+    unrefunded: Cycles,
+) -> CanisterHttpRequestContext {
+    let mut context = canister_http_request_context(pricing_version, UNIX_EPOCH);
+    context.request = RequestBuilder::default()
+        .sender(sender)
+        .receiver(subnet_id.into())
+        .sender_reply_callback(callback_id)
+        .payment(payment)
+        .build();
+    context.refund_status.refundable_cycles = unrefunded + ALREADY_REFUNDED;
+    context.refund_status.refunded_cycles = ALREADY_REFUNDED;
+    context
+}
+
+/// Pushes `context` as an in-flight HTTP outcall, also reserving a slot for its
+/// response in `subnet_queues`, as inducting the request would have.
+fn push_in_flight_canister_http_call(
+    system_metadata: &mut SystemMetadata,
+    subnet_queues: &mut CanisterQueues,
+    context: CanisterHttpRequestContext,
+) {
+    subnet_queues
+        .push_input(context.request.clone().into(), InputQueueType::LocalSubnet)
+        .unwrap();
+    subnet_queues.pop_input().unwrap();
+    system_metadata
+        .subnet_call_context_manager
+        .push_context(SubnetCallContext::CanisterHttpRequest(context));
+}
+
+/// Pushes `context` as an HTTP outcall whose response has already been delivered.
+/// The delivered context is created when retrieving the one that was pushed.
+fn push_delivered_canister_http_call(
+    system_metadata: &mut SystemMetadata,
+    context: CanisterHttpRequestContext,
+) {
+    let callback_id = system_metadata
+        .subnet_call_context_manager
+        .push_context(SubnetCallContext::CanisterHttpRequest(context));
+    system_metadata
+        .subnet_call_context_manager
+        .retrieve_context(callback_id, &no_op_logger())
+        .unwrap();
+}
+
+/// Splitting off subnet A' settles the HTTP outcalls of the canisters that have
+/// migrated to subnet B, without losing any of the cycles still owed to them:
+/// In-progress outcalls are rejected, refunding the cycles left on the request plus
+/// anyoutstanding refund in the context.
+/// Already delivered outcalls (only retained in order to account for late refunds)
+/// are dropped, with the cycles they still owe pooled as refunds. The outcalls of
+/// canisters that stay behind are left untouched.
+#[test]
+fn online_split_settles_canister_http_calls_of_migrated_canisters() {
+    // We will be splitting subnet A into A' and B.
+    const SUBNET_A: SubnetId = SUBNET_0;
+    const SUBNET_B: SubnetId = SUBNET_1;
+
+    // `LOCAL` is retained on subnet A', `MIGRATED` is split off to subnet B.
+    const LOCAL: CanisterId = CanisterId::from_u64(1);
+    const MIGRATED_U64: u64 = 2;
+    const MIGRATED: CanisterId = CanisterId::from_u64(MIGRATED_U64);
+    let routing_table = RoutingTable::try_from(btreemap! {
+        CanisterIdRange {start: CanisterId::from_u64(0), end: CanisterId::from_u64(MIGRATED_U64 - 1)} => SUBNET_A,
+        CanisterIdRange {start: MIGRATED, end: MIGRATED} => SUBNET_B,
+        CanisterIdRange {start: CanisterId::from_u64(MIGRATED_U64 + 1), end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
+    })
+    .unwrap();
+
+    let mut system_metadata = SystemMetadata::new(SUBNET_A, SubnetType::Application);
+    system_metadata.modify_network_topology(|network_topology| {
+        network_topology.routing_table = Arc::new(routing_table);
+    });
+    let mut subnet_queues = CanisterQueues::default();
+
+    // Two in-progress outcalls of the migrated canister. Under pay-as-you-go pricing
+    // the payment was taken out up front, and moved into the context.
+    const PAYG_CALLBACK: CallbackId = CallbackId::new(1);
+    const PAYG_UNREFUNDED: Cycles = Cycles::new(12_000);
+    push_in_flight_canister_http_call(
+        &mut system_metadata,
+        &mut subnet_queues,
+        canister_http_context_for_split(
+            MIGRATED,
+            SUBNET_A,
+            PAYG_CALLBACK,
+            PricingVersion::PayAsYouGo,
+            Cycles::zero(),
+            PAYG_UNREFUNDED,
+        ),
+    );
+    // Under legacy pricing the caller is refunded through the payment left
+    // on the request, `refund_status` being populated for observability only. Refunding
+    // it as well would hand out the same cycles twice.
+    const LEGACY_CALLBACK: CallbackId = CallbackId::new(2);
+    const LEGACY_PAYMENT: Cycles = Cycles::new(7_000);
+    push_in_flight_canister_http_call(
+        &mut system_metadata,
+        &mut subnet_queues,
+        canister_http_context_for_split(
+            MIGRATED,
+            SUBNET_A,
+            LEGACY_CALLBACK,
+            PricingVersion::Legacy,
+            LEGACY_PAYMENT,
+            Cycles::new(10_000),
+        ),
+    );
+    // And one of the canister that stays behind.
+    let local_in_flight = canister_http_context_for_split(
+        LOCAL,
+        SUBNET_A,
+        CallbackId::new(3),
+        PricingVersion::PayAsYouGo,
+        Cycles::zero(),
+        Cycles::new(10_000),
+    );
+    push_in_flight_canister_http_call(
+        &mut system_metadata,
+        &mut subnet_queues,
+        local_in_flight.clone(),
+    );
+
+    // Two already delivered outcalls of the migrated canister, so that their refunds
+    // are expected to accumulate...
+    const DELIVERED_UNREFUNDED_1: Cycles = Cycles::new(11_000);
+    const DELIVERED_UNREFUNDED_2: Cycles = Cycles::new(2_000);
+    for (callback_id, unrefunded) in [
+        (CallbackId::new(4), DELIVERED_UNREFUNDED_1),
+        (CallbackId::new(5), DELIVERED_UNREFUNDED_2),
+    ] {
+        push_delivered_canister_http_call(
+            &mut system_metadata,
+            canister_http_context_for_split(
+                MIGRATED,
+                SUBNET_A,
+                callback_id,
+                PricingVersion::PayAsYouGo,
+                Cycles::zero(),
+                unrefunded,
+            ),
+        );
+    }
+    // ...and one of the canister that stays behind.
+    let local_delivered = canister_http_context_for_split(
+        LOCAL,
+        SUBNET_A,
+        CallbackId::new(6),
+        PricingVersion::PayAsYouGo,
+        Cycles::zero(),
+        Cycles::new(10_000),
+    );
+    push_delivered_canister_http_call(&mut system_metadata, local_delivered.clone());
+
+    // Split off subnet A'.
+    let mut refunds = RefundPool::default();
+    let metadata_a = system_metadata
+        .online_split(SUBNET_A, &mut subnet_queues, &mut refunds)
+        .unwrap();
+
+    // Only the local canister's outcalls are retained, unchanged, of either kind.
+    let contexts = &metadata_a.subnet_call_context_manager;
+    assert_eq!(
+        vec![&local_in_flight],
+        contexts
+            .canister_http_request_contexts
+            .values()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        vec![&local_delivered],
+        contexts
+            .delivered_canister_http_request_contexts
+            .values()
+            .collect::<Vec<_>>()
+    );
+
+    // The migrated canister is pooled the cycles owed by its delivered outcalls.
+    assert_eq!(
+        vec![(MIGRATED, DELIVERED_UNREFUNDED_1 + DELIVERED_UNREFUNDED_2)],
+        refunds
+            .iter()
+            .map(|refund| (refund.recipient(), refund.amount()))
+            .collect::<Vec<_>>()
+    );
+
+    // And its in-progress outcalls were rejected, refunding the rest.
+    let expected_reject = |callback_id: CallbackId, refund: Cycles| {
+        RequestOrResponse::Response(Arc::new(Response {
+            originator: MIGRATED,
+            respondent: SUBNET_A.into(),
+            originator_reply_callback: callback_id,
+            refund,
+            response_payload: Payload::Reject(RejectContext::new(
+                RejectCode::SysTransient,
+                format!("Canister {MIGRATED} migrated during a subnet split"),
+            )),
+            deadline: CoarseTime::from_secs_since_unix_epoch(0),
+        }))
+    };
+    let mut rejects = Vec::new();
+    while let Some(msg) = subnet_queues.pop_canister_output(&MIGRATED) {
+        rejects.push(msg);
+    }
+    assert_eq!(
+        vec![
+            expected_reject(PAYG_CALLBACK, PAYG_UNREFUNDED),
+            expected_reject(LEGACY_CALLBACK, LEGACY_PAYMENT),
+        ],
+        rejects
+    );
+
+    // Nothing was enqueued for the canister that stayed behind.
+    assert_eq!(None, subnet_queues.pop_canister_output(&LOCAL));
+}
+
+/// Same as above, but for the legacy `split()` + `after_split()` code path: the
+/// second phase must settle the migrated canisters' outcalls just the same.
+#[test]
+fn after_split_settles_canister_http_calls_of_migrated_canisters() {
+    const SUBNET_A: SubnetId = SUBNET_0;
+
+    const LOCAL: CanisterId = CanisterId::from_u64(1);
+    const MIGRATED: CanisterId = CanisterId::from_u64(2);
+    let is_local_canister = |canister_id: CanisterId| canister_id == LOCAL;
+
+    const IN_FLIGHT_CALLBACK: CallbackId = CallbackId::new(1);
+    const IN_FLIGHT_UNREFUNDED: Cycles = Cycles::new(10_000);
+    const DELIVERED_UNREFUNDED: Cycles = Cycles::new(2_000);
+
+    let mut system_metadata = SystemMetadata::new(SUBNET_A, SubnetType::Application);
+    let mut subnet_queues = CanisterQueues::default();
+    push_in_flight_canister_http_call(
+        &mut system_metadata,
+        &mut subnet_queues,
+        canister_http_context_for_split(
+            MIGRATED,
+            SUBNET_A,
+            IN_FLIGHT_CALLBACK,
+            PricingVersion::PayAsYouGo,
+            Cycles::zero(),
+            IN_FLIGHT_UNREFUNDED,
+        ),
+    );
+    push_delivered_canister_http_call(
+        &mut system_metadata,
+        canister_http_context_for_split(
+            MIGRATED,
+            SUBNET_A,
+            CallbackId::new(2),
+            PricingVersion::PayAsYouGo,
+            Cycles::zero(),
+            DELIVERED_UNREFUNDED,
+        ),
+    );
+
+    // Split off subnet A', phase 1 (which retains all subnet call contexts), then
+    // phase 2.
+    let mut metadata_a = system_metadata.split(SUBNET_A, None).unwrap();
+    let mut refunds = RefundPool::default();
+    metadata_a.after_split(is_local_canister, &mut subnet_queues, &mut refunds);
+
+    // Both contexts are gone.
+    let contexts = &metadata_a.subnet_call_context_manager;
+    assert!(contexts.canister_http_request_contexts.is_empty());
+    assert!(contexts.delivered_canister_http_request_contexts.is_empty());
+
+    // The delivered outcall's refund was pooled.
+    assert_eq!(
+        vec![(MIGRATED, DELIVERED_UNREFUNDED)],
+        refunds
+            .iter()
+            .map(|refund| (refund.recipient(), refund.amount()))
+            .collect::<Vec<_>>()
+    );
+
+    // And the in-progress one was rejected, refunding what it owed.
+    assert_eq!(
+        Some(RequestOrResponse::Response(Arc::new(Response {
+            originator: MIGRATED,
+            respondent: SUBNET_A.into(),
+            originator_reply_callback: IN_FLIGHT_CALLBACK,
+            refund: IN_FLIGHT_UNREFUNDED,
+            response_payload: Payload::Reject(RejectContext::new(
+                RejectCode::SysTransient,
+                format!("Canister {MIGRATED} migrated during a subnet split"),
+            )),
+            deadline: CoarseTime::from_secs_since_unix_epoch(0),
+        }))),
+        subnet_queues.pop_canister_output(&MIGRATED)
+    );
 }
 
 pub fn generate_pre_signature(

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1515,6 +1515,9 @@ impl ReplicatedState {
     /// * Updates canisters' input schedules, based on `self.canister_states`.
     /// * Prunes the ingress history, retaining only messages addressed to this
     ///   subnet and messages in terminal states (which will time out).
+    /// * Rejects in-progress subnet messages (management calls and HTTP outcalls)
+    ///   that can no longer be handled here, pooling any refunds owed to the
+    ///   canisters that have migrated away.
     pub fn after_split(&mut self) {
         // Destructure `self` in order for the compiler to enforce an explicit decision
         // whenever new fields are added.
@@ -1525,7 +1528,7 @@ impl ReplicatedState {
             metadata,
             subnet_queues,
             consensus_queue: _,
-            refunds: _,
+            refunds,
             epoch_query_stats,
         } = self;
 
@@ -1561,6 +1564,7 @@ impl ReplicatedState {
         metadata.after_split(
             |canister_id| canister_states.contains_key(&canister_id),
             subnet_queues,
+            refunds,
         );
 
         // Reset query stats after subnet split.
@@ -1681,7 +1685,7 @@ impl ReplicatedState {
         //
         // Prunes the ingress history. And, on *subnet A'* rejects in-progress management
         // calls targeting canisters migrated to *subnet B*.
-        metadata = metadata.online_split(subnet_id, &mut subnet_queues)?;
+        metadata = metadata.online_split(subnet_id, &mut subnet_queues, &mut refunds)?;
 
         Ok(Self {
             canister_states,


### PR DESCRIPTION
## Background
Under the new HTTP outcalls pay-as-you-go pricing, the caller's payment is split into a per-replica allowance which is stored in the context. Each replica consumes part of this allowance to produce their share of the response. Any unspent cycles out of this allowance are transferred back to the caller (initial refund). A late replica which didn't participate in the response, may still issue its refund later, after the call already received a response. Both the initial and late refunds are credited to the canister directly.

For this purpose, there are two collections holding HTTP outcalls in the call context manager: one holding in progress requests (waiting for the response and initial refund), and one holding delivered requests (waiting for late asynchronous refunds).

## Problem
During a subnet split, some canisters may move to a different subnet. Currently, all HTTP contexts stay on the original subnet (A'). Most (if not all) of the in-progress contexts will likely time out because:
1. The committee of a fully-replicated request changed completely, and can no longer collect the required shares.
2. The dedicated node of a non-replicated request may now be on a different subnet.
3. The chosen (min, max, total_requests) of a flexible outcall no longer make sense on a subnet half the size.
4. The selected committee of a flexible outcall was split into two subnets.
5. The transform function belongs to a canister that no longer exists on the subnet.

For legacy pricing, this is generally fine, since any refund is part of the timeout response, which can still be routed to the calling canister, even if it moved to a different subnet.

However, under pay-as-you-go pricing, any refunds can no longer be credited if the canister moved to a different subnet.

## Proposed Changes
Starting with this PR, we reject all in-flight HTTP contexts of canisters that were split off, and attach any outstanding refund to the response directly, without waiting for any refund shares (the call is refunded in full). This way, no new delivered context waiting for further refunds is created. 

Any existing delivered contexts for migrated canisters are also removed. The outstanding refunds are inserted as refund messages into the refund pool, which are routed to the receiving canisters.