### PR TITLE
chore: use a dedicated RBE cluster for release builds

### DIFF
--- a/.github/workflows/ci-rbe-evaluation.yml
+++ b/.github/workflows/ci-rbe-evaluation.yml
@@ -170,6 +170,8 @@ jobs:
     name: Bazel Test All on RBE
     continue-on-error: true
     needs: [config, infer-bazel-targets]
+    environment:
+      name: ${{ case(needs.config.outputs.release-build == 'true', 'release-remote-build-execution-cluster', '') }}
     runs-on: namespace-profile-rbe-driver-amd64-linux-16x32
     container:
       image: nscr.io/c9ptjuknd7oc6/ic-build@sha256:4f5db2c7a9349a5e656c8b72499ebeacb1c3d177a352f2b1a6d9b2aa48147e9d
@@ -194,8 +196,29 @@ jobs:
     steps:
       - uses: namespacelabs/nscloud-setup@v0
       - name: Set up Bazel Remote Execution
+        # For release builds we use a different RBE cluster than the one used for PRs to reduce cache poisoning attacks.
+        # We select this cluster by passing a secret --key which is provided by the environment release-remote-build-execution-cluster
+        # which is only accessible on protected branches.
+        env:
+          RELEASE_BUILD: ${{ needs.config.outputs.release-build }}
+          RBE_CLUSTER_KEY: ${{ secrets.SECRET_RBE_CLUSTER_KEY }}
+        shell: bash
         run: |
-          nsc bazel execution setup --enable_remote_asset_api --bazelrc=/tmp/bazel-rbe.bazelrc
+          set -euo pipefail
+
+          args=(--enable_remote_asset_api --bazelrc=/tmp/bazel-rbe.bazelrc)
+
+          if [[ "$RELEASE_BUILD" == 'true' ]]; then
+            # Fail loudly rather than passing an empty --key: nsc would then fall back to the
+            # default cluster, silently running the release build on the same cluster as PRs.
+            if [[ -z "$RBE_CLUSTER_KEY" ]]; then
+              echo "::error::release build but SECRET_RBE_CLUSTER_KEY is empty; refusing to fall back to the shared PR cluster"
+              exit 1
+            fi
+            args+=(--key="$RBE_CLUSTER_KEY")
+          fi
+
+          nsc bazel execution setup "${args[@]}"
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
See [slack thread](https://dfinity.slack.com/archives/C07D4GX784U/p1786002758159979).

To reduce cache poisoning attacks we would like release builds to be executed on a different RBE cluster than the one used for PRs. This is accomplished by configuring `nsc bazel execution setup` with a  `--key=<SECRET_RBE_CLUSTER_KEY>` documented as:

```
$ nsc bazel setup --help
...
      --key string  Stable identifier that disambiguates multiple parallel execution clusters for the same workspace. Defaults to 'default'.
```

`secrets.SECRET_RBE_CLUSTER_KEY` is only provided by the GitHub environment `release-remote-build-execution-cluster` which is only accessible on the protected branches: `hotfix-*`, `master` and `rc--*` which only a selected number of authorised users can push to.

There's one current issue: `public-hotfix-*` branches set `release-build` to `true` but they are not protected in the same way as the before mentioned branches, i.e. anybody with Write access can push to them. This means that the RBE job will fail on them. I'll probably fix this by not setting `release-build` to `true` for  `public-hotfix-*` branches. I don't think they need it. But I need to confirm with the relevant engineers. See: https://github.com/dfinity/ic/pull/11047.