### PR TITLE
chore: don't run CI on public-hotfix branches

### DIFF
--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - 'dev-gh-*'
-      - 'public-hotfix-*'
   pull_request:
     branches-ignore:
       - hotfix-* # This is to ensure that this workflow is not triggered twice on ic-private, as it's already triggered from release-testing

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -89,7 +89,7 @@ jobs:
 
           # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
           # the full build to occur (including versioning)
-          protected_branches=("^master$" "^rc--" "^hotfix-" "^public-hotfix-")
+          protected_branches=("^master$" "^rc--" "^hotfix-")
           for pattern in "${protected_branches[@]}"; do
               if [[ "$BRANCH_NAME" =~ $pattern ]]; then
                   is_protected_branch="true"
@@ -235,7 +235,7 @@ jobs:
           bazel_args=( --config=flaky_retry ) # auto retry eg systests
           if [[ "$CI_EVENT_NAME" == 'merge_group' ]]; then
               bazel_args+=( --test_timeout_filters=short,moderate --flaky_test_attempts=3 )
-          elif [[ $BRANCH_NAME =~ ^(hotfix-|public-hotfix-) ]]; then
+          elif [[ $BRANCH_NAME =~ ^hotfix- ]]; then
               bazel_args+=( --test_timeout_filters=short,moderate )
           else
               bazel_args+=( --keep_going )
@@ -661,8 +661,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'CI_RUN_CARGO_JOBS') ||
           env.BRANCH_NAME == 'master' ||
           startsWith(env.BRANCH_NAME, 'rc--') ||
-          startsWith(env.BRANCH_NAME, 'hotfix-') ||
-          startsWith(env.BRANCH_NAME, 'public-hotfix-')
+          startsWith(env.BRANCH_NAME, 'hotfix-')
         shell: bash
         env:
           # on dind_small cargo sometimes runs out of files (when building and linting). This trades
@@ -745,7 +744,6 @@ jobs:
           steps.filter.outputs.container-run == 'true' ||
           env.BRANCH_NAME == 'master' ||
           startsWith(env.BRANCH_NAME, 'rc--') ||
-          startsWith(env.BRANCH_NAME, 'hotfix-') ||
-          startsWith(env.BRANCH_NAME, 'public-hotfix-')
+          startsWith(env.BRANCH_NAME, 'hotfix-')
         run: |
           ./ci/container/container-run.sh ${{ matrix.command }}

--- a/.github/workflows/ci-rbe-evaluation.yml
+++ b/.github/workflows/ci-rbe-evaluation.yml
@@ -44,7 +44,7 @@ jobs:
 
           # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
           # the full build to occur (including versioning)
-          protected_branches=("^master$" "^rc--" "^hotfix-" "^public-hotfix-")
+          protected_branches=("^master$" "^rc--" "^hotfix-")
           for pattern in "${protected_branches[@]}"; do
               if [[ "$BRANCH_NAME" =~ $pattern ]]; then
                   is_protected_branch="true"
@@ -210,7 +210,7 @@ jobs:
           bazel_args=( --config=flaky_retry ) # auto retry eg systests
           if [[ "$CI_EVENT_NAME" == 'merge_group' ]]; then
               bazel_args+=( --test_timeout_filters=short,moderate --flaky_test_attempts=3 )
-          elif [[ $BRANCH_NAME =~ ^(hotfix-|public-hotfix-) ]]; then
+          elif [[ $BRANCH_NAME =~ ^hotfix- ]]; then
               bazel_args+=( --test_timeout_filters=short,moderate )
           else
               bazel_args+=( --keep_going )


### PR DESCRIPTION
When a hotfix lands on a `public-hotfix-*` branch it has already been build, released and deployed so it doesn't have to be build and released again.

It's also the case that  `public-hotfix-*` branches are not protected in the same way as `master`, `rc--*` and `hotfix-*`, i.e. any user with Write access to the repo can push to them.

We would like to make branches that build releases more secure. The end goal is that builds on those branches will run on a cluster separate from the one used for PRs to reduce the risk of cache poisoning attacks. `public-hotfix-*` branches currently trigger a release build which conflicts with this.

So this commit simply removes any `public-hotfix-*` trigger from our CI logic so it's treated like a normal feature branch. Note that the GitHub branch protection for `public-hotfix-*` remains in place.