### PR TITLE
feat: migrate remaining ic-cdk ::call to Call

### DIFF
--- a/rs/boundary_node/rate_limits/canister/canister.rs
+++ b/rs/boundary_node/rate_limits/canister/canister.rs
@@ -1,5 +1,4 @@
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use crate::access_control::{AccessLevelResolver, WithAuthorization};
 use crate::add_config::{AddsConfig, ConfigAdder};
@@ -15,7 +14,7 @@ use crate::metrics::{
 use crate::state::{CanisterApi, init_version_and_config, with_canister_state};
 use candid::Principal;
 use ic_canister_log::{export as export_logs, log};
-use ic_cdk::api::call::call;
+use ic_cdk::call::Call;
 use ic_cdk::{
     api::{accept_message, msg_caller, msg_method_name},
     init, inspect_message, post_upgrade, query, update,
@@ -260,17 +259,18 @@ fn periodically_poll_api_boundary_nodes(interval: u64, canister_api: Arc<dyn Can
         async move {
             let canister_id = Principal::from(REGISTRY_CANISTER_ID);
 
-            let (call_status, message) = match call::<
-                _,
-                (Result<Vec<ApiBoundaryNodeIdRecord>, String>,),
-            >(
-                canister_id,
-                REGISTRY_CANISTER_METHOD,
-                (&GetApiBoundaryNodeIdsRequest {},),
-            )
-            .await
-            {
-                Ok((Ok(api_bn_records),)) => {
+            let response = Call::unbounded_wait(canister_id, REGISTRY_CANISTER_METHOD)
+                .with_arg(GetApiBoundaryNodeIdsRequest {})
+                .await
+                .map_err(|err| err.to_string())
+                .and_then(|response| {
+                    response
+                        .candid::<Result<Vec<ApiBoundaryNodeIdRecord>, String>>()
+                        .map_err(|err| err.to_string())
+                });
+
+            let (call_status, message) = match response {
+                Ok(Ok(api_bn_records)) => {
                     // Set authorized readers of the rate-limit config.
                     canister_api.set_api_boundary_nodes_principals(
                         api_bn_records.into_iter().filter_map(|n| n.id).collect(),
@@ -285,7 +285,7 @@ fn periodically_poll_api_boundary_nodes(interval: u64, canister_api: Arc<dyn Can
                     });
                     ("success", "")
                 }
-                Ok((Err(err),)) => {
+                Ok(Err(err)) => {
                     log!(
                         P0,
                         "[poll_api_boundary_nodes]: failed to fetch nodes from registry {err:?}",

--- a/rs/nervous_system/long_message/src/lib.rs
+++ b/rs/nervous_system/long_message/src/lib.rs
@@ -1,6 +1,7 @@
-#![allow(deprecated)]
 #[cfg(target_arch = "wasm32")]
 use ic_cdk::api::{call_context_instruction_counter, canister_self, instruction_counter};
+#[cfg(target_arch = "wasm32")]
+use ic_cdk::call::Call;
 use ic_cdk::query;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -51,7 +52,7 @@ async fn make_noop_call() {}
 /// Makes a call to a no-op function defined in this library.
 #[cfg(target_arch = "wasm32")]
 async fn make_noop_call() {
-    () = ic_cdk::call(canister_self(), "__long_message_noop", ())
+    let _response = Call::unbounded_wait(canister_self(), "__long_message_noop")
         .await
         .unwrap();
 }

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -10,12 +10,12 @@
 //! Of course, after calling the Management canister's `install_code` method,
 //! this start the canister back up again, and unlocks it.
 
-#![allow(deprecated)]
 use crate::{LOG_PREFIX, private::perform_offline_canister_maintenance};
 use candid::{CandidType, Deserialize, Encode, Principal};
 use dfn_core::api::CanisterId;
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
+use ic_cdk::call::{Call, CallFailed, RejectCode};
 use ic_crypto_sha2::Sha256;
 use ic_management_canister_types_private::{
     CanisterInstallModeV2, ChunkHash, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
@@ -265,7 +265,9 @@ pub async fn change_canister(request: ChangeCanisterRequest) -> Result<(), Strin
     // This handles errors coming from install_code (which is more or less a
     // thin wrapper around the Management canister method), such as the
     // DESTINATION_INVALID (3) reject code.
-    result.map_err(|(rejection_code, message)| {
+    result.map_err(|err| {
+        let (rejection_code, message) = map_call_error(err);
+
         format!(
             "Attempt to call install_code with request {request_str} failed with code \
              {rejection_code:?}: {message}"
@@ -273,8 +275,22 @@ pub async fn change_canister(request: ChangeCanisterRequest) -> Result<(), Strin
     })
 }
 
+/// Translates a failed call into the `(reject code, message)` pair that the error message
+/// above reports. Reports the same codes that the deprecated `ic_cdk::api::call` did.
+fn map_call_error(err: CallFailed) -> (RejectCode, String) {
+    match err {
+        CallFailed::CallRejected(rejected) => (
+            rejected.reject_code().unwrap_or(RejectCode::SysUnknown),
+            rejected.reject_message().to_string(),
+        ),
+
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient, err.to_string()),
+    }
+}
+
 /// Calls a function of the management canister to install the requested code.
-async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::CallResult<()> {
+async fn install_code(request: ChangeCanisterRequest) -> Result<(), CallFailed> {
     let ChangeCanisterRequest {
         mode,
         canister_id,
@@ -308,12 +324,13 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
             arg,
             sender_canister_version,
         };
-        ic_cdk::api::call::call(
+        Call::unbounded_wait(
             Principal::try_from(IC_00.get().as_slice()).unwrap(),
             "install_chunked_code",
-            (&argument,),
         )
+        .with_arg(&argument)
         .await
+        .map(|_reply| ())
     } else {
         let argument = InstallCodeArgsV2 {
             mode,
@@ -322,12 +339,13 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
             arg,
             sender_canister_version,
         };
-        ic_cdk::api::call::call(
+        Call::unbounded_wait(
             Principal::try_from(IC_00.get().as_slice()).unwrap(),
             "install_code",
-            (&argument,),
         )
+        .with_arg(&argument)
         .await
+        .map(|_reply| ())
     }
 }
 

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -15,7 +15,7 @@ use candid::{CandidType, Deserialize, Encode, Principal};
 use dfn_core::api::CanisterId;
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
-use ic_cdk::call::{Call, CallFailed, RejectCode};
+use ic_cdk::call::{Call, CallFailed};
 use ic_crypto_sha2::Sha256;
 use ic_management_canister_types_private::{
     CanisterInstallModeV2, ChunkHash, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
@@ -265,28 +265,11 @@ pub async fn change_canister(request: ChangeCanisterRequest) -> Result<(), Strin
     // This handles errors coming from install_code (which is more or less a
     // thin wrapper around the Management canister method), such as the
     // DESTINATION_INVALID (3) reject code.
+    // `CallFailed`'s `Display` already spells out the failure (for a reject, it
+    // includes the reject code and the callee's message).
     result.map_err(|err| {
-        let (rejection_code, message) = map_call_error(err);
-
-        format!(
-            "Attempt to call install_code with request {request_str} failed with code \
-             {rejection_code:?}: {message}"
-        )
+        format!("Attempt to call install_code with request {request_str} failed: {err}")
     })
-}
-
-/// Translates a failed call into the `(reject code, message)` pair that the error message
-/// above reports. Reports the same codes that the deprecated `ic_cdk::api::call` did.
-fn map_call_error(err: CallFailed) -> (RejectCode, String) {
-    match err {
-        CallFailed::CallRejected(rejected) => (
-            rejected.reject_code().unwrap_or(RejectCode::SysUnknown),
-            rejected.reject_message().to_string(),
-        ),
-
-        // The call never left this canister, so it may well succeed if retried.
-        err => (RejectCode::SysTransient, err.to_string()),
-    }
 }
 
 /// Calls a function of the management canister to install the requested code.

--- a/rs/nervous_system/runtime/src/lib.rs
+++ b/rs/nervous_system/runtime/src/lib.rs
@@ -1,7 +1,7 @@
-#![allow(deprecated)]
 use async_trait::async_trait;
 use candid::utils::{ArgumentDecoder, ArgumentEncoder};
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_cdk::call::{Call, Error as IcCdkCallError, RejectCode};
 use std::future::Future;
 
 // A trait to help parameterize the switch from dfn_core to ic_cdk. It should
@@ -106,6 +106,23 @@ impl Runtime for DfnRuntime {
 
 pub struct CdkRuntime;
 
+/// Translates a failed call into the `(reject code, message)` pair that
+/// [`Runtime`] reports to its callers.
+fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+    match err {
+        IcCdkCallError::CallRejected(rejected) => (
+            rejected.raw_reject_code() as i32,
+            rejected.reject_message().to_string(),
+        ),
+        // A response that cannot be decoded means the callee misbehaved.
+        IcCdkCallError::CandidDecodeFailed(err) => {
+            (RejectCode::CanisterError as i32, err.to_string())
+        }
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient as i32, err.to_string()),
+    }
+}
+
 #[async_trait]
 impl Runtime for CdkRuntime {
     // This method does not do clean up.
@@ -131,9 +148,12 @@ impl Runtime for CdkRuntime {
         Out: for<'a> ArgumentDecoder<'a>,
     {
         let principal_id = PrincipalId::from(id);
-        ic_cdk::api::call::call(principal_id.into(), method, args)
+        Call::unbounded_wait(principal_id.into(), method)
+            .with_args(&args)
             .await
-            .map_err(|(code, msg)| (code as i32, msg))
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple().map_err(IcCdkCallError::from))
+            .map_err(map_call_error)
     }
 
     async fn call_bytes_with_cleanup(
@@ -142,9 +162,11 @@ impl Runtime for CdkRuntime {
         args: &[u8],
     ) -> Result<Vec<u8>, (i32, String)> {
         let principal_id = PrincipalId::from(id);
-        ic_cdk::api::call::call_raw(principal_id.into(), method, args, 0)
+        Call::unbounded_wait(principal_id.into(), method)
+            .with_raw_args(args)
             .await
-            .map_err(|(code, msg)| (code as i32, msg))
+            .map(|response| response.into_bytes())
+            .map_err(|err| map_call_error(err.into()))
     }
 
     fn spawn_future<F: 'static + Future<Output = ()>>(future: F) {

--- a/rs/nervous_system/runtime/src/lib.rs
+++ b/rs/nervous_system/runtime/src/lib.rs
@@ -108,7 +108,11 @@ pub struct CdkRuntime;
 
 /// Translates a failed call into the `(reject code, message)` pair that
 /// [`Runtime`] reports to its callers.
-fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+///
+/// The match is deliberately exhaustive (rather than using a catch-all arm) so
+/// that a new [`IcCdkCallError`] variant forces us to revisit this mapping
+/// instead of silently classifying it as [`RejectCode::SysTransient`].
+fn into_reject_code_and_message(err: IcCdkCallError) -> (i32, String) {
     match err {
         IcCdkCallError::CallRejected(rejected) => (
             rejected.raw_reject_code() as i32,
@@ -118,8 +122,14 @@ fn map_call_error(err: IcCdkCallError) -> (i32, String) {
         IcCdkCallError::CandidDecodeFailed(err) => {
             (RejectCode::CanisterError as i32, err.to_string())
         }
-        // The call never left this canister, so it may well succeed if retried.
-        err => (RejectCode::SysTransient as i32, err.to_string()),
+        // Neither of these ever left this canister, so the call may well succeed
+        // if retried.
+        IcCdkCallError::InsufficientLiquidCycleBalance(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
+        IcCdkCallError::CallPerformFailed(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
     }
 }
 
@@ -153,7 +163,7 @@ impl Runtime for CdkRuntime {
             .await
             .map_err(IcCdkCallError::from)
             .and_then(|response| response.candid_tuple().map_err(IcCdkCallError::from))
-            .map_err(map_call_error)
+            .map_err(into_reject_code_and_message)
     }
 
     async fn call_bytes_with_cleanup(
@@ -166,7 +176,7 @@ impl Runtime for CdkRuntime {
             .with_raw_args(args)
             .await
             .map(|response| response.into_bytes())
-            .map_err(|err| map_call_error(err.into()))
+            .map_err(|err| into_reject_code_and_message(err.into()))
     }
 
     fn spawn_future<F: 'static + Future<Output = ()>>(future: F) {

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -1,10 +1,9 @@
-#![allow(deprecated)]
 pub use ic_management_canister_types::CanisterSettings;
 
 use candid::{CandidType, Nat};
-use ic_cdk::api::{
-    call::{CallResult, RejectionCode},
-    msg_caller,
+use ic_cdk::{
+    api::msg_caller,
+    call::{Call, Error as IcCdkCallError, RejectCode},
 };
 use std::time::{Duration, SystemTime};
 
@@ -66,29 +65,53 @@ pub fn caller() -> PrincipalId {
     PrincipalId::from(msg_caller())
 }
 
+/// Translates a failed call into the `(reject code, message)` pair that [`call_protobuf`]
+/// and this canister's error messages report.
+pub fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+    match err {
+        IcCdkCallError::CallRejected(rejected) => (
+            rejected.raw_reject_code() as i32,
+            rejected.reject_message().to_string(),
+        ),
+        // A response that cannot be decoded means the callee misbehaved.
+        IcCdkCallError::CandidDecodeFailed(err) => {
+            (RejectCode::CanisterError as i32, err.to_string())
+        }
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient as i32, err.to_string()),
+    }
+}
+
+/// A Protobuf codec failure is not a reject, so no `RejectCode` really describes it.
+/// `SysUnknown` has the same numeric value (6) as the `RejectionCode::Unknown` that this
+/// used to report, so callers that log the code observe no change.
+const PROTOBUF_CODEC_FAILURE_CODE: i32 = RejectCode::SysUnknown as i32;
+
 // Duplicating some functionality that is no longer available
 // after migration to ic_cdk
 pub async fn call_protobuf<Arg, Res>(
     canister_id: CanisterId,
     method_name: &str,
     arg: Arg,
-) -> CallResult<Res>
+) -> Result<Res, (i32, String)>
 where
     Arg: ToProto,
     Res: ToProto,
 {
     let bytes = ProtoBuf::new(arg)
         .into_bytes()
-        .map_err(|e| (RejectionCode::Unknown, e.to_string()))?;
+        .map_err(|e| (PROTOBUF_CODEC_FAILURE_CODE, e.to_string()))?;
 
-    let res: CallResult<Vec<u8>> =
-        ic_cdk::api::call::call_raw(canister_id.get().0, method_name, bytes.as_slice(), 0).await;
+    let response = Call::unbounded_wait(canister_id.get().0, method_name)
+        .take_raw_args(bytes)
+        .await
+        .map_err(|err| map_call_error(err.into()))?;
 
-    res.and_then(|bytes| {
-        Ok(ProtoBuf::<Res>::from_bytes(bytes)
-            .map_err(|e| (RejectionCode::Unknown, e.to_string()))?
-            .into_inner())
-    })
+    let res = ProtoBuf::<Res>::from_bytes(response.into_bytes())
+        .map_err(|e| (PROTOBUF_CODEC_FAILURE_CODE, e.to_string()))?
+        .into_inner();
+
+    Ok(res)
 }
 
 pub fn now_system_time() -> SystemTime {

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -67,7 +67,11 @@ pub fn caller() -> PrincipalId {
 
 /// Translates a failed call into the `(reject code, message)` pair that [`call_protobuf`]
 /// and this canister's error messages report.
-pub fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+///
+/// The match is deliberately exhaustive (rather than using a catch-all arm) so
+/// that a new [`IcCdkCallError`] variant forces us to revisit this mapping
+/// instead of silently classifying it as [`RejectCode::SysTransient`].
+pub fn into_reject_code_and_message(err: IcCdkCallError) -> (i32, String) {
     match err {
         IcCdkCallError::CallRejected(rejected) => (
             rejected.raw_reject_code() as i32,
@@ -77,8 +81,14 @@ pub fn map_call_error(err: IcCdkCallError) -> (i32, String) {
         IcCdkCallError::CandidDecodeFailed(err) => {
             (RejectCode::CanisterError as i32, err.to_string())
         }
-        // The call never left this canister, so it may well succeed if retried.
-        err => (RejectCode::SysTransient as i32, err.to_string()),
+        // Neither of these ever left this canister, so the call may well succeed
+        // if retried.
+        IcCdkCallError::InsufficientLiquidCycleBalance(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
+        IcCdkCallError::CallPerformFailed(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
     }
 }
 
@@ -105,7 +115,7 @@ where
     let response = Call::unbounded_wait(canister_id.get().0, method_name)
         .take_raw_args(bytes)
         .await
-        .map_err(|err| map_call_error(err.into()))?;
+        .map_err(|err| into_reject_code_and_message(err.into()))?;
 
     let res = ProtoBuf::<Res>::from_bytes(response.into_bytes())
         .map_err(|e| (PROTOBUF_CODEC_FAILURE_CODE, e.to_string()))?

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use candid::{CandidType, Encode, Nat};
 use core::cmp::Ordering;
 use cycles_minting_canister::*;
@@ -6,9 +5,10 @@ use environment::Environment;
 use exchange_rate_canister::{UpdateExchangeRateError, UpdateExchangeRateState};
 use ic_cdk::{
     api::{
-        call::CallResult, canister_cycle_balance, canister_self, certified_data_set,
-        msg_cycles_accept, msg_cycles_available, msg_reject, msg_reply,
+        canister_cycle_balance, canister_self, certified_data_set, msg_cycles_accept,
+        msg_cycles_available, msg_reject, msg_reply,
     },
+    call::{Call, Error as IcCdkCallError},
     heartbeat, init, post_upgrade, pre_upgrade, println, query, update,
 };
 use ic_crypto_tree_hash::{
@@ -2041,14 +2041,12 @@ async fn burn_and_log(from_subaccount: Subaccount, amount: Tokens) {
         to: minting_account_id,
         created_at_time: None,
     };
-    let res: CallResult<BlockIndex> = call_protobuf(ledger_canister_id, "send_pb", send_args).await;
+    let res: Result<BlockIndex, (i32, String)> =
+        call_protobuf(ledger_canister_id, "send_pb", send_args).await;
 
     match res {
         Ok(block) => print(format!("{msg} done in block {block}.")),
-        Err((code, err)) => {
-            let code = code as i32;
-            print(format!("{msg} failed with code {code}: {err:?}"))
-        }
+        Err((code, err)) => print(format!("{msg} failed with code {code}: {err:?}")),
     }
 }
 
@@ -2089,14 +2087,11 @@ async fn refund_icp(
             to,
             created_at_time: None,
         };
-        let send_res: CallResult<BlockIndex> =
+        let send_res: Result<BlockIndex, (i32, String)> =
             call_protobuf(ledger_canister_id, "send_pb", send_args).await;
-        let block = send_res.map_err(|(code, err)| {
-            let code = code as i32;
-            NotifyError::Other {
-                error_code: NotifyErrorCode::RefundFailed as u64,
-                error_message: format!("Refund to {to} failed with code {code}: {err}"),
-            }
+        let block = send_res.map_err(|(code, err)| NotifyError::Other {
+            error_code: NotifyErrorCode::RefundFailed as u64,
+            error_message: format!("Refund to {to} failed with code {code}: {err}"),
         })?;
 
         print(format!("Refund to {to} done in block {block}."));
@@ -2121,21 +2116,18 @@ async fn deposit_cycles(
         ensure_balance(cycles, limiter_to_use)?;
     }
 
-    let res: CallResult<()> = ic_cdk::api::call::call_with_payment128(
+    let _response = Call::unbounded_wait(
         candid::Principal::management_canister(),
         METHOD_DEPOSIT_CYCLES,
-        (CanisterIdRecord {
-            canister_id: canister_id.get().0,
-        },),
-        u128::from(cycles),
     )
-    .await;
-
-    res.map_err(|(code, msg)| {
-        format!(
-            "Depositing cycles failed with code {}: {:?}",
-            code as i32, msg
-        )
+    .with_arg(&CanisterIdRecord {
+        canister_id: canister_id.get().0,
+    })
+    .with_cycles(u128::from(cycles))
+    .await
+    .map_err(|err| {
+        let (code, msg) = map_call_error(err.into());
+        format!("Depositing cycles failed with code {code}: {msg:?}")
     })?;
 
     Ok(())
@@ -2159,20 +2151,20 @@ async fn do_mint_cycles(
         memo: deposit_memo,
     };
 
-    let result: CallResult<(CyclesLedgerDepositResult,)> = ic_cdk::api::call::call_with_payment128(
-        cycles_ledger_canister_id.get().0,
-        "deposit",
-        (arg,),
-        u128::from(cycles),
-    )
-    .await;
-
-    result.map(|r| r.0).map_err(|(code, msg)| {
-        format!(
-            "Cycles ledger rejected deposit call with code {}: {:?}",
-            code as i32, msg
-        )
-    })
+    Call::unbounded_wait(cycles_ledger_canister_id.get().0, "deposit")
+        .with_arg(&arg)
+        .with_cycles(u128::from(cycles))
+        .await
+        .map_err(IcCdkCallError::from)
+        .and_then(|response| {
+            response
+                .candid::<CyclesLedgerDepositResult>()
+                .map_err(IcCdkCallError::from)
+        })
+        .map_err(|err| {
+            let (code, msg) = map_call_error(err);
+            format!("Cycles ledger rejected deposit call with code {code}: {msg:?}")
+        })
 }
 
 async fn do_create_canister(
@@ -2265,28 +2257,31 @@ async fn do_create_canister(
         });
 
     for subnet_id in subnets {
-        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment128(
-            subnet_id.get().0,
-            METHOD_CREATE_CANISTER,
-            (CreateCanisterArgs {
+        let result = Call::unbounded_wait(subnet_id.get().0, METHOD_CREATE_CANISTER)
+            .with_arg(&CreateCanisterArgs {
                 settings: Some(canister_settings.clone()),
                 sender_canister_version: Some(ic_cdk::api::canister_version()),
-            },),
-            u128::from(cycles),
-        )
-        .await;
+            })
+            .with_cycles(u128::from(cycles))
+            .await
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<CanisterIdRecord>()
+                    .map_err(IcCdkCallError::from)
+            });
 
         let canister_id = match result {
-            Ok((canister_id_record,)) => {
+            Ok(canister_id_record) => {
                 // Safe: canister_id returned by the management canister is always a valid canister principal.
                 CanisterId::unchecked_from_principal(PrincipalId::from(
                     canister_id_record.canister_id,
                 ))
             }
-            Err((code, msg)) => {
+            Err(err) => {
+                let (code, msg) = map_call_error(err);
                 let err = format!(
-                    "Creating canister in subnet {} failed with code {}: {}",
-                    subnet_id, code as i32, msg
+                    "Creating canister in subnet {subnet_id} failed with code {code}: {msg}"
                 );
                 print(format!("[cycles] {err}"));
                 last_err = Some(err);
@@ -2346,21 +2341,14 @@ fn get_subnets_for(controller_id: &PrincipalId) -> Vec<SubnetId> {
 }
 
 async fn get_rng() -> Result<StdRng, String> {
-    let res: CallResult<(Vec<u8>,)> = ic_cdk::call(
-        candid::Principal::management_canister(),
-        METHOD_RAW_RAND,
-        (),
-    )
-    .await;
-
-    let bytes = res
-        .map_err(|(code, msg)| {
-            format!(
-                "Getting random bytes failed with code {}: {:?}",
-                code as i32, msg
-            )
-        })?
-        .0;
+    let bytes = Call::unbounded_wait(candid::Principal::management_canister(), METHOD_RAW_RAND)
+        .await
+        .map_err(IcCdkCallError::from)
+        .and_then(|response| response.candid::<Vec<u8>>().map_err(IcCdkCallError::from))
+        .map_err(|err| {
+            let (code, msg) = map_call_error(err);
+            format!("Getting random bytes failed with code {code}: {msg:?}")
+        })?;
 
     Ok(StdRng::from_seed(bytes[0..32].try_into().unwrap()))
 }

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -2126,7 +2126,7 @@ async fn deposit_cycles(
     .with_cycles(u128::from(cycles))
     .await
     .map_err(|err| {
-        let (code, msg) = map_call_error(err.into());
+        let (code, msg) = into_reject_code_and_message(err.into());
         format!("Depositing cycles failed with code {code}: {msg:?}")
     })?;
 
@@ -2162,7 +2162,7 @@ async fn do_mint_cycles(
                 .map_err(IcCdkCallError::from)
         })
         .map_err(|err| {
-            let (code, msg) = map_call_error(err);
+            let (code, msg) = into_reject_code_and_message(err);
             format!("Cycles ledger rejected deposit call with code {code}: {msg:?}")
         })
 }
@@ -2279,7 +2279,7 @@ async fn do_create_canister(
                 ))
             }
             Err(err) => {
-                let (code, msg) = map_call_error(err);
+                let (code, msg) = into_reject_code_and_message(err);
                 let err = format!(
                     "Creating canister in subnet {subnet_id} failed with code {code}: {msg}"
                 );
@@ -2346,7 +2346,7 @@ async fn get_rng() -> Result<StdRng, String> {
         .map_err(IcCdkCallError::from)
         .and_then(|response| response.candid::<Vec<u8>>().map_err(IcCdkCallError::from))
         .map_err(|err| {
-            let (code, msg) = map_call_error(err);
+            let (code, msg) = into_reject_code_and_message(err);
             format!("Getting random bytes failed with code {code}: {msg:?}")
         })?;
 

--- a/rs/nns/common/src/registry.rs
+++ b/rs/nns/common/src/registry.rs
@@ -1,6 +1,5 @@
-#![allow(deprecated)]
 use ic_base_types::{PrincipalId, SubnetId};
-use ic_cdk::api::call::call_raw;
+use ic_cdk::call::{Call, CallFailed};
 use ic_nervous_system_canisters::registry::RegistryCanister;
 use ic_nns_constants::REGISTRY_CANISTER_ID;
 use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetRecord};
@@ -27,14 +26,11 @@ pub async fn get_value<T: Message + Default>(
     key: &[u8],
     version: Option<u64>,
 ) -> Result<(T, u64), Error> {
-    let current_result: Vec<u8> = call_raw(
-        REGISTRY_CANISTER_ID.get().0,
-        "get_value",
-        serialize_get_value_request(key.to_vec(), version).unwrap(),
-        0,
-    )
-    .await
-    .unwrap();
+    let current_result: Vec<u8> = Call::unbounded_wait(REGISTRY_CANISTER_ID.get().0, "get_value")
+        .take_raw_args(serialize_get_value_request(key.to_vec(), version).unwrap())
+        .await
+        .unwrap()
+        .into_bytes();
 
     let response = deserialize_get_value_response(current_result)?;
 
@@ -59,19 +55,19 @@ pub async fn mutate_registry(
     preconditions: Vec<Precondition>,
 ) -> Result<u64, String> {
     let mutation_bytes = serialize_atomic_mutate_request(mutations, preconditions);
-    let response_bytes = call_raw(
-        REGISTRY_CANISTER_ID.get().0,
-        "atomic_mutate",
-        mutation_bytes,
-        0,
-    )
-    .await
-    .map_err(|e| {
-        format!(
-            "The call to the registry's 'atomic_mutate' method failed due to: {}",
-            e.1
-        )
-    })?;
+    let response_bytes = Call::unbounded_wait(REGISTRY_CANISTER_ID.get().0, "atomic_mutate")
+        .take_raw_args(mutation_bytes)
+        .await
+        .map_err(|err| {
+            // Report just the reject message, as the deprecated `call_raw` did.
+            let message = match err {
+                CallFailed::CallRejected(rejected) => rejected.reject_message().to_string(),
+                err => err.to_string(),
+            };
+
+            format!("The call to the registry's 'atomic_mutate' method failed due to: {message}")
+        })?
+        .into_bytes();
     let response = RegistryAtomicMutateResponse::decode(response_bytes.as_slice())
         .map_err(|e| format!("The registry's response to 'atomic_mutate' could not be decoded as a RegistryAtomicMutateResponse due to: {e} "))?;
     match response.errors.len() {
@@ -116,13 +112,11 @@ pub fn get_subnet_ids_from_subnet_list(subnet_list: SubnetListRecord) -> Vec<Sub
 
 /// Returns the latest version of the registry
 pub async fn get_latest_version() -> u64 {
-    let response: Vec<u8> = call_raw(
-        REGISTRY_CANISTER_ID.get().0,
-        "get_latest_version",
-        vec![],
-        0,
-    )
-    .await
-    .unwrap();
+    let response: Vec<u8> =
+        Call::unbounded_wait(REGISTRY_CANISTER_ID.get().0, "get_latest_version")
+            .with_raw_args(&[])
+            .await
+            .unwrap()
+            .into_bytes();
     deserialize_get_latest_version_response(response).unwrap()
 }

--- a/rs/nns/nns.bzl
+++ b/rs/nns/nns.bzl
@@ -24,5 +24,5 @@ CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = {
     "governance-canister.wasm.gz": 24,
     "governance-canister_test.wasm.gz": 26,
     "registry-canister.wasm.gz": 17,
-    "root-canister.wasm.gz": 5,
+    "root-canister.wasm.gz": 6,
 }

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -1,7 +1,6 @@
-#![allow(deprecated)]
 use async_trait::async_trait;
 use ic_base_types::{PrincipalId, SubnetId};
-use ic_cdk::api::call::{CallResult, RejectionCode};
+use ic_cdk::call::{Call, Error as IcCdkCallError, RejectCode};
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_management_canister_types_private::{
     CanisterInstallMode::Install, CanisterSettingsArgsBuilder, CreateCanisterArgs, InstallCodeArgs,
@@ -78,22 +77,23 @@ impl CanisterApi for CanisterApiImpl {
             .with_controllers(vec![controller_id])
             .with_wasm_memory_limit(wasm_memory_limit);
 
-        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment128(
-            target_subnet.get().0,
-            &Method::CreateCanister.to_string(),
-            (CreateCanisterArgs {
+        Call::unbounded_wait(target_subnet.get().0, &Method::CreateCanister.to_string())
+            .with_arg(&CreateCanisterArgs {
                 settings: Some(settings.build()),
                 sender_canister_version: Some(ic_cdk::api::canister_version()),
-            },),
-            cycles.get(),
-        )
-        .await;
-
-        result
+            })
+            .with_cycles(cycles.get())
+            .await
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<CanisterIdRecord>()
+                    .map_err(IcCdkCallError::from)
+            })
             .map_err(handle_call_error(format!(
                 "Creating canister in subnet {target_subnet} failed"
             )))
-            .map(|record| record.0.get_canister_id())
+            .map(|record| record.get_canister_id())
     }
 
     /// See CanisterApi::delete_canister
@@ -102,16 +102,13 @@ impl CanisterApi for CanisterApiImpl {
         self.stop_canister(canister).await?;
 
         // TODO(NNS1-1524) We need to collect the cycles from the canister before we delete it
-        let response: CallResult<()> = ic_cdk::call(
-            CanisterId::ic_00().get().0,
-            "delete_canister",
-            (CanisterIdRecord::from(canister),),
-        )
-        .await;
-
-        response.map_err(handle_call_error(format!(
-            "Failed to delete canister {canister}"
-        )))
+        Call::unbounded_wait(CanisterId::ic_00().get().0, "delete_canister")
+            .with_arg(CanisterIdRecord::from(canister))
+            .await
+            .map(|_reply| ())
+            .map_err(handle_call_error(format!(
+                "Failed to delete canister {canister}"
+            )))
     }
 
     /// See CanisterApi::install_wasm
@@ -128,12 +125,13 @@ impl CanisterApi for CanisterApiImpl {
             arg: init_payload,
             sender_canister_version: Some(ic_cdk::api::canister_version()),
         };
-        let install_res: CallResult<()> =
-            ic_cdk::call(CanisterId::ic_00().get().0, "install_code", (install_args,)).await;
-
-        install_res.map_err(handle_call_error(format!(
-            "Failed to install WASM on canister {target_canister}"
-        )))
+        Call::unbounded_wait(CanisterId::ic_00().get().0, "install_code")
+            .with_arg(&install_args)
+            .await
+            .map(|_reply| ())
+            .map_err(handle_call_error(format!(
+                "Failed to install WASM on canister {target_canister}"
+            )))
     }
 
     /// See CanisterApi::set_controller
@@ -150,12 +148,13 @@ impl CanisterApi for CanisterApiImpl {
             sender_canister_version: Some(ic_cdk::api::canister_version()),
         };
 
-        let result: CallResult<()> =
-            ic_cdk::call(CanisterId::ic_00().get().0, "update_settings", (args,)).await;
-
-        result.map_err(handle_call_error(format!(
-            "Failed to update controllers for canister {canister}"
-        )))
+        Call::unbounded_wait(CanisterId::ic_00().get().0, "update_settings")
+            .with_arg(&args)
+            .await
+            .map(|_reply| ())
+            .map_err(handle_call_error(format!(
+                "Failed to update controllers for canister {canister}"
+            )))
     }
 
     fn this_canister_has_enough_cycles(&self, required_cycles: u128) -> Result<u128, String> {
@@ -193,24 +192,39 @@ impl CanisterApi for CanisterApiImpl {
         target: CanisterId,
         cycles: u128,
     ) -> Result<(), String> {
-        let response: CallResult<()> = ic_cdk::api::call::call_with_payment128(
-            CanisterId::ic_00().get().0,
-            "deposit_cycles",
-            (CanisterIdRecord::from(target),),
-            cycles,
-        )
-        .await;
-
-        response.map_err(handle_call_error(format!(
-            "Failed to send cycles to canister {target}"
-        )))
+        Call::unbounded_wait(CanisterId::ic_00().get().0, "deposit_cycles")
+            .with_arg(CanisterIdRecord::from(target))
+            .with_cycles(cycles)
+            .await
+            .map(|_reply| ())
+            .map_err(handle_call_error(format!(
+                "Failed to send cycles to canister {target}"
+            )))
     }
 }
 
-/// This handles the errors returned from ic_cdk::call (and related methods)
-fn handle_call_error(prefix: String) -> impl FnOnce((RejectionCode, String)) -> String {
-    move |(code, msg)| {
-        let err = format!("{}: error code {}: {}", prefix, code as i32, msg);
+/// Translates a failed call into the `(reject code, message)` pair that the error messages
+/// below report.
+fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+    match err {
+        IcCdkCallError::CallRejected(rejected) => (
+            rejected.raw_reject_code() as i32,
+            rejected.reject_message().to_string(),
+        ),
+        // A response that cannot be decoded means the callee misbehaved.
+        IcCdkCallError::CandidDecodeFailed(err) => {
+            (RejectCode::CanisterError as i32, err.to_string())
+        }
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient as i32, err.to_string()),
+    }
+}
+
+/// This handles the errors returned from Call::unbounded_wait (and related methods)
+fn handle_call_error<E: Into<IcCdkCallError>>(prefix: String) -> impl FnOnce(E) -> String {
+    move |err| {
+        let (code, msg) = map_call_error(err.into());
+        let err = format!("{prefix}: error code {code}: {msg}");
         println!("{}{}", LOG_PREFIX, err);
         err
     }
@@ -218,18 +232,13 @@ fn handle_call_error(prefix: String) -> impl FnOnce((RejectionCode, String)) -> 
 
 impl CanisterApiImpl {
     async fn stop_canister(&self, canister: CanisterId) -> Result<(), String> {
-        () = ic_cdk::call(
-            CanisterId::ic_00().get().0,
-            "stop_canister",
-            (CanisterIdRecord::from(canister),),
-        )
-        .await
-        .map_err(|(code, msg)| {
-            format!(
-                "Unable to stop target canister: error code {}: {}",
-                code as i32, msg
-            )
-        })?;
+        let _response = Call::unbounded_wait(CanisterId::ic_00().get().0, "stop_canister")
+            .with_arg(CanisterIdRecord::from(canister))
+            .await
+            .map_err(|err| {
+                let (code, msg) = map_call_error(err.into());
+                format!("Unable to stop target canister: error code {code}: {msg}")
+            })?;
 
         let mut count = 0;
         // Wait until canister is in the stopped state.

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -105,7 +105,8 @@ impl CanisterApi for CanisterApiImpl {
         Call::unbounded_wait(CanisterId::ic_00().get().0, "delete_canister")
             .with_arg(CanisterIdRecord::from(canister))
             .await
-            .map(|_reply| ())
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple::<()>().map_err(IcCdkCallError::from))
             .map_err(handle_call_error(format!(
                 "Failed to delete canister {canister}"
             )))
@@ -128,7 +129,8 @@ impl CanisterApi for CanisterApiImpl {
         Call::unbounded_wait(CanisterId::ic_00().get().0, "install_code")
             .with_arg(&install_args)
             .await
-            .map(|_reply| ())
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple::<()>().map_err(IcCdkCallError::from))
             .map_err(handle_call_error(format!(
                 "Failed to install WASM on canister {target_canister}"
             )))
@@ -151,7 +153,8 @@ impl CanisterApi for CanisterApiImpl {
         Call::unbounded_wait(CanisterId::ic_00().get().0, "update_settings")
             .with_arg(&args)
             .await
-            .map(|_reply| ())
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple::<()>().map_err(IcCdkCallError::from))
             .map_err(handle_call_error(format!(
                 "Failed to update controllers for canister {canister}"
             )))
@@ -196,7 +199,8 @@ impl CanisterApi for CanisterApiImpl {
             .with_arg(CanisterIdRecord::from(target))
             .with_cycles(cycles)
             .await
-            .map(|_reply| ())
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple::<()>().map_err(IcCdkCallError::from))
             .map_err(handle_call_error(format!(
                 "Failed to send cycles to canister {target}"
             )))
@@ -205,7 +209,11 @@ impl CanisterApi for CanisterApiImpl {
 
 /// Translates a failed call into the `(reject code, message)` pair that the error messages
 /// below report.
-fn map_call_error(err: IcCdkCallError) -> (i32, String) {
+///
+/// The match is deliberately exhaustive (rather than using a catch-all arm) so
+/// that a new [`IcCdkCallError`] variant forces us to revisit this mapping
+/// instead of silently classifying it as [`RejectCode::SysTransient`].
+fn into_reject_code_and_message(err: IcCdkCallError) -> (i32, String) {
     match err {
         IcCdkCallError::CallRejected(rejected) => (
             rejected.raw_reject_code() as i32,
@@ -215,15 +223,24 @@ fn map_call_error(err: IcCdkCallError) -> (i32, String) {
         IcCdkCallError::CandidDecodeFailed(err) => {
             (RejectCode::CanisterError as i32, err.to_string())
         }
-        // The call never left this canister, so it may well succeed if retried.
-        err => (RejectCode::SysTransient as i32, err.to_string()),
+        // Neither of these ever left this canister, so the call may well succeed
+        // if retried.
+        IcCdkCallError::InsufficientLiquidCycleBalance(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
+        IcCdkCallError::CallPerformFailed(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
     }
 }
 
 /// This handles the errors returned from Call::unbounded_wait (and related methods)
-fn handle_call_error<E: Into<IcCdkCallError>>(prefix: String) -> impl FnOnce(E) -> String {
+fn handle_call_error<E>(prefix: String) -> impl FnOnce(E) -> String
+where
+    E: Into<IcCdkCallError>,
+{
     move |err| {
-        let (code, msg) = map_call_error(err.into());
+        let (code, msg) = into_reject_code_and_message(err.into());
         let err = format!("{prefix}: error code {code}: {msg}");
         println!("{}{}", LOG_PREFIX, err);
         err
@@ -232,11 +249,13 @@ fn handle_call_error<E: Into<IcCdkCallError>>(prefix: String) -> impl FnOnce(E) 
 
 impl CanisterApiImpl {
     async fn stop_canister(&self, canister: CanisterId) -> Result<(), String> {
-        let _response = Call::unbounded_wait(CanisterId::ic_00().get().0, "stop_canister")
+        Call::unbounded_wait(CanisterId::ic_00().get().0, "stop_canister")
             .with_arg(CanisterIdRecord::from(canister))
             .await
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| response.candid_tuple::<()>().map_err(IcCdkCallError::from))
             .map_err(|err| {
-                let (code, msg) = map_call_error(err.into());
+                let (code, msg) = into_reject_code_and_message(err);
                 format!("Unable to stop target canister: error code {code}: {msg}")
             })?;
 

--- a/rs/rust_canisters/call_tree_test/src/main.rs
+++ b/rs/rust_canisters/call_tree_test/src/main.rs
@@ -1,11 +1,12 @@
-#![allow(deprecated)]
 //! This module contains a canister used for XNet integration test.
 use candid::{CandidType, Principal};
-use ic_cdk::api::{call::call_raw, canister_self};
+use ic_cdk::api::canister_self;
+use ic_cdk::call::Call;
 use ic_cdk::query;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::cmp::min;
+use std::future::IntoFuture;
 use std::str::FromStr;
 
 const MB: usize = 1 << 20;
@@ -101,12 +102,11 @@ async fn start(arguments: Arguments) -> Vec<Message> {
                 receiver: entry.canister_id.clone(),
             });
         }
-        futures.push(call_raw(
-            Principal::from_str(&entry.canister_id).unwrap(),
-            "start",
-            msg,
-            0,
-        ));
+        futures.push(
+            Call::unbounded_wait(Principal::from_str(&entry.canister_id).unwrap(), "start")
+                .take_raw_args(msg)
+                .into_future(),
+        );
     }
 
     for f in futures::future::join_all(futures).await {
@@ -115,7 +115,7 @@ async fn start(arguments: Arguments) -> Vec<Message> {
             Ok(response) => {
                 if arguments.debug {
                     let mut returned_messages: Vec<Message> =
-                        serde_json::from_slice(&response).unwrap();
+                        serde_json::from_slice(&response.into_bytes()).unwrap();
                     messages.append(&mut returned_messages);
                 }
             }

--- a/rs/rust_canisters/ecdsa/src/main.rs
+++ b/rs/rust_canisters/ecdsa/src/main.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Encode, candid_method};
+use candid::{CandidType, candid_method};
 use ic_cdk::api::debug_print;
 use ic_cdk::call::Call;
 use ic_cdk::update;
@@ -31,23 +31,20 @@ async fn get_sig(options: Options) {
         options.key_name, options.derivation_path,
     ));
     let response = Call::unbounded_wait(IC_00.into(), &Ic00Method::SignWithECDSA.to_string())
-        .take_raw_args(
-            Encode!(&SignWithECDSAArgs {
-                message_hash: [0; 32],
-                derivation_path: DerivationPath::new(
-                    options
-                        .derivation_path
-                        .into_iter()
-                        .map(ByteBuf::from)
-                        .collect()
-                ),
-                key_id: EcdsaKeyId {
-                    curve: EcdsaCurve::Secp256k1,
-                    name: options.key_name,
-                },
-            })
-            .unwrap(),
-        )
+        .with_arg(SignWithECDSAArgs {
+            message_hash: [0; 32],
+            derivation_path: DerivationPath::new(
+                options
+                    .derivation_path
+                    .into_iter()
+                    .map(ByteBuf::from)
+                    .collect(),
+            ),
+            key_id: EcdsaKeyId {
+                curve: EcdsaCurve::Secp256k1,
+                name: options.key_name,
+            },
+        })
         .with_cycles(1_000_000_000_000)
         .await;
     debug_print(format!("got result {response:?}"));

--- a/rs/rust_canisters/ecdsa/src/main.rs
+++ b/rs/rust_canisters/ecdsa/src/main.rs
@@ -1,6 +1,6 @@
-#![allow(deprecated)]
 use candid::{CandidType, Encode, candid_method};
-use ic_cdk::api::{call::call_raw, debug_print};
+use ic_cdk::api::debug_print;
+use ic_cdk::call::Call;
 use ic_cdk::update;
 use ic_management_canister_types_private::{
     DerivationPath, EcdsaCurve, EcdsaKeyId, IC_00, Method as Ic00Method, SignWithECDSAArgs,
@@ -30,27 +30,26 @@ async fn get_sig(options: Options) {
         "calling get sig with key {} and derivation path {:?}",
         options.key_name, options.derivation_path,
     ));
-    let response = call_raw(
-        IC_00.into(),
-        &Ic00Method::SignWithECDSA.to_string(),
-        Encode!(&SignWithECDSAArgs {
-            message_hash: [0; 32],
-            derivation_path: DerivationPath::new(
-                options
-                    .derivation_path
-                    .into_iter()
-                    .map(ByteBuf::from)
-                    .collect()
-            ),
-            key_id: EcdsaKeyId {
-                curve: EcdsaCurve::Secp256k1,
-                name: options.key_name,
-            },
-        })
-        .unwrap(),
-        1_000_000_000_000,
-    )
-    .await;
+    let response = Call::unbounded_wait(IC_00.into(), &Ic00Method::SignWithECDSA.to_string())
+        .take_raw_args(
+            Encode!(&SignWithECDSAArgs {
+                message_hash: [0; 32],
+                derivation_path: DerivationPath::new(
+                    options
+                        .derivation_path
+                        .into_iter()
+                        .map(ByteBuf::from)
+                        .collect()
+                ),
+                key_id: EcdsaKeyId {
+                    curve: EcdsaCurve::Secp256k1,
+                    name: options.key_name,
+                },
+            })
+            .unwrap(),
+        )
+        .with_cycles(1_000_000_000_000)
+        .await;
     debug_print(format!("got result {response:?}"));
 }
 

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -1,5 +1,4 @@
 // TODO: Jira ticket NNS1-3556
-#![allow(deprecated)]
 #![allow(static_mut_refs)]
 use async_trait::async_trait;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -7,6 +6,7 @@ use ic_canister_log::log;
 use ic_canister_profiler::{measure_span, measure_span_async};
 use ic_cdk::{
     api::{canister_self, msg_caller},
+    call::{Call, Error as IcCdkCallError, RejectCode},
     init, post_upgrade, pre_upgrade, println, query, update,
 };
 use ic_cdk_timers::TimerId;
@@ -124,6 +124,27 @@ impl CanisterEnv {
     }
 }
 
+/// Translates a failed call into the `(error code, message)` pair that
+/// [`Environment::call_canister`] reports to its callers.
+fn map_call_error(err: IcCdkCallError) -> (Option<i32>, String) {
+    let (code, message) = match err {
+        IcCdkCallError::CallRejected(rejected) => (
+            rejected.raw_reject_code() as i32,
+            rejected.reject_message().to_string(),
+        ),
+
+        // A response that cannot be decoded means the callee misbehaved.
+        IcCdkCallError::CandidDecodeFailed(err) => {
+            (RejectCode::CanisterError as i32, err.to_string())
+        }
+
+        // The call never left this canister, so it may well succeed if retried.
+        err => (RejectCode::SysTransient as i32, err.to_string()),
+    };
+
+    (Some(code), message)
+}
+
 #[async_trait]
 impl Environment for CanisterEnv {
     fn now(&self) -> u64 {
@@ -155,11 +176,13 @@ impl Environment for CanisterEnv {
             /* message: */ String,
         ),
     > {
-        // Due to object safety constraints in Rust, call_canister sends and returns bytes, so we are using
-        // call_raw here instead of call, which requires known candid types.
-        ic_cdk::api::call::call_raw(canister_id.get().0, method_name, &arg, 0)
+        // Due to object safety constraints in Rust, call_canister sends and returns bytes, so we
+        // are passing raw arguments here instead of Candid ones, which require known types.
+        Call::unbounded_wait(canister_id.get().0, method_name)
+            .take_raw_args(arg)
             .await
-            .map_err(|(rejection_code, message)| (Some(rejection_code as i32), message))
+            .map(|response| response.into_bytes())
+            .map_err(|err| map_call_error(err.into()))
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -126,7 +126,11 @@ impl CanisterEnv {
 
 /// Translates a failed call into the `(error code, message)` pair that
 /// [`Environment::call_canister`] reports to its callers.
-fn map_call_error(err: IcCdkCallError) -> (Option<i32>, String) {
+///
+/// The match is deliberately exhaustive (rather than using a catch-all arm) so
+/// that a new [`IcCdkCallError`] variant forces us to revisit this mapping
+/// instead of silently classifying it as [`RejectCode::SysTransient`].
+fn into_reject_code_and_message(err: IcCdkCallError) -> (Option<i32>, String) {
     let (code, message) = match err {
         IcCdkCallError::CallRejected(rejected) => (
             rejected.raw_reject_code() as i32,
@@ -138,8 +142,14 @@ fn map_call_error(err: IcCdkCallError) -> (Option<i32>, String) {
             (RejectCode::CanisterError as i32, err.to_string())
         }
 
-        // The call never left this canister, so it may well succeed if retried.
-        err => (RejectCode::SysTransient as i32, err.to_string()),
+        // Neither of these ever left this canister, so the call may well succeed
+        // if retried.
+        IcCdkCallError::InsufficientLiquidCycleBalance(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
+        IcCdkCallError::CallPerformFailed(err) => {
+            (RejectCode::SysTransient as i32, err.to_string())
+        }
     };
 
     (Some(code), message)
@@ -182,7 +192,7 @@ impl Environment for CanisterEnv {
             .take_raw_args(arg)
             .await
             .map(|response| response.into_bytes())
-            .map_err(|err| map_call_error(err.into()))
+            .map_err(|err| into_reject_code_and_message(err.into()))
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/rs/sns/swap/src/clients.rs
+++ b/rs/sns/swap/src/clients.rs
@@ -1,10 +1,10 @@
-#![allow(deprecated)]
 use crate::pb::v1::{
     CanisterCallError, SetDappControllersRequest, SetDappControllersResponse,
     SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
 };
 use async_trait::async_trait;
 use ic_base_types::CanisterId;
+use ic_cdk::call::{Call, Error as IcCdkCallError};
 use ic_sns_governance::pb::v1::{
     ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse, ManageNeuron, ManageNeuronResponse, SetMode,
     SetModeResponse,
@@ -34,9 +34,15 @@ impl SnsRootClient for RealSnsRootClient {
         &mut self,
         request: SetDappControllersRequest,
     ) -> Result<SetDappControllersResponse, CanisterCallError> {
-        ic_cdk::call(self.canister_id.get().0, "set_dapp_controllers", (request,))
+        Call::unbounded_wait(self.canister_id.get().0, "set_dapp_controllers")
+            .with_arg(&request)
             .await
-            .map(|response: (SetDappControllersResponse,)| response.0)
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<SetDappControllersResponse>()
+                    .map_err(IcCdkCallError::from)
+            })
             .map_err(CanisterCallError::from)
     }
 }
@@ -72,19 +78,31 @@ impl SnsGovernanceClient for RealSnsGovernanceClient {
         &mut self,
         request: ManageNeuron,
     ) -> Result<ManageNeuronResponse, CanisterCallError> {
-        ic_cdk::call(self.canister_id.get().0, "manage_neuron", (request,))
+        Call::unbounded_wait(self.canister_id.get().0, "manage_neuron")
+            .with_arg(&request)
             .await
-            .map(|response: (ManageNeuronResponse,)| response.0)
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<ManageNeuronResponse>()
+                    .map_err(IcCdkCallError::from)
+            })
             .map_err(CanisterCallError::from)
     }
 
     async fn set_mode(&mut self, request: SetMode) -> Result<SetModeResponse, CanisterCallError> {
         // TODO: Eliminate repetitive code. At least textually, the only
         // difference is the second argument that gets passed to
-        // ic_cdk::call (the name of the method).
-        ic_cdk::call(self.canister_id.get().0, "set_mode", (request,))
+        // Call::unbounded_wait (the name of the method).
+        Call::unbounded_wait(self.canister_id.get().0, "set_mode")
+            .with_arg(request)
             .await
-            .map(|response: (SetModeResponse,)| response.0)
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<SetModeResponse>()
+                    .map_err(IcCdkCallError::from)
+            })
             .map_err(CanisterCallError::from)
     }
 
@@ -92,9 +110,15 @@ impl SnsGovernanceClient for RealSnsGovernanceClient {
         &mut self,
         request: ClaimSwapNeuronsRequest,
     ) -> Result<ClaimSwapNeuronsResponse, CanisterCallError> {
-        ic_cdk::call(self.canister_id.get().0, "claim_swap_neurons", (request,))
+        Call::unbounded_wait(self.canister_id.get().0, "claim_swap_neurons")
+            .with_arg(&request)
             .await
-            .map(|response: (ClaimSwapNeuronsResponse,)| response.0)
+            .map_err(IcCdkCallError::from)
+            .and_then(|response| {
+                response
+                    .candid::<ClaimSwapNeuronsResponse>()
+                    .map_err(IcCdkCallError::from)
+            })
             .map_err(CanisterCallError::from)
     }
 }
@@ -123,13 +147,18 @@ impl NnsGovernanceClient for RealNnsGovernanceClient {
         &mut self,
         request: SettleNeuronsFundParticipationRequest,
     ) -> Result<SettleNeuronsFundParticipationResponse, CanisterCallError> {
-        ic_cdk::call(
+        Call::unbounded_wait(
             self.canister_id.get().0,
             "settle_neurons_fund_participation",
-            (request,),
         )
+        .with_arg(&request)
         .await
-        .map(|response: (SettleNeuronsFundParticipationResponse,)| response.0)
+        .map_err(IcCdkCallError::from)
+        .and_then(|response| {
+            response
+                .candid::<SettleNeuronsFundParticipationResponse>()
+                .map_err(IcCdkCallError::from)
+        })
         .map_err(CanisterCallError::from)
     }
 }

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::{
     clients::{NnsGovernanceClient, SnsGovernanceClient, SnsRootClient},
     environment::CanisterEnvironment,
@@ -29,7 +28,7 @@ use crate::{
 };
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
-use ic_cdk::api::call::RejectionCode;
+use ic_cdk::call::{Error as IcCdkCallError, RejectCode};
 use ic_ledger_core::Tokens;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
 use ic_nervous_system_common::{
@@ -108,11 +107,26 @@ impl From<(Option<i32>, String)> for CanisterCallError {
     }
 }
 
-impl From<(RejectionCode, String)> for CanisterCallError {
-    fn from(value: (RejectionCode, String)) -> Self {
+impl From<IcCdkCallError> for CanisterCallError {
+    fn from(err: IcCdkCallError) -> Self {
+        let (code, description) = match err {
+            IcCdkCallError::CallRejected(rejected) => (
+                rejected.raw_reject_code() as i32,
+                rejected.reject_message().to_string(),
+            ),
+
+            // A response that cannot be decoded means the callee misbehaved.
+            IcCdkCallError::CandidDecodeFailed(err) => {
+                (RejectCode::CanisterError as i32, err.to_string())
+            }
+
+            // The call never left this canister, so it may well succeed if retried.
+            err => (RejectCode::SysTransient as i32, err.to_string()),
+        };
+
         Self {
-            code: Some(value.0 as i32),
-            description: value.1,
+            code: Some(code),
+            description,
         }
     }
 }

--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -108,6 +108,9 @@ impl From<(Option<i32>, String)> for CanisterCallError {
 }
 
 impl From<IcCdkCallError> for CanisterCallError {
+    // The match is deliberately exhaustive (rather than using a catch-all arm) so
+    // that a new `IcCdkCallError` variant forces us to revisit this mapping
+    // instead of silently classifying it as `RejectCode::SysTransient`.
     fn from(err: IcCdkCallError) -> Self {
         let (code, description) = match err {
             IcCdkCallError::CallRejected(rejected) => (
@@ -120,8 +123,14 @@ impl From<IcCdkCallError> for CanisterCallError {
                 (RejectCode::CanisterError as i32, err.to_string())
             }
 
-            // The call never left this canister, so it may well succeed if retried.
-            err => (RejectCode::SysTransient as i32, err.to_string()),
+            // Neither of these ever left this canister, so the call may well
+            // succeed if retried.
+            IcCdkCallError::InsufficientLiquidCycleBalance(err) => {
+                (RejectCode::SysTransient as i32, err.to_string())
+            }
+            IcCdkCallError::CallPerformFailed(err) => {
+                (RejectCode::SysTransient as i32, err.to_string())
+            }
         };
 
         Self {


### PR DESCRIPTION
This migrates the governance & boundary node canisters to the new `ic-cdk` `Call` interface. This is the last big step before we can fully migrate to `ic-cdk` v0.20.

This builds on https://github.com/dfinity/ic/pull/10995.