### PR TITLE
chore(system-tests): lower DEFAULT_MEMORY_KIB_PER_VM from 24GiB to 4GiB

### DIFF
--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -69,45 +69,29 @@ const DKG_INTERVAL: u64 = 29;
 const SUBNET_SIZE: usize = 4;
 const DIVERGENCE_LOG_STR: &str = "The state hash of the CUP at height ";
 
-// Per-VM memory used on the local backend. There all VMs run on a single host,
-// so the Farm default of 24 GiB per VM would let the 4 VMs of the System subnet
-// collectively exceed the host's RAM and thrash swap. That starves the consensus
-// finalizer, so the subnet can't finalize the upgrade CUP and the test fails with
-// `Replica was running the old version only!`. 4 GiB per VM keeps all VMs
-// comfortably within the host's RAM.
-const LOCAL_BACKEND_VM_MEMORY: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024);
-
 pub fn setup(env: TestEnv) {
-    let mut ic = InternetComputer::new().add_subnet(
-        Subnet::new(SubnetType::System)
-            .add_nodes(SUBNET_SIZE)
-            .with_chain_key_config(ChainKeyConfig {
-                key_configs: make_key_ids_for_all_schemes()
-                    .into_iter()
-                    .map(|key_id| KeyConfig {
-                        max_queue_size: 20,
-                        pre_signatures_to_create_in_advance: key_id
-                            .requires_pre_signatures()
-                            .then_some(7),
-                        key_id,
-                    })
-                    .collect(),
-                signature_request_timeout_ns: None,
-                idkg_key_rotation_period_ms: None,
-                max_parallel_pre_signature_transcripts_in_creation: None,
-            })
-            .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
-    );
-    // On the local backend, cap the per-VM memory so all VMs fit within the
-    // single host's RAM (see `LOCAL_BACKEND_VM_MEMORY`). On Farm, keep the
-    // generous default.
-    if SystemTestBackend::from_env() == SystemTestBackend::Local {
-        ic = ic.with_resource_overrides(VmResourceOverrides {
-            memory_kibibytes: Some(LOCAL_BACKEND_VM_MEMORY),
-            ..Default::default()
-        });
-    }
-    ic.setup_and_start(&env)
+    InternetComputer::new()
+        .add_subnet(
+            Subnet::new(SubnetType::System)
+                .add_nodes(SUBNET_SIZE)
+                .with_chain_key_config(ChainKeyConfig {
+                    key_configs: make_key_ids_for_all_schemes()
+                        .into_iter()
+                        .map(|key_id| KeyConfig {
+                            max_queue_size: 20,
+                            pre_signatures_to_create_in_advance: key_id
+                                .requires_pre_signatures()
+                                .then_some(7),
+                            key_id,
+                        })
+                        .collect(),
+                    signature_request_timeout_ns: None,
+                    idkg_key_rotation_period_ms: None,
+                    max_parallel_pre_signature_transcripts_in_creation: None,
+                })
+                .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
+        )
+        .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());

--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -46,10 +46,9 @@ use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        ic::{AmountOfMemoryKiB, InternetComputer, Subnet, VmResourceOverrides},
+        ic::{InternetComputer, Subnet},
         test_env::{HasIcPrepDir, TestEnv},
         test_env_api::*,
-        test_setup::SystemTestBackend,
     },
     util::{MessageCanister, block_on, get_nns_node},
 };

--- a/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
+++ b/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
@@ -42,32 +42,14 @@ const DKG_INTERVAL: u64 = 9;
 const SUBNET_SIZE: usize = 4;
 const NUM_READ_RETRIES: usize = 10;
 
-// Per-VM memory used on the local backend. There all VMs run on a single host,
-// so the Farm default of 24 GiB per VM would let the 4 System VMs collectively
-// exceed the host's RAM. Under Namespace remote execution the host is an even
-// smaller RBE worker, so the VMs thrash and freeze while the orchestrator
-// unpacks and writes the ~579 MiB update image to disk during the upgrade. The
-// frozen nodes never rejoin, so the test times out waiting for them to report
-// the new version. 4 GiB per VM keeps all 4 VMs comfortably within the host's
-// RAM (matching the sibling `upgrade_downgrade_*_subnet_test`s).
-const LOCAL_BACKEND_VM_MEMORY: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024);
-
 fn config(env: TestEnv) {
-    let mut ic = InternetComputer::new().add_subnet(
-        Subnet::new(SubnetType::System)
-            .add_nodes(SUBNET_SIZE)
-            .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
-    );
-    // On the local backend, cap the per-VM memory so all VMs fit within the
-    // single host's RAM (see `LOCAL_BACKEND_VM_MEMORY`). On Farm, keep the
-    // generous default.
-    if SystemTestBackend::from_env() == SystemTestBackend::Local {
-        ic = ic.with_resource_overrides(VmResourceOverrides {
-            memory_kibibytes: Some(LOCAL_BACKEND_VM_MEMORY),
-            ..Default::default()
-        });
-    }
-    ic.setup_and_start(&env)
+    InternetComputer::new()
+        .add_subnet(
+            Subnet::new(SubnetType::System)
+                .add_nodes(SUBNET_SIZE)
+                .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
+        )
+        .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());

--- a/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
+++ b/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
@@ -28,10 +28,9 @@ use ic_consensus_system_test_utils::{
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::{
-    ic::{AmountOfMemoryKiB, InternetComputer, Subnet, VmResourceOverrides},
+    ic::{InternetComputer, Subnet},
     test_env::TestEnv,
     test_env_api::*,
-    test_setup::SystemTestBackend,
 };
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::{JournalStreamer, block_on};

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -19,15 +19,12 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::canister_agent::HasCanisterAgentCapability;
 use ic_system_test_driver::canister_requests;
 use ic_system_test_driver::driver::group::SystemTestGroup;
-use ic_system_test_driver::driver::ic::{
-    AmountOfMemoryKiB, InternetComputer, Subnet, VmResourceOverrides,
-};
+use ic_system_test_driver::driver::ic::{InternetComputer, Subnet};
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::driver::test_env_api::{
     GetFirstHealthyNodeSnapshot, HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer,
     SubnetSnapshot, get_guestos_img_version,
 };
-use ic_system_test_driver::driver::test_setup::SystemTestBackend;
 use ic_system_test_driver::generic_workload_engine::engine::Engine;
 use ic_system_test_driver::generic_workload_engine::metrics::{
     LoadTestMetricsProvider, RequestOutcome,

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -45,14 +45,6 @@ const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
 const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
 
-// Per-VM memory used on the local backend. There all VMs run on a single host,
-// so the Farm default of 24 GiB per VM would let the 5 VMs (1 System + 4
-// Application) collectively exceed the host's RAM and thrash swap. That starves
-// the consensus finalizer, so the subnet can't finalize the upgrade CUP and the
-// test fails with `Replica was running the old version only!`. 4 GiB per VM
-// keeps all 5 VMs comfortably within the host's RAM.
-const LOCAL_BACKEND_VM_MEMORY: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024);
-
 fn setup(env: TestEnv) {
     let subnet_under_test = Subnet::new(SubnetType::Application)
         .add_nodes(SUBNET_SIZE)
@@ -73,19 +65,10 @@ fn setup(env: TestEnv) {
             max_parallel_pre_signature_transcripts_in_creation: None,
         });
 
-    let mut ic = InternetComputer::new()
+    InternetComputer::new()
         .add_subnet(Subnet::fast_single_node(SubnetType::System))
-        .add_subnet(subnet_under_test);
-    // On the local backend, cap the per-VM memory so all VMs fit within the
-    // single host's RAM (see `LOCAL_BACKEND_VM_MEMORY`). On Farm, keep the
-    // generous default.
-    if SystemTestBackend::from_env() == SystemTestBackend::Local {
-        ic = ic.with_resource_overrides(VmResourceOverrides {
-            memory_kibibytes: Some(LOCAL_BACKEND_VM_MEMORY),
-            ..Default::default()
-        });
-    }
-    ic.setup_and_start(&env)
+        .add_subnet(subnet_under_test)
+        .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
@@ -27,30 +27,14 @@ const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
 const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
 const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
-// Per-VM memory used on the local backend. There all VMs run on a single host,
-// so the Farm default of 24 GiB per VM would let the 4 VMs of the System subnet
-// collectively exceed the host's RAM and thrash swap. That starves the consensus
-// finalizer, so the subnet can't finalize the upgrade CUP and the test fails with
-// `Replica was running the old version only!`. 4 GiB per VM keeps all VMs
-// comfortably within the host's RAM.
-const LOCAL_BACKEND_VM_MEMORY: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024);
-
 fn setup(env: TestEnv) {
     let subnet_under_test = Subnet::new(SubnetType::System)
         .add_nodes(SUBNET_SIZE)
         .with_dkg_interval_length(Height::from(DKG_INTERVAL));
 
-    let mut ic = InternetComputer::new().add_subnet(subnet_under_test);
-    // On the local backend, cap the per-VM memory so all VMs fit within the
-    // single host's RAM (see `LOCAL_BACKEND_VM_MEMORY`). On Farm, keep the
-    // generous default.
-    if SystemTestBackend::from_env() == SystemTestBackend::Local {
-        ic = ic.with_resource_overrides(VmResourceOverrides {
-            memory_kibibytes: Some(LOCAL_BACKEND_VM_MEMORY),
-            ..Default::default()
-        });
-    }
-    ic.setup_and_start(&env)
+    InternetComputer::new()
+        .add_subnet(subnet_under_test)
+        .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
@@ -8,15 +8,12 @@ use ic_consensus_system_test_utils::rw_message::{
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
-use ic_system_test_driver::driver::ic::{
-    AmountOfMemoryKiB, InternetComputer, Subnet, VmResourceOverrides,
-};
+use ic_system_test_driver::driver::ic::{InternetComputer, Subnet};
 use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::test_env_api::{
     GetFirstHealthyNodeSnapshot, HasTopologySnapshot, get_guestos_img_version,
 };
-use ic_system_test_driver::driver::test_setup::SystemTestBackend;
 use ic_system_test_driver::systest;
 use ic_types::Height;
 use slog::info;

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use url::Url;
 
 const DEFAULT_VCPUS_PER_VM: NrOfVCPUs = NrOfVCPUs::new(6);
-const DEFAULT_MEMORY_KIB_PER_VM: AmountOfMemoryKiB = AmountOfMemoryKiB::new(25165824); // 24GiB
+const DEFAULT_MEMORY_KIB_PER_VM: AmountOfMemoryKiB = AmountOfMemoryKiB::new(4 * 1024 * 1024); // 4GiB
 const DEFAULT_VM_RESOURCES: VmResources = VmResources {
     vcpus: DEFAULT_VCPUS_PER_VM,
     memory_kibibytes: DEFAULT_MEMORY_KIB_PER_VM,


### PR DESCRIPTION
# What

Lowers the default memory of a system-test VM from 24GiB to 4GiB and drops the custom overrides in certain system-tests for the `SystemTestBackend::Local` backend that made the same change.

# Why

We would like to pack more system-tests on a single RBE worker (64GB RAM). It would therefor be better if the VMs used less memory. Some system-tests already lowered the VM RAM to 4GiB. This change lowers it by default.

All system-tests (with `CI_ALL_BAZEL_TARGETS`) run fine and don't flake with this change across multiple runs.  