### PR TITLE
fix(test-utils): drop Discretionary Access Control (DAC) capabilities instead of forking to `nobody`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14947,6 +14947,7 @@ dependencies = [
  "libc",
  "static_assertions",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14945,6 +14945,7 @@ version = "0.9.0"
 dependencies = [
  "ic-test-utilities-privileges-macros",
  "libc",
+ "static_assertions",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14944,7 +14944,7 @@ name = "ic-test-utilities-privileges"
 version = "0.9.0"
 dependencies = [
  "ic-test-utilities-privileges-macros",
- "nix 0.31.3",
+ "libc",
  "tempfile",
 ]
 

--- a/rs/crypto/internal/crypto_service_provider/src/public_key_store/proto_pubkey_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/public_key_store/proto_pubkey_store/tests.rs
@@ -282,11 +282,11 @@ fn should_panic_on_opening_corrupt_pubkey_store() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
 #[should_panic(expected = "Failed to read public key store data: Permission denied")]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_read_without_read_permissions() {
     let temp_dir = mk_temp_dir_with_permissions(0o700);
     copy_file_to_dir(pubkey_store_in_test_resources().as_path(), temp_dir.path());
@@ -300,10 +300,10 @@ fn should_fail_to_read_without_read_permissions() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_write_without_write_permissions() {
     let temp_dir = mk_temp_dir_with_permissions(0o700);
     copy_file_to_dir(pubkey_store_in_test_resources().as_path(), temp_dir.path());

--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
@@ -387,10 +387,10 @@ fn should_be_idempotent_when_opening_secret_key_store() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_write_to_read_only_secret_key_store_directory() {
     let rng = &mut reproducible_rng();
     let (temp_dir, mut secret_key_store) = open_existing_secret_key_store_in_temp_dir(
@@ -421,10 +421,10 @@ fn should_fail_to_write_to_read_only_secret_key_store_directory() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_write_to_secret_key_store_directory_without_execute_permissions() {
     let (temp_dir, mut secret_key_store) = open_existing_secret_key_store_in_temp_dir(
         &SecretKeyStoreVersion::V3,
@@ -455,10 +455,10 @@ fn should_fail_to_write_to_secret_key_store_directory_without_execute_permission
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_write_to_secret_key_store_directory_without_write_permissions() {
     let (temp_dir, mut secret_key_store) = open_existing_secret_key_store_in_temp_dir(
         &SecretKeyStoreVersion::V3,
@@ -1311,11 +1311,11 @@ mod zeroize_old_secret_key_store {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
 #[should_panic(expected = "Error reading SKS data: Permission denied")]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn should_fail_to_read_from_secret_key_store_with_no_read_permissions() {
     let temp_dir: TempDir = mk_temp_dir_with_permissions(0o700);
     copy_file_to_dir(

--- a/rs/sns/cli/src/propose/propose_tests.rs
+++ b/rs/sns/cli/src/propose/propose_tests.rs
@@ -33,10 +33,10 @@ fn test_ensure_file_exists_and_is_writeable_succeeds_when_creating_file() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn test_ensure_file_exists_and_is_writeable_fails_if_non_writeable() {
     // Setup
     let temp_file = NamedTempFile::new().expect("Failed to create tmp file");
@@ -78,10 +78,10 @@ fn test_save_proposal_id_to_file_succeeds() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn test_save_proposal_id_to_file_fails_if_write_fails() {
     // Setup
     let temp_file = NamedTempFile::new().expect("Failed to create tmp file");

--- a/rs/state_manager/src/checkpoint/tests.rs
+++ b/rs/state_manager/src/checkpoint/tests.rs
@@ -182,10 +182,10 @@ fn can_make_a_checkpoint() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn scratchpad_dir_is_deleted_if_checkpointing_failed() {
     with_test_replica_logger(|log| {
         let tmp = tmpdir("checkpoint");
@@ -372,10 +372,10 @@ fn returns_not_found_for_missing_checkpoints() {
 }
 
 // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get the
-// permission denial this test expects, run as `nobody` when root
-// (e.g. under Bazel remote execution).
+// permission denial this test expects, drop that capability for the duration
+// of the test (test actions run as root under Bazel remote execution).
 #[test]
-#[ic_test_utilities_privileges::as_nobody_when_root]
+#[ic_test_utilities_privileges::enforce_file_permissions]
 fn reports_an_error_on_misconfiguration() {
     with_test_replica_logger(|log| {
         let tmp = tmpdir("checkpoint_reports_an_error_on_misconfiguration");

--- a/rs/sys/src/fs.rs
+++ b/rs/sys/src/fs.rs
@@ -1197,10 +1197,11 @@ mod tests {
         }
 
         // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get
-        // the permission denial this test expects, run as `nobody` when
-        // root (e.g. under Bazel remote execution).
+        // the permission denial this test expects, drop that capability for
+        // the duration of the test (test actions run as root under Bazel
+        // remote execution).
         #[test]
-        #[ic_test_utilities_privileges::as_nobody_when_root]
+        #[ic_test_utilities_privileges::enforce_file_permissions]
         fn should_return_error_if_permission_is_denied() {
             let temp_dir =
                 tempfile::TempDir::new().expect("failed to create a temporary directory");
@@ -1267,10 +1268,11 @@ mod tests {
         }
 
         // Root bypasses file permission bits (CAP_DAC_OVERRIDE), so to get
-        // the permission denial this test expects, run as `nobody` when
-        // root (e.g. under Bazel remote execution).
+        // the permission denial this test expects, drop that capability for
+        // the duration of the test (test actions run as root under Bazel
+        // remote execution).
         #[test]
-        #[ic_test_utilities_privileges::as_nobody_when_root]
+        #[ic_test_utilities_privileges::enforce_file_permissions]
         fn should_return_error_if_permission_is_denied() {
             let temp_dir =
                 tempfile::TempDir::new().expect("failed to create a temporary directory");

--- a/rs/test_utilities/privileges/BUILD.bazel
+++ b/rs/test_utilities/privileges/BUILD.bazel
@@ -9,7 +9,11 @@ rust_library(
     crate_name = "ic_test_utilities_privileges",
     proc_macro_deps = ["//rs/test_utilities/privileges/macros"],
     version = "0.9.0",
-    deps = ["@crate_index//:nix"],
+    deps = [
+        # Keep sorted.
+        "@crate_index//:libc",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_test(

--- a/rs/test_utilities/privileges/BUILD.bazel
+++ b/rs/test_utilities/privileges/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
     deps = [
         # Keep sorted.
         "@crate_index//:libc",
+        "@crate_index//:static_assertions",
         "@crate_index//:tempfile",
     ],
 )

--- a/rs/test_utilities/privileges/BUILD.bazel
+++ b/rs/test_utilities/privileges/BUILD.bazel
@@ -25,5 +25,6 @@ rust_test(
         # Keep sorted.
         ":privileges",
         "@crate_index//:tempfile",
+        "@crate_index//:tokio",
     ],
 )

--- a/rs/test_utilities/privileges/Cargo.toml
+++ b/rs/test_utilities/privileges/Cargo.toml
@@ -8,7 +8,5 @@ documentation.workspace = true
 
 [dependencies]
 ic-test-utilities-privileges-macros = { path = "macros" }
-nix = { workspace = true }
-
-[dev-dependencies]
+libc = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/test_utilities/privileges/Cargo.toml
+++ b/rs/test_utilities/privileges/Cargo.toml
@@ -11,3 +11,6 @@ ic-test-utilities-privileges-macros = { path = "macros" }
 libc = { workspace = true }
 static_assertions = { workspace = true }
 tempfile = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/rs/test_utilities/privileges/Cargo.toml
+++ b/rs/test_utilities/privileges/Cargo.toml
@@ -9,4 +9,5 @@ documentation.workspace = true
 [dependencies]
 ic-test-utilities-privileges-macros = { path = "macros" }
 libc = { workspace = true }
+static_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/test_utilities/privileges/macros/src/lib.rs
+++ b/rs/test_utilities/privileges/macros/src/lib.rs
@@ -1,38 +1,39 @@
 //! Proc-macro companion of `ic-test-utilities-privileges`.
 //!
-//! Don't depend on this crate directly: use the [`as_nobody_when_root`]
+//! Don't depend on this crate directly: use the [`enforce_file_permissions`]
 //! attribute re-exported from `ic_test_utilities_privileges`.
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Error, ItemFn, ReturnType, parse_macro_input};
+use syn::{Error, ItemFn, parse_macro_input};
 
-/// Runs the annotated test as the unprivileged `nobody` user when the process
-/// is root, and unchanged otherwise.
+/// Runs the annotated test with the filesystem permission bits enforced against
+/// it, even when the test process is privileged.
 ///
 /// This is attribute sugar for wrapping the whole test body in
-/// `ic_test_utilities_privileges::run_as_nobody_if_root`: root bypasses file
-/// permission bits (`CAP_DAC_OVERRIDE`), so tests asserting `PermissionDenied`
-/// only observe the denial when dropping to `nobody` on root-run workers
-/// (e.g. under Bazel remote execution). See the documentation of
-/// `run_as_nobody_if_root` for the exact semantics.
+/// `ic_test_utilities_privileges::run_with_file_permissions_enforced`: root
+/// bypasses file permission bits via `CAP_DAC_OVERRIDE`/`CAP_DAC_READ_SEARCH`,
+/// so tests asserting `PermissionDenied` only observe the denial once those are
+/// dropped (e.g. under Bazel remote execution, which runs test actions as root).
+/// See the documentation of `run_with_file_permissions_enforced` for the exact
+/// semantics and limitations.
 ///
 /// Place it after `#[test]` (and `#[should_panic]`, which keeps working since
-/// the wrapper re-raises the child's panic message):
+/// the body runs in-process and its panic propagates unchanged):
 ///
 /// ```ignore
 /// #[test]
-/// #[ic_test_utilities_privileges::as_nobody_when_root]
+/// #[ic_test_utilities_privileges::enforce_file_permissions]
 /// fn should_deny_write() {
 ///     // ... assertions relying on file permission bits ...
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn as_nobody_when_root(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn enforce_file_permissions(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
         return Error::new_spanned(
             proc_macro2::TokenStream::from(attr),
-            "#[as_nobody_when_root] takes no arguments",
+            "#[enforce_file_permissions] takes no arguments",
         )
         .to_compile_error()
         .into();
@@ -43,16 +44,12 @@ pub fn as_nobody_when_root(attr: TokenStream, item: TokenStream) -> TokenStream 
     if let Some(asyncness) = &item_fn.sig.asyncness {
         return Error::new_spanned(
             asyncness,
-            "#[as_nobody_when_root] does not support async functions: \
-             forking around an async runtime does not compose",
-        )
-        .to_compile_error()
-        .into();
-    }
-    if let ReturnType::Type(_, ty) = &item_fn.sig.output {
-        return Error::new_spanned(
-            ty,
-            "#[as_nobody_when_root] only supports functions without a return type",
+            "#[enforce_file_permissions] does not support async functions: capabilities \
+             are a per-thread property, so a future resumed on another runtime worker \
+             thread would still hold CAP_DAC_OVERRIDE. Wrap the blocking assertion in \
+             `ic_test_utilities_privileges::run_with_file_permissions_enforced` instead, \
+             or place this attribute above `#[tokio::test]` (whose default current_thread \
+             flavour polls on the calling thread)",
         )
         .to_compile_error()
         .into();
@@ -68,7 +65,7 @@ pub fn as_nobody_when_root(attr: TokenStream, item: TokenStream) -> TokenStream 
     quote! {
         #(#attrs)*
         #vis #sig {
-            ::ic_test_utilities_privileges::run_as_nobody_if_root(|| #block);
+            ::ic_test_utilities_privileges::run_with_file_permissions_enforced(|| #block)
         }
     }
     .into()

--- a/rs/test_utilities/privileges/macros/src/lib.rs
+++ b/rs/test_utilities/privileges/macros/src/lib.rs
@@ -45,11 +45,14 @@ pub fn enforce_file_permissions(attr: TokenStream, item: TokenStream) -> TokenSt
         return Error::new_spanned(
             asyncness,
             "#[enforce_file_permissions] does not support async functions: capabilities \
-             are a per-thread property, so a future resumed on another runtime worker \
-             thread would still hold CAP_DAC_OVERRIDE. Wrap the blocking assertion in \
-             `ic_test_utilities_privileges::run_with_file_permissions_enforced` instead, \
-             or place this attribute above `#[tokio::test]` (whose default current_thread \
-             flavour polls on the calling thread)",
+             are a per-thread property, and there is no synchronous scope to drop them \
+             for. Put this attribute *below* `#[tokio::test]` instead — attribute macros \
+             expand top-down, so `#[tokio::test]` then expands first and this one wraps \
+             the synchronous `block_on` wrapper it produces (which also builds the \
+             runtime inside the guarded scope, so its worker threads inherit the drop). \
+             Alternatively call \
+             `ic_test_utilities_privileges::run_with_file_permissions_enforced` directly \
+             around the blocking assertion",
         )
         .to_compile_error()
         .into();

--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -1,275 +1,346 @@
-//! A test helper for running permission-sensitive assertions as an
-//! unprivileged user.
+//! A test helper for asserting that filesystem permission bits are enforced.
 //!
 //! Many tests assert that a filesystem operation fails with
-//! [`std::io::ErrorKind::PermissionDenied`]. Such assertions only hold for a
-//! non-root user: root holds `CAP_DAC_OVERRIDE` and therefore bypasses the
-//! `rwx` permission bits. When the test process runs as root (for example under
-//! some remote-execution setups) those tests instead observe the operation
-//! *succeeding* and fail.
+//! [`std::io::ErrorKind::PermissionDenied`]. Such an assertion only holds for a
+//! process that does *not* hold `CAP_DAC_OVERRIDE`/`CAP_DAC_READ_SEARCH`: those
+//! two capabilities let their holder (in practice, root) bypass the `rwx`
+//! permission bits. Under remote-execution setups that run Bazel test actions as
+//! uid 0 the operation therefore *succeeds*, and the test fails.
 //!
-//! [`run_as_nobody_if_root`] runs a closure as the unprivileged `nobody` user
-//! when the current process is root, and unchanged (in-process) otherwise.
-//! The [`as_nobody_when_root`] attribute is sugar wrapping a whole test body
-//! in [`run_as_nobody_if_root`], avoiding the closure and its indentation.
+//! [`run_with_file_permissions_enforced`] drops exactly those two capabilities
+//! from the effective set of the *calling thread*, runs a closure, and restores
+//! them afterwards — including while unwinding from a panic. The
+//! [`enforce_file_permissions`] attribute is sugar wrapping a whole test body in
+//! it, avoiding the closure and its indentation.
+//!
+//! # Limitations
+//!
+//! The helper makes the kernel enforce the permission bits against the calling
+//! thread. It is not a sandbox, and three things are deliberately outside what
+//! it can express. None is reachable from the current call sites, and each one
+//! fails loudly (the guarded assertion expects a denial, so a bypass makes the
+//! test fail rather than pass):
+//!
+//! * `access(2)`/`faccessat(2)` re-raise the effective set from the permitted
+//!   set whenever the *real* uid is 0, so they keep reporting access as granted
+//!   no matter what this helper does. Assert on a real operation
+//!   ([`std::fs::File::open`], [`std::fs::write`], ...) rather than on an
+//!   access check.
+//! * Only the calling thread and threads it goes on to create are affected;
+//!   capabilities are copied at thread creation. Work handed to a thread that
+//!   *already* existed — a global runtime, a `OnceLock` thread pool — runs with
+//!   the full sets. Create such pools inside the closure.
+//! * `execve` as uid 0 restores the full capability sets, so a subprocess
+//!   spawned inside the closure regains `CAP_DAC_OVERRIDE`.
 
-/// Attribute form of [`run_as_nobody_if_root`]; see its documentation.
-pub use ic_test_utilities_privileges_macros::as_nobody_when_root;
+/// Attribute form of [`run_with_file_permissions_enforced`]; see its documentation.
+pub use ic_test_utilities_privileges_macros::enforce_file_permissions;
 
 #[cfg(target_os = "linux")]
 mod imp {
-    use nix::libc;
-    use nix::sys::wait::{WaitStatus, waitpid};
-    use nix::unistd::{ForkResult, Gid, Uid, fork, geteuid, setgid, setgroups, setuid};
-    use std::ffi::CString;
-    use std::io::{PipeWriter, Read, Write};
-    use std::os::unix::fs::{PermissionsExt, chown};
-    use std::panic::{AssertUnwindSafe, catch_unwind};
-    use std::path::PathBuf;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::io;
+    use std::marker::PhantomData;
 
-    /// The conventional uid/gid of the unprivileged `nobody`/`nogroup` user.
-    /// Using the numeric id directly means no `/etc/passwd` entry is required.
-    const NOBODY: u32 = 65534;
+    /// Capability bit numbers (see `<linux/capability.h>`); both are < 32 so
+    /// they live in the first of the two 32-bit capability words.
+    const CAP_DAC_OVERRIDE: u32 = 1;
+    const CAP_DAC_READ_SEARCH: u32 = 2;
 
-    /// The exit code a child uses to signal that `action` panicked. Matches the
-    /// exit code the standard test harness uses for a failing test.
-    const PANIC_EXIT_CODE: i32 = 101;
-
-    /// Runs `action`, first dropping to the unprivileged `nobody` user if the
-    /// current process is running as root.
+    /// The capabilities that let their holder bypass the `rwx` permission bits:
+    /// `CAP_DAC_OVERRIDE` (read, write, and — for files with at least one
+    /// execute bit — execute) and `CAP_DAC_READ_SEARCH` (read, and search on
+    /// directories). These two are exactly what the kernel consults in
+    /// `generic_permission()`, so dropping both, and only both, is the minimal
+    /// change that makes it enforce the permission bits against us.
     ///
-    /// When the effective uid is not `0`, `action` simply runs in-process, so
-    /// behavior is unchanged for the common (non-root) case. When it is `0`,
-    /// `action` runs in a forked child that redirects the temporary directory to
-    /// a `nobody`-owned location and then drops its supplementary groups, group,
-    /// and user to `nobody` (which also clears `CAP_DAC_OVERRIDE`), so that
-    /// filesystem permission bits are enforced.
+    /// `CAP_FOWNER` is deliberately *not* dropped: it is not consulted by that
+    /// path, so keeping it weakens no assertion, and tests routinely `chmod`
+    /// back the files they made inaccessible in order to clean up.
+    const DAC_BYPASS_MASK: u32 = (1 << CAP_DAC_OVERRIDE) | (1 << CAP_DAC_READ_SEARCH);
+
+    /// `_LINUX_CAPABILITY_VERSION_3`: 64-bit capabilities, i.e. two data words.
+    /// The version matters — `_LINUX_CAPABILITY_VERSION_1` is still accepted by
+    /// modern kernels but silently truncates the capability sets to their lower
+    /// 32 bits, permanently discarding everything above `CAP_AUDIT_READ`.
+    const CAP_VERSION_3: u32 = 0x2008_0522;
+
+    /// The `libc` crate does not expose the capability get/set structs, so
+    /// declare them here to match the kernel's stable `capget(2)`/`capset(2)`
+    /// ABI for `_LINUX_CAPABILITY_VERSION_3`: a header plus an array of two
+    /// 32-bit data words (covering capabilities 0..64).
     ///
-    /// The child's outcome is mirrored in the caller: if `action` panics, the
-    /// caller panics with the same message (so `#[should_panic]`, including
-    /// `expected = "..."`, keeps working); if it returns, the caller returns.
+    /// `pid: 0` designates the *calling thread*. Capabilities are a per-thread
+    /// property, and `capset` compares a non-zero `pid` against the caller's
+    /// thread id, so `0` is also the only value that works from a thread other
+    /// than the main one.
+    #[repr(C)]
+    struct CapHeader {
+        version: u32,
+        pid: libc::c_int,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct CapData {
+        effective: u32,
+        permitted: u32,
+        inheritable: u32,
+    }
+
+    fn header() -> CapHeader {
+        CapHeader {
+            version: CAP_VERSION_3,
+            pid: 0,
+        }
+    }
+
+    /// Reads the calling thread's capability sets.
+    fn capget() -> io::Result<[CapData; 2]> {
+        let mut header = header();
+        let mut data = [CapData::default(); 2];
+        // SAFETY: `capget` reads `header` and writes exactly the two `CapData`
+        // words that `_LINUX_CAPABILITY_VERSION_3` prescribes. Both pointers
+        // are derived from live, correctly aligned `#[repr(C)]` locals that
+        // outlive the call, and the syscall has no effect beyond writing
+        // through them.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_capget,
+                &mut header as *mut CapHeader,
+                data.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(data)
+    }
+
+    /// Sets the calling thread's *effective* capability word for capabilities
+    /// 0..32.
     ///
-    /// # Notes
-    /// * The *whole* closure runs in the child, so any temporary files it
-    ///   creates are owned by `nobody`; restricting their permissions therefore
-    ///   denies `nobody` exactly as it would a normal non-root owner. Threads
-    ///   spawned by `action` also run as `nobody`.
-    /// * Temporary directories must be derived from `TMPDIR`/`TEST_TMPDIR` (as
-    ///   `tempfile` and `ic_test_utilities_tmpdir::tmpdir` are); the child points
-    ///   both at a `nobody`-owned base with mode `0700`, prepared by the parent.
-    ///   The parent also grants others-execute on the base's ancestor
-    ///   directories where missing, so `nobody` can traverse into it even when
-    ///   the temp root is not world-traversable (as under some sandboxed
-    ///   remote-execution setups); see `TmpDirRedirect::prepare`.
-    /// * The parent test process may be multi-threaded, and after `fork` the
-    ///   child must not wait on locks that another parent thread held at fork
-    ///   time. The temp base and the `putenv(3)` strings are therefore prepared
-    ///   in the parent before forking, and the child avoids `std::env::set_var`
-    ///   (and with it `std`'s global environment lock), using only direct
-    ///   syscalls to drop privileges and `_exit(2)` to terminate.
-    pub fn run_as_nobody_if_root<F: FnOnce()>(action: F) {
-        if geteuid().as_raw() != 0 {
-            action();
-            return;
+    /// `capset` always writes all three sets at once, so the current ones are
+    /// read back first and the permitted and inheritable sets — and the second
+    /// data word, for capabilities 32..64 — are handed back verbatim. Leaving
+    /// the permitted set alone is what makes restoring infallible: the kernel
+    /// only requires `effective ⊆ permitted`, so re-raising a capability that
+    /// was effective a moment ago is always accepted.
+    fn set_effective_low_word(effective: u32) -> io::Result<()> {
+        let mut header = header();
+        let mut data = capget()?;
+        data[0].effective = effective;
+        // SAFETY: `capset` reads `header` and the two `CapData` words; both
+        // pointers are derived from live, correctly aligned `#[repr(C)]` locals
+        // that outlive the call, and the syscall writes through neither.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_capset,
+                &mut header as *mut CapHeader,
+                data.as_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
         }
-        run_forked(action);
-    }
-
-    /// The temp-dir redirection for the child, prepared in the parent (where
-    /// allocating and taking locks is safe, since no fork has happened yet).
-    struct TmpDirRedirect {
-        /// The `nobody`-owned (mode `0700`) base directory for the child's
-        /// temporary files, removed by the parent once the child has exited.
-        base: PathBuf,
-        /// `putenv`-style `NAME=VALUE` strings. After `putenv(3)` the child's
-        /// `environ` references them directly, so they must stay allocated for
-        /// the child's whole lifetime. This holds because the child `_exit`s
-        /// inside `run_forked`, while this struct is still live in its frame.
-        env_entries: [CString; 2],
-    }
-
-    impl TmpDirRedirect {
-        /// Creates the base directory (as root, in the parent) and hands it
-        /// over to `nobody` with mode `0700`, so the unprivileged child owns
-        /// everything beneath it and no world-writable directory is created.
-        fn prepare() -> Self {
-            // Distinguishes concurrently prepared bases within one process.
-            static SEQ: AtomicUsize = AtomicUsize::new(0);
-            let temp_root = std::env::temp_dir();
-            let base = temp_root.join(format!(
-                "ic-nobody-{}-{}",
-                std::process::id(),
-                SEQ.fetch_add(1, Ordering::Relaxed)
-            ));
-            // `create_dir` rather than `create_dir_all`: fail instead of
-            // silently adopting a pre-existing directory of unknown ownership.
-            std::fs::create_dir(&base).expect("failed to create the nobody temp base");
-            chown(&base, Some(NOBODY), Some(NOBODY)).expect("failed to chown the nobody temp base");
-            std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700))
-                .expect("failed to chmod the nobody temp base");
-            // The child creates its temporary files under `base` as `nobody`,
-            // which requires *search* (execute) permission on every ancestor
-            // directory. Some sandboxed remote-execution setups leave the temp
-            // root not world-traversable: Namespace's
-            // `namespace_action_isolation=sandboxed` runs the action as uid 0
-            // with `TMPDIR` unset, so `std::env::temp_dir()` is a root-owned,
-            // non-traversable `/tmp` that `nobody` cannot descend into. As root
-            // (in the parent) grant others-execute on each ancestor that lacks
-            // it — the minimal relaxation permitting traversal, without exposing
-            // directory listings or write access (the base itself stays `0700`
-            // `nobody`). The sandbox is ephemeral and per-action, so this has no
-            // effect beyond the running test.
-            //
-            // Confine this to the default temp root (`/tmp`, used precisely
-            // because `TMPDIR` is unset). An explicitly-configured `TMPDIR` is
-            // left untouched, so running tests as root *outside* the sandbox
-            // cannot be steered into world-traversing a sensitive directory
-            // (e.g. `TMPDIR=/root/tmp` must not relax `/root`).
-            if temp_root == std::path::Path::new("/tmp") {
-                grant_ancestor_traversal(&base);
-            }
-            let entry = |name: &str| {
-                CString::new(format!("{name}={}", base.display()))
-                    .expect("temp base path contains an interior NUL byte")
-            };
-            Self {
-                env_entries: [entry("TMPDIR"), entry("TEST_TMPDIR")],
-                base,
-            }
-        }
-
-        /// Points `TMPDIR`/`TEST_TMPDIR` at the prepared base; runs in the
-        /// forked child.
-        ///
-        /// Uses `putenv(3)` with the pre-allocated strings instead of
-        /// `std::env::set_var`, because the latter takes `std`'s global
-        /// environment lock: if another thread of the parent held it at `fork`
-        /// time, it would never be released in the child.
-        fn apply_in_child(&self) -> nix::Result<()> {
-            for entry in &self.env_entries {
-                // SAFETY: `entry` points to a valid, NUL-terminated string that
-                // stays allocated for the child's whole lifetime (see the
-                // `env_entries` field documentation).
-                if unsafe { libc::putenv(entry.as_ptr() as *mut libc::c_char) } != 0 {
-                    return Err(nix::errno::Errno::last());
-                }
-            }
-            Ok(())
-        }
-    }
-
-    /// Adds others-execute (search) permission to every ancestor directory of
-    /// `dir`, so the unprivileged `nobody` child can traverse the path down to
-    /// it. Only the execute bit is added, and only to directories that lack it,
-    /// so no directory becomes listable or writable by others. Runs as root in
-    /// the parent; see the call site in `TmpDirRedirect::prepare` for why this
-    /// is needed under sandboxed remote execution.
-    fn grant_ancestor_traversal(dir: &std::path::Path) {
-        // `ancestors()` yields `dir` first; skip it (it is already owned by
-        // `nobody`) and walk its parent, grandparent, ... up to the root.
-        for ancestor in dir.ancestors().skip(1) {
-            let Ok(metadata) = std::fs::metadata(ancestor) else {
-                // Unreadable ancestor (e.g. we walked above the mount root):
-                // nothing to relax here.
-                continue;
-            };
-            let mode = metadata.permissions().mode();
-            if mode & 0o001 == 0 {
-                std::fs::set_permissions(ancestor, std::fs::Permissions::from_mode(mode | 0o001))
-                    .unwrap_or_else(|err| {
-                        panic!(
-                            "failed to make {} traversable for nobody: {err}",
-                            ancestor.display()
-                        )
-                    });
-            }
-        }
-    }
-
-    fn run_forked<F: FnOnce()>(action: F) {
-        // Prepared before forking; see `TmpDirRedirect`.
-        let redirect = TmpDirRedirect::prepare();
-        // Pipe used to forward the child's panic message to the parent.
-        let (mut reader, writer) = std::io::pipe().expect("failed to create pipe");
-
-        match unsafe { fork() }.expect("fork failed") {
-            ForkResult::Child => {
-                drop(reader);
-                let mut writer = writer;
-                let code = run_child(action, &redirect, &mut writer);
-                // `_exit(2)` rather than `exit(3)`: skip the `atexit(3)`
-                // handlers and stdio flushing inherited from the parent, which
-                // must not run in the forked child of a (potentially
-                // multi-threaded) test process.
-                unsafe { libc::_exit(code) }
-            }
-            ForkResult::Parent { child } => {
-                drop(writer);
-                let mut message = String::new();
-                let _ = reader.read_to_string(&mut message);
-                let status = waitpid(child, None).expect("waitpid failed");
-                let _ = std::fs::remove_dir_all(&redirect.base);
-                match status {
-                    WaitStatus::Exited(_, 0) => {}
-                    WaitStatus::Exited(_, code) if code == PANIC_EXIT_CODE => {
-                        // Re-raise the child's panic (with its message) so that
-                        // `#[should_panic]` matches and the failure is visible.
-                        panic!("{message}");
-                    }
-                    other => panic!("unprivileged child process did not exit cleanly: {other:?}"),
-                }
-            }
-        }
-    }
-
-    /// Runs `action` in the forked child as `nobody`, returning the process exit
-    /// code: `0` on success, [`PANIC_EXIT_CODE`] on panic.
-    fn run_child<F: FnOnce()>(
-        action: F,
-        redirect: &TmpDirRedirect,
-        writer: &mut PipeWriter,
-    ) -> i32 {
-        if let Err(err) = redirect_tmp_and_drop_privileges(redirect) {
-            let _ = write!(writer, "failed to drop privileges to nobody: {err}");
-            return PANIC_EXIT_CODE;
-        }
-        match catch_unwind(AssertUnwindSafe(action)) {
-            Ok(()) => 0,
-            Err(payload) => {
-                let _ = write!(writer, "{}", panic_message(payload.as_ref()));
-                PANIC_EXIT_CODE
-            }
-        }
-    }
-
-    fn redirect_tmp_and_drop_privileges(redirect: &TmpDirRedirect) -> nix::Result<()> {
-        redirect.apply_in_child()?;
-
-        // Order matters: drop the supplementary groups and gid while we still
-        // hold `CAP_SETGID` (i.e. before dropping the uid).
-        setgroups(&[])?;
-        setgid(Gid::from_raw(NOBODY))?;
-        setuid(Uid::from_raw(NOBODY))?;
         Ok(())
     }
 
-    fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
-        if let Some(s) = payload.downcast_ref::<&str>() {
-            (*s).to_string()
-        } else if let Some(s) = payload.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "unprivileged action panicked with a non-string payload".to_string()
+    /// Whether the calling thread currently holds a capability that lets it
+    /// bypass the file permission bits.
+    ///
+    /// Outside [`run_with_file_permissions_enforced`] this answers "am I running
+    /// privileged", which is `true` on a remote-execution worker running test
+    /// actions as uid 0 and `false` for an ordinary user; inside it, it is
+    /// `false` either way.
+    pub fn bypasses_file_permissions() -> bool {
+        let data = capget().unwrap_or_else(|err| panic!("capget failed: {err}"));
+        data[0].effective & DAC_BYPASS_MASK != 0
+    }
+
+    /// Restores the capabilities that [`drop_dac_bypass`] took away when it goes
+    /// out of scope, including while unwinding from a panic in the action —
+    /// which is why this is a guard and not a pair of calls around it.
+    struct RestoreDacBypass {
+        /// The subset of [`DAC_BYPASS_MASK`] that was effective before the drop
+        /// and therefore has to be raised again.
+        dropped: u32,
+        /// Capabilities are per-thread, so the guard has to be dropped on the
+        /// thread that created it. Making it `!Send` lets the compiler enforce
+        /// that rather than leaving it to a comment.
+        _not_send: PhantomData<*const ()>,
+    }
+
+    impl Drop for RestoreDacBypass {
+        fn drop(&mut self) {
+            let restore = || -> io::Result<()> {
+                let effective = capget()?[0].effective;
+                set_effective_low_word(effective | self.dropped)
+            };
+            if let Err(err) = restore() {
+                // Unreachable in practice: the permitted set was left untouched
+                // and `self.dropped` was effective moments ago, so the kernel
+                // has no grounds to refuse. Should it happen anyway, the thread
+                // is left permanently deprivileged — and the test harness runs
+                // later tests on this same thread when it is not parallel — so
+                // failing quietly is not an option. `abort` rather than `panic!`
+                // because panicking here while already unwinding would abort
+                // anyway, having first destroyed the original failure message.
+                eprintln!(
+                    "failed to restore CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH \
+                     (0x{:08x}) after the action, aborting to avoid running \
+                     later tests on a deprivileged thread: {err}",
+                    self.dropped
+                );
+                std::process::abort();
+            }
         }
+    }
+
+    /// Runs `action` with the file permission bits enforced against the caller,
+    /// and returns its result.
+    ///
+    /// `CAP_DAC_OVERRIDE` and `CAP_DAC_READ_SEARCH` are removed from the
+    /// effective capability set of the calling thread for the duration of
+    /// `action`, so a test asserting [`std::io::ErrorKind::PermissionDenied`]
+    /// observes the denial even when the test process runs as root (as under
+    /// some remote-execution setups). For an ordinary unprivileged process the
+    /// two capabilities are not held in the first place, and this costs a single
+    /// `capget(2)`.
+    ///
+    /// The caller keeps its uid and its ownership of everything it creates, so
+    /// `chmod`-based teardown inside `action` keeps working.
+    ///
+    /// See the crate documentation for what this does *not* cover.
+    pub fn run_with_file_permissions_enforced<T>(action: impl FnOnce() -> T) -> T {
+        let _guard = drop_dac_bypass();
+        action()
+    }
+
+    /// Drops the DAC-bypass capabilities from the calling thread, returning the
+    /// guard that restores them, or `None` if they were not held anyway.
+    fn drop_dac_bypass() -> Option<RestoreDacBypass> {
+        let before = capget().unwrap_or_else(|err| panic!("capget failed: {err}"))[0];
+        let dropped = before.effective & DAC_BYPASS_MASK;
+        if dropped == 0 {
+            // The ordinary unprivileged case: the permission bits are already
+            // enforced against us and no `capset` is issued at all. Note this
+            // deliberately keys off the capabilities rather than off
+            // `geteuid() == 0`, which is neither necessary (file capabilities)
+            // nor sufficient (uid 0 in a user namespace with an empty set).
+            return None;
+        }
+        set_effective_low_word(before.effective & !DAC_BYPASS_MASK).unwrap_or_else(|err| {
+            // Lowering effective capabilities is unconditionally permitted, so
+            // this cannot legitimately fail — and carrying on would run the
+            // action privileged, i.e. decide the assertions it guards for the
+            // wrong reason.
+            panic!(
+                "capset failed while dropping CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH \
+                 (effective 0x{:08x}): {err}",
+                before.effective
+            )
+        });
+        // Construct the guard *before* the checks below, so that a failing check
+        // unwinds through it and restores the capabilities rather than leaving
+        // the thread deprivileged.
+        let guard = RestoreDacBypass {
+            dropped,
+            _not_send: PhantomData,
+        };
+        assert_dac_bypass_cleared(before.permitted);
+        assert_permission_bits_enforced();
+        Some(guard)
+    }
+
+    /// Reads the capability sets back and panics unless the DAC-bypass bits are
+    /// really gone and the permitted set is untouched.
+    ///
+    /// This is what keeps a mistake here — a wrong bit number, a wrong
+    /// capability version, a `capset` that reported success without taking
+    /// effect — from quietly reverting every caller to running fully privileged,
+    /// where the assertions they exist for would no longer mean anything.
+    fn assert_dac_bypass_cleared(permitted_before: u32) {
+        let after = capget().unwrap_or_else(|err| panic!("capget failed: {err}"))[0];
+        assert_eq!(
+            after.effective & DAC_BYPASS_MASK,
+            0,
+            "CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH are still effective after capset \
+             (effective 0x{:08x}, permitted 0x{:08x}); the file permission bits would \
+             not be enforced, so the assertions guarded by this helper would be \
+             decided for the wrong reason",
+            after.effective,
+            after.permitted,
+        );
+        assert_eq!(
+            after.permitted, permitted_before,
+            "capset changed the permitted set (0x{:08x} -> 0x{:08x}); restoring the \
+             effective set afterwards may no longer be possible",
+            permitted_before, after.permitted,
+        );
+    }
+
+    /// Confirms behaviourally, once per process, that the permission bits are
+    /// now enforced: creates a mode `0000` file and checks that reading it is
+    /// denied.
+    ///
+    /// [`assert_dac_bypass_cleared`] proves the capability bits are clear; this
+    /// proves the kernel acts on that in the environment the tests really run
+    /// in, which is the whole reason this crate exists. It runs only when
+    /// capabilities were in fact dropped, and at most once per test binary.
+    ///
+    /// Note the probe has to be a real read: `access(2)` restores the effective
+    /// set from the permitted set whenever the real uid is 0, so it would report
+    /// success here regardless and defeat the check.
+    fn assert_permission_bits_enforced() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::OnceLock;
+
+        static PROBED: OnceLock<()> = OnceLock::new();
+        PROBED.get_or_init(|| {
+            let Ok(dir) = tempfile::tempdir() else {
+                // A temp directory we cannot create is not evidence of
+                // anything, so a failure to *set up* the probe skips it rather
+                // than failing the test that happened to run it first.
+                return;
+            };
+            let path = dir.path().join("unreadable");
+            let setup = std::fs::write(&path, b"probe").and_then(|()| {
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000))
+            });
+            if setup.is_err() {
+                return;
+            }
+            let denied = std::fs::read(&path)
+                .err()
+                .map(|err| err.kind() == std::io::ErrorKind::PermissionDenied)
+                .unwrap_or(false);
+            // Make the file removable again before asserting, so a failure here
+            // does not also leave `dir` undeletable.
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+            assert!(
+                denied,
+                "reading a mode 0000 file succeeded even though \
+                 CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH were dropped; the file permission \
+                 bits are not being enforced against this process, so the assertions \
+                 guarded by this helper are meaningless"
+            );
+        });
     }
 }
 
 #[cfg(target_os = "linux")]
-pub use imp::run_as_nobody_if_root;
+pub use imp::{bypasses_file_permissions, run_with_file_permissions_enforced};
 
-/// On non-Linux platforms, dropping privileges is a no-op: `action` runs directly.
+/// On non-Linux platforms there are no capabilities to drop, so `action` runs
+/// directly. The affected tests are Linux-only in practice: this crate exists
+/// for Linux remote-execution workers that run test actions as uid 0.
 #[cfg(not(target_os = "linux"))]
-pub fn run_as_nobody_if_root<F: FnOnce()>(action: F) {
-    action();
+pub fn run_with_file_permissions_enforced<T>(action: impl FnOnce() -> T) -> T {
+    action()
+}
+
+/// See the Linux implementation; there is no equivalent notion elsewhere.
+#[cfg(not(target_os = "linux"))]
+pub fn bypasses_file_permissions() -> bool {
+    false
 }

--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -165,10 +165,16 @@ mod imp {
         /// and therefore has to be raised again.
         dropped: u32,
         /// Capabilities are per-thread, so the guard has to be dropped on the
-        /// thread that created it. Making it `!Send` lets the compiler enforce
-        /// that rather than leaving it to a comment.
+        /// thread that created it: moving it elsewhere would raise capabilities
+        /// on a thread that never dropped them and leave this one deprivileged.
+        /// A `PhantomData` over a raw pointer opts the whole struct out of
+        /// `Send`/`Sync` — raw pointers implement neither — so the compiler
+        /// enforces that rather than leaving it to a comment. The assertion
+        /// below keeps it that way.
         _not_send: PhantomData<*const ()>,
     }
+
+    static_assertions::assert_not_impl_any!(RestoreDacBypass: Send, Sync);
 
     impl Drop for RestoreDacBypass {
         fn drop(&mut self) {
@@ -219,8 +225,8 @@ mod imp {
     /// Drops the DAC-bypass capabilities from the calling thread, returning the
     /// guard that restores them, or `None` if they were not held anyway.
     fn drop_dac_bypass() -> Option<RestoreDacBypass> {
-        let before = capget().unwrap_or_else(|err| panic!("capget failed: {err}"))[0];
-        let dropped = before.effective & DAC_BYPASS_MASK;
+        let before = capget().unwrap_or_else(|err| panic!("capget failed: {err}"));
+        let dropped = before[0].effective & DAC_BYPASS_MASK;
         if dropped == 0 {
             // The ordinary unprivileged case: the permission bits are already
             // enforced against us and no `capset` is issued at all. Note this
@@ -229,7 +235,7 @@ mod imp {
             // nor sufficient (uid 0 in a user namespace with an empty set).
             return None;
         }
-        set_effective_low_word(before.effective & !DAC_BYPASS_MASK).unwrap_or_else(|err| {
+        set_effective_low_word(before[0].effective & !DAC_BYPASS_MASK).unwrap_or_else(|err| {
             // Lowering effective capabilities is unconditionally permitted, so
             // this cannot legitimately fail — and carrying on would run the
             // action privileged, i.e. decide the assertions it guards for the
@@ -237,7 +243,7 @@ mod imp {
             panic!(
                 "capset failed while dropping CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH \
                  (effective 0x{:08x}): {err}",
-                before.effective
+                before[0].effective
             )
         });
         // Construct the guard *before* the checks below, so that a failing check
@@ -247,36 +253,49 @@ mod imp {
             dropped,
             _not_send: PhantomData,
         };
-        assert_dac_bypass_cleared(before.permitted);
+        assert_dac_bypass_cleared(&before);
         assert_permission_bits_enforced();
         Some(guard)
     }
 
     /// Reads the capability sets back and panics unless the DAC-bypass bits are
-    /// really gone and the permitted set is untouched.
+    /// really gone and nothing but the effective set changed.
     ///
     /// This is what keeps a mistake here — a wrong bit number, a wrong
     /// capability version, a `capset` that reported success without taking
     /// effect — from quietly reverting every caller to running fully privileged,
     /// where the assertions they exist for would no longer mean anything.
-    fn assert_dac_bypass_cleared(permitted_before: u32) {
-        let after = capget().unwrap_or_else(|err| panic!("capget failed: {err}"))[0];
+    ///
+    /// Both capability words are compared, not just the low one holding the two
+    /// bits of interest. That is what catches a `capset` issued with
+    /// `_LINUX_CAPABILITY_VERSION_1`, whose single-word ABI modern kernels still
+    /// accept while silently zeroing the *upper* word of the permitted and
+    /// inheritable sets — discarding `CAP_AUDIT_READ` and everything above it.
+    fn assert_dac_bypass_cleared(before: &[CapData; 2]) {
+        let after = capget().unwrap_or_else(|err| panic!("capget failed: {err}"));
         assert_eq!(
-            after.effective & DAC_BYPASS_MASK,
+            after[0].effective & DAC_BYPASS_MASK,
             0,
             "CAP_DAC_OVERRIDE/CAP_DAC_READ_SEARCH are still effective after capset \
              (effective 0x{:08x}, permitted 0x{:08x}); the file permission bits would \
              not be enforced, so the assertions guarded by this helper would be \
              decided for the wrong reason",
-            after.effective,
-            after.permitted,
+            after[0].effective,
+            after[0].permitted,
         );
-        assert_eq!(
-            after.permitted, permitted_before,
-            "capset changed the permitted set (0x{:08x} -> 0x{:08x}); restoring the \
-             effective set afterwards may no longer be possible",
-            permitted_before, after.permitted,
-        );
+        for (word, (before, after)) in before.iter().zip(after.iter()).enumerate() {
+            assert_eq!(
+                (after.permitted, after.inheritable),
+                (before.permitted, before.inheritable),
+                "capset changed more than the effective set in capability word {word} \
+                 (permitted 0x{:08x} -> 0x{:08x}, inheritable 0x{:08x} -> 0x{:08x}); \
+                 restoring the effective set afterwards may no longer be possible",
+                before.permitted,
+                after.permitted,
+                before.inheritable,
+                after.inheritable,
+            );
+        }
     }
 
     /// Confirms behaviourally, once per process, that the permission bits are

--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -29,7 +29,12 @@
 //! * Only the calling thread and threads it goes on to create are affected;
 //!   capabilities are copied at thread creation. Work handed to a thread that
 //!   *already* existed — a global runtime, a `OnceLock` thread pool — runs with
-//!   the full sets. Create such pools inside the closure.
+//!   the full sets. Create such pools inside the closure, and make sure they
+//!   have terminated by the time it returns: the guard restores only the
+//!   thread it was created on, so a thread spawned inside that outlives the
+//!   closure keeps the reduced sets for the rest of its life. That is harmless
+//!   for one that simply exits, but a pool stashed somewhere global would go
+//!   on to deny later, unrelated work.
 //! * `execve` as uid 0 restores the full capability sets, so a subprocess
 //!   spawned inside the closure regains `CAP_DAC_OVERRIDE`.
 

--- a/rs/test_utilities/privileges/src/lib.rs
+++ b/rs/test_utilities/privileges/src/lib.rs
@@ -72,7 +72,7 @@ mod imp {
     /// The `libc` crate does not expose the capability get/set structs, so
     /// declare them here to match the kernel's stable `capget(2)`/`capset(2)`
     /// ABI for `_LINUX_CAPABILITY_VERSION_3`: a header plus an array of two
-    /// 32-bit data words (covering capabilities 0..64).
+    /// 32-bit data words (covering capability numbers 0 to 63).
     ///
     /// `pid: 0` designates the *calling thread*. Capabilities are a per-thread
     /// property, and `capset` compares a non-zero `pid` against the caller's
@@ -121,12 +121,12 @@ mod imp {
         Ok(data)
     }
 
-    /// Sets the calling thread's *effective* capability word for capabilities
-    /// 0..32.
+    /// Sets the calling thread's *effective* capability word for capability
+    /// numbers 0 to 31.
     ///
     /// `capset` always writes all three sets at once, so the current ones are
     /// read back first and the permitted and inheritable sets — and the second
-    /// data word, for capabilities 32..64 — are handed back verbatim. Leaving
+    /// data word, for capability numbers 32 to 63 — are handed back verbatim. Leaving
     /// the permitted set alone is what makes restoring infallible: the kernel
     /// only requires `effective ⊆ permitted`, so re-raising a capability that
     /// was effective a moment ago is always accepted.

--- a/rs/test_utilities/privileges/tests/smoke.rs
+++ b/rs/test_utilities/privileges/tests/smoke.rs
@@ -1,32 +1,52 @@
-//! Smoke tests for `run_as_nobody_if_root`.
+//! Smoke tests for `run_with_file_permissions_enforced`.
 //!
-//! When run as a regular user these exercise the in-process path; when run as
-//! root (e.g. on a Bazel remote-execution worker) they exercise the forked,
-//! privilege-dropping path.
+//! When run as a regular user these exercise the no-op path; when run as root
+//! (e.g. on a Bazel remote-execution worker) they additionally exercise the
+//! capability-dropping path. Every assertion below is written to hold either
+//! way, so nothing is silently skipped on a developer machine.
+//!
+//! To exercise the privileged path locally:
+//!
+//! ```text
+//! sudo -E env "PATH=$PATH" cargo test -p ic-test-utilities-privileges
+//! ```
 
-use ic_test_utilities_privileges::run_as_nobody_if_root;
+use ic_test_utilities_privileges::{bypasses_file_permissions, run_with_file_permissions_enforced};
 use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, Barrier};
+
+/// Creates a file and makes it inaccessible, returning the temp dir holding it
+/// (the caller keeps it alive) and the path.
+fn unreadable_file(mode: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let path = dir.path().join("file");
+    std::fs::write(&path, b"before").expect("failed to create the file");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode))
+        .expect("failed to restrict the file");
+    (dir, path)
+}
 
 #[test]
 fn should_return_success() {
-    run_as_nobody_if_root(|| {});
+    run_with_file_permissions_enforced(|| {});
+}
+
+#[test]
+fn should_return_the_action_result() {
+    assert_eq!(run_with_file_permissions_enforced(|| 42), 42);
 }
 
 #[test]
 #[should_panic(expected = "boom: 42")]
 fn should_propagate_panic_message() {
-    run_as_nobody_if_root(|| panic!("boom: {}", 42));
+    run_with_file_permissions_enforced(|| panic!("boom: {}", 42));
 }
 
 #[test]
 fn should_deny_write_to_read_only_file() {
-    run_as_nobody_if_root(|| {
-        let dir = tempfile::tempdir().expect("failed to create a temp dir");
-        let path = dir.path().join("read-only");
-        std::fs::write(&path, b"before").expect("failed to create the file");
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400))
-            .expect("failed to make the file read-only");
+    run_with_file_permissions_enforced(|| {
+        let (_dir, path) = unreadable_file(0o400);
 
         let err = std::fs::write(&path, b"after").expect_err("write should be denied");
 
@@ -35,15 +55,145 @@ fn should_deny_write_to_read_only_file() {
 }
 
 #[test]
-fn should_spawn_many_concurrently() {
-    // Regression test for fork-safety: forking from a multi-threaded process
-    // must not deadlock the children (e.g. on locks that another thread of the
-    // parent held at fork time).
+fn should_deny_read_of_mode_000_file() {
+    run_with_file_permissions_enforced(|| {
+        let (_dir, path) = unreadable_file(0o000);
+
+        let err = std::fs::read(&path).expect_err("read should be denied");
+
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    });
+}
+
+#[test]
+fn should_deny_traversal_of_non_searchable_directory() {
+    // The only assertion here that fails if `CAP_DAC_OVERRIDE` is dropped but
+    // `CAP_DAC_READ_SEARCH` is not: searching a directory needs one of the two.
+    run_with_file_permissions_enforced(|| {
+        let dir = tempfile::tempdir().expect("failed to create a temp dir");
+        let path = dir.path().join("file");
+        std::fs::write(&path, b"contents").expect("failed to create the file");
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o600))
+            .expect("failed to make the directory non-searchable");
+
+        let err = std::fs::read(&path).expect_err("traversal should be denied");
+
+        // Restore before `dir` is dropped so that it can be cleaned up.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("failed to make the directory searchable again");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    });
+}
+
+#[test]
+fn should_drop_the_bypass_inside_and_restore_it_afterwards() {
+    let before = bypasses_file_permissions();
+
+    run_with_file_permissions_enforced(|| {
+        assert!(
+            !bypasses_file_permissions(),
+            "the DAC bypass should be dropped inside the action"
+        );
+    });
+
+    assert_eq!(
+        bypasses_file_permissions(),
+        before,
+        "the DAC bypass should be restored after the action"
+    );
+}
+
+#[test]
+fn should_restore_the_bypass_after_a_panic() {
+    let before = bypasses_file_permissions();
+
+    let result = std::panic::catch_unwind(|| {
+        run_with_file_permissions_enforced(|| panic!("boom"));
+    });
+
+    assert!(result.is_err(), "the panic should propagate");
+    assert_eq!(
+        bypasses_file_permissions(),
+        before,
+        "the DAC bypass should be restored while unwinding"
+    );
+}
+
+#[test]
+fn should_drop_the_bypass_in_threads_spawned_by_the_action() {
+    // Threads inherit the capability sets of the thread that creates them, so a
+    // thread spawned inside the action must see the permission bits enforced
+    // too. Several call sites rely on this (they hand the filesystem work to a
+    // worker thread they spawn).
+    run_with_file_permissions_enforced(|| {
+        std::thread::spawn(|| {
+            assert!(
+                !bypasses_file_permissions(),
+                "a thread spawned inside the action should inherit the drop"
+            );
+            let (_dir, path) = unreadable_file(0o400);
+            let err = std::fs::write(&path, b"after").expect_err("write should be denied");
+            assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+        })
+        .join()
+        .expect("the spawned thread panicked");
+    });
+}
+
+#[test]
+fn should_not_affect_other_threads() {
+    // The load-bearing property of the whole design: capabilities are
+    // per-thread, so dropping them here must leave a thread that already exists
+    // untouched. Were this wrong, the ~500-test crypto binary would produce
+    // random `PermissionDenied` failures in tests unrelated to the one that
+    // dropped them.
+    let before = bypasses_file_permissions();
+    // Two rendezvous points: the first is reached while the main thread is
+    // inside the action, the second releases it once the observer is done.
+    let entered = Arc::new(Barrier::new(2));
+    let observed = Arc::new(Barrier::new(2));
+
+    let observer = std::thread::spawn({
+        let (entered, observed) = (Arc::clone(&entered), Arc::clone(&observed));
+        move || {
+            entered.wait();
+            let bypasses = bypasses_file_permissions();
+            // ... and check it behaves accordingly, not just that the bit is set.
+            let (_dir, path) = unreadable_file(0o400);
+            let denied = std::fs::write(&path, b"after").is_err();
+            observed.wait();
+            (bypasses, denied)
+        }
+    });
+
+    run_with_file_permissions_enforced(|| {
+        entered.wait();
+        observed.wait();
+    });
+
+    let (bypasses, denied) = observer.join().expect("the observer thread panicked");
+    assert_eq!(
+        bypasses, before,
+        "dropping the DAC bypass must not affect a thread that already existed"
+    );
+    assert_eq!(
+        denied, !before,
+        "a pre-existing thread should still write a read-only file it owns iff it \
+         holds the DAC bypass"
+    );
+}
+
+#[test]
+fn should_be_usable_concurrently_from_many_threads() {
+    // Regression test for the fork-based implementation this replaced, which
+    // deadlocked when called from a multi-threaded process. It now also covers
+    // concurrent drops and restores not interfering with one another.
     let handles: Vec<_> = (0..8)
         .map(|i| {
             std::thread::spawn(move || {
                 for _ in 0..8 {
-                    run_as_nobody_if_root(|| {
+                    run_with_file_permissions_enforced(|| {
+                        assert!(!bypasses_file_permissions());
                         let dir = tempfile::tempdir().expect("failed to create a temp dir");
                         std::fs::write(dir.path().join("file"), format!("{i}"))
                             .expect("failed to write");
@@ -61,27 +211,46 @@ mod attribute_form {
     use super::*;
 
     #[test]
-    #[ic_test_utilities_privileges::as_nobody_when_root]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_return_success() {}
 
     #[test]
     #[should_panic(expected = "boom: 42")]
-    #[ic_test_utilities_privileges::as_nobody_when_root]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_propagate_panic_message() {
         panic!("boom: {}", 42);
     }
 
     #[test]
-    #[ic_test_utilities_privileges::as_nobody_when_root]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_deny_write_to_read_only_file() {
-        let dir = tempfile::tempdir().expect("failed to create a temp dir");
-        let path = dir.path().join("read-only");
-        std::fs::write(&path, b"before").expect("failed to create the file");
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400))
-            .expect("failed to make the file read-only");
+        let (_dir, path) = unreadable_file(0o400);
 
         let err = std::fs::write(&path, b"after").expect_err("write should be denied");
 
         assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
+    fn should_deny_read_of_mode_000_file() {
+        let (_dir, path) = unreadable_file(0o000);
+
+        let err = std::fs::read(&path).expect_err("read should be denied");
+
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
+    fn should_support_a_return_type() -> std::io::Result<()> {
+        let (_dir, path) = unreadable_file(0o000);
+        assert_eq!(
+            std::fs::read(&path)
+                .expect_err("read should be denied")
+                .kind(),
+            ErrorKind::PermissionDenied
+        );
+        Ok(())
     }
 }

--- a/rs/test_utilities/privileges/tests/smoke.rs
+++ b/rs/test_utilities/privileges/tests/smoke.rs
@@ -159,9 +159,16 @@ fn should_not_affect_other_threads() {
         move || {
             entered.wait();
             let bypasses = bypasses_file_permissions();
-            // ... and check it behaves accordingly, not just that the bit is set.
-            let (_dir, path) = file_with_mode(0o400);
-            let denied = std::fs::write(&path, b"after").is_err();
+            // ... and check it behaves accordingly, not just that the bit is
+            // set. This has to be a mode 000 *read*, which either capability
+            // bypasses, so that it matches what `bypasses_file_permissions`
+            // reports. A write to a mode 0400 file would not: only
+            // `CAP_DAC_OVERRIDE` bypasses that, so a process holding just
+            // `CAP_DAC_READ_SEARCH` would be denied the write while still
+            // reporting `true`, and this test would fail despite the thread
+            // isolation it checks working perfectly.
+            let (_dir, path) = file_with_mode(0o000);
+            let denied = std::fs::read(&path).is_err();
             observed.wait();
             (bypasses, denied)
         }
@@ -179,8 +186,44 @@ fn should_not_affect_other_threads() {
     );
     assert_eq!(
         denied, !before,
-        "a pre-existing thread should still write a read-only file it owns iff it \
-         holds the DAC bypass"
+        "a pre-existing thread should still read a mode 000 file it owns iff it \
+         holds a DAC bypass capability"
+    );
+}
+
+#[test]
+fn should_leave_a_thread_that_outlives_the_action_deprivileged() {
+    // The flip side of inheritance, and the reason the crate docs tell callers
+    // to join whatever they spawn before the closure returns: the guard
+    // restores only the thread it was created on, so a thread spawned inside
+    // that outlives the closure keeps the reduced sets for good. Harmless for a
+    // thread that just exits, but a pool stashed somewhere global would go on
+    // to deny later, unrelated work. Pinned here so the documented hazard is
+    // real behaviour rather than speculation.
+    let before = bypasses_file_permissions();
+    let (send, recv) = std::sync::mpsc::channel();
+    let (answer_send, answer_recv) = std::sync::mpsc::channel();
+
+    run_with_file_permissions_enforced(|| {
+        std::thread::spawn(move || {
+            // Outlives the closure: it keeps answering after the guard is gone.
+            while recv.recv().is_ok() {
+                let _ = answer_send.send(bypasses_file_permissions());
+            }
+        });
+    });
+
+    assert_eq!(
+        bypasses_file_permissions(),
+        before,
+        "this thread should have been restored"
+    );
+    send.send(()).expect("the outliving thread is gone");
+    assert!(
+        !answer_recv
+            .recv()
+            .expect("the outliving thread did not answer"),
+        "a thread spawned inside the action keeps the reduced sets after it returns"
     );
 }
 

--- a/rs/test_utilities/privileges/tests/smoke.rs
+++ b/rs/test_utilities/privileges/tests/smoke.rs
@@ -16,9 +16,10 @@ use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::{Arc, Barrier};
 
-/// Creates a file and makes it inaccessible, returning the temp dir holding it
-/// (the caller keeps it alive) and the path.
-fn unreadable_file(mode: u32) -> (tempfile::TempDir, std::path::PathBuf) {
+/// Creates a file with the given permission bits, returning the temp dir
+/// holding it (which the caller must keep alive, since dropping it deletes the
+/// file) and the path to it.
+fn file_with_mode(mode: u32) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempfile::tempdir().expect("failed to create a temp dir");
     let path = dir.path().join("file");
     std::fs::write(&path, b"before").expect("failed to create the file");
@@ -46,7 +47,7 @@ fn should_propagate_panic_message() {
 #[test]
 fn should_deny_write_to_read_only_file() {
     run_with_file_permissions_enforced(|| {
-        let (_dir, path) = unreadable_file(0o400);
+        let (_dir, path) = file_with_mode(0o400);
 
         let err = std::fs::write(&path, b"after").expect_err("write should be denied");
 
@@ -57,7 +58,7 @@ fn should_deny_write_to_read_only_file() {
 #[test]
 fn should_deny_read_of_mode_000_file() {
     run_with_file_permissions_enforced(|| {
-        let (_dir, path) = unreadable_file(0o000);
+        let (_dir, path) = file_with_mode(0o000);
 
         let err = std::fs::read(&path).expect_err("read should be denied");
 
@@ -131,7 +132,7 @@ fn should_drop_the_bypass_in_threads_spawned_by_the_action() {
                 !bypasses_file_permissions(),
                 "a thread spawned inside the action should inherit the drop"
             );
-            let (_dir, path) = unreadable_file(0o400);
+            let (_dir, path) = file_with_mode(0o400);
             let err = std::fs::write(&path, b"after").expect_err("write should be denied");
             assert_eq!(err.kind(), ErrorKind::PermissionDenied);
         })
@@ -159,7 +160,7 @@ fn should_not_affect_other_threads() {
             entered.wait();
             let bypasses = bypasses_file_permissions();
             // ... and check it behaves accordingly, not just that the bit is set.
-            let (_dir, path) = unreadable_file(0o400);
+            let (_dir, path) = file_with_mode(0o400);
             let denied = std::fs::write(&path, b"after").is_err();
             observed.wait();
             (bypasses, denied)
@@ -224,7 +225,7 @@ mod attribute_form {
     #[test]
     #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_deny_write_to_read_only_file() {
-        let (_dir, path) = unreadable_file(0o400);
+        let (_dir, path) = file_with_mode(0o400);
 
         let err = std::fs::write(&path, b"after").expect_err("write should be denied");
 
@@ -234,7 +235,7 @@ mod attribute_form {
     #[test]
     #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_deny_read_of_mode_000_file() {
-        let (_dir, path) = unreadable_file(0o000);
+        let (_dir, path) = file_with_mode(0o000);
 
         let err = std::fs::read(&path).expect_err("read should be denied");
 
@@ -244,7 +245,7 @@ mod attribute_form {
     #[test]
     #[ic_test_utilities_privileges::enforce_file_permissions]
     fn should_support_a_return_type() -> std::io::Result<()> {
-        let (_dir, path) = unreadable_file(0o000);
+        let (_dir, path) = file_with_mode(0o000);
         assert_eq!(
             std::fs::read(&path)
                 .expect_err("read should be denied")

--- a/rs/test_utilities/privileges/tests/smoke.rs
+++ b/rs/test_utilities/privileges/tests/smoke.rs
@@ -255,3 +255,40 @@ mod attribute_form {
         Ok(())
     }
 }
+
+/// The attribute rejects `async fn`, and its error message tells the reader to
+/// place it *below* `#[tokio::test]` instead. Attribute macros expand top-down,
+/// so that ordering — and only that ordering — lets `#[tokio::test]` expand
+/// first and produce the synchronous `block_on` wrapper that this attribute can
+/// then wrap. Getting it backwards reproduces the very error the message is
+/// trying to help the reader escape, so the advice is pinned here rather than
+/// left to prose.
+mod below_tokio_test {
+    use super::*;
+
+    #[tokio::test]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
+    async fn should_enforce_permissions_across_await_points() {
+        assert!(!bypasses_file_permissions());
+
+        let (_dir, path) = file_with_mode(0o400);
+        tokio::task::yield_now().await;
+
+        let err = std::fs::write(&path, b"after").expect_err("write should be denied");
+        assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ic_test_utilities_privileges::enforce_file_permissions]
+    async fn should_enforce_permissions_in_spawned_tasks() {
+        // The runtime is built by the wrapper `#[tokio::test]` generates, which
+        // this attribute wraps — so it is constructed inside the guarded scope
+        // and its worker threads inherit the drop, multi-threaded flavour and
+        // all.
+        let bypasses_in_task = tokio::spawn(async { bypasses_file_permissions() })
+            .await
+            .expect("the spawned task panicked");
+
+        assert!(!bypasses_in_task);
+    }
+}


### PR DESCRIPTION
# What

Replaces the fork-based `run_as_nobody_if_root` with `run_with_file_permissions_enforced`, which drops `CAP_DAC_OVERRIDE` and `CAP_DAC_READ_SEARCH` from the effective capability set of the calling thread and runs the test body in-process. The attribute is renamed accordingly: `#[as_nobody_when_root]` → `#[enforce_file_permissions]`.

# Why

The fork-based helper deadlocks.

`fork()` is called from the Rust libtest harness, which is multi-threaded, and the child then runs the arbitrary test body — malloc, file I/O, logging, thread spawns. When a sibling harness thread holds the malloc arena lock at fork time, the child never makes progress, and the parent blocks forever in `reader.read_to_string()`, which runs *before* `waitpid` so there is not even a timeout path. The existing doc comment anticipates this hazard, but its mitigations only cover the helper's own code, not the arbitrary body it invokes.

Over 118 `Bazel Test All on RBE` jobs (Aug 5–7):

| Target | Harness | Executions | Hangs |
|---|---|---|---|
| `crypto_service_provider_test` | 503 tests | 20 | **7** (5 flaky + 2 hard timeout) |
| `state_manager_test` | large | 25 | **3** |
| `sys_test` | small | 94 | 0 |
| `sns_test` | `--test-threads=1` | 94 | 0 |
| `smoke_test` | small | 94 | 0 |

The risk scales with harness thread count, and every observed hang was in an `as_nobody_when_root` test. The failures are bimodal — `crypto_service_provider_test` normally finishes in 6–18 s but hit its 300 s wall — which is a deadlock signature rather than slowness.

These are the two largest sources of RBE flakiness. They are plain `rust_test`s with no `cpu` exec property, so they are unrelated to `cpus_oversubscription_factor`, but they would pollute the signal from any oversubscription experiment.

# How

`CAP_DAC_OVERRIDE` and `CAP_DAC_READ_SEARCH` are the only capabilities the kernel consults in `generic_permission()`, so clearing them from the effective set makes it enforce the ordinary `rwx` bits against a uid-0 process. Capabilities are per-thread and `capset(2)` with `pid = 0` affects only the calling thread, so the drop is scoped to exactly the annotated test — which is what makes it safe under a parallel harness. A `!Send` `Drop` guard restores them, including while unwinding from a panic.

**This is fail-safe.** Every call site asserts an operation is *denied*, so a drop that silently failed to take effect makes the test fail rather than pass. On top of that the helper re-reads the capability sets and asserts the bits are clear (and that the permitted set is untouched), and probes once per process that a mode `0000` file really cannot be read. The probe deliberately uses a real read rather than `access(2)`, which re-raises the effective set from the permitted set whenever the real uid is 0.

Staying uid 0 removes the reason for the `TMPDIR`/`TEST_TMPDIR` redirection and for `grant_ancestor_traversal`, which added `o+x` to every ancestor of `/tmp`; both are deleted along with the fork, pipe and `waitpid` machinery. `#[should_panic(expected = ...)]` now matches the native panic instead of a message forwarded over a pipe.

The raw `capget`/`capset` mirrors the existing `raise_ambient_net_caps` in `rs/tests/driver/src/driver/local_backend.rs`. `nix` is swapped for `libc` — both were already vendored, so no repin is needed.

Three limitations are documented in the crate docs. None is reachable from any current call site, and each fails loudly rather than silently: `access(2)` re-raises the effective set as above; only the calling thread and threads it *creates* are affected; and `execve` as uid 0 restores the full sets.

# Testing

The dev-container's root has the full effective set (`Current: =ep`), like an RBE worker, so the bug reproduces locally. Running the 503-test `crypto_service_provider_test` binary as root:

| | runs as root | hangs |
|---|---|---|
| old fork-based code | 25 | **3** |
| this PR | 40 | **0** |

`state_manager_test` is 25/25 as root; `sys_test`, `sns_test` and `smoke_test` pass as root too. The control run is the point — without it, a green result would only show that the environment never reproduced the bug.

That the drop genuinely takes effect is shown by the tests themselves: were it a no-op, `should_fail_to_read_without_read_permissions` would fail on every root run, since root would simply read the mode-`0000` file. Both `should_panic(expected = ...)` sites also pass as root.

Also: `cargo check` on all six affected crates, `cargo fmt`, `ci/scripts/rust-lint.sh` (exit 0), `bazel build //... --nobuild` (exit 0), buildifier clean, and all five affected Bazel targets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
