### PR TITLE
feat: bump build-info

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c36aa7b484a384810bc7d713e52ef735c6b22b5958a89a9d4c1c231810d8272b",
+  "checksum": "647170affacac693377b15401dd1ebc9e641c21437d8afe01196df78bff56371",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -9273,15 +9273,15 @@
       ],
       "license_file": null
     },
-    "build-info 0.0.27": {
+    "build-info 0.0.45": {
       "name": "build-info",
-      "version": "0.0.27",
+      "version": "0.0.45",
       "package_url": "https://github.com/danielschemmel/build-info/",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity-lab/build-info",
           "commitish": {
-            "Rev": "701a696844fba5c87df162fbbc1ccef96f27c9d7"
+            "Rev": "27ba16a68aa312de66f2ebd0f16665f1429eee36"
           },
           "strip_prefix": "build-info"
         }
@@ -9307,9 +9307,7 @@
         ],
         "crate_features": {
           "common": [
-            "build-info-common",
             "default",
-            "lazy_static",
             "runtime"
           ],
           "selects": {}
@@ -9317,31 +9315,27 @@
         "deps": {
           "common": [
             {
-              "id": "build-info-common 0.0.27",
+              "id": "build-info-common 0.0.45",
               "target": "build_info_common"
             },
             {
-              "id": "lazy_static 1.5.0",
-              "target": "lazy_static"
+              "id": "ciborium 0.2.2",
+              "target": "ciborium"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
+        "edition": "2024",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "build-info-proc 0.0.27",
+              "id": "build-info-proc 0.0.45",
               "target": "build_info_proc"
-            },
-            {
-              "id": "proc-macro-hack 0.5.20+deprecated",
-              "target": "proc_macro_hack"
             }
           ],
           "selects": {}
         },
-        "version": "0.0.27"
+        "version": "0.0.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9350,15 +9344,15 @@
       ],
       "license_file": null
     },
-    "build-info-build 0.0.27": {
+    "build-info-build 0.0.45": {
       "name": "build-info-build",
-      "version": "0.0.27",
+      "version": "0.0.45",
       "package_url": "https://github.com/danielschemmel/build-info/",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity-lab/build-info",
           "commitish": {
-            "Rev": "701a696844fba5c87df162fbbc1ccef96f27c9d7"
+            "Rev": "27ba16a68aa312de66f2ebd0f16665f1429eee36"
           },
           "strip_prefix": "build-info-build"
         }
@@ -9389,32 +9383,16 @@
               "target": "anyhow"
             },
             {
-              "id": "base64 0.13.1",
-              "target": "base64"
-            },
-            {
-              "id": "bincode 1.3.3",
-              "target": "bincode"
-            },
-            {
-              "id": "build-info-common 0.0.27",
+              "id": "build-info-common 0.0.45",
               "target": "build_info_common"
             },
             {
-              "id": "cargo_metadata 0.14.2",
-              "target": "cargo_metadata"
+              "id": "ciborium 0.2.2",
+              "target": "ciborium"
             },
             {
               "id": "glob 0.3.1",
               "target": "glob"
-            },
-            {
-              "id": "lazy_static 1.5.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "pretty_assertions 1.4.0",
-              "target": "pretty_assertions"
             },
             {
               "id": "rustc_version 0.4.0",
@@ -9425,14 +9403,18 @@
               "target": "serde_json"
             },
             {
-              "id": "xz2 0.1.7",
-              "target": "xz2"
+              "id": "z85 3.0.7",
+              "target": "z85"
+            },
+            {
+              "id": "zstd 0.13.2",
+              "target": "zstd"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.0.27"
+        "edition": "2024",
+        "version": "0.0.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9441,15 +9423,15 @@
       ],
       "license_file": null
     },
-    "build-info-common 0.0.27": {
+    "build-info-common 0.0.45": {
       "name": "build-info-common",
-      "version": "0.0.27",
+      "version": "0.0.45",
       "package_url": "https://github.com/danielschemmel/build-info/",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity-lab/build-info",
           "commitish": {
-            "Rev": "701a696844fba5c87df162fbbc1ccef96f27c9d7"
+            "Rev": "27ba16a68aa312de66f2ebd0f16665f1429eee36"
           },
           "strip_prefix": "build-info-common"
         }
@@ -9476,13 +9458,16 @@
         "crate_features": {
           "common": [
             "default",
-            "enable-serde",
             "serde"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
+            {
+              "id": "derive_more 2.1.1",
+              "target": "derive_more"
+            },
             {
               "id": "semver 1.0.27",
               "target": "semver"
@@ -9494,17 +9479,8 @@
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.0.27"
+        "edition": "2024",
+        "version": "0.0.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9513,15 +9489,15 @@
       ],
       "license_file": null
     },
-    "build-info-proc 0.0.27": {
+    "build-info-proc 0.0.45": {
       "name": "build-info-proc",
-      "version": "0.0.27",
+      "version": "0.0.45",
       "package_url": "https://github.com/danielschemmel/build-info/",
       "repository": {
         "Git": {
           "remote": "https://github.com/dfinity-lab/build-info",
           "commitish": {
-            "Rev": "701a696844fba5c87df162fbbc1ccef96f27c9d7"
+            "Rev": "27ba16a68aa312de66f2ebd0f16665f1429eee36"
           },
           "strip_prefix": "build-info-proc"
         }
@@ -9555,32 +9531,24 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.104",
-              "target": "anyhow"
-            },
-            {
-              "id": "base64 0.13.1",
-              "target": "base64"
-            },
-            {
-              "id": "bincode 1.3.3",
-              "target": "bincode"
-            },
-            {
-              "id": "build-info-common 0.0.27",
+              "id": "build-info-common 0.0.45",
               "target": "build_info_common"
             },
             {
-              "id": "num-bigint 0.4.6",
+              "id": "ciborium 0.2.2",
+              "target": "ciborium"
+            },
+            {
+              "id": "manyhow 0.11.4",
+              "target": "manyhow"
+            },
+            {
+              "id": "num-bigint 0.5.1",
               "target": "num_bigint"
             },
             {
               "id": "num-traits 0.2.19",
               "target": "num_traits"
-            },
-            {
-              "id": "proc-macro-error 1.0.4",
-              "target": "proc_macro_error"
             },
             {
               "id": "proc-macro2 1.0.106",
@@ -9595,27 +9563,22 @@
               "target": "serde_json"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.119",
               "target": "syn"
             },
             {
-              "id": "xz2 0.1.7",
-              "target": "xz2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
+              "id": "z85 3.0.7",
+              "target": "z85"
+            },
             {
-              "id": "proc-macro-hack 0.5.20+deprecated",
-              "target": "proc_macro_hack"
+              "id": "zstd 0.13.2",
+              "target": "zstd"
             }
           ],
           "selects": {}
         },
-        "version": "0.0.27"
+        "edition": "2024",
+        "version": "0.0.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -12448,14 +12411,14 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "ciborium 0.2.1": {
+    "ciborium 0.2.2": {
       "name": "ciborium",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/enarx/ciborium",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ciborium/0.2.1/download",
-          "sha256": "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+          "url": "https://static.crates.io/crates/ciborium/0.2.2/download",
+          "sha256": "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
         }
       },
       "targets": [
@@ -12487,11 +12450,11 @@
         "deps": {
           "common": [
             {
-              "id": "ciborium-io 0.2.1",
+              "id": "ciborium-io 0.2.2",
               "target": "ciborium_io"
             },
             {
-              "id": "ciborium-ll 0.2.1",
+              "id": "ciborium-ll 0.2.2",
               "target": "ciborium_ll"
             },
             {
@@ -12502,7 +12465,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -12510,14 +12473,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ciborium-io 0.2.1": {
+    "ciborium-io 0.2.2": {
       "name": "ciborium-io",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/enarx/ciborium",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ciborium-io/0.2.1/download",
-          "sha256": "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+          "url": "https://static.crates.io/crates/ciborium-io/0.2.2/download",
+          "sha256": "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
         }
       },
       "targets": [
@@ -12547,7 +12510,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -12555,14 +12518,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ciborium-ll 0.2.1": {
+    "ciborium-ll 0.2.2": {
       "name": "ciborium-ll",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/enarx/ciborium",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ciborium-ll/0.2.1/download",
-          "sha256": "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+          "url": "https://static.crates.io/crates/ciborium-ll/0.2.2/download",
+          "sha256": "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
         }
       },
       "targets": [
@@ -12587,18 +12550,18 @@
         "deps": {
           "common": [
             {
-              "id": "ciborium-io 0.2.1",
+              "id": "ciborium-io 0.2.2",
               "target": "ciborium_io"
             },
             {
-              "id": "half 1.8.2",
+              "id": "half 2.7.1",
               "target": "half"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -15954,7 +15917,7 @@
               "target": "cast"
             },
             {
-              "id": "ciborium 0.2.1",
+              "id": "ciborium 0.2.2",
               "target": "ciborium"
             },
             {
@@ -20144,11 +20107,11 @@
               "target": "bs58"
             },
             {
-              "id": "build-info 0.0.27",
+              "id": "build-info 0.0.45",
               "target": "build_info"
             },
             {
-              "id": "build-info-build 0.0.27",
+              "id": "build-info-build 0.0.45",
               "target": "build_info_build"
             },
             {
@@ -20209,7 +20172,7 @@
               "target": "chrono"
             },
             {
-              "id": "ciborium 0.2.1",
+              "id": "ciborium 0.2.2",
               "target": "ciborium"
             },
             {
@@ -29232,6 +29195,65 @@
       ],
       "license_file": "LICENSE"
     },
+    "half 2.7.1": {
+      "name": "half",
+      "version": "2.7.1",
+      "package_url": "https://github.com/VoidStarKat/half-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/half/2.7.1/download",
+          "sha256": "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "half",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "half",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "zerocopy 0.8.56",
+              "target": "zerocopy"
+            }
+          ],
+          "selects": {
+            "cfg(target_arch = \"spirv\")": [
+              {
+                "id": "crunchy 0.2.2",
+                "target": "crunchy"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "2.7.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "handlebars 6.4.0": {
       "name": "handlebars",
       "version": "6.4.0",
@@ -35837,7 +35859,7 @@
               "target": "candid"
             },
             {
-              "id": "ciborium 0.2.1",
+              "id": "ciborium 0.2.2",
               "target": "ciborium"
             },
             {
@@ -44897,6 +44919,138 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "manyhow 0.11.4": {
+      "name": "manyhow",
+      "version": "0.11.4",
+      "package_url": "https://github.com/ModProg/manyhow",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/manyhow/0.11.4/download",
+          "sha256": "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "manyhow",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "manyhow",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "macros",
+            "syn",
+            "syn2"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.47",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.119",
+              "target": "syn",
+              "alias": "syn2"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "manyhow-macros 0.11.4",
+              "target": "manyhow_macros",
+              "alias": "macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.11.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "manyhow-macros 0.11.4": {
+      "name": "manyhow-macros",
+      "version": "0.11.4",
+      "package_url": "https://github.com/ModProg/manyhow",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/manyhow-macros/0.11.4/download",
+          "sha256": "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "manyhow_macros",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "manyhow_macros",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro-utils 0.10.0",
+              "target": "proc_macro_utils"
+            },
+            {
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.47",
+              "target": "quote"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.11.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "maplit 1.0.2": {
       "name": "maplit",
       "version": "1.0.2",
@@ -48518,6 +48672,65 @@
         },
         "edition": "2021",
         "version": "0.4.6"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "num-bigint 0.5.1": {
+      "name": "num-bigint",
+      "version": "0.5.1",
+      "package_url": "https://github.com/rust-num/num-bigint",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/num-bigint/0.5.1/download",
+          "sha256": "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "num_bigint",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "num_bigint",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "num-integer 0.1.46",
+              "target": "num_integer"
+            },
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -56307,33 +56520,21 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "proc-macro-hack 0.5.20+deprecated": {
-      "name": "proc-macro-hack",
-      "version": "0.5.20+deprecated",
-      "package_url": "https://github.com/dtolnay/proc-macro-hack",
+    "proc-macro-utils 0.10.0": {
+      "name": "proc-macro-utils",
+      "version": "0.10.0",
+      "package_url": "https://github.com/ModProg/proc-macro-utils",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/proc-macro-hack/0.5.20+deprecated/download",
-          "sha256": "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+          "url": "https://static.crates.io/crates/proc-macro-utils/0.10.0/download",
+          "sha256": "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
         }
       },
       "targets": [
         {
-          "ProcMacro": {
-            "crate_name": "proc_macro_hack",
+          "Library": {
+            "crate_name": "proc_macro_utils",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -56343,33 +56544,41 @@
           }
         }
       ],
-      "library_target_name": "proc_macro_hack",
+      "library_target_name": "proc_macro_utils",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "parser",
+            "proc-macro",
+            "proc-macro2",
+            "quote",
+            "smallvec"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "proc-macro-hack 0.5.20+deprecated",
-              "target": "build_script_build"
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.47",
+              "target": "quote"
+            },
+            {
+              "id": "smallvec 1.15.1",
+              "target": "smallvec"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.5.20+deprecated"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
+        "edition": "2021",
+        "version": "0.10.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -91986,6 +92195,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "z85 3.0.7": {
+      "name": "z85",
+      "version": "3.0.7",
+      "package_url": "https://github.com/decafbad/z85",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/z85/3.0.7/download",
+          "sha256": "c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "z85",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "z85",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2024",
+        "version": "3.0.7"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-Apache"
+    },
     "zerocopy 0.7.32": {
       "name": "zerocopy",
       "version": "0.7.32",
@@ -92043,6 +92291,95 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "zerocopy 0.8.56": {
+      "name": "zerocopy",
+      "version": "0.8.56",
+      "package_url": "https://github.com/google/zerocopy",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zerocopy/0.8.56/download",
+          "sha256": "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "zerocopy",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zerocopy",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "derive",
+            "simd",
+            "zerocopy-derive"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "zerocopy 0.8.56",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "zerocopy-derive 0.8.56",
+              "target": "zerocopy_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.56"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "zerocopy-derive 0.7.32": {
       "name": "zerocopy-derive",
       "version": "0.7.32",
@@ -92091,6 +92428,63 @@
         },
         "edition": "2018",
         "version": "0.7.32"
+      },
+      "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "zerocopy-derive 0.8.56": {
+      "name": "zerocopy-derive",
+      "version": "0.8.56",
+      "package_url": "https://github.com/google/zerocopy",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zerocopy-derive/0.8.56/download",
+          "sha256": "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "zerocopy_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zerocopy_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.47",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.119",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.56"
       },
       "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -93082,6 +93476,7 @@
       "aarch64-unknown-linux-gnu"
     ],
     "cfg(target_arch = \"riscv64\")": [],
+    "cfg(target_arch = \"spirv\")": [],
     "cfg(target_arch = \"wasm32\")": [
       "wasm32-unknown-unknown"
     ],
@@ -93174,8 +93569,8 @@
     "bitcoin 0.28.2",
     "bitcoin-dogecoin 0.32.7-doge.0",
     "bs58 0.5.1",
-    "build-info 0.0.27",
-    "build-info-build 0.0.27",
+    "build-info 0.0.45",
+    "build-info-build 0.0.45",
     "by_address 1.1.0",
     "byte-unit 4.0.19",
     "byteorder 1.5.0",
@@ -93190,7 +93585,7 @@
     "chacha20poly1305 0.10.1",
     "chrono 0.4.41",
     "chrono 0.4.42",
-    "ciborium 0.2.1",
+    "ciborium 0.2.2",
     "cidr 0.2.3",
     "clap 4.5.53",
     "colored 2.0.4",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -304,7 +304,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -1563,61 +1563,55 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "build-info"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
  "build-info-common",
  "build-info-proc",
- "lazy_static",
- "proc-macro-hack",
+ "ciborium",
 ]
 
 [[package]]
 name = "build-info-build"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
- "bincode",
  "build-info-common",
- "cargo_metadata",
+ "ciborium",
  "glob",
- "lazy_static",
- "pretty_assertions",
  "rustc_version",
  "serde_json",
- "xz2",
+ "z85",
+ "zstd 0.13.2",
 ]
 
 [[package]]
 name = "build-info-common"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
- "derive_more 0.99.17",
+ "derive_more 2.1.1",
  "semver",
  "serde",
 ]
 
 [[package]]
 name = "build-info-proc"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
- "anyhow",
- "base64 0.13.1",
- "bincode",
  "build-info-common",
- "num-bigint 0.4.6",
+ "ciborium",
+ "manyhow",
+ "num-bigint 0.5.1",
  "num-traits",
- "proc-macro-error",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.109",
- "xz2",
+ "syn 2.0.119",
+ "z85",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -2083,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -2094,18 +2088,18 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.7.1",
 ]
 
 [[package]]
@@ -4957,6 +4951,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.56",
+]
+
+[[package]]
 name = "handlebars"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7669,6 +7674,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8236,6 +8264,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -9482,10 +9520,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+name = "proc-macro-utils"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -11199,7 +11242,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.2",
  "serde",
 ]
 
@@ -15153,12 +15196,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "z85"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675"
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive 0.8.56",
 ]
 
 [[package]]
@@ -15166,6 +15224,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,61 +1599,55 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "build-info"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
  "build-info-common",
  "build-info-proc",
- "lazy_static",
- "proc-macro-hack",
+ "ciborium",
 ]
 
 [[package]]
 name = "build-info-build"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
- "bincode",
  "build-info-common",
- "cargo_metadata",
+ "ciborium",
  "glob",
- "lazy_static",
- "pretty_assertions",
  "rustc_version",
  "serde_json",
- "xz2",
+ "z85",
+ "zstd",
 ]
 
 [[package]]
 name = "build-info-common"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
- "derive_more 0.99.20",
+ "derive_more 2.1.1",
  "semver",
  "serde",
 ]
 
 [[package]]
 name = "build-info-proc"
-version = "0.0.27"
-source = "git+https://github.com/dfinity-lab/build-info?rev=701a696844fba5c87df162fbbc1ccef96f27c9d7#701a696844fba5c87df162fbbc1ccef96f27c9d7"
+version = "0.0.45"
+source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
- "anyhow",
- "base64 0.13.1",
- "bincode",
  "build-info-common",
- "num-bigint 0.4.6",
+ "ciborium",
+ "manyhow",
+ "num-bigint 0.5.1",
  "num-traits",
- "proc-macro-error",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.109",
- "xz2",
+ "syn 2.0.117",
+ "z85",
+ "zstd",
 ]
 
 [[package]]
@@ -3638,19 +3632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn 2.0.117",
 ]
 
@@ -17543,17 +17524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17592,6 +17562,29 @@ dependencies = [
  "shell-escape",
  "tracing",
  "tui-textarea",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -18502,6 +18495,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -20020,34 +20023,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-utils"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "smallvec",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -26206,15 +26190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
-
-[[package]]
 name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26257,6 +26232,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "z85"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -628,8 +628,8 @@ bitcoin = { package = "bitcoin-dogecoin", version = "0.32.7-doge.0", features = 
 ] }
 # build-info and build-info-build MUST be kept in sync!
 bs58 = "^0.5.0"
-build-info = { git = "https://github.com/dfinity-lab/build-info", rev = "701a696844fba5c87df162fbbc1ccef96f27c9d7" }
-build-info-build = { git = "https://github.com/dfinity-lab/build-info", rev = "701a696844fba5c87df162fbbc1ccef96f27c9d7", default-features = false }
+build-info = { git = "https://github.com/dfinity-lab/build-info", rev = "27ba16a68aa312de66f2ebd0f16665f1429eee36" }
+build-info-build = { git = "https://github.com/dfinity-lab/build-info", rev = "27ba16a68aa312de66f2ebd0f16665f1429eee36", default-features = false }
 by_address = "^1.1.0"
 byteorder = "^1.3.4"
 bytes = "1.9.0"
@@ -643,7 +643,7 @@ chrono = { version = "0.4.42", default-features = false, features = [
     "clock",
     "serde",
 ] }
-ciborium = "0.2.1"
+ciborium = "0.2.2"
 clap = { version = "4.5.20", features = ["derive", "string"] }
 colored = "^2.0.0"
 comparable = { version = "0.5", features = ["derive"] }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -22,7 +22,7 @@ rust.toolchain(
 # Repin with `CARGO_BAZEL_REPIN=true bazel build @crate_index//...`
 ICRC_1_REV = "26a80d777e079644cd69e883e18dad1a201f5b1a"
 
-BUILD_INFO_REV = "701a696844fba5c87df162fbbc1ccef96f27c9d7"
+BUILD_INFO_REV = "27ba16a68aa312de66f2ebd0f16665f1429eee36"
 
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 
@@ -296,7 +296,7 @@ crate.spec(
 )
 crate.spec(
     package = "ciborium",
-    version = "^0.2.1",
+    version = "^0.2.2",
 )
 crate.spec(
     package = "cidr",


### PR DESCRIPTION
This bumps the `build-info` crate to [the latest
version](https://github.com/dfinity-lab/build-info/commit/27ba16a68aa312de66f2ebd0f16665f1429eee36) of our fork which includes some crate upgrades, notably syn 1 -> 2.

For the Cargo build this is strictly a clean up; for the Bazel build however (due to some ic-os tools) this introduces some new crate duplication.

This is a stopgap solution and in due time we'll remove build-info entirely: the crate is not widely used, pulls in lots of dependencies and what it does is better achieved using Bazel stamping.