### PR TITLE
chore: bump cryptography to 50 in rosetta-api

### DIFF
--- a/rs/rosetta-api/examples/icp/python/requirements.txt
+++ b/rs/rosetta-api/examples/icp/python/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2025.6.15
 cffi==1.17.1
 charset-normalizer==3.4.2
-cryptography==48.0.1
+cryptography==50.0.0
 idna==3.15
 pycparser==2.22
 requests==2.33.0

--- a/rs/rosetta-api/examples/icrc1/python/requirements.txt
+++ b/rs/rosetta-api/examples/icrc1/python/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2025.6.15
 cffi==1.17.1
 charset-normalizer==3.4.2
-cryptography==48.0.1
+cryptography==50.0.0
 idna==3.15
 pycparser==2.22
 requests==2.33.0


### PR DESCRIPTION
The previous version has a vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2026-69248

The changes here close the CVE fully after
https://github.com/dfinity/ic/pull/11059 and
https://github.com/dfinity/ic/pull/11050.