### PR TITLE
chore(bazel): move C++ libraries from rust `deps` to `link_deps`

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "647170affacac693377b15401dd1ebc9e641c21437d8afe01196df78bff56371",
+  "checksum": "0f17f4cd43f4bc4637280b8f3c8a6c297e4c0e266413471687c9acccedffcb61",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -19570,13 +19570,13 @@
           ],
           "selects": {}
         },
-        "extra_deps": {
+        "edition": "2021",
+        "extra_link_deps": {
           "common": [
             "@@//third_party:devmapper"
           ],
           "selects": {}
         },
-        "edition": "2021",
         "version": "0.3.1"
       },
       "build_script_attrs": {
@@ -41925,13 +41925,13 @@
           ],
           "selects": {}
         },
-        "extra_deps": {
+        "edition": "2021",
+        "extra_link_deps": {
           "common": [
             "@@//third_party:cryptsetup"
           ],
           "selects": {}
         },
-        "edition": "2021",
         "version": "0.6.0"
       },
       "build_script_attrs": {
@@ -43019,13 +43019,13 @@
           ],
           "selects": {}
         },
-        "extra_deps": {
+        "edition": "2018",
+        "extra_link_deps": {
           "common": [
             "@@//third_party:systemd"
           ],
           "selects": {}
         },
-        "edition": "2018",
         "version": "0.9.3"
       },
       "build_script_attrs": {
@@ -82432,6 +82432,12 @@
           "selects": {}
         },
         "edition": "2018",
+        "extra_link_deps": {
+          "common": [
+            "@@//third_party:libvirt"
+          ],
+          "selects": {}
+        },
         "version": "0.3.0"
       },
       "build_script_attrs": {

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -2212,15 +2212,19 @@ crate.annotation(
 )
 crate.annotation(
     crate = "devicemapper-sys",
-    deps = ["@@//third_party:devmapper"],
+    link_deps = ["@@//third_party:devmapper"],
 )
 crate.annotation(
     crate = "libcryptsetup-rs-sys",
-    deps = ["@@//third_party:cryptsetup"],
+    link_deps = ["@@//third_party:cryptsetup"],
 )
 crate.annotation(
     crate = "libsystemd-sys",
-    deps = ["@@//third_party:systemd"],
+    link_deps = ["@@//third_party:systemd"],
+)
+crate.annotation(
+    crate = "virt-sys",
+    link_deps = ["@@//third_party:libvirt"],
 )
 crate.annotation(
     crate = "p256",

--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -45,7 +45,6 @@ rust_binary(
         "@crate_index//:tracing",
         "@crate_index//:uuid",
         "@crate_index//:virt",
-        "@libvirt",
     ],
 )
 
@@ -93,7 +92,6 @@ rust_binary(
         "@crate_index//:tracing",
         "@crate_index//:uuid",
         "@crate_index//:virt",
-        "@libvirt",
     ],
 )
 
@@ -189,6 +187,5 @@ rust_test(
         "@crate_index//:tracing",
         "@crate_index//:uuid",
         "@crate_index//:virt",
-        "@libvirt",
     ],
 )

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,5 +1,5 @@
 # Aliases into the host-import repos (see BUILD.devmapper.bazel and
-# BUILD.cryptsetup.bazel), so that crate annotations in
+# BUILD.cryptsetup.bazel), so that the `link_deps` of the crate annotations in
 # bazel/rust.MODULE.bazel can reference them with stable root-repo labels
 # (apparent repo names like @devmapper don't resolve from inside the
 # generated crate repositories).
@@ -12,6 +12,12 @@ alias(
 alias(
     name = "devmapper",
     actual = "@devmapper//:devmapper",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libvirt",
+    actual = "@libvirt//:libvirt",
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,8 +1,8 @@
-# Aliases into the host-import repos (see BUILD.devmapper.bazel and
-# BUILD.cryptsetup.bazel), so that the `link_deps` of the crate annotations in
-# bazel/rust.MODULE.bazel can reference them with stable root-repo labels
-# (apparent repo names like @devmapper don't resolve from inside the
-# generated crate repositories).
+# Aliases into the host-import repos (see BUILD.cryptsetup.bazel,
+# BUILD.devmapper.bazel, BUILD.libvirt.bazel and BUILD.libsystemd.bazel), so
+# that the `link_deps` of the crate annotations in bazel/rust.MODULE.bazel can
+# reference them with stable root-repo labels (apparent repo names like
+# @devmapper don't resolve from inside the generated crate repositories).
 alias(
     name = "cryptsetup",
     actual = "@cryptsetup//:cryptsetup",


### PR DESCRIPTION
Since the rules_rust update in #10919, `rust_library`/`rust_binary`/`rust_test` print a deprecation warning for every `cc_library` found in their `deps` — e.g. [this run](https://github.com/dfinity/ic/actions/runs/31178310153/job/92865651208):

```
WARNING: Target @@+new_local_repository+libsystemd//:libsystemd in 'deps' of
@@rules_rust++crate+crate_index__libsystemd-sys-0.9.3//:libsystemd_sys is a C++ library.
Only Rust targets are allowed in 'deps'. Please use 'link_deps' for manual FFI linkage.
Support for C++ libraries in 'deps' is deprecated and will be removed in a future release.
```

Support is slated for removal, so this is a build break waiting on the next rules_rust bump, not just log noise.

## Changes

- Switch the `devicemapper-sys`, `libcryptsetup-rs-sys` and `libsystemd-sys` crate annotations from `deps` to `link_deps`. Behaviour-preserving: for a target that only provides `CcInfo`, `transform_link_deps` builds exactly the same `DepVariantInfo` that `transform_deps` does.
- `guest_vm_runner` hit the same warning by listing `@libvirt` directly in the `deps` of its two `rust_binary`s and one `rust_test`. Rather than repeat the attribute move three times, attach the library to the `virt-sys` crate instead — it is a pkg-config `-sys` crate (`links = "virt"`) just like the three above, so this is the pattern `bazel/pkg-config.patch` already documents: *"The `-l` libs resolve against cc_import dependencies that link the host library by explicit path"*. This needs a new `//third_party:libvirt` alias, since apparent repo names don't resolve from inside the generated crate repositories.
- Repin `Cargo.Bazel.json.lock` (checksum + the four `extra_deps` → `extra_link_deps` entries; `Cargo.Bazel.toml.lock` is untouched).

## Verification

`bazel query` confirms `//rs/ic_os/os_tools/guest_vm_runner`, `//rs/ic_os/os_tools/guest_disk` and `//rs/ic_os/device` are the only in-repo consumers of these four crates. Rebuilding all three with the analysis cache discarded: **6 warnings before, 0 after**, and the `NEEDED` entries of the resulting `guest_vm_runner` and `guest_disk` binaries are byte-identical (`libvirt.so.0`, `libsystemd.so.0`, `libcryptsetup.so.12` all still linked).

`bazel build //... --nobuild` is clean and `//rs/ic_os/os_tools/guest_vm_runner:guest_vm_runner_test` passes. The two remaining tests over these targets (`guest_disk_test`, `upgrade_device_mapper_test`) are `manual` because they need root; they build, and are exercised via `//rs/tests/node:root_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)