### PR TITLE
feat: bump comparable and use fork

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "97a9cd320431b891c4d7c4d2690ad10b3886460adea34efc6f00568501485396",
+  "checksum": "d219ecf3003ae760b2a967cbf6532e80a278a2640cd74d57ab32af145fae636f",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -13286,14 +13286,17 @@
       ],
       "license_file": "LICENSE"
     },
-    "comparable 0.5.4": {
+    "comparable 0.5.6": {
       "name": "comparable",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "package_url": "https://github.com/jwiegley/comparable",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/comparable/0.5.4/download",
-          "sha256": "eb513ee8037bf08c5270ecefa48da249f4c58e57a71ccfce0a5b0877d2a20eb2"
+        "Git": {
+          "remote": "https://github.com/dfinity/comparable",
+          "commitish": {
+            "Rev": "8338f595496454f9e770389e2edc0d96e137a4e9"
+          },
+          "strip_prefix": "comparable"
         }
       },
       "targets": [
@@ -13339,17 +13342,17 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "comparable_derive 0.5.4",
+              "id": "comparable_derive 0.5.6",
               "target": "comparable_derive"
             },
             {
-              "id": "comparable_helper 0.5.4",
+              "id": "comparable_helper 0.5.6",
               "target": "comparable_helper"
             }
           ],
           "selects": {}
         },
-        "version": "0.5.4"
+        "version": "0.5.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13358,14 +13361,17 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "comparable_derive 0.5.4": {
+    "comparable_derive 0.5.6": {
       "name": "comparable_derive",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "package_url": "https://github.com/jwiegley/comparable",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/comparable_derive/0.5.4/download",
-          "sha256": "a54b9c40054eb8999c5d1d36fdc90e4e5f7ff0d1d9621706f360b3cbc8beb828"
+        "Git": {
+          "remote": "https://github.com/dfinity/comparable",
+          "commitish": {
+            "Rev": "8338f595496454f9e770389e2edc0d96e137a4e9"
+          },
+          "strip_prefix": "comparable_derive"
         }
       },
       "targets": [
@@ -13390,7 +13396,7 @@
         "deps": {
           "common": [
             {
-              "id": "convert_case 0.4.0",
+              "id": "convert_case 0.6.0",
               "target": "convert_case"
             },
             {
@@ -13402,14 +13408,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.4"
+        "version": "0.5.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13418,14 +13424,17 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "comparable_helper 0.5.4": {
+    "comparable_helper 0.5.6": {
       "name": "comparable_helper",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "package_url": "https://github.com/jwiegley/comparable",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/comparable_helper/0.5.4/download",
-          "sha256": "fb5437e327e861081c91270becff184859f706e3e50f5301a9d4dc8eb50752c3"
+        "Git": {
+          "remote": "https://github.com/dfinity/comparable",
+          "commitish": {
+            "Rev": "8338f595496454f9e770389e2edc0d96e137a4e9"
+          },
+          "strip_prefix": "comparable_helper"
         }
       },
       "targets": [
@@ -13462,14 +13471,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.119",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.4"
+        "version": "0.5.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19894,7 +19903,7 @@
               "target": "colored"
             },
             {
-              "id": "comparable 0.5.4",
+              "id": "comparable 0.5.6",
               "target": "comparable"
             },
             {
@@ -92880,7 +92889,7 @@
     "cidr 0.2.3",
     "clap 4.5.53",
     "colored 2.0.4",
-    "comparable 0.5.4",
+    "comparable 0.5.6",
     "console 0.11.3",
     "convert_case 0.6.0",
     "crc32fast 1.3.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2220,9 +2220,8 @@ dependencies = [
 
 [[package]]
 name = "comparable"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb513ee8037bf08c5270ecefa48da249f4c58e57a71ccfce0a5b0877d2a20eb2"
+version = "0.5.6"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
 dependencies = [
  "comparable_derive",
  "comparable_helper",
@@ -2232,26 +2231,24 @@ dependencies = [
 
 [[package]]
 name = "comparable_derive"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b9c40054eb8999c5d1d36fdc90e4e5f7ff0d1d9621706f360b3cbc8beb828"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "comparable_helper"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5437e327e861081c91270becff184859f706e3e50f5301a9d4dc8eb50752c3"
+version = "0.5.6"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "comparable_helper"
+version = "0.5.6"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,8 +2350,7 @@ dependencies = [
 [[package]]
 name = "comparable"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838d2d21a142bc619c262bb2145d1af0a2e3dccfcb1360bbc47ae4c6686e1ec6"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
 dependencies = [
  "comparable_derive",
  "comparable_helper",
@@ -2362,25 +2361,23 @@ dependencies = [
 [[package]]
 name = "comparable_derive"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef8fab462495e2956b0666a4fb50c6c5058bdbd2c2bc91c5894a03f916177f"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "comparable_helper"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7a1af3ce1ccc3c9a6edfc769672c5d7512959e292882beca663843a660eb9e"
+source = "git+https://github.com/dfinity/comparable?rev=8338f595496454f9e770389e2edc0d96e137a4e9#8338f595496454f9e770389e2edc0d96e137a4e9"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2678,12 +2675,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -646,7 +646,9 @@ chrono = { version = "0.4.42", default-features = false, features = [
 ciborium = "0.2.2"
 clap = { version = "4.5.20", features = ["derive", "string"] }
 colored = "^2.0.0"
-comparable = { version = "0.5", features = ["derive"] }
+# Fork of `comparable` migrated to syn 2 (upstream still uses syn 1), so it no
+# longer forces a duplicate syn 1.0 into the dependency graph.
+comparable = { git = "https://github.com/dfinity/comparable", rev = "8338f595496454f9e770389e2edc0d96e137a4e9", features = ["derive"] }
 crc32fast = "^1.2.0"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 crossbeam-channel = "0.5.15"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -24,6 +24,9 @@ ICRC_1_REV = "26a80d777e079644cd69e883e18dad1a201f5b1a"
 
 BUILD_INFO_REV = "27ba16a68aa312de66f2ebd0f16665f1429eee36"
 
+# Fork of `comparable` migrated to syn 2 (upstream still uses syn 1).
+COMPARABLE_REV = "8338f595496454f9e770389e2edc0d96e137a4e9"
+
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 
 # Rust crates.
@@ -318,8 +321,9 @@ crate.spec(
     features = [
         "derive",
     ],
+    git = "https://github.com/dfinity/comparable",
     package = "comparable",
-    version = "^0.5",
+    rev = COMPARABLE_REV,
 )
 crate.spec(
     package = "console",


### PR DESCRIPTION
This upgrades to the latest `comparable` version, and switch to our fork which includes a `syn` upgrade (1 -> 2):

https://github.com/jwiegley/comparable/pull/19