### PR TITLE
fix: patch pcre2-sys for reproducibility

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "97a9cd320431b891c4d7c4d2690ad10b3886460adea34efc6f00568501485396",
+  "checksum": "d91ca13fc43395e00e4eca2185177395832956e38e29bed36fe9eef5561bf4fb",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -52649,7 +52649,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/pcre2-sys/0.2.8/download",
-          "sha256": "25b8a7b5253a4465b873a21ee7e8d6ec561a57eed5d319621bec36bea35c86ae"
+          "sha256": "25b8a7b5253a4465b873a21ee7e8d6ec561a57eed5d319621bec36bea35c86ae",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:pcre2-sys.patch"
+          ]
         }
       },
       "targets": [

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d219ecf3003ae760b2a967cbf6532e80a278a2640cd74d57ab32af145fae636f",
+  "checksum": "987c09bb853448361351d6b167b9e528c23cea8fdaa95ce28b65cc3a9114fbce",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",

--- a/bazel/pcre2-sys.patch
+++ b/bazel/pcre2-sys.patch
@@ -1,0 +1,39 @@
+# Patch for determinism issues.
+#
+# pcre2-sys's build script (with PCRE2_SYS_STATIC=1) enumerates the bundled
+# PCRE2 C sources with an unsorted `std::fs::read_dir`, so the member order of
+# the produced archive is the filesystem's directory-iteration order — stable
+# on any one machine but different across machines (e.g. ext4 iterates in
+# name-hash order with a per-filesystem seed). The order leaks into binaries
+# linking the archive as the order of their STT_FILE symbols, which made
+# //rs/ic_os/open_rootfs (and hence the GuestOS image) non-reproducible
+# across machines. Sort the sources to make the archive deterministic.
+#
+# Upstream PR: https://github.com/BurntSushi/rust-pcre2/pull/58
+diff --git a/build.rs b/build.rs
+index 4a6fcad..3329e54 100644
+--- a/build.rs
++++ b/build.rs
+@@ -52,6 +52,11 @@ fn main() {
+     enable_jit(&target, &mut builder);
+ 
+     builder.include(upstream.join("src")).include(upstream.join("include"));
++    // read_dir returns entries in filesystem iteration order, which differs
++    // between machines. That order becomes the archive's member order and
++    // leaks into downstream binaries (e.g. as the order of their STT_FILE
++    // symbols), breaking reproducible builds. Sort to make it deterministic.
++    let mut sources = Vec::new();
+     for result in std::fs::read_dir(upstream.join("src")).unwrap() {
+         let dent = result.unwrap();
+         let path = dent.path();
+@@ -70,6 +75,10 @@ fn main() {
+         {
+             continue;
+         }
++        sources.push(path);
++    }
++    sources.sort();
++    for path in sources {
+         builder.file(path);
+     }
+ 

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -2200,6 +2200,13 @@ crate.annotation(
 crate.annotation(
     build_script_env = {"PCRE2_SYS_STATIC": "1"},
     crate = "pcre2-sys",
+    # Patch for determinism issues: the build script enumerates the bundled
+    # PCRE2 C sources with an unsorted `read_dir`, so the archive member order
+    # depends on the build machine's filesystem and leaks into binaries that
+    # link it (the STT_FILE symbol order), making the GuestOS image
+    # non-reproducible across machines. The patch sorts the sources.
+    patch_args = ["-p1"],
+    patches = ["@@//bazel:pcre2-sys.patch"],
 )
 crate.annotation(
     # Disabling the libudev probe makes the vendored libusb fall back to its


### PR DESCRIPTION
## Problem

`repro-check --guestos` fails for every commit since 9e2920593e (the zig cc → hermetic-llvm switch, #10991): the locally built GuestOS `update-img.tar.zst` hashes differently from the CI/CDN artifact (e.g. local `fc824312…` vs CDN `2f31b0e5…` at 9e29205), while being perfectly stable across rebuilds on the same machine.

## Root cause

9e2920593e set `PCRE2_SYS_STATIC=1` on `pcre2-sys` (to fix the host-library `-L` leak class under the hermetic toolchain), which makes the crate's build script compile the bundled PCRE2 C sources. That `build.rs` enumerates the sources with an **unsorted `std::fs::read_dir`**, so the member order of the produced `libpcre2.a` is the build machine's filesystem iteration order — stable per machine, but different across machines (ext4 iterates in name-hash order with a per-filesystem seed chosen at mkfs time).

The order leaks into `open_rootfs` (the only pcre2 consumer shipped in an IC-OS image, via `partition_tools`): lld records one `STT_FILE` symbol per loaded archive member, in load order. All pcre2 *code* is GC'd (`--gc-sections` — nothing in `open_rootfs` calls it), so the binaries differ **only** in the order of their `pcre2_*.c` `STT_FILE` symtab entries and the corresponding `.strtab` bytes. Diffing the local vs CDN images file-by-file: `/opt/ic/bin/open_rootfs` is the **only** differing file in the entire rootfs (boot partition differences are the cascade: the initramfs embeds `open_rootfs`, `boot_args` carries the root's verity hash, and `launch-measurements.json` follows).

Why the "Build Determinism" job didn't catch it: (a) on 9e29205 (and its parent) it was **skipped** — `needs: [build-ic, bazel-test-all]` with no `if:`, and Bazel Test All's *test* step failed after the artifacts had already been uploaded; (b) even when it runs (verified green on later master commits with the defect present), it compares two builds within the uniformly-provisioned dind fleet, which agrees with itself on readdir order — only a build outside the fleet exposes the difference.

## Fix

Patch the crate's `build.rs` to collect and sort the sources before handing them to `cc::Build` (`bazel/pcre2-sys.patch`, wired via `crate.annotation` like the existing `rustix`/`askama` determinism patches, lockfile repinned via `./bin/bazel-pin.sh`). Same file set, deterministic order → the archive is byte-identical regardless of the build machine.

Upstream PR: https://github.com/BurntSushi/rust-pcre2/pull/58

## Verification

- `patch -p1` applies cleanly against pristine pcre2-sys 0.2.8; `bazel build //... --nobuild` and `bazel run //:buildifier` pass.
- `bazel build --config=local //rs/ic_os/open_rootfs:open_rootfs` in the dev container: the rebuilt `libpcre2.a` member order is sorted (`ar t | sort -c`), i.e. no longer filesystem-dependent (before the patch it matched the machine's raw readdir order 1:1).
- Definitive confirmation will be the first `repro-check --guestos` against a CI build that includes this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)