### PR TITLE
fix: don't skip Build Determinism when bazel-test-all tests fail

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -584,9 +584,7 @@ jobs:
     # uploads them on failure too) and — on release builds — the artifacts
     # were already published to the CDN. Without this condition a single
     # failing/flaky test silently skipped the determinism check while the
-    # artifacts still shipped (e.g. 9e2920593e and f18ab1c843 shipped
-    # unchecked; the pcre2-sys non-reproducibility fixed in #11090 went
-    # unnoticed that way). `build-ic` still has to succeed: it produces the
+    # artifacts still shipped. `build-ic` still has to succeed: it produces the
     # no-cache side of the comparison (and is skipped on merge_group, where
     # there is nothing to compare).
     if: ${{ !cancelled() && needs.build-ic.result == 'success' }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -579,6 +579,17 @@ jobs:
     name: Build Determinism
     runs-on: ubuntu-latest
     needs: [build-ic, bazel-test-all]
+    # Run even when `bazel-test-all` fails: its test failures happen *after*
+    # its build succeeded, its execution logs were uploaded (the bazel action
+    # uploads them on failure too) and — on release builds — the artifacts
+    # were already published to the CDN. Without this condition a single
+    # failing/flaky test silently skipped the determinism check while the
+    # artifacts still shipped (e.g. 9e2920593e and f18ab1c843 shipped
+    # unchecked; the pcre2-sys non-reproducibility fixed in #11090 went
+    # unnoticed that way). `build-ic` still has to succeed: it produces the
+    # no-cache side of the comparison (and is skipped on merge_group, where
+    # there is nothing to compare).
+    if: ${{ !cancelled() && needs.build-ic.result == 'success' }}
     steps:
       - name: Download execution logs (cache)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Problem

`build-determinism` (which compares per-artifact digests between the remote-cache-enabled **Bazel Test All** build and the no-cache **Build IC** build) declared `needs: [build-ic, bazel-test-all]` with no `if:` — so any test failure in Bazel Test All skipped it. By the time tests run in that job, its build step has succeeded, its execution logs are uploaded (the `.github/actions/bazel` action uploads them `if: success() || failure()`), and on release builds the artifacts have **already been published to the CDN** by the "Upload artifacts" step.

Net effect: an ordinary flaky/failing test disables the determinism gate for artifacts that still ship. That's exactly how `9e2920593e` and `f18ab1c843` reached the CDN with the check silently skipped (both master pushes had test failures; verified via the jobs API — `Build Determinism: skipped` on both runs). The pcre2-sys non-reproducibility introduced by `9e2920593e` (fixed in #11090) went unnoticed until `repro-check` failed on a dev machine.

## Fix

```yaml
if: ${{ !cancelled() && needs.build-ic.result == 'success' }}
```

- Bazel Test All test failures no longer skip the comparison — the execlogs it needs exist even when that job fails.
- `build-ic` must still have succeeded: it produces the no-cache side of the comparison, and it is skipped on `merge_group` runs — where the determinism job stays skipped exactly as before.
- Cancelled runs stay skipped.

Found while root-causing the GuestOS reproducibility regression (see #11090 for the full analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)