### PR TITLE
fix: adapt II init args to new mainnet candid

### DIFF
--- a/rs/pocket_ic_server/src/external_canister_types.rs
+++ b/rs/pocket_ic_server/src/external_canister_types.rs
@@ -158,14 +158,6 @@ pub struct InternetIdentityFrontendInit {
 }
 
 #[derive(CandidType)]
-pub struct SsoCredentialMigrationEntry {
-    pub discovery_domain: String,
-    pub issuer: String,
-    pub client_id: String,
-    pub name: Option<String>,
-}
-
-#[derive(CandidType)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
     pub archive_config: Option<ArchiveConfig>,
@@ -176,7 +168,6 @@ pub struct InternetIdentityInit {
     pub new_flow_origins: Option<Vec<String>>,
     pub openid_configs: Option<Vec<OpenIdConfig>>,
     pub sso_allow_insecure_discovery: Option<bool>,
-    pub sso_credential_migration: Option<Vec<SsoCredentialMigrationEntry>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,
     pub is_production: Option<bool>,
@@ -187,5 +178,4 @@ pub struct InternetIdentityInit {
     pub dnssec_config: Option<Option<DnssecConfig>>,
     pub doh_config: Option<Option<DohConfig>>,
     pub mcp_official_url: Option<Option<String>>,
-    pub mcp_config_migration: Option<bool>,
 }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2100,9 +2100,7 @@ impl PocketIcSubnets {
             //         max_cache_age_secs = opt (3_600 : nat64);
             //         allowed_domains = vec { "gmail.com"; "googlemail.com"; "outlook.com"; "hotmail.com"; "msn.com"; "live.com"; "icloud.com"; "me.com"; "mac.com"; "yahoo.com"; "ymail.com"; "aol.com"; "zoho.com"; "fastmail.com"; "fastmail.fm"; "hey.com"; "yandex.com"; "yandex.ru"; "mail.ru"; "qq.com"; "163.com"; "126.com"; "naver.com"; "daum.net";};
             //       };
-            //       sso_credential_migration = null;
             //       is_production = opt true;
-            //       mcp_config_migration = null;
             //       backend_canister_id = opt principal "rdmx6-jaaaa-aaaaa-aaadq-cai";
             //       enable_dapps_explorer = opt false;
             //       assigned_user_number_range = opt record {
@@ -2241,7 +2239,6 @@ impl PocketIcSubnets {
                 new_flow_origins: None,        // DIFFERENT FROM ICP MAINNET
                 openid_configs: openid_google, // DIFFERENT FROM ICP MAINNET
                 sso_allow_insecure_discovery: None,
-                sso_credential_migration: None,
                 analytics_config: None, // DIFFERENT FROM ICP MAINNET
                 enable_dapps_explorer: Some(false),
                 is_production: Some(false), // DIFFERENT FROM ICP MAINNET
@@ -2252,7 +2249,6 @@ impl PocketIcSubnets {
                 dnssec_config: None,                // DIFFERENT FROM ICP MAINNET
                 doh_config: None,                   // DIFFERENT FROM ICP MAINNET
                 mcp_official_url: None,             // DIFFERENT FROM ICP MAINNET
-                mcp_config_migration: None,
             });
             ii_subnet
                 .state_machine


### PR DESCRIPTION
The mainnet canister revision bump moved Internet Identity from `release-2026-07-31` to `release-2026-08-07`, whose candid drops the one-off migration flags `sso_credential_migration` and `mcp_config_migration` from `InternetIdentityInit`. This broke `//rs/pocket_ic_server:external_types_tests`.