### PR TITLE
feat: deduplicate pprof-related dependencies

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "cd7b92369e4d498b6965c0e0bc5ccb8b54b93625fcf019e728c5f73909055231",
+  "checksum": "30910d61ae2a85ff78c48df31f8f827448980a04806846d2a25450109bdf5259",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -47011,6 +47011,8 @@
             "default",
             "ioctl",
             "memoffset",
+            "process",
+            "signal",
             "socket"
           ],
           "selects": {}
@@ -54580,7 +54582,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/pprof-rs",
           "commitish": {
-            "Rev": "7f5228262196e3eb9c8d1ddbaca984787dea331a"
+            "Rev": "9159b45ecc3540d7fc44c6a6e70a173676cfa771"
           }
         }
       },
@@ -54663,7 +54665,7 @@
               "target": "log"
             },
             {
-              "id": "nix 0.30.1",
+              "id": "nix 0.27.1",
               "target": "nix"
             },
             {
@@ -54683,7 +54685,7 @@
               "target": "smallvec"
             },
             {
-              "id": "spin 0.10.1",
+              "id": "spin 0.9.8",
               "target": "spin"
             },
             {
@@ -70205,56 +70207,11 @@
         ],
         "crate_features": {
           "common": [
-            "mutex",
-            "once",
-            "spin_mutex"
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.9.8"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "spin 0.10.1": {
-      "name": "spin",
-      "version": "0.10.1",
-      "package_url": "https://github.com/mvdnes/spin-rs.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/spin/0.10.1/download",
-          "sha256": "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "spin",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "spin",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
             "barrier",
             "default",
             "lazy",
             "lock_api",
+            "lock_api_crate",
             "mutex",
             "once",
             "rwlock",
@@ -70273,7 +70230,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.10.1"
+        "version": "0.9.8"
       },
       "license": "MIT",
       "license_ids": [

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -7109,7 +7109,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -7917,7 +7917,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "pprof"
 version = "0.15.0"
-source = "git+https://github.com/dfinity/pprof-rs?rev=7f5228262196e3eb9c8d1ddbaca984787dea331a#7f5228262196e3eb9c8d1ddbaca984787dea331a"
+source = "git+https://github.com/dfinity/pprof-rs?rev=9159b45ecc3540d7fc44c6a6e70a173676cfa771#9159b45ecc3540d7fc44c6a6e70a173676cfa771"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -9214,13 +9214,13 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.30.1",
+ "nix 0.27.1",
  "once_cell",
  "prost",
  "prost-build",
  "sha2 0.10.9",
  "smallvec",
- "spin 0.10.1",
+ "spin",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
@@ -11705,12 +11705,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spin"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16962,7 +16962,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -17953,7 +17953,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
@@ -19769,7 +19769,7 @@ dependencies = [
 [[package]]
 name = "pprof"
 version = "0.15.0"
-source = "git+https://github.com/dfinity/pprof-rs?rev=7f5228262196e3eb9c8d1ddbaca984787dea331a#7f5228262196e3eb9c8d1ddbaca984787dea331a"
+source = "git+https://github.com/dfinity/pprof-rs?rev=9159b45ecc3540d7fc44c6a6e70a173676cfa771#9159b45ecc3540d7fc44c6a6e70a173676cfa771"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -19779,13 +19779,13 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.30.1",
+ "nix 0.27.1",
  "once_cell",
  "prost",
  "prost-build",
  "sha2 0.10.9",
  "smallvec",
- "spin 0.10.0",
+ "spin",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
@@ -22835,12 +22835,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -813,7 +813,7 @@ pem = { version = "^3", default-features = false, features = ["std"] }
 pin-project-lite = "^0.2"
 ping = "0.5.0"
 pkcs8 = "0.10.2"
-pprof = { git = "https://github.com/dfinity/pprof-rs", rev = "7f5228262196e3eb9c8d1ddbaca984787dea331a", default-features = false, features = [
+pprof = { git = "https://github.com/dfinity/pprof-rs", rev = "9159b45ecc3540d7fc44c6a6e70a173676cfa771", default-features = false, features = [
     "criterion",
     "flamegraph",
     "prost-codec",
@@ -977,6 +977,7 @@ uuid = { version = "=1.12.1", features = ["v4", "serde"] }
 virt = "0.4"
 walkdir = "2.3.3"
 walrus = "0.26.4"
+warp = { version = "0.3.7", features = ["tls"] }
 wasm-encoder = { version = "0.252.0", features = ["wasmparser"] }
 wasm-smith = { version = "0.252.0", default-features = false, features = ["wasmparser"] }
 wasmparser = "0.252.0"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1207,7 +1207,7 @@ crate.spec(
     # https://github.com/tikv/pprof-rs
     git = "https://github.com/dfinity/pprof-rs",
     package = "pprof",
-    rev = "7f5228262196e3eb9c8d1ddbaca984787dea331a",
+    rev = "9159b45ecc3540d7fc44c6a6e70a173676cfa771",
 )
 crate.spec(
     package = "predicates",

--- a/rs/https_outcalls/adapter/Cargo.toml
+++ b/rs/https_outcalls/adapter/Cargo.toml
@@ -45,7 +45,7 @@ socks5-impl = { version = "0.6", features = ["tokio"] }
 tempfile = { workspace = true }
 tokio-rustls = { workspace = true }
 uuid = { workspace = true }
-warp = { version = "0.3.7", features = ["tls"] }
+warp = { workspace = true }
 
 [features]
 http = []


### PR DESCRIPTION
This tweaks the crate versions used by pprof to align with what we already have in the repo.