### PR TITLE
fix: CanisterDidNotReply for failed calls in composite queries

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -456,21 +456,7 @@ impl SystemStateModifications {
         let subnet_ids: BTreeSet<PrincipalId> =
             network_topology.subnets().keys().map(|s| s.get()).collect();
         for mut msg in self.requests {
-            if msg.receiver == IC_00 && is_composite_query {
-                // Requests to the management canister made by a composite query
-                // (including from its callbacks) are neither validated nor routed
-                // based on the method and the payload: they are executed by the query
-                // handler against the state of the own subnet (or rejected by it if
-                // the method cannot be executed in the non-replicated mode). Note
-                // that composite queries are always executed in the non-replicated
-                // mode.
-                //
-                // In particular, such a request must not be rejected here: the reject
-                // response would be pushed onto the canister's input queue, which is
-                // never inducted while evaluating a query call graph, and hence the
-                // composite query would fail with `CanisterDidNotReply`.
-                Self::push_message(system_state, time, msg, logger)?;
-            } else if msg.receiver == IC_00 {
+            if !is_composite_query && msg.receiver == IC_00 {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
                 {
                     Ok(()) => {
@@ -511,16 +497,7 @@ impl SystemStateModifications {
                         )?;
                     }
                 }
-            } else if subnet_ids.contains(&msg.receiver.get()) && is_composite_query {
-                // A management canister call made by a composite query that provides the
-                // target subnet ID directly in the request. Just like a request addressed
-                // to `IC_00` above, it is neither validated nor routed here and, for the
-                // very same reason, it must not be rejected here either. Instead, it is
-                // rejected by the query handler with `CanisterNotFound`: only requests
-                // addressed to `IC_00` are executed as management canister calls in a
-                // composite query.
-                Self::push_message(system_state, time, msg, logger)?;
-            } else if subnet_ids.contains(&msg.receiver.get()) {
+            } else if !is_composite_query && subnet_ids.contains(&msg.receiver.get()) {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
                 {
                     Ok(()) => {
@@ -550,6 +527,20 @@ impl SystemStateModifications {
                     }
                 }
             } else {
+                // A request made by a composite query (including from its callbacks) is
+                // neither validated nor routed here, no matter its receiver: if it is
+                // addressed to `IC_00`, it is executed by the query handler against the
+                // state of the own subnet (or rejected by it if the method cannot be
+                // executed in the non-replicated mode; note that composite queries are
+                // always executed in the non-replicated mode); if it provides a subnet ID
+                // directly as the receiver, it is rejected by the query handler with
+                // `CanisterNotFound` since only requests addressed to `IC_00` are executed
+                // as management canister calls in a composite query.
+                //
+                // In particular, such a request must not be rejected here: the reject
+                // response would be pushed onto the canister's input queue, which is
+                // never inducted while evaluating a query call graph, and hence the
+                // composite query would fail with `CanisterDidNotReply`.
                 Self::push_message(system_state, time, msg, logger)?;
             }
         }

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -531,8 +531,8 @@ impl SystemStateModifications {
                 // neither validated nor routed here, no matter its receiver: if it is
                 // addressed to `IC_00`, it is executed by the query handler against the
                 // state of the own subnet (or rejected by it if the method cannot be
-                // executed in the non-replicated mode; note that composite queries are
-                // always executed in the non-replicated mode); if it provides a subnet ID
+                // executed in non-replicated mode; note that composite queries are
+                // always executed in non-replicated mode); if it provides a subnet ID
                 // directly as the receiver, it is rejected by the query handler with
                 // `CanisterNotFound` since only requests addressed to `IC_00` are executed
                 // as management canister calls in a composite query.

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -456,32 +456,37 @@ impl SystemStateModifications {
         let subnet_ids: BTreeSet<PrincipalId> =
             network_topology.subnets().keys().map(|s| s.get()).collect();
         for mut msg in self.requests {
-            if msg.receiver == IC_00 {
+            if msg.receiver == IC_00 && is_composite_query {
+                // Requests to the management canister made by a composite query
+                // (including from its callbacks) are neither validated nor routed
+                // based on the method and the payload: they are executed by the query
+                // handler against the state of the own subnet (or rejected by it if
+                // the method cannot be executed in the non-replicated mode). Note
+                // that composite queries are always executed in the non-replicated
+                // mode.
+                //
+                // In particular, such a request must not be rejected here: the reject
+                // response would be pushed onto the canister's input queue, which is
+                // never inducted while evaluating a query call graph, and hence the
+                // composite query would fail with `CanisterDidNotReply`.
+                msg.receiver = CanisterId::from(own_subnet_id);
+                Self::push_message(system_state, time, msg, logger)?;
+            } else if msg.receiver == IC_00 {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
                 {
                     Ok(()) => {
                         // This is a request to the management canister.
                         // Update the receiver to the appropriate subnet.
-                        let destination = if is_composite_query {
-                            // Requests to the management canister made by a composite
-                            // query (including from its callbacks) are not routed
-                            // based on the method and the payload: they are
-                            // executed by the query handler against the state of the own
-                            // subnet (or rejected by it if the method cannot be executed
-                            // in the non-replicated mode). Note that composite queries
-                            // are always executed in the non-replicated mode.
-                            Ok(own_subnet_id.get())
-                        } else {
-                            routing::resolve_destination(
-                                network_topology,
-                                msg.method_name.as_str(),
-                                msg.method_payload.as_slice(),
-                                own_subnet_id,
-                                system_state.canister_id(),
-                                logger,
-                            )
-                        };
-                        match destination.map(CanisterId::unchecked_from_principal) {
+                        match routing::resolve_destination(
+                            network_topology,
+                            msg.method_name.as_str(),
+                            msg.method_payload.as_slice(),
+                            own_subnet_id,
+                            system_state.canister_id(),
+                            logger,
+                        )
+                        .map(CanisterId::unchecked_from_principal)
+                        {
                             Ok(destination_subnet) => {
                                 msg.receiver = destination_subnet;
                                 Self::push_message(system_state, time, msg, logger)?;

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -469,7 +469,6 @@ impl SystemStateModifications {
                 // response would be pushed onto the canister's input queue, which is
                 // never inducted while evaluating a query call graph, and hence the
                 // composite query would fail with `CanisterDidNotReply`.
-                msg.receiver = CanisterId::from(own_subnet_id);
                 Self::push_message(system_state, time, msg, logger)?;
             } else if msg.receiver == IC_00 {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
@@ -512,6 +511,15 @@ impl SystemStateModifications {
                         )?;
                     }
                 }
+            } else if subnet_ids.contains(&msg.receiver.get()) && is_composite_query {
+                // A management canister call made by a composite query that provides the
+                // target subnet ID directly in the request. Just like a request addressed
+                // to `IC_00` above, it is neither validated nor routed here and, for the
+                // very same reason, it must not be rejected here either. Instead, it is
+                // rejected by the query handler with `CanisterNotFound`: only requests
+                // addressed to `IC_00` are executed as management canister calls in a
+                // composite query.
+                Self::push_message(system_state, time, msg, logger)?;
             } else if subnet_ids.contains(&msg.receiver.get()) {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
                 {

--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -929,7 +929,7 @@ impl<'a> QueryContext<'a> {
         };
 
         // Reject the calls to all the management canister methods that cannot be
-        // executed in the non-replicated mode, as well as the calls to methods not
+        // executed in non-replicated mode, as well as the calls to methods not
         // exported by the management canister at all, with the same error as for
         // such a query sent by an end user to the management canister.
         let method = match parse_query_method(&request.method_name) {

--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -826,10 +826,12 @@ impl<'a> QueryContext<'a> {
 
         let canister_id = request.receiver;
 
-        // Requests to the management canister made by a composite query are routed
-        // to the own subnet, so the own subnet ID as the receiver means that this
-        // is a call to the management canister.
-        if canister_id.get() == self.hypervisor.subnet_id().get() {
+        // Requests to the management canister made by a composite query are not
+        // routed to a destination subnet, i.e. they reach the query handler with
+        // `IC_00` as the receiver. A request providing a subnet ID directly in the
+        // request is not treated as a management canister call: it is rejected
+        // below with `CanisterNotFound`, as no canister with that ID exists.
+        if canister_id == CanisterId::ic_00() {
             return self.handle_ic00_request(&request, to_query_result);
         }
 
@@ -927,10 +929,9 @@ impl<'a> QueryContext<'a> {
         };
 
         // Reject the calls to all the management canister methods that cannot be
-        // executed in the non-replicated mode with the same error as for such a
-        // query sent by an end user to the management canister. Note that calls to
-        // methods not exported by the management canister at all are rejected
-        // before they even reach the query handler.
+        // executed in the non-replicated mode, as well as the calls to methods not
+        // exported by the management canister at all, with the same error as for
+        // such a query sent by an end user to the management canister.
         let method = match parse_query_method(&request.method_name) {
             Ok(method) => method,
             Err(err) => return reject(err),

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1692,30 +1692,6 @@ fn composite_query_call_to_own_subnet_id_on_nns_subnet() {
     composite_query_call_to_own_subnet_id_impl(true);
 }
 
-#[test]
-fn composite_query_call_to_own_subnet_id_rejects_unknown_methods() {
-    let mut test = ExecutionTestBuilder::new().build();
-    let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
-    let own_subnet_id = test.state().metadata.own_subnet_id;
-
-    let reply = test
-        .non_replicated_query(
-            canister_id,
-            "composite_query",
-            subnet_composite_query(
-                CanisterId::from(own_subnet_id),
-                "unknown",
-                Encode!().unwrap(),
-            ),
-        )
-        .unwrap();
-
-    assert_eq!(
-        reply,
-        WasmResult::Reply(format!("Canister {own_subnet_id} not found").into_bytes())
-    );
-}
-
 // A composite query cannot cross subnet boundaries: a request addressed to a
 // remote subnet ID is rejected by the query handler (and not silently dropped
 // while pushing the outgoing requests).

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1365,18 +1365,25 @@ fn test_list_canisters_success() {
     );
 }
 
-/// Returns a composite query calling the given management canister method
-/// with the given payload and replying with the reply or the reject message.
-fn ic00_composite_query(method_name: &str, payload: Vec<u8>) -> Vec<u8> {
+/// Returns a composite query calling the given method of the given receiver
+/// (`IC_00` or a subnet ID) with the given payload and replying with the reply
+/// or the reject message.
+fn subnet_composite_query(receiver: CanisterId, method_name: &str, payload: Vec<u8>) -> Vec<u8> {
     wasm()
         .call_simple(
-            CanisterId::ic_00(),
+            receiver,
             method_name,
             call_args()
                 .other_side(payload)
                 .on_reject(wasm().reject_message().append_and_reply()),
         )
         .build()
+}
+
+/// Returns a composite query calling the given management canister method
+/// with the given payload and replying with the reply or the reject message.
+fn ic00_composite_query(method_name: &str, payload: Vec<u8>) -> Vec<u8> {
+    subnet_composite_query(CanisterId::ic_00(), method_name, payload)
 }
 
 #[test]
@@ -1631,6 +1638,91 @@ fn composite_query_call_to_management_canister_from_callback_rejects_unknown_met
     assert_eq!(
         reply,
         WasmResult::Reply(b"Query method unknown not found.".to_vec())
+    );
+}
+
+// A management canister call may also provide the target subnet ID directly in
+// the request. Such a call is not executed as a management canister call by the
+// query handler; it is rejected with `CanisterNotFound` and, in particular, the
+// reject response is propagated to the caller.
+#[test]
+fn composite_query_call_to_own_subnet_id() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    let own_subnet_id = test.state().metadata.own_subnet_id;
+    // The caller is not an NNS canister.
+    assert_ne!(
+        own_subnet_id,
+        test.state().metadata.network_topology.nns_subnet_id
+    );
+
+    let reply = test
+        .non_replicated_query(
+            canister_id,
+            "composite_query",
+            subnet_composite_query(
+                CanisterId::from(own_subnet_id),
+                "canister_status",
+                CanisterIdRecord::from(canister_id).encode(),
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(
+        reply,
+        WasmResult::Reply(format!("Canister {own_subnet_id} not found").into_bytes())
+    );
+}
+
+#[test]
+fn composite_query_call_to_own_subnet_id_rejects_unknown_methods() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    let own_subnet_id = test.state().metadata.own_subnet_id;
+
+    let reply = test
+        .non_replicated_query(
+            canister_id,
+            "composite_query",
+            subnet_composite_query(
+                CanisterId::from(own_subnet_id),
+                "unknown",
+                Encode!().unwrap(),
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(
+        reply,
+        WasmResult::Reply(format!("Canister {own_subnet_id} not found").into_bytes())
+    );
+}
+
+// A composite query cannot cross subnet boundaries: a request addressed to a
+// remote subnet ID is rejected by the query handler (and not silently dropped
+// while pushing the outgoing requests).
+#[test]
+fn composite_query_call_to_remote_subnet_id() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    let nns_subnet_id = test.state().metadata.network_topology.nns_subnet_id;
+    assert_ne!(nns_subnet_id, test.state().metadata.own_subnet_id);
+
+    let reply = test
+        .non_replicated_query(
+            canister_id,
+            "composite_query",
+            subnet_composite_query(
+                CanisterId::from(nns_subnet_id),
+                "canister_status",
+                CanisterIdRecord::from(canister_id).encode(),
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(
+        reply,
+        WasmResult::Reply(format!("Canister {nns_subnet_id} not found").into_bytes())
     );
 }
 

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1586,19 +1586,52 @@ fn composite_query_call_to_management_canister_rejects_unknown_methods() {
     let mut test = ExecutionTestBuilder::new().build();
     let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
 
-    let err = test
+    let reply = test
         .non_replicated_query(
             canister_id,
             "composite_query",
             ic00_composite_query("unknown", Encode!().unwrap()),
         )
-        .unwrap_err();
+        .unwrap();
 
-    // Calls to methods not exported by the management canister are rejected
-    // before the request is even pushed onto the output queue and thus the
-    // reject response is not propagated to the caller.
-    // TODO(EXC-1655): fix reject response propagation.
-    assert_eq!(err.code(), ErrorCode::CanisterDidNotReply);
+    // The call is rejected with the same error as a query sent by an end user
+    // to the management canister.
+    assert_eq!(
+        reply,
+        WasmResult::Reply(b"Query method unknown not found.".to_vec())
+    );
+}
+
+// Calls to the management canister made from a reply callback of a composite
+// query must be handled in exactly the same way as calls made from the
+// composite query method itself.
+#[test]
+fn composite_query_call_to_management_canister_from_callback_rejects_unknown_methods() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_a = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    let canister_b = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+
+    // Canister A calls the management canister in the reply callback of a
+    // nested composite query call to canister B.
+    let reply = test
+        .non_replicated_query(
+            canister_a,
+            "composite_query",
+            wasm()
+                .composite_query(
+                    canister_b,
+                    call_args()
+                        .other_side(wasm().reply_data(b"pong"))
+                        .on_reply(ic00_composite_query("unknown", Encode!().unwrap())),
+                )
+                .build(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        reply,
+        WasmResult::Reply(b"Query method unknown not found.".to_vec())
+    );
 }
 
 #[test]

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -12,7 +12,7 @@ use ic_management_canister_types_private::{
 use ic_test_utilities::universal_canister::{call_args, wasm};
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_test_utilities_state::CanisterStateBuilder;
-use ic_test_utilities_types::ids::{canister_test_id, user_test_id};
+use ic_test_utilities_types::ids::{canister_test_id, subnet_test_id, user_test_id};
 use ic_types::{
     NumInstructions,
     ingress::WasmResult,
@@ -1645,15 +1645,23 @@ fn composite_query_call_to_management_canister_from_callback_rejects_unknown_met
 // the request. Such a call is not executed as a management canister call by the
 // query handler; it is rejected with `CanisterNotFound` and, in particular, the
 // reject response is propagated to the caller.
-#[test]
-fn composite_query_call_to_own_subnet_id() {
-    let mut test = ExecutionTestBuilder::new().build();
+//
+// Outside of composite queries, such a call is only allowed for NNS canisters
+// and rejected for all other canisters, and hence both cases are covered here.
+fn composite_query_call_to_own_subnet_id_impl(own_subnet_is_nns: bool) {
+    let subnet_id = subnet_test_id(1);
+    let mut builder = ExecutionTestBuilder::new().with_own_subnet_id(subnet_id);
+    if own_subnet_is_nns {
+        builder = builder.with_nns_subnet_id(subnet_id);
+    }
+    let mut test = builder.build();
     let canister_id = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
     let own_subnet_id = test.state().metadata.own_subnet_id;
-    // The caller is not an NNS canister.
-    assert_ne!(
-        own_subnet_id,
-        test.state().metadata.network_topology.nns_subnet_id
+    assert_eq!(own_subnet_id, subnet_id);
+    // The caller is an NNS canister if and only if the own subnet is the NNS subnet.
+    assert_eq!(
+        own_subnet_id == test.state().metadata.network_topology.nns_subnet_id,
+        own_subnet_is_nns
     );
 
     let reply = test
@@ -1672,6 +1680,16 @@ fn composite_query_call_to_own_subnet_id() {
         reply,
         WasmResult::Reply(format!("Canister {own_subnet_id} not found").into_bytes())
     );
+}
+
+#[test]
+fn composite_query_call_to_own_subnet_id() {
+    composite_query_call_to_own_subnet_id_impl(false);
+}
+
+#[test]
+fn composite_query_call_to_own_subnet_id_on_nns_subnet() {
+    composite_query_call_to_own_subnet_id_impl(true);
 }
 
 #[test]


### PR DESCRIPTION
Requests to the management canister made by a composite query are executed by the query handler against the state of the own subnet, and thus they are not routed based on the method and the payload. However, that short-circuit was nested inside the `Ok(())` arm of `validate_sender_canister_version`, which fails with `CanisterMethodNotFound` for a method name that is not a management canister method at all. Such a request was hence rejected via `reject_subnet_output_request`, which pushes the reject response onto the canister's input queue. Input queues are never inducted while evaluating a query call graph, so the reject response was lost and the composite query failed with `CanisterDidNotReply` instead.

Skip validation together with routing for composite queries so that the request reaches the query handler, which rejects it with the same error as a query sent by an end user to the management canister ("Query method <name> not found."). This is safe: all management canister query methods have no sender canister version in their payload and every method that does carry one is rejected as not being a query method anyway.

Since `is_composite_query` also covers the reply and reject callbacks of a composite query, this fixes calls made from those callbacks as well; a regression test is added for that case.

Finally, calls with a subnet ID as the callee are now rejected with "Canister <subnet_id> not found" in composite queries instead of failing with `CanisterDidNotReply`.