### PR TITLE
test: Fix tests asserting on `ReplicatedStateMetrics`

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -199,7 +199,7 @@ pub struct StateManagerMetrics {
     fast_forward_height: IntGauge,
     no_state_clone_count: IntCounter,
     skip_optimization_missing_cert_count: IntCounter,
-    skipped_state_observations: IntCounter,
+    state_observation_blocked_duration: Histogram,
 }
 
 #[derive(Clone)]
@@ -528,9 +528,10 @@ impl StateManagerMetrics {
             "How often we could have skipped state cloning but did not because no certification was available.",
         );
 
-        let skipped_state_observations = metrics_registry.int_counter(
-            "state_manager_skipped_state_observations",
-            "Number of `ReplicatedStateMetrics::observe` invocations skipped because the background metrics thread was still busy.",
+        let metrics_observation_blocked_duration = metrics_registry.histogram(
+            "state_manager_observe_metrics_blocked_duration_seconds",
+            "Duration spent blocked on the critical path handing off a `ReplicatedStateMetrics::observe` invocation to the background metrics thread, in seconds. Zero when enqueued immediately.",
+            decimal_buckets_with_zero(-3, 0),
         );
 
         Self {
@@ -565,7 +566,7 @@ impl StateManagerMetrics {
             fast_forward_height,
             no_state_clone_count,
             skip_optimization_missing_cert_count,
-            skipped_state_observations,
+            state_observation_blocked_duration: metrics_observation_blocked_duration,
         }
     }
 
@@ -1403,7 +1404,11 @@ impl StateManagerImpl {
             invariants: replicated_state_invariants.map(Arc::new),
             worker_thread: WorkerThread::new(
                 "StateMetrics",
-                metrics.skipped_state_observations.clone(),
+                // One slot of slack, so that we need not block if the worker thread has not
+                // been scheduled since the previous round. May hold on to a `ReplicatedState`
+                // (which the State Manager likely also holds, as the latest state).
+                1,
+                metrics.state_observation_blocked_duration.clone(),
             ),
         };
 
@@ -4536,9 +4541,9 @@ impl ReplicatedStateMetricsThread {
     /// Enqueues background metric observations and invariant checks for the given
     /// state.
     ///
-    /// No-op if the worker thread is backlogged with earlier enqueued tasks. Since
-    /// neither metrics nor invariant checks are critical to correct functioning of
-    /// the replica, this is preferable to blocking on the critical path.
+    /// Blocks if the worker thread has not yet picked up the previously enqueued
+    /// observation, recording the time spent blocked in
+    /// `state_manager_observe_metrics_blocked_duration_seconds`.
     fn enqueue_observe_and_check(
         &self,
         state: Arc<ReplicatedState>,

--- a/rs/utils/thread/src/worker_thread.rs
+++ b/rs/utils/thread/src/worker_thread.rs
@@ -1,40 +1,43 @@
 //! A background thread that runs workloads off the critical path.
 //!
-//! Backpressure: we use a synchronous, zero-capacity channel, with the worker
-//! thread blocking on `recv()` when not processing a workload. If a new
-//! workload arrives while the worker is busy, the new workload is dropped and a
-//! "skipped" counter is bumped.
+//! Backpressure: we use a bounded channel and block the caller when it is
+//! full, so workloads are never dropped. A capacity above zero means that the
+//! caller does not block if the worker thread has not been scheduled (e.g.
+//! under heavy load); with the trade-off that the queued workloads (and
+//! whatever they capture) are held on to until the worker gets to them.
 //!
 //! The struct is `Send + Sync` and shuts down cleanly on `Drop`: dropping the
-//! sender closes the channel, the worker completes any in-progress workload,
-//! its `recv()` returns `Err`, and the `JoinOnDrop` handle joins the thread.
+//! sender closes the channel, the worker completes the in-progress workload and
+//! any queued ones, its `recv()` returns `Err`, and the `JoinOnDrop` handle joins
+//! the thread.
 
 use crate::JoinOnDrop;
 use crossbeam_channel::{Sender, TrySendError, bounded};
-use prometheus::IntCounter;
+use prometheus::Histogram;
 
 /// A workload to be executed by the worker thread.
 pub type Workload = Box<dyn FnOnce() + Send>;
 
 enum Job {
     Workload(Workload),
-    /// Test-only barrier: enqueued with `send()`, will only unblock when the worker
-    /// thread is idle (having completed any in-progress job).
-    Flush(),
+    /// Test-only barrier: the worker acknowledges it once it has completed all
+    /// jobs enqueued before it.
+    Flush(Sender<()>),
 }
 
 /// A worker thread that executes workloads in the background.
 pub struct WorkerThread {
     sender: Sender<Job>,
-    skipped: IntCounter,
+    blocked_duration: Histogram,
     _handle: JoinOnDrop<()>,
 }
 
 impl WorkerThread {
-    pub fn new(name: &str, skipped: IntCounter) -> Self {
-        // Synchronous channel: worker blocks on `recv()`, sender, using `try_send()`
-        // doesn't block when enqueuing jobs.
-        let (sender, receiver) = bounded::<Job>(0);
+    /// Spawns a worker thread, with a channel of the given capacity.
+    /// `blocked_duration` records how long each `enqueue()` call had to block (zero
+    /// if it did not).
+    pub fn new(name: &str, capacity: usize, blocked_duration: Histogram) -> Self {
+        let (sender, receiver) = bounded::<Job>(capacity);
 
         let handle = JoinOnDrop::new(
             std::thread::Builder::new()
@@ -45,8 +48,10 @@ impl WorkerThread {
                             Job::Workload(workload) => {
                                 workload();
                             }
-                            Job::Flush() => {
-                                // No need to do anything: sender already knows the worker is idle.
+                            Job::Flush(ack) => {
+                                // All jobs enqueued earlier have been completed. Ignore send errors, the sender
+                                // may have given up waiting.
+                                let _ = ack.send(());
                             }
                         }
                     }
@@ -55,20 +60,26 @@ impl WorkerThread {
         );
         Self {
             sender,
-            skipped,
+            blocked_duration,
             _handle: handle,
         }
     }
 
-    /// Enqueues a workload. If the worker is busy and the channel is full, drops
-    /// the workload and increments the `skipped` counter rather than blocking the
-    /// caller.
+    /// Enqueues a workload, blocking if the channel is full (i.e. until the worker
+    /// thread has caught up).
     pub fn enqueue(&self, workload: Workload) {
         match self.sender.try_send(Job::Workload(workload)) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => {
-                self.skipped.inc();
+            Ok(()) => {
+                self.blocked_duration.observe(0.0);
             }
+
+            Err(TrySendError::Full(job)) => {
+                let _timer = self.blocked_duration.start_timer();
+                self.sender
+                    .send(job)
+                    .expect("worker thread has exited unexpectedly");
+            }
+
             Err(TrySendError::Disconnected(_)) => {
                 // Don't allow the worker thread to exit silently (e.g. by panicking).
                 panic!("worker thread has exited unexpectedly");
@@ -76,13 +87,19 @@ impl WorkerThread {
         }
     }
 
-    /// Test-only: blocks until the worker thread has completed any previous
-    /// workload.
+    /// Test-only: blocks until the worker thread has completed all current and/or
+    /// enqueued workloads.
     #[doc(hidden)]
     pub fn flush_channel(&self) {
-        // Blocking send waits for the worker thread to complete any in-progress job.
+        // Capacity of 1, so the worker thread never blocks on acknowledging.
+        let (ack, ack_receiver) = bounded::<()>(1);
         self.sender
-            .send(Job::Flush())
+            .send(Job::Flush(ack))
+            .expect("worker thread has exited unexpectedly");
+        // Jobs are executed in order, so the acknowledgement means that all workloads
+        // enqueued before the barrier have been completed.
+        ack_receiver
+            .recv()
             .expect("worker thread has exited unexpectedly");
     }
 }
@@ -91,48 +108,91 @@ impl WorkerThread {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
 
-    fn skipped_counter() -> IntCounter {
+    fn blocked_duration_histogram() -> Histogram {
         let registry = ic_metrics::MetricsRegistry::new();
-        registry.int_counter("test_skipped", "Skipped workloads.")
+        registry.histogram(
+            "test_blocked_duration",
+            "Time spent blocked enqueuing workloads.",
+            vec![0.0, 1.0],
+        )
     }
 
+    /// Every enqueued workload is executed, however many of them there are and
+    /// whatever the channel capacity.
     #[test]
-    fn enqueue_does_not_block_caller_under_load() {
-        // Spam the worker with many workloads and ensure that the caller is
-        // never blocked: with a synchronous channel, the surplus must be
-        // dropped via the `skipped` counter rather than queued. We only
-        // assert that the loop completes promptly and that `skipped + processed`
-        // accounts for all the workloads we attempted.
+    fn all_workloads_are_executed() {
         const N: u64 = 1_000;
 
-        let completed = Arc::new(AtomicU64::new(0));
-        let skipped = skipped_counter();
+        for capacity in [0, 1, 10] {
+            let completed = Arc::new(AtomicU64::new(0));
+            let blocked_duration = blocked_duration_histogram();
 
-        let worker_thread = WorkerThread::new("test_worker_thread_skip", skipped.clone());
-        // Wait for the worker thread to become responsive.
-        worker_thread.flush_channel();
+            let worker_thread = WorkerThread::new(
+                "test_worker_thread_execute_all",
+                capacity,
+                blocked_duration.clone(),
+            );
 
-        for _ in 0..N {
-            let completed = Arc::clone(&completed);
-            worker_thread.enqueue(Box::new(move || {
-                completed.fetch_add(1, Ordering::Relaxed);
-            }));
+            for _ in 0..N {
+                let completed = Arc::clone(&completed);
+                worker_thread.enqueue(Box::new(move || {
+                    completed.fetch_add(1, Ordering::Relaxed);
+                }));
+            }
+            worker_thread.flush_channel();
+
+            assert_eq!(N, completed.load(Ordering::Relaxed));
+            assert_eq!(N, blocked_duration.get_sample_count());
         }
+    }
+
+    /// Enqueuing blocks (and records the time spent blocked) while the worker
+    /// thread is busy and the channel is full.
+    #[test]
+    fn enqueue_blocks_while_channel_is_full() {
+        const WORKLOAD_DURATION: Duration = Duration::from_millis(100);
+
+        let blocked_duration = blocked_duration_histogram();
+        let worker_thread =
+            WorkerThread::new("test_worker_thread_block", 0, blocked_duration.clone());
+
+        // With a zero capacity channel, this workload is picked up immediately.
+        worker_thread.enqueue(Box::new(|| std::thread::sleep(WORKLOAD_DURATION)));
+
+        // And this one can only be enqueued once the above has completed.
+        let since = Instant::now();
+        worker_thread.enqueue(Box::new(|| {}));
+        assert!(since.elapsed() >= WORKLOAD_DURATION / 2);
+        assert!(blocked_duration.get_sample_sum() > 0.0);
+    }
+
+    /// Flushing waits for the in-progress workload to complete.
+    #[test]
+    fn flush_waits_for_workload_completion() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let worker_thread =
+            WorkerThread::new("test_worker_thread_flush", 1, blocked_duration_histogram());
+
+        let workload_completed = Arc::clone(&completed);
+        worker_thread.enqueue(Box::new(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            workload_completed.store(true, Ordering::Relaxed);
+        }));
         worker_thread.flush_channel();
 
-        // Completed vs skipped counts are non-deterministic (scheduling dependent), but
-        // they should both be non-zero and must sum to the number of attempts.
-        let completed = completed.load(Ordering::Relaxed);
-        assert!(completed > 0);
-        assert!(skipped.get() > 0);
-        assert_eq!(completed + skipped.get(), N);
+        assert!(completed.load(Ordering::Relaxed));
     }
 
     #[test]
     fn flush_is_a_no_op_when_idle() {
-        let worker_thread = WorkerThread::new("test_worker_thread_flush_idle", skipped_counter());
+        let worker_thread = WorkerThread::new(
+            "test_worker_thread_flush_idle",
+            1,
+            blocked_duration_histogram(),
+        );
         // Should return promptly even with nothing in the queue.
         worker_thread.flush_channel();
     }


### PR DESCRIPTION
`ReplicatedStateMetrics` are observed asynchronously, from a worker thread triggered by `StateManager::commit_and_certify()`. A zero capacity channel between StateManager and the worker thread means that whenever the worker thread is busy (which is often true during excessively high load, such as when lots of tests run concurrently) some metric observations are skipped, so waiting for the worker thread to complete its current observation is not sufficient to ensure correctness.

Instead, make `WorkerThread::enqueue()` blocking, so no metric observations are ever skipped (particularly since the `state_manager_skipped_state_observations` metric shows that on busy subnets we skip about 5% of `ReplicatedStateMetrics` observations, which is not ideal). And make the `WorkerThread` channel size configurable, with `ReplicatedStateMetricsThread` using a size 1 channel, to make it less likely for the DSM main thread to block when enqueuing metrics observations in case the worker thread was not scheduled (which apparently happens in the replica under heavy load).