### PR TITLE
fix(node-rewards): correct the second reward reduction cohort

### DIFF
--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -292,9 +292,9 @@ const REWARD_REDUCTIONS: &[RewardReduction] = &[
         ],
     },
     // Second round: 50% for three months for the node providers that failed to respond within the
-    // 24h window in BOTH of the two most recent incident-response smoke tests (June 13 and July 27,
-    // 2026) — the same "two consecutive misses" rule as the first round, moved forward by one
-    // drill. A late (>24h) response counts as a failure. Providers from the round above that have
+    // 24h window in BOTH of the incident-response smoke tests of June 13 and July 27, 2026 — the
+    // same "two consecutive misses" rule as the first round, applied to the drill pair that follows
+    // it. A late (>24h) response counts as a failure. Providers from the round above that have
     // since recovered are deliberately absent here, so their reduction ends with that round's
     // window on 2026-10-15 and they are rewarded in full from the second half of October on.
     // Providers in both rounds are reduced continuously from 2026-07-15 to 2026-11-01 — at 50%,

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -291,12 +291,23 @@ const REWARD_REDUCTIONS: &[RewardReduction] = &[
             "hzqcb-iiagd-4erjo-qn7rq-syqro-zztl6-cpble-atnkd-2c6bg-bxjoa-qae", // Zondax AG
         ],
     },
-    // Second round: 50% for three months for the node providers that failed the incident-response
-    // requirement in the follow-up review. Providers from the round above that have since recovered
-    // are deliberately absent here, so their reduction ends with that round's window on 2026-10-15
-    // and they are rewarded in full from the second half of October on. Providers in both rounds
-    // are reduced continuously from 2026-07-15 to 2026-11-01 — at 50%, not 25%, on the overlapping
-    // days.
+    // Second round: 50% for three months for the node providers that failed to respond within the
+    // 24h window in BOTH of the two most recent incident-response smoke tests (June 13 and July 27,
+    // 2026) — the same "two consecutive misses" rule as the first round, moved forward by one
+    // drill. A late (>24h) response counts as a failure. Providers from the round above that have
+    // since recovered are deliberately absent here, so their reduction ends with that round's
+    // window on 2026-10-15 and they are rewarded in full from the second half of October on.
+    // Providers in both rounds are reduced continuously from 2026-07-15 to 2026-11-01 — at 50%,
+    // not 25%, on the overlapping days.
+    //
+    // Corrected on 2026-08-12: this cohort was originally populated from the July 27 drill alone
+    // rather than the June 13 + July 27 pair. That wrongly included MI Servers, which replied in
+    // time in June and so never missed two in a row, and wrongly omitted ParaFi Technologies NS
+    // LLC, which was late in both. Editing an existing entry is admissible here only because no
+    // day of this window had been minted yet — the 2026-07-15..2026-08-15 reward period was still
+    // open — so nothing already paid out is rewritten. See the append-only note above; once a day
+    // in the window has been minted, a wrongly included provider can no longer be made whole
+    // through this table, because multipliers are constrained to (0, 1).
     RewardReduction {
         start: (2026, 8, 1),
         end: (2026, 11, 1),
@@ -314,8 +325,8 @@ const REWARD_REDUCTIONS: &[RewardReduction] = &[
             "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe", // Extragone SA
             "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae", // Iancu Aurel
             "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe", // InfoObjects
-            "izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe", // MI Servers
             "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae", // Neptune Partners
+            "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe", // ParaFi Technologies NS LLC
             "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae", // Reist Telecom AG
             "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae", // Starbase
             "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe", // Zarety
@@ -927,5 +938,26 @@ mod reward_reduction_tests {
                 "duplicate provider in a reward reduction round"
             );
         }
+    }
+
+    /// The second round is the June 13 + July 27 pair, not the July 27 drill alone. Pinned by
+    /// principal: the count-based assertions above survive a one-for-one swap, which is exactly
+    /// how these two providers were originally mis-assigned.
+    #[test]
+    fn second_round_follows_the_two_consecutive_misses_rule() {
+        let second_round = REWARD_REDUCTIONS[1].providers;
+
+        // Late in both June and July — a late reply counts as a failure, so in scope.
+        assert!(
+            second_round
+                .contains(&"2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe"),
+            "ParaFi Technologies NS LLC replied late in both drills and belongs in the second round"
+        );
+        // Replied in time in June and missed only July, so it never missed two drills in a row.
+        assert!(
+            !second_round
+                .contains(&"izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe"),
+            "MI Servers missed only the July drill and must not be reduced"
+        );
     }
 }

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -970,4 +970,85 @@ mod reward_reduction_tests {
             "MI Servers missed only the July drill and must not be reduced"
         );
     }
+
+    // The exact cohort of each round, pinned by principal. The assertions in
+    // `reward_reduction_round_membership_is_as_intended` are count-based and survive a
+    // one-for-one swap, which is how MI Servers and ParaFi Technologies NS LLC were originally
+    // mis-assigned. Only a literal list makes a cohort change visible in review. This is a
+    // deliberate second copy of each cohort: changing a round means changing both, and the drill
+    // outcomes in the comments are the reason each provider is in the list.
+
+    /// First round: missed the 24h window in BOTH the May 20 and June 13, 2026 drills.
+    const FIRST_ROUND_COHORT: [&str; 19] = [
+        "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe", // 43rd Big Idea Films (no reply / no reply)
+        "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe", // 87m Neuron (late / no reply)
+        "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe", // 100 Count Holdings (late / late)
+        "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe", // Arceau NP LLC (no reply / no reply)
+        "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe", // Bitmoon (no reply / no reply)
+        "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe", // BLP22 (late / no reply)
+        "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae", // BlockTech Ventures (no reply / no reply)
+        "i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe", // Conic Ventures (no reply / no reply)
+        "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe", // Decentralized Entities Foundation (no reply / no reply)
+        "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe", // Extragone SA (no reply / no reply)
+        "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae", // Iancu Aurel (no reply / no reply)
+        "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe", // InfoObjects (no reply / no reply)
+        "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae", // Neptune Partners (no reply / no reply)
+        "r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae", // Pindar Technology Limited (no reply / no reply)
+        "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae", // Power Meta Corporation (no reply / no reply)
+        "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe", // Wancloud limited (late / late)
+        "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe", // Zarety (no reply / no reply)
+        "pa5mu-yxsey-b4yrk-bodka-dhjnm-a3nx4-w2grw-3b766-ddr6e-nupu4-pqe", // Zenith Code LLC (no reply / no reply)
+        "hzqcb-iiagd-4erjo-qn7rq-syqro-zztl6-cpble-atnkd-2c6bg-bxjoa-qae", // Zondax AG (no reply / no reply)
+    ];
+
+    /// Second round: missed the 24h window in BOTH the June 13 and July 27, 2026 drills.
+    const SECOND_ROUND_COHORT: [&str; 18] = [
+        "2dgp4-h57n4-a4kgx-n4uun-huo3a-wbdlc-m57wd-jtkuh-g5vcc-fcbby-6qe", // 100 Count Holdings (late / no reply)
+        "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe", // 43rd Big Idea Films (no reply / no reply)
+        "cp5ib-twnmx-h4dvd-isef2-tu44u-kb2ka-fise5-m4hta-hnxoq-k45mm-hqe", // ACCUSET SOLUTIONS (no reply / no reply)
+        "kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae", // Anonstake (no reply / no reply)
+        "ss6oe-fm7b2-b5r57-y3x74-omrz5-d5pgy-5iwtw-4aew5-aqj3l-6ydra-wqe", // Arceau NP LLC (no reply / no reply)
+        "mjnyf-lzqq6-s7fzb-62rqm-xzvge-5oa26-humwp-dvwxp-jxxkf-hoel7-fqe", // Bitmoon (no reply / no reply)
+        "ks7ow-zvs7i-ratdk-azq34-zio2b-gbekj-qjicg-pfhp3-ovhgu-k5qql-dae", // BlockTech Ventures (no reply / no reply)
+        "sma3p-ivkif-hz7nu-ngmvq-ibnjg-nubke-zf6gh-wbnfc-2dlng-l3die-zqe", // BLP22 (no reply / no reply)
+        "w4buy-lgwzr-pccs7-huzhh-qqnws-rns75-iaoox-jolrm-xs2ra-vdu3o-2qe", // Decentralized Entities Foundation (no reply / no reply)
+        "7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe", // Extragone SA (no reply / no reply)
+        "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae", // Iancu Aurel (no reply / no reply)
+        "7ws2n-wqorv-vmo4m-5e222-n42c3-hk43s-ei3kp-4hpbn-xlkzo-jgv7i-tqe", // InfoObjects (no reply / no reply)
+        "4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae", // Neptune Partners (no reply / no reply)
+        "2hl5k-umjdt-ykii4-goecz-kkps6-nvl53-l7ost-p4mcp-qmnmw-rzrfc-mqe", // ParaFi Technologies NS LLC (late / late)
+        "ma7dp-gz4tg-3c2wv-pgnsv-wna7u-czvhu-fpu47-t4dr6-gzxql-wr2m2-qae", // Reist Telecom AG (no reply / no reply)
+        "sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae", // Starbase (no reply / no reply)
+        "glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe", // Zarety (no reply / no reply)
+        "hzqcb-iiagd-4erjo-qn7rq-syqro-zztl6-cpble-atnkd-2c6bg-bxjoa-qae", // Zondax AG (no reply / no reply)
+    ];
+
+    #[test]
+    fn reward_reduction_cohorts_are_pinned() {
+        assert_eq!(
+            REWARD_REDUCTIONS.len(),
+            2,
+            "a new round needs a pinned cohort here"
+        );
+        for (round, expected, label) in [
+            (
+                &REWARD_REDUCTIONS[0],
+                FIRST_ROUND_COHORT.as_slice(),
+                "first",
+            ),
+            (
+                &REWARD_REDUCTIONS[1],
+                SECOND_ROUND_COHORT.as_slice(),
+                "second",
+            ),
+        ] {
+            let actual: BTreeSet<&str> = round.providers.iter().copied().collect();
+            let expected: BTreeSet<&str> = expected.iter().copied().collect();
+            assert_eq!(
+                actual, expected,
+                "{label} round cohort changed; update it only together with the drill results it \
+                 encodes"
+            );
+        }
+    }
 }

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -233,11 +233,21 @@ impl NodeRewardsCanister {
 //   * Each window is expressed as fixed UTC calendar dates. Reward calculation is deterministic
 //     given the stored daily metrics, so querying any past day always returns the same result, and
 //     each entry's reduction reverts automatically at its `end` without a further upgrade.
-//   * Entries are only ever APPENDED, never edited or removed — not even once their window has
-//     passed. Nothing in this canister persists computed rewards: every query recomputes the
-//     requested days from the stored raw metrics using the table compiled into the running Wasm.
-//     Editing or deleting a past entry therefore silently rewrites the canister's account of days
-//     that have already been minted.
+//   * An entry MUST NOT be changed once any day in its window has been minted. Nothing in this
+//     canister persists computed rewards: every query recomputes the requested days from the
+//     stored raw metrics using the table compiled into the running Wasm. Editing or deleting an
+//     entry that covers a minted day therefore silently rewrites this canister's account of what
+//     was paid, in either direction: a removed provider reads as never reduced, an added one as
+//     reduced on days it was in fact paid in full.
+//   * In practice that makes the table append-only. A window that has already started is normally
+//     partly minted, so correcting a live entry is admissible only in the narrow case where no day
+//     of its window has been minted yet, and only until the open reward period is minted. The
+//     second round was corrected under exactly that exception on 2026-08-12; see the note on that
+//     entry. Treat it as the exception rather than the precedent: when in doubt, append.
+//   * A wrongly INCLUDED provider cannot be made whole through this table once its days are
+//     minted, because multipliers are constrained to (0, 1) and no entry can raise rewards. A
+//     wrongly OMITTED provider can always be added by a later entry, though its window then starts
+//     later than the rest of its cohort's.
 //   * A new entry's `start` must not predate the first day of the current, not-yet-minted reward
 //     period. Governance advances its reward period past every day it has minted and never
 //     recomputes those days, so a reduction reaching further back is a no-op in terms of tokens
@@ -259,7 +269,8 @@ struct RewardReduction {
     providers: &'static [&'static str],
 }
 
-/// The reward reductions applied so far, in the order they were introduced. Append-only; see the
+/// The reward reductions applied so far, in the order they were introduced. Entries are appended,
+/// not edited: an entry covering a day that has already been minted must never change. See the
 /// design notes above before touching an existing entry.
 const REWARD_REDUCTIONS: &[RewardReduction] = &[
     // First round: 50% for three months for the node providers that failed to respond within the
@@ -303,11 +314,10 @@ const REWARD_REDUCTIONS: &[RewardReduction] = &[
     // Corrected on 2026-08-12: this cohort was originally populated from the July 27 drill alone
     // rather than the June 13 + July 27 pair. That wrongly included MI Servers, which replied in
     // time in June and so never missed two in a row, and wrongly omitted ParaFi Technologies NS
-    // LLC, which was late in both. Editing an existing entry is admissible here only because no
-    // day of this window had been minted yet — the 2026-07-15..2026-08-15 reward period was still
-    // open — so nothing already paid out is rewritten. See the append-only note above; once a day
-    // in the window has been minted, a wrongly included provider can no longer be made whole
-    // through this table, because multipliers are constrained to (0, 1).
+    // LLC, which was late in both. This edit fell under the narrow exception described in the
+    // design notes above: no day of this window had been minted yet, since the
+    // 2026-07-15..2026-08-15 reward period was still open, so nothing already paid out was
+    // rewritten.
     RewardReduction {
         start: (2026, 8, 1),
         end: (2026, 11, 1),


### PR DESCRIPTION
## What

The second node provider reward reduction round (added in #10965 / proposal 143260) was populated from the **July 27 smoke test alone** rather than from the **June 13 + July 27 pair**, so it did not implement the "failed two consecutive drills" rule established by motion 142724.

Two providers were affected:

| Provider | Jun 13 | Jul 27 | Was | Should be | Why |
|---|:--:|:--:|---|---|---|
| **MI Servers** (37 nodes) | ✅ in 24h | ❌ no reply | in round 2 | **out** | Replied in time in June — never missed two in a row |
| **ParaFi Technologies NS LLC** (37 nodes) | ⚠️ late | ⚠️ late | absent | **in** | Late in both, and a late reply counts as a failure |

Round 2 stays at 18 providers. **Round 1 is unchanged.**

## Why this is safe to edit rather than append

The table is append-only precisely because editing a past entry silently rewrites days that have already been minted. That does not apply here: round 2 starts 2026-08-01 and **no day of its window has been minted yet** — the 2026-07-15..2026-08-15 reward period is still open. Nothing already paid out is rewritten.

This is also why it is urgent. The next minting is due **on or just after 2026-08-14 12:39 UTC** (governance mints every `ONE_YEAR_SECONDS / 12` = 30.4375 days; last mint was 2026-07-15 02:09 UTC per `get_most_recent_monthly_node_provider_rewards`). After that, MI Servers will have been paid at 50% for the first half of August and cannot be made whole through this table, because multipliers are constrained to `(0, 1)`.

## Duration for the 13 providers in both rounds

The 13 providers in both rounds are reduced continuously from 2026-07-15 to 2026-11-01, so 3.5 months rather than three. That is the intended outcome, not an artefact of the overlap: they missed the May 20 + June 13 pair and then missed the June 13 + July 27 pair, and each pair of consecutive misses starts a fresh three-month clock. Round 1's window is therefore deliberately left as it is.

This settles the open question raised in #10965, which asked whether the first round's `end` should instead be shortened so those providers get three months in total. Under a restarting clock it should not, and shortening it would in any case rewrite days that have already been minted.

## Verification against the rule

Both rounds were re-derived from the drill results below, independently of the code, and now match it exactly:

- **Round 1** = failed 20 May **and** 13 Jun → **19 providers** ✅ matches
- **Round 2** = failed 13 Jun **and** 27 Jul → **18 providers** ✅ matches

Before this change, round 2 was instead exactly the 27 Jul "no reply" list.

## Full smoke test tracking table

All 79 providers that were in the population for at least one drill. A **late (>24h) reply counts as a failure**, same as no reply.

✅ replied in 24h · ⚠️ late · ❌ no reply · – not in that drill's population · ● in that reduction round

| Node provider | 20 May | 13 Jun | 27 Jul | R1 | R2 | Nodes |
|---|:--:|:--:|:--:|:--:|:--:|--:|
| 100 Count Holdings, LLC | ⚠️ | ⚠️ | ❌ | ● | ● | 28 |
| 43rd Big Idea Films | ❌ | ❌ | ❌ | ● | ● | 14 |
| 87m Neuron, LLC | ⚠️ | ❌ | ✅ | ● |  | 42 |
| ACCUSET SOLUTIONS | ✅ | ❌ | ❌ |  | ● | 10 |
| achermann.swiss | ✅ | ❌ | ✅ |  |  | 1 |
| Aitubi AG | ✅ | ✅ | ✅ |  |  | 1 |
| Allusion | ✅ | ✅ | ✅ |  |  | 37 |
| AlpineDC SA | ✅ | ⚠️ | ✅ |  |  | 1 |
| Anonstake | ✅ | ❌ | ❌ |  | ● | 16 |
| ANTHONY ISAAKIDIS | ✅ | ✅ | ✅ |  |  | 23 |
| ANYPOINT PTY LTD | ✅ | ❌ | ✅ |  |  | 10 |
| Arceau NP LLC | ❌ | ❌ | ❌ | ● | ● | 23 |
| Artem Horodyskyi | ✅ | ✅ | ✅ |  |  | 7 |
| Avalution AG | ✅ | ❌ | ✅ |  |  | 1 |
| Bianca-Martina Rohner | ✅ | ✅ | ✅ |  |  | 4 |
| Bigger Capital | ✅ | ✅ | ✅ |  |  | 28 |
| Bitmoon | ❌ | ❌ | ❌ | ● | ● | 3 |
| Blockchain Development Labs | ✅ | ✅ | ✅ |  |  | 42 |
| Blockchain Innovation Group | ✅ | ✅ | ✅ |  |  | 1 |
| BlockFinance | ✅ | ✅ | ✅ |  |  | 9 |
| BlockTech Ventures, LLC | ❌ | ❌ | ❌ | ● | ● | 28 |
| BLP22, LLC | ⚠️ | ❌ | ❌ | ● | ● | 14 |
| Blue Ant LLC | ❌ | ✅ | ⚠️ |  |  | 37 |
| Conic Ventures | ❌ | ❌ | ✅ | ● |  | 4 |
| CoreLedger | ✅ | ❌ | ✅ |  |  | 1 |
| Decentralized | ✅ | ❌ | ✅ |  |  | 1 |
| Decentralized Entities Foundation | ❌ | ❌ | ❌ | ● | ● | 17 |
| Extragone SA | ❌ | ❌ | ❌ | ● | ● | 37 |
| Fractal Labs AG | ✅ | ✅ | ✅ |  |  | 37 |
| Geeta Kalwani | ✅ | ✅ | ✅ |  |  | 4 |
| Geodd Pvt Ltd | ✅ | ✅ | ✅ |  |  | 6 |
| GeoNodes LLC | ✅ | ✅ | ✅ |  |  | 16 |
| George Bassadone | ✅ | ✅ | ✅ |  |  | 25 |
| Giant Leaf, LLC | ❌ | ✅ | ✅ |  |  | 37 |
| Honeycomb Capital (Pty) Ltd | ✅ | ✅ | ✅ |  |  | 12 |
| Iancu Aurel | ❌ | ❌ | ❌ | ● | ● | 28 |
| Icaria Systems Pty Ltd | ✅ | ✅ | ✅ |  |  | 18 |
| Illusions In Art (Pty) Ltd | ✅ | ✅ | ✅ |  |  | 6 |
| InfoObjects | ❌ | ❌ | ❌ | ● | ● | 4 |
| Ivanov Oleksandr | ✅ | ✅ | ✅ |  |  | 7 |
| Karel Frank | ✅ | ✅ | ✅ |  |  | 18 |
| Kontrapunt (Pty) Ltd | ✅ | ✅ | ✅ |  |  | 6 |
| Krishna Enterprises | ✅ | ⚠️ | ✅ |  |  | 15 |
| LTIN AG | ✅ | ✅ | ✅ |  |  | 1 |
| Lukas Helebrandt | ✅ | ✅ | ✅ |  |  | 6 |
| Maksym Ishchenko | ✅ | ✅ | ✅ |  |  | 7 |
| Mariano Stoll | ✅ | ✅ | ✅ |  |  | 4 |
| Marvelous Web3 | ✅ | ❌ | ✅ |  |  | 14 |
| MB Patrankos šūvis | ✅ | ✅ | ✅ |  |  | 10 |
| MI Servers **← removed** | ✅ | ✅ | ❌ |  |  | 37 |
| Neptune Partners | ❌ | ❌ | ❌ | ● | ● | 25 |
| NODAO | ✅ | ✅ | ✅ |  |  | 37 |
| NOKU SA | ✅ | ❌ | – |  |  | 1 |
| NoviSystems, LLC | ✅ | ✅ | ✅ |  |  | 3 |
| OneSixtyTwo Digital Capital | ✅ | ✅ | ✅ |  |  | 42 |
| Origin Game | ⚠️ | ✅ | ✅ |  |  | 7 |
| ParaFi Technologies NS LLC **← added** | ✅ | ⚠️ | ⚠️ |  | ● | 37 |
| Pindar Technology Limited | ❌ | ❌ | ✅ | ● |  | 36 |
| Power Meta Corporation | ❌ | ❌ | ✅ | ● |  | 5 |
| Privoxy Solutions, LLC | ✅ | ✅ | ✅ |  |  | 3 |
| Protocol16 | ✅ | ✅ | ✅ |  |  | 23 |
| Reist Telecom AG | ✅ | ❌ | ❌ |  | ● | 23 |
| Rivram Inc | ✅ | ⚠️ | ✅ |  |  | 13 |
| senseLAN | ✅ | ✅ | ✅ |  |  | 1 |
| SolNet | ✅ | ⚠️ | ✅ |  |  | 1 |
| Starbase | ✅ | ❌ | ❌ |  | ● | 38 |
| Swiss Datalink AG | ✅ | ❌ | ✅ |  |  | 1 |
| Sygnum Bank | ✅ | ✅ | ✅ |  |  | 37 |
| Tomahawk | ✅ | ✅ | – |  |  | — |
| Uvaca Labs LLC | ⚠️ | ✅ | ⚠️ |  |  | 23 |
| vestra ICT AG | ✅ | ❌ | ✅ |  |  | 1 |
| Virtual Hive Ltd | ✅ | ✅ | ✅ |  |  | 23 |
| Vladyslav Popov | ✅ | ✅ | ✅ |  |  | 14 |
| Wancloud limited | ⚠️ | ⚠️ | ✅ | ● |  | 10 |
| Web3game | ⚠️ | ✅ | ✅ |  |  | 17 |
| Wolkboer (Pty) Ltd | ✅ | ✅ | ✅ |  |  | 6 |
| Zarety LLC | ❌ | ❌ | ❌ | ● | ● | 37 |
| Zenith Code LLC | ❌ | ❌ | ✅ | ● |  | 2 |
| Zondax AG | ❌ | ❌ | ❌ | ● | ● | 2 |

**Drill participation:** #1 20 May 55/79 · #2 13 Jun 42/79 · #3 27 Jul 56/77.

Two providers left the population and are out of scope either way: Tomahawk (left the network; replied in time in both drills it was part of) and NOKU SA (no active nodes on 27 Jul).

## Testing

Adds `second_round_follows_the_two_consecutive_misses_rule`, which pins both principals by name. The existing `reward_reduction_round_membership_is_as_intended` only asserts round sizes (19/18/13) — a one-for-one swap passes it unchanged, which is exactly how the original error went unnoticed.

- `cargo check -p ic-node-rewards-canister --lib` — clean
- `cargo fmt --check` — clean
- clippy `--all-targets` with the repo's deny-set — clean
- `bazel build //rs/node_rewards/canister:{nrc,nrc-test}` — clean
- `bazel test` on all 5 affected targets — **5/5 pass**, 36/36 tests in `nrc_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

