### PR TITLE
chore: Better error messages for invalid pubkeys

### DIFF
--- a/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
@@ -99,6 +99,10 @@ pub fn algo_id_and_public_key_bytes_from_der(
     kp.get_algo_id_and_public_key_bytes()
 }
 
+/// The maximum nesting depth of constructed ASN.1 elements accepted in a
+/// DER-encoded key.
+pub const MAX_DER_NESTING_DEPTH: usize = 4;
+
 /// Parser for DER-encoded keys.
 struct KeyDerParser {
     key_der: Vec<u8>,
@@ -120,7 +124,11 @@ impl KeyDerParser {
         let asn1_parts = self.parse_pk()?;
         let key_seq = Self::ensure_single_asn1_sequence(asn1_parts)?;
         if key_seq.len() != 2 {
-            return Err(Self::parsing_error("Expected exactly two ASN.1 blocks."));
+            return Err(Self::parsing_error(&format!(
+                "Expected the SubjectPublicKeyInfo SEQUENCE to contain 2 elements \
+                 (algorithm and subjectPublicKey), got {}",
+                key_seq.len()
+            )));
         }
 
         let algo_id = Self::algorithm_identifier(&key_seq[0])?;
@@ -157,17 +165,28 @@ impl KeyDerParser {
                     (ASN1Block::ObjectIdentifier(_, algo_oid), None) => Ok(
                         PkixAlgorithmIdentifier::new_with_empty_param(algo_oid.clone()),
                     ),
-                    (_, _) => Err(Self::parsing_error(
-                        "algorithm identifier has unexpected type",
-                    )),
+                    (_, _) => Err(Self::parsing_error(&format!(
+                        "Expected the AlgorithmIdentifier SEQUENCE to contain an OBJECT \
+                         IDENTIFIER optionally followed by NULL or another OBJECT IDENTIFIER, \
+                         got {}{}",
+                        Self::asn1_type_name(algo_oid),
+                        algo_params
+                            .map(|params| format!(" followed by {}", Self::asn1_type_name(params)))
+                            .unwrap_or_default()
+                    ))),
                 }
             } else {
-                Err(Self::parsing_error(
-                    "algorithm identifier has unexpected size",
-                ))
+                Err(Self::parsing_error(&format!(
+                    "Expected the AlgorithmIdentifier SEQUENCE to contain 1 or 2 elements \
+                     (algorithm and optional parameters), got {}",
+                    oid_parts.len()
+                )))
             }
         } else {
-            Err(Self::parsing_error("Expected algorithm identifier"))
+            Err(Self::parsing_error(&format!(
+                "Expected the algorithm to be an AlgorithmIdentifier SEQUENCE, got {}",
+                Self::asn1_type_name(oid_seq)
+            )))
         }
     }
 
@@ -175,13 +194,37 @@ impl KeyDerParser {
     fn public_key_bytes(key_part: &ASN1Block) -> Result<Vec<u8>, KeyDerParsingError> {
         if let ASN1Block::BitString(_offset, bits_count, key_bytes) = key_part {
             if *bits_count != key_bytes.len() * 8 {
-                return Err(Self::parsing_error("Inconsistent key length"));
+                return Err(Self::parsing_error(&format!(
+                    "Expected the subjectPublicKey BIT STRING to contain whole octets, \
+                     got {} bits in {} octets",
+                    bits_count,
+                    key_bytes.len()
+                )));
             }
             Ok(key_bytes.to_vec())
         } else {
             Err(Self::parsing_error(&format!(
-                "Expected BitString, got {key_part:?}"
+                "Expected the subjectPublicKey to be a BIT STRING, got {}",
+                Self::asn1_type_name(key_part)
             )))
+        }
+    }
+
+    /// Returns the name of the ASN.1 type of `block`, for use in error
+    /// messages. Only the name is returned, not the contents.
+    fn asn1_type_name(block: &ASN1Block) -> &'static str {
+        match block {
+            ASN1Block::Boolean(..) => "a BOOLEAN",
+            ASN1Block::Integer(..) => "an INTEGER",
+            ASN1Block::BitString(..) => "a BIT STRING",
+            ASN1Block::OctetString(..) => "an OCTET STRING",
+            ASN1Block::Null(..) => "NULL",
+            ASN1Block::ObjectIdentifier(..) => "an OBJECT IDENTIFIER",
+            ASN1Block::Sequence(..) => "a SEQUENCE",
+            ASN1Block::Set(..) => "a SET",
+            ASN1Block::Explicit(..) => "an explicitly tagged value",
+            ASN1Block::Unknown(..) => "a value of an unknown ASN.1 type",
+            _ => "a value of another ASN.1 type",
         }
     }
 
@@ -192,8 +235,81 @@ impl KeyDerParser {
         }
     }
 
+    /// Returns an error if `der` nests constructed ASN.1 elements more than
+    /// [`MAX_DER_NESTING_DEPTH`] levels deep. The scan only walks the
+    /// tag-length headers and leaves the actual decoding (and any other
+    /// structural error) to `simple_asn1`.
+    fn check_der_nesting_depth(der: &[u8]) -> Result<(), KeyDerParsingError> {
+        // Exclusive end offsets of the constructed elements that are currently
+        // open; their number is the current nesting depth.
+        let mut open_elements_end: Vec<usize> = Vec::new();
+        let mut index = 0;
+        while index < der.len() {
+            while let Some(&end) = open_elements_end.last() {
+                if end <= index {
+                    open_elements_end.pop();
+                } else {
+                    break;
+                }
+            }
+
+            // Identifier octets: skip the high-tag-number form if present.
+            let first_identifier_octet = der[index];
+            let constructed = first_identifier_octet & 0x20 != 0;
+            index += 1;
+            if first_identifier_octet & 0x1f == 0x1f {
+                while index < der.len() && der[index] & 0x80 != 0 {
+                    index += 1;
+                }
+                index += 1;
+            }
+
+            // Length octets: short form, or long form giving the octet count.
+            let Some(&first_length_octet) = der.get(index) else {
+                return Ok(());
+            };
+            index += 1;
+            let content_length = if first_length_octet & 0x80 == 0 {
+                first_length_octet as usize
+            } else {
+                let num_length_octets = (first_length_octet & 0x7f) as usize;
+                if num_length_octets == 0 || num_length_octets > core::mem::size_of::<usize>() {
+                    return Ok(());
+                }
+                let mut length = 0;
+                for _ in 0..num_length_octets {
+                    let Some(&octet) = der.get(index) else {
+                        return Ok(());
+                    };
+                    length = (length << 8) | octet as usize;
+                    index += 1;
+                }
+                length
+            };
+
+            let Some(content_end) = index.checked_add(content_length) else {
+                return Ok(());
+            };
+            if content_end > der.len() {
+                return Ok(());
+            }
+            if constructed {
+                if open_elements_end.len() + 1 > MAX_DER_NESTING_DEPTH {
+                    return Err(Self::parsing_error(&format!(
+                        "DER nesting depth exceeds the maximum of {MAX_DER_NESTING_DEPTH}"
+                    )));
+                }
+                open_elements_end.push(content_end);
+            } else {
+                index = content_end;
+            }
+        }
+        Ok(())
+    }
+
     /// parses the entire DER-string provided upon construction.
     fn parse_pk(&self) -> Result<Vec<ASN1Block>, KeyDerParsingError> {
+        Self::check_der_nesting_depth(&self.key_der)?;
         simple_asn1::from_der(&self.key_der)
             .map_err(|e| Self::parsing_error(&format!("Error in DER encoding: {e}")))
     }
@@ -205,12 +321,19 @@ impl KeyDerParser {
         mut parts: Vec<ASN1Block>,
     ) -> Result<Vec<ASN1Block>, KeyDerParsingError> {
         if parts.len() != 1 {
-            return Err(Self::parsing_error("Expected exactly one ASN.1 block."));
+            return Err(Self::parsing_error(&format!(
+                "Expected a single top-level SubjectPublicKeyInfo element, got {}",
+                parts.len()
+            )));
         }
-        if let ASN1Block::Sequence(_offset, part) = parts.remove(0) {
+        let part = parts.remove(0);
+        if let ASN1Block::Sequence(_offset, part) = part {
             Ok(part)
         } else {
-            Err(Self::parsing_error("Expected an ASN.1 sequence."))
+            Err(Self::parsing_error(&format!(
+                "Expected the SubjectPublicKeyInfo to be a SEQUENCE, got {}",
+                Self::asn1_type_name(&part)
+            )))
         }
     }
 }

--- a/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/tests.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/tests.rs
@@ -13,3 +13,136 @@ fn should_have_compatible_subject_public_key_info_der_encoder_and_decoder() {
     assert_eq!(algo_id.oid, oid);
     assert_eq!(pubkey_bytes, pubkey);
 }
+
+/// Encodes `content_length` in the DER definite-length form.
+fn der_definite_length(content_length: usize) -> Vec<u8> {
+    if content_length < 0x80 {
+        return vec![content_length as u8];
+    }
+    let mut length_octets = Vec::new();
+    let mut remaining = content_length;
+    while remaining > 0 {
+        length_octets.insert(0, (remaining & 0xff) as u8);
+        remaining >>= 8;
+    }
+    let mut encoded = vec![0x80 | length_octets.len() as u8];
+    encoded.extend_from_slice(&length_octets);
+    encoded
+}
+
+/// Builds a DER `NULL` wrapped in `depth` definite-length `SEQUENCE`s.
+fn sequences_around_null(depth: usize) -> Vec<u8> {
+    let null = [0x05_u8, 0x00];
+    let mut headers: Vec<Vec<u8>> = Vec::with_capacity(depth);
+    let mut inner_length = null.len();
+    for _ in 0..depth {
+        let mut header = vec![0x30_u8];
+        header.extend_from_slice(&der_definite_length(inner_length));
+        inner_length += header.len();
+        headers.push(header);
+    }
+    let mut der = Vec::with_capacity(inner_length);
+    for header in headers.iter().rev() {
+        der.extend_from_slice(header);
+    }
+    der.extend_from_slice(&null);
+    der
+}
+
+#[test]
+fn should_reject_key_with_der_nesting_above_the_maximum_depth() {
+    let der = sequences_around_null(MAX_DER_NESTING_DEPTH + 1);
+    assert!(algo_id_and_public_key_bytes_from_der(&der).is_err());
+}
+
+#[test]
+fn should_accept_der_nesting_up_to_the_maximum_depth() {
+    let der = sequences_around_null(MAX_DER_NESTING_DEPTH);
+    assert_eq!(KeyDerParser::check_der_nesting_depth(&der), Ok(()));
+}
+
+#[test]
+fn should_reject_der_nesting_above_the_maximum_depth() {
+    let der = sequences_around_null(MAX_DER_NESTING_DEPTH + 1);
+    assert!(KeyDerParser::check_der_nesting_depth(&der).is_err());
+}
+
+#[test]
+fn should_accept_realistic_public_key_der() {
+    let oid = oid!(1, 2, 3, 4, 5);
+    let der = subject_public_key_info_der(oid, b"subject public key").unwrap();
+    assert_eq!(KeyDerParser::check_der_nesting_depth(&der), Ok(()));
+}
+
+#[test]
+fn should_name_the_asn1_type_of_an_unexpected_subject_public_key() {
+    let der = simple_asn1::to_der(&ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Sequence(0, vec![ASN1Block::ObjectIdentifier(0, oid!(1, 2, 3, 4, 5))]),
+            ASN1Block::OctetString(0, b"subject public key".to_vec()),
+        ],
+    ))
+    .unwrap();
+
+    let error = algo_id_and_public_key_bytes_from_der(&der).unwrap_err();
+
+    assert_eq!(
+        error.internal_error,
+        "Expected the subjectPublicKey to be a BIT STRING, got an OCTET STRING"
+    );
+}
+
+#[test]
+fn should_report_the_number_of_elements_of_a_malformed_algorithm_identifier() {
+    let der = simple_asn1::to_der(&ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Sequence(
+                0,
+                vec![
+                    ASN1Block::ObjectIdentifier(0, oid!(1, 2, 3, 4, 5)),
+                    ASN1Block::Null(0),
+                    ASN1Block::Null(0),
+                ],
+            ),
+            ASN1Block::BitString(0, 8, vec![0x00]),
+        ],
+    ))
+    .unwrap();
+
+    let error = algo_id_and_public_key_bytes_from_der(&der).unwrap_err();
+
+    assert_eq!(
+        error.internal_error,
+        "Expected the AlgorithmIdentifier SEQUENCE to contain 1 or 2 elements \
+         (algorithm and optional parameters), got 3"
+    );
+}
+
+#[test]
+fn should_report_the_types_of_unexpected_algorithm_identifier_parameters() {
+    let der = simple_asn1::to_der(&ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Sequence(
+                0,
+                vec![
+                    ASN1Block::ObjectIdentifier(0, oid!(1, 2, 3, 4, 5)),
+                    ASN1Block::Integer(0, 42.into()),
+                ],
+            ),
+            ASN1Block::BitString(0, 8, vec![0x00]),
+        ],
+    ))
+    .unwrap();
+
+    let error = algo_id_and_public_key_bytes_from_der(&der).unwrap_err();
+
+    assert_eq!(
+        error.internal_error,
+        "Expected the AlgorithmIdentifier SEQUENCE to contain an OBJECT IDENTIFIER \
+         optionally followed by NULL or another OBJECT IDENTIFIER, got an OBJECT IDENTIFIER \
+         followed by an INTEGER"
+    );
+}

--- a/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript/error_conversions/tests.rs
+++ b/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript/error_conversions/tests.rs
@@ -21,7 +21,7 @@ mod load_transcript_error_conversions {
         assert_eq!(
             result,
             DkgLoadTranscriptError::InvalidTranscript(InvalidArgumentError {
-                message: "Malformed Unspecified data: 0xNone. Internal error: some error"
+                message: "Malformed Unspecified data: <none>. Internal error: some error"
                     .to_string()
             })
         );

--- a/rs/crypto/standalone-sig-verifier/src/sign_utils.rs
+++ b/rs/crypto/standalone-sig-verifier/src/sign_utils.rs
@@ -6,7 +6,9 @@ use crate::algorithm_identifiers::{
 };
 use ic_crypto_iccsa as iccsa;
 use ic_crypto_internal_basic_sig_cose as cose;
-use ic_crypto_internal_basic_sig_der_utils::algo_id_and_public_key_bytes_from_der;
+use ic_crypto_internal_basic_sig_der_utils::{
+    PkixAlgorithmIdentifier, algo_id_and_public_key_bytes_from_der,
+};
 use ic_crypto_internal_basic_sig_rsa_pkcs1 as rsa;
 use ic_types::crypto::{AlgorithmId, BasicSig, CryptoError, CryptoResult, UserPublicKey};
 
@@ -111,11 +113,29 @@ pub fn user_public_key_from_bytes(
         return Err(CryptoError::MalformedPublicKey {
             algorithm: AlgorithmId::Unspecified,
             key_bytes: Some(bytes.to_vec()),
-            internal_error: "Unsupported or unparsable public key".to_string(),
+            internal_error: format!(
+                "Unsupported public key algorithm identifier: {}",
+                algorithm_identifier_for_error(&pkix_algo_id)
+            ),
         });
     };
 
     Ok((UserPublicKey { key, algorithm_id }, content_type))
+}
+
+/// Renders a parsed algorithm identifier for an error message, truncating
+/// long identifiers.
+fn algorithm_identifier_for_error(algo_id: &PkixAlgorithmIdentifier) -> String {
+    const MAX_CHARS: usize = 256;
+    let rendered = format!("{algo_id:?}");
+    if rendered.chars().count() <= MAX_CHARS {
+        rendered
+    } else {
+        format!(
+            "{}...",
+            rendered.chars().take(MAX_CHARS).collect::<String>()
+        )
+    }
 }
 
 /// Encodes a raw ed25519 public key into DER.

--- a/rs/crypto/tests/request_id_signatures.rs
+++ b/rs/crypto/tests/request_id_signatures.rs
@@ -370,7 +370,7 @@ fn should_fail_parsing_ec_keys_on_unsupported_curves() {
         assert_matches!(
             pk_result,
             Err(CryptoError::MalformedPublicKey { internal_error, .. })
-            if internal_error.contains("Unsupported or unparsable public key")
+            if internal_error.contains("Unsupported public key algorithm identifier")
         );
     }
 }
@@ -443,4 +443,24 @@ fn crypto_component(config: &CryptoConfig) -> CryptoComponent {
     ic_crypto_node_key_generation::generate_node_signing_keys(vault.as_ref());
 
     CryptoComponent::new(config, None, Arc::new(dummy_registry), no_op_logger(), None)
+}
+
+#[test]
+fn should_report_the_algorithm_identifier_of_an_unsupported_public_key() {
+    // A valid prime192v1 public key, i.e. a supported algorithm OID (ECDSA) with
+    // an unsupported curve OID as its parameters.
+    const VALID_PRIME192V1_PUBKEY_DER_HEX: &str = "3049301306072a8648ce3d020106082a8648ce3d0301010332000425adc4047e9dcf0d7efbe6bb6e76794555c51f0dfd6f7f90f3067f69e17e989d5969f68e9aefbef70a1788af0b86c03e";
+    let pk_der = hex::decode(VALID_PRIME192V1_PUBKEY_DER_HEX).expect("invalid hex");
+
+    let error = user_public_key_from_bytes(&pk_der).unwrap_err();
+
+    let CryptoError::MalformedPublicKey { internal_error, .. } = &error else {
+        panic!("unexpected error: {error}");
+    };
+    // The identifier is rendered in full, i.e. it is not truncated.
+    assert!(
+        internal_error.starts_with("Unsupported public key algorithm identifier:")
+            && !internal_error.ends_with("..."),
+        "unexpected error: {internal_error}"
+    );
 }

--- a/rs/tests/crypto/request_signature_test.rs
+++ b/rs/tests/crypto/request_signature_test.rs
@@ -6,6 +6,7 @@ use ic_agent::{
     Identity,
     identity::{AnonymousIdentity, Prime256v1Identity, Secp256k1Identity},
 };
+use ic_crypto_internal_basic_sig_der_utils::MAX_DER_NESTING_DEPTH;
 use ic_crypto_test_utils_reproducible_rng::{ReproducibleRng, reproducible_rng};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -17,6 +18,7 @@ use ic_system_test_driver::util::{
     UniversalCanister, agent_with_identity, block_on, expiry_time, random_ed25519_identity,
     sign_query, sign_read_state, sign_update,
 };
+use ic_types::PrincipalId;
 use ic_types::messages::{
     Blob, HttpCallContent, HttpCanisterUpdate, HttpQueryContent, HttpReadState,
     HttpReadStateContent, HttpRequestEnvelope, HttpUserQuery,
@@ -305,6 +307,28 @@ pub fn request_signature_test(env: TestEnv) {
                 random_ecdsa_secp256k1_identity(rng),
                 canister.canister_id(),
                 rng,
+            )
+            .await;
+
+            info!(
+                logger,
+                "Testing a request whose sender_pubkey nests DER elements beyond the accepted depth. \
+                 Should fail."
+            );
+            test_request_with_too_deeply_nested_public_key_der_is_rejected(
+                node_url.as_str(),
+                canister.canister_id(),
+            )
+            .await;
+
+            info!(
+                logger,
+                "Testing valid requests from the anonymous user again. Should succeed."
+            );
+            test_valid_request_succeeds(
+                node_url.as_str(),
+                AnonymousIdentity,
+                canister.canister_id(),
             )
             .await;
         }
@@ -915,6 +939,154 @@ async fn test_request_with_invalid_signature_fails<T: Identity + 'static>(
             assert_eq!(res.status(), 400);
         }
     }
+}
+
+// Sends a query, an update and a read_state request whose `sender_pubkey` is a
+// valid DER `NULL` wrapped in more nested `SEQUENCE`s than are accepted. Each
+// must be rejected with HTTP 400. No valid signature is needed: the envelope
+// carries an empty signature and a sender that self-authenticates to the
+// malformed key, which is enough to reach public-key parsing during request
+// authentication.
+async fn test_request_with_too_deeply_nested_public_key_der_is_rejected(
+    url: &str,
+    canister_id: Principal,
+) {
+    const NESTING_DEPTH: usize = MAX_DER_NESTING_DEPTH + 1;
+    let client = reqwest::Client::new();
+
+    let pubkey_der = sequences_around_null(NESTING_DEPTH);
+    let sender = Blob(
+        PrincipalId::new_self_authenticating(&pubkey_der)
+            .as_slice()
+            .to_vec(),
+    );
+    let arg = Blob(wasm().caller().reply_data_append().reply().build());
+    let sent = "failed to send the request";
+
+    // Query.
+    let content = HttpQueryContent::Query {
+        query: HttpUserQuery {
+            canister_id: Blob(canister_id.as_slice().to_vec()),
+            method_name: "query".to_string(),
+            arg: arg.clone(),
+            sender: sender.clone(),
+            ingress_expiry: expiry_time().as_nanos() as u64,
+            nonce: None,
+            sender_info: None,
+        },
+    };
+    let envelope = HttpRequestEnvelope {
+        content,
+        sender_delegation: None,
+        sender_pubkey: Some(Blob(pubkey_der.clone())),
+        sender_sig: Some(Blob(vec![])),
+    };
+    for api_version in ALL_QUERY_API_VERSIONS {
+        let res = client
+            .post(format!(
+                "{url}api/v{api_version}/canister/{canister_id}/query"
+            ))
+            .header("Content-Type", "application/cbor")
+            .body(serde_cbor::ser::to_vec(&envelope).unwrap())
+            .send()
+            .await
+            .expect(sent);
+        assert_eq!(res.status(), 400);
+    }
+
+    // Update.
+    let content = HttpCallContent::Call {
+        update: HttpCanisterUpdate {
+            canister_id: Blob(canister_id.as_slice().to_vec()),
+            method_name: "update".to_string(),
+            arg: arg.clone(),
+            sender: sender.clone(),
+            ingress_expiry: expiry_time().as_nanos() as u64,
+            nonce: None,
+            sender_info: None,
+        },
+    };
+    let envelope = HttpRequestEnvelope {
+        content,
+        sender_delegation: None,
+        sender_pubkey: Some(Blob(pubkey_der.clone())),
+        sender_sig: Some(Blob(vec![])),
+    };
+    for api_version in ALL_UPDATE_API_VERSIONS {
+        let res = client
+            .post(format!(
+                "{url}api/v{api_version}/canister/{canister_id}/call"
+            ))
+            .header("Content-Type", "application/cbor")
+            .body(serde_cbor::ser::to_vec(&envelope).unwrap())
+            .send()
+            .await
+            .expect(sent);
+        assert_eq!(res.status(), 400);
+    }
+
+    // Read state.
+    let content = HttpReadStateContent::ReadState {
+        read_state: HttpReadState {
+            sender: sender.clone(),
+            paths: vec![],
+            ingress_expiry: expiry_time().as_nanos() as u64,
+            nonce: None,
+        },
+    };
+    let envelope = HttpRequestEnvelope {
+        content,
+        sender_delegation: None,
+        sender_pubkey: Some(Blob(pubkey_der.clone())),
+        sender_sig: Some(Blob(vec![])),
+    };
+    for api_version in ALL_READ_STATE_API_VERSIONS {
+        let res = client
+            .post(format!(
+                "{url}api/v{api_version}/canister/{canister_id}/read_state"
+            ))
+            .header("Content-Type", "application/cbor")
+            .body(serde_cbor::ser::to_vec(&envelope).unwrap())
+            .send()
+            .await
+            .expect(sent);
+        assert_eq!(res.status(), 400);
+    }
+}
+
+// Builds a DER `NULL` wrapped in `depth` definite-length `SEQUENCE`s.
+fn sequences_around_null(depth: usize) -> Vec<u8> {
+    let null = [0x05_u8, 0x00];
+    let mut headers: Vec<Vec<u8>> = Vec::with_capacity(depth);
+    let mut inner_length = null.len();
+    for _ in 0..depth {
+        let mut header = vec![0x30_u8];
+        header.extend_from_slice(&der_definite_length(inner_length));
+        inner_length += header.len();
+        headers.push(header);
+    }
+    let mut der = Vec::with_capacity(inner_length);
+    for header in headers.iter().rev() {
+        der.extend_from_slice(header);
+    }
+    der.extend_from_slice(&null);
+    der
+}
+
+// Encodes `content_length` in the DER definite-length form.
+fn der_definite_length(content_length: usize) -> Vec<u8> {
+    if content_length < 0x80 {
+        return vec![content_length as u8];
+    }
+    let mut length_octets = Vec::new();
+    let mut remaining = content_length;
+    while remaining > 0 {
+        length_octets.insert(0, (remaining & 0xff) as u8);
+        remaining >>= 8;
+    }
+    let mut encoded = vec![0x80 | length_octets.len() as u8];
+    encoded.extend_from_slice(&length_octets);
+    encoded
 }
 
 pub fn sign_query_with_empty_domain_separator(

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -515,6 +515,26 @@ impl std::error::Error for CryptoError {
     }
 }
 
+/// The maximum number of bytes of a byte string that is hex-encoded into an
+/// error message by [`ellipsized_hex`].
+const MAX_ELLIPSIZED_HEX_BYTES: usize = 64;
+
+/// Hex-encodes `bytes` for use in an error message.
+///
+/// Byte strings longer than [`MAX_ELLIPSIZED_HEX_BYTES`] are truncated and
+/// their length is appended instead, so that error messages stay short.
+pub(crate) fn ellipsized_hex(bytes: &[u8]) -> String {
+    if bytes.len() <= MAX_ELLIPSIZED_HEX_BYTES {
+        hex::encode(bytes)
+    } else {
+        format!(
+            "{}... ({} bytes)",
+            hex::encode(&bytes[..MAX_ELLIPSIZED_HEX_BYTES]),
+            bytes.len()
+        )
+    }
+}
+
 impl fmt::Debug for CryptoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -546,7 +566,7 @@ impl fmt::Debug for CryptoError {
             CryptoError::TlsSecretKeyNotFound { certificate_der } => write!(
                 f,
                 "Cannot find TLS secret key for certificate (DER encoding) 0x{}",
-                hex::encode(certificate_der)
+                ellipsized_hex(certificate_der)
             ),
 
             CryptoError::MalformedSecretKey { algorithm, .. } => {
@@ -561,7 +581,7 @@ impl fmt::Debug for CryptoError {
                 f,
                 "Malformed {:?} public key: {}, error: {}",
                 algorithm,
-                hex::encode(key_bytes),
+                ellipsized_hex(key_bytes),
                 internal_error,
             ),
             CryptoError::MalformedPublicKey {
@@ -578,7 +598,7 @@ impl fmt::Debug for CryptoError {
                 f,
                 "Malformed {:?} signature: [{}] error: '{}'",
                 algorithm,
-                hex::encode(sig_bytes),
+                ellipsized_hex(sig_bytes),
                 internal_error
             ),
             CryptoError::MalformedPop {
@@ -589,7 +609,7 @@ impl fmt::Debug for CryptoError {
                 f,
                 "Malformed {:?} PoP: [{}] error: '{}'",
                 algorithm,
-                hex::encode(pop_bytes),
+                ellipsized_hex(pop_bytes),
                 internal_error
             ),
 
@@ -602,8 +622,8 @@ impl fmt::Debug for CryptoError {
                 f,
                 "{:?} signature could not be verified: public key {}, signature {}, error: {}",
                 algorithm,
-                hex::encode(public_key_bytes),
-                hex::encode(sig_bytes),
+                ellipsized_hex(public_key_bytes),
+                ellipsized_hex(sig_bytes),
                 internal_error,
             ),
             CryptoError::PopVerification {
@@ -615,8 +635,8 @@ impl fmt::Debug for CryptoError {
                 f,
                 "{:?} PoP could not be verified: public key {}, pop {}, error: {}",
                 algorithm,
-                hex::encode(public_key_bytes),
-                hex::encode(pop_bytes),
+                ellipsized_hex(public_key_bytes),
+                ellipsized_hex(pop_bytes),
                 internal_error,
             ),
 

--- a/rs/types/types/src/crypto/error.rs
+++ b/rs/types/types/src/crypto/error.rs
@@ -1,7 +1,7 @@
 //! Defines crypto error types.
 pub mod conversions;
 pub use super::CryptoError;
-use crate::crypto::AlgorithmId;
+use crate::crypto::{AlgorithmId, ellipsized_hex};
 use serde::{Deserialize, Serialize};
 use std::fmt; // Probably move all the errors into this file
 
@@ -29,6 +29,15 @@ impl fmt::Display for InternalError {
     }
 }
 
+/// Renders optional byte strings for an error message, hex-encoding and
+/// ellipsizing the bytes if they are present.
+fn optional_bytes_for_error(bytes: Option<&[u8]>) -> String {
+    match bytes {
+        Some(bytes) => format!("0x{}", ellipsized_hex(bytes)),
+        None => "<none>".to_string(),
+    }
+}
+
 /// Occurs if a public key is malformed.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
 pub struct MalformedPublicKeyError {
@@ -41,9 +50,9 @@ impl fmt::Display for MalformedPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Malformed {:?} public key: 0x{:?}. Internal error: {}",
+            "Malformed {:?} public key: {}. Internal error: {}",
             self.algorithm,
-            self.key_bytes.as_ref().map(hex::encode),
+            optional_bytes_for_error(self.key_bytes.as_deref()),
             self.internal_error
         )
     }
@@ -61,9 +70,9 @@ impl fmt::Display for MalformedDataError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Malformed {:?} data: 0x{:?}. Internal error: {}",
+            "Malformed {:?} data: {}. Internal error: {}",
             self.algorithm,
-            self.data.as_ref().map(hex::encode),
+            optional_bytes_for_error(self.data.as_deref()),
             self.internal_error
         )
     }

--- a/rs/types/types/src/crypto/tests.rs
+++ b/rs/types/types/src/crypto/tests.rs
@@ -259,3 +259,100 @@ mod current_node_public_keys {
         }
     }
 }
+
+mod error_messages {
+    use crate::crypto::error::{MalformedDataError, MalformedPublicKeyError};
+    use crate::crypto::{AlgorithmId, CryptoError, MAX_ELLIPSIZED_HEX_BYTES, ellipsized_hex};
+
+    #[test]
+    fn should_hex_encode_short_byte_strings_in_full() {
+        let bytes = vec![0xab_u8; MAX_ELLIPSIZED_HEX_BYTES];
+
+        assert_eq!(ellipsized_hex(&bytes), hex::encode(&bytes));
+    }
+
+    #[test]
+    fn should_ellipsize_long_byte_strings() {
+        let bytes = vec![0xab_u8; MAX_ELLIPSIZED_HEX_BYTES + 1];
+
+        let hex = ellipsized_hex(&bytes);
+
+        assert_eq!(
+            hex,
+            format!(
+                "{}... ({} bytes)",
+                hex::encode(&bytes[..MAX_ELLIPSIZED_HEX_BYTES]),
+                bytes.len()
+            )
+        );
+    }
+
+    #[test]
+    fn should_bound_the_length_of_error_messages_for_large_byte_strings() {
+        let bytes = vec![0xab_u8; 5 * 1024 * 1024];
+
+        let errors = [
+            CryptoError::MalformedPublicKey {
+                algorithm: AlgorithmId::Ed25519,
+                key_bytes: Some(bytes.clone()),
+                internal_error: "some error".to_string(),
+            },
+            CryptoError::MalformedSignature {
+                algorithm: AlgorithmId::Ed25519,
+                sig_bytes: bytes.clone(),
+                internal_error: "some error".to_string(),
+            },
+            CryptoError::SignatureVerification {
+                algorithm: AlgorithmId::Ed25519,
+                public_key_bytes: bytes.clone(),
+                sig_bytes: bytes.clone(),
+                internal_error: "some error".to_string(),
+            },
+        ];
+
+        for error in errors {
+            assert!(
+                error.to_string().len() < 1024,
+                "error message not bounded: {}",
+                &error.to_string()[..256]
+            );
+        }
+    }
+
+    #[test]
+    fn should_render_absent_byte_strings_without_hex_prefix() {
+        let public_key_error = MalformedPublicKeyError {
+            algorithm: AlgorithmId::Unspecified,
+            key_bytes: None,
+            internal_error: "some error".to_string(),
+        };
+        let data_error = MalformedDataError {
+            algorithm: AlgorithmId::Unspecified,
+            internal_error: "some error".to_string(),
+            data: None,
+        };
+
+        assert_eq!(
+            public_key_error.to_string(),
+            "Malformed Unspecified public key: <none>. Internal error: some error"
+        );
+        assert_eq!(
+            data_error.to_string(),
+            "Malformed Unspecified data: <none>. Internal error: some error"
+        );
+    }
+
+    #[test]
+    fn should_hex_encode_present_byte_strings() {
+        let error = MalformedPublicKeyError {
+            algorithm: AlgorithmId::Ed25519,
+            key_bytes: Some(vec![0x01, 0x02, 0x03]),
+            internal_error: "some error".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Malformed Ed25519 public key: 0x010203. Internal error: some error"
+        );
+    }
+}


### PR DESCRIPTION
This commit gives a bit better error messages for various ways how a public key / principal can be invalid, mainly for debuggability.