### PR TITLE
fix(node-rewards): report whether rewards were computed, and the per-message instructions

### DIFF
--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -2,6 +2,7 @@ use crate::chrono_utils::last_unix_timestamp_nanoseconds;
 use crate::metrics::MetricsManager;
 use crate::registry_querier::RegistryQuerier;
 use crate::storage::{NaiveDateStorable, VM};
+use crate::telemetry;
 use candid::Principal;
 use chrono::{DateTime, NaiveDate};
 use ic_base_types::{PrincipalId, SubnetId};
@@ -536,6 +537,14 @@ impl NodeRewardsCanister {
 
         let mut rewards_per_node_provider: BTreeMap<Principal, u64> = BTreeMap::new();
 
+        // The self-call at the end of each iteration ends that message, so one day is computed per
+        // message. That makes a day's instructions the number the subnet's instruction limits
+        // apply to — a message pauses until a later round above the per-slice limit, and traps
+        // above the per-message limit — whereas nothing bounds their sum across the call context.
+        // The costliest day is therefore what says how much headroom is left.
+        let mut instruction_counter = telemetry::InstructionCounter::default();
+        let mut max_message_instructions = 0;
+
         let algorithm_version = request.algorithm_version.unwrap_or_default();
         for day in from_date.iter_days().take_while(|d| *d <= to_date) {
             let result_for_day = canister
@@ -553,6 +562,8 @@ impl NodeRewardsCanister {
                     .or_insert(provider_rewards.total_adjusted_rewards_xdr_permyriad);
             }
 
+            max_message_instructions = max_message_instructions.max(instruction_counter.lap());
+
             #[cfg(target_arch = "wasm32")]
             let _ = ic_cdk::call::Call::bounded_wait(
                 ic_cdk::api::canister_self(),
@@ -561,6 +572,12 @@ impl NodeRewardsCanister {
             .await
             .unwrap();
         }
+
+        telemetry::PROMETHEUS_METRICS.with_borrow_mut(|metrics| {
+            metrics.record_last_get_node_providers_rewards_max_message_instructions(
+                max_message_instructions,
+            )
+        });
 
         Ok(NodeProvidersRewards {
             algorithm_version,

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -562,8 +562,6 @@ impl NodeRewardsCanister {
                     .or_insert(provider_rewards.total_adjusted_rewards_xdr_permyriad);
             }
 
-            max_message_instructions = max_message_instructions.max(instruction_counter.lap());
-
             #[cfg(target_arch = "wasm32")]
             let _ = ic_cdk::call::Call::bounded_wait(
                 ic_cdk::api::canister_self(),
@@ -571,6 +569,12 @@ impl NodeRewardsCanister {
             )
             .await
             .unwrap();
+
+            // Lapped after the self-call rather than before it: issuing the call is itself part of
+            // the message that the call ends, and the counter keeps accumulating across the
+            // boundary, so reading it here closes the measurement where the message actually
+            // ended.
+            max_message_instructions = max_message_instructions.max(instruction_counter.lap());
         }
 
         telemetry::PROMETHEUS_METRICS.with_borrow_mut(|metrics| {

--- a/rs/node_rewards/canister/src/telemetry.rs
+++ b/rs/node_rewards/canister/src/telemetry.rs
@@ -1,5 +1,23 @@
 use std::cell::RefCell;
 
+/// The instructions executed so far in the current call context, which spans every message the
+/// call is made of, not just the one running now.
+#[cfg(target_arch = "wasm32")]
+fn call_context_instructions() -> u64 {
+    ic_cdk::api::call_context_instruction_counter()
+}
+
+/// Outside a canister — in unit tests — there is no counter to read, so every measurement is zero.
+#[cfg(not(target_arch = "wasm32"))]
+fn call_context_instructions() -> u64 {
+    0
+}
+
+/// The current time, as the whole seconds since the Unix epoch that Prometheus timestamps use.
+fn now_seconds() -> f64 {
+    (crate::canister::current_time().as_nanos_since_unix_epoch() / 1_000_000_000) as f64
+}
+
 /// Instruction counter helper that counts instructions in the call context.
 pub struct InstructionCounter {
     start: u64,
@@ -10,7 +28,7 @@ impl InstructionCounter {
     /// Creates a new instruction counter.  If the argument is None,
     /// the current context instruction counter is used.
     pub fn new(start_counter: Option<u64>) -> Self {
-        let c = start_counter.unwrap_or(ic_cdk::api::call_context_instruction_counter());
+        let c = start_counter.unwrap_or(call_context_instructions());
         Self {
             start: c,
             lap_start: c,
@@ -21,7 +39,7 @@ impl InstructionCounter {
     /// lap() or (if never called) the instantiation of this counter,
     /// and returns them.
     pub fn lap(&mut self) -> u64 {
-        let now = ic_cdk::api::call_context_instruction_counter();
+        let now = call_context_instructions();
         let difference = now - self.lap_start;
         self.lap_start = now;
         difference
@@ -30,7 +48,7 @@ impl InstructionCounter {
     /// Returns the instructions executed since the instantiation of
     /// this counter.
     pub fn sum(self) -> u64 {
-        ic_cdk::api::call_context_instruction_counter() - self.start
+        call_context_instructions() - self.start
     }
 }
 
@@ -59,34 +77,56 @@ pub struct PrometheusMetrics {
     /// Records the number of instructions spent in last sync
     last_sync_instructions: f64,
 
+    /// Records the time the last node provider rewards calculation succeeded.
+    last_get_node_providers_rewards_success: f64,
+
     /// Number of instruction for executing get_node_providers_rewards
     last_get_node_providers_rewards_instructions: f64,
+
+    /// Number of instructions spent by the costliest single message of the last
+    /// get_node_providers_rewards.
+    last_get_node_providers_rewards_max_message_instructions: f64,
 }
 
 static LAST_SYNC_START_HELP: &str = "Last time the sync of metrics started.  If this metric is present but zero, the first sync during this canister's current execution has not yet begun or taken place.";
 static LAST_SYNC_END_HELP: &str = "Last time the sync of metrics ended (successfully or with failure).  If this metric is present but zero, the first sync during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last sync start should yield a positive value if the sync ended (successfully or with errors), and a negative value if the sync is still ongoing but has not finished.";
 static LAST_SYNC_SUCCESS_HELP: &str = "Last time the sync of metrics succeeded.  If this metric is present but zero, no sync has yet succeeded during this canister's current execution.  Else, subtracting this number from last_sync_start_timestamp_seconds gives a positive time delta when the last sync succeeded, or a negative value if either the last sync failed or a sync is currently being performed.  By definition, this and last_sync_end_timestamp_seconds will be identical when the last sync succeeded.";
 static LAST_SYNC_INSTRUCTIONS_HELP: &str = "Count of instructions that the last sync incurred.  Label total is the sum total of instructions, and the other labels represent different phases.";
+
+static LAST_GET_NODE_PROVIDERS_REWARDS_SUCCESS_HELP: &str = "Last time a node provider rewards calculation succeeded.  If this metric is present but zero, none has succeeded during this canister's current execution.  The calculation is attempted once a day, so a value much older than that means node provider rewards can no longer be computed, and is the condition worth alerting on.";
+
+static LAST_GET_NODE_PROVIDERS_REWARDS_INSTRUCTIONS_HELP: &str = "Count of instructions that the canister's own daily rewards calculation incurred, summed over its whole call context.  It always covers the same number of days, so it is comparable over time, but the calculation splits itself into one message per day and no instruction limit applies to the sum across them: this measures cost and its trend, not how much headroom is left.  For headroom see last_get_node_providers_rewards_max_message_instructions.";
+
+static LAST_GET_NODE_PROVIDERS_REWARDS_MAX_MESSAGE_INSTRUCTIONS_HELP: &str = "Count of instructions incurred by the costliest single message of the last rewards calculation to complete, whether that was the canister's own daily one or a caller's.  A message computes one day of the reward period, and this is the number the subnet's instruction limits apply to: above the per-slice limit a message pauses and resumes in a later round, and above the per-message limit it traps.";
+
 impl PrometheusMetrics {
     pub fn mark_last_sync_start(&mut self) {
-        self.last_sync_start = (ic_cdk::api::time() / 1_000_000_000) as f64
+        self.last_sync_start = now_seconds()
     }
 
     pub fn mark_last_sync_success(&mut self) {
-        self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
+        self.last_sync_end = now_seconds();
         self.last_sync_success = self.last_sync_end
     }
 
     pub fn mark_last_sync_failure(&mut self) {
-        self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64
+        self.last_sync_end = now_seconds()
     }
 
     pub fn record_last_sync_instructions(&mut self, total: u64) {
         self.last_sync_instructions = total as f64;
     }
 
+    pub fn mark_last_get_node_providers_rewards_success(&mut self) {
+        self.last_get_node_providers_rewards_success = now_seconds()
+    }
+
     pub fn record_last_get_node_providers_rewards_instructions(&mut self, total: u64) {
         self.last_get_node_providers_rewards_instructions = total as f64;
+    }
+
+    pub fn record_last_get_node_providers_rewards_max_message_instructions(&mut self, max: u64) {
+        self.last_get_node_providers_rewards_max_message_instructions = max as f64;
     }
 
     pub fn encode_metrics(
@@ -139,10 +179,29 @@ impl PrometheusMetrics {
             LAST_SYNC_INSTRUCTIONS_HELP,
         )?;
 
+        // Node provider rewards calculation success timestamp seconds.
+        //
+        // * 0.0 -> no calculation has succeeded since the canister started.
+        // * Any other positive number -> the last time one succeeded. The calculation is attempted
+        //   daily, so this going stale is what says rewards can no longer be computed. A failed
+        //   attempt deliberately leaves the two instruction metrics below untouched: failing early
+        //   is cheaper than succeeding, so recording it would read as the cost improving.
+        w.encode_gauge(
+            "last_get_node_providers_rewards_success_timestamp_seconds",
+            self.last_get_node_providers_rewards_success,
+            LAST_GET_NODE_PROVIDERS_REWARDS_SUCCESS_HELP,
+        )?;
+
         w.encode_gauge(
             "last_get_node_providers_rewards_instructions",
             self.last_get_node_providers_rewards_instructions,
-            LAST_SYNC_INSTRUCTIONS_HELP,
+            LAST_GET_NODE_PROVIDERS_REWARDS_INSTRUCTIONS_HELP,
+        )?;
+
+        w.encode_gauge(
+            "last_get_node_providers_rewards_max_message_instructions",
+            self.last_get_node_providers_rewards_max_message_instructions,
+            LAST_GET_NODE_PROVIDERS_REWARDS_MAX_MESSAGE_INSTRUCTIONS_HELP,
         )?;
 
         Ok(())
@@ -151,4 +210,76 @@ impl PrometheusMetrics {
 
 thread_local! {
     pub static PROMETHEUS_METRICS: RefCell<PrometheusMetrics> = RefCell::new(PrometheusMetrics::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_metrics(metrics: &PrometheusMetrics) -> String {
+        let mut encoder = ic_metrics_encoder::MetricsEncoder::new(vec![], 0);
+        metrics.encode_metrics(&mut encoder).unwrap();
+
+        String::from_utf8(encoder.into_inner()).unwrap()
+    }
+
+    /// Alert rules refer to these by name, in a repository that cannot be changed in the same
+    /// commit as this one, so renaming one silently stops the alert from ever firing again.
+    #[test]
+    fn test_reward_calculation_metrics_are_exposed_under_their_alerted_names() {
+        // Step 1: Prepare the world.
+        let mut metrics = PrometheusMetrics::default();
+
+        // Step 2: Run the code under test.
+        metrics.record_last_get_node_providers_rewards_instructions(40_000_000_000);
+        metrics.record_last_get_node_providers_rewards_max_message_instructions(1_100_000_000);
+        let encoded = encoded_metrics(&metrics);
+
+        // Step 3: Verify results.
+        assert!(
+            encoded.contains("last_get_node_providers_rewards_instructions 40000000000"),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains("last_get_node_providers_rewards_max_message_instructions 1100000000"),
+            "{encoded}"
+        );
+        // Never marked successful, so it stays at zero rather than looking recent.
+        assert!(
+            encoded.contains("last_get_node_providers_rewards_success_timestamp_seconds 0"),
+            "{encoded}"
+        );
+    }
+
+    /// The two instruction metrics describe different quantities, and the alert on headroom must
+    /// use the per-message one: only that number is bounded by the subnet's instruction limits.
+    #[test]
+    fn test_per_message_instructions_are_reported_separately_from_the_total() {
+        let mut metrics = PrometheusMetrics::default();
+
+        metrics.record_last_get_node_providers_rewards_instructions(40_000_000_000);
+        metrics.record_last_get_node_providers_rewards_max_message_instructions(1_100_000_000);
+
+        assert_eq!(
+            metrics.last_get_node_providers_rewards_instructions,
+            40_000_000_000.0
+        );
+        assert_eq!(
+            metrics.last_get_node_providers_rewards_max_message_instructions,
+            1_100_000_000.0
+        );
+    }
+
+    #[test]
+    fn test_success_is_marked_with_the_current_time() {
+        let mut metrics = PrometheusMetrics::default();
+        assert_eq!(metrics.last_get_node_providers_rewards_success, 0.0);
+
+        metrics.mark_last_get_node_providers_rewards_success();
+
+        assert_eq!(
+            metrics.last_get_node_providers_rewards_success,
+            now_seconds()
+        );
+    }
 }

--- a/rs/node_rewards/canister/src/telemetry.rs
+++ b/rs/node_rewards/canister/src/telemetry.rs
@@ -275,11 +275,16 @@ mod tests {
         let mut metrics = PrometheusMetrics::default();
         assert_eq!(metrics.last_get_node_providers_rewards_success, 0.0);
 
+        // Bracketed rather than compared to a single later reading: off wasm the clock is the real
+        // one, so the mark and that reading can land either side of a second boundary.
+        let before = now_seconds();
         metrics.mark_last_get_node_providers_rewards_success();
+        let after = now_seconds();
 
-        assert_eq!(
-            metrics.last_get_node_providers_rewards_success,
-            now_seconds()
+        let marked = metrics.last_get_node_providers_rewards_success;
+        assert!(
+            (before..=after).contains(&marked),
+            "marked {marked}, which is outside {before}..={after}"
         );
     }
 }

--- a/rs/node_rewards/canister/src/timer_tasks.rs
+++ b/rs/node_rewards/canister/src/timer_tasks.rs
@@ -239,15 +239,23 @@ impl RecurringAsyncTaskNonSend for GetNodeProvidersRewardsInstructionsExporter {
         };
 
         let instruction_counter = telemetry::InstructionCounter::default();
-        if let Err(e) =
-            NodeRewardsCanister::get_node_providers_rewards(self.canister, request).await
-        {
-            ic_cdk::println!("Failed to get node providers rewards: {:?}", e);
+        match NodeRewardsCanister::get_node_providers_rewards(self.canister, request).await {
+            Ok(_) => {
+                telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| {
+                    m.mark_last_get_node_providers_rewards_success();
+                    m.record_last_get_node_providers_rewards_instructions(
+                        instruction_counter.sum(),
+                    );
+                });
+            }
+            Err(e) => {
+                // The instruction metrics are deliberately left alone. A calculation that gives up
+                // partway through costs less than one that finishes, so recording it would show
+                // the cost falling at the moment rewards stopped being computed. What reports the
+                // failure is the success timestamp above going stale.
+                ic_cdk::println!("Failed to get node providers rewards: {:?}", e);
+            }
         }
-
-        telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| {
-            m.record_last_get_node_providers_rewards_instructions(instruction_counter.sum())
-        });
 
         (Self::default_delay(), self)
     }


### PR DESCRIPTION
## Why

`NRCHighInstructionCount` has been paging #eng-dre: it fires when `last_get_node_providers_rewards_instructions` exceeds 40 billion (currently ~40.04 billion on mainnet). Investigating it turned up two problems with the metric itself.

**The threshold maps to nothing.** That metric sums instructions over a whole call context. `get_node_providers_rewards` splits itself into one message per day of the reward period (the `reset_instructions` self-call from #9410), and no instruction limit applies to the sum across them. 40 billion is `MAX_INSTRUCTIONS_PER_MESSAGE` for an **application** subnet; this canister runs on the NNS, a **system** subnet, where the per-message limit is 50 billion — against roughly 1.1 billion actually spent per message. Nothing traps, nothing stalls, and execution is free on system subnets, so there is no cost signal either.

**And it inverts on failure.** The daily exporter task swallowed the error from a failed calculation and recorded the instruction count regardless. A calculation that gives up partway through costs less than one that finishes, so the number would have *dropped* — clearing the alert — at exactly the moment node provider rewards stopped being computed. The canister's most important function had no working alert.

## What changed

Export what an alert can act on:

| metric | |
|---|---|
| `last_get_node_providers_rewards_success_timestamp_seconds` | **new.** Set only on success. The task runs daily, so this going stale is the condition that means rewards can no longer be computed. |
| `last_get_node_providers_rewards_max_message_instructions` | **new.** Costliest single day-message of the last calculation to complete — the number the subnet's limits actually apply to. Above the per-slice limit (2B) a message pauses and resumes in a later round; above the per-message limit (50B) it traps. |
| `last_get_node_providers_rewards_instructions` | kept as a cost trend. Its help text described the *sync* task; it now describes itself. |

A failed calculation now leaves both instruction metrics untouched instead of reporting a lower cost.

The per-message number comes from `InstructionCounter::lap()`, which already existed in `telemetry.rs` and had **no callers** — written for this and never wired up.

## Follow-up outside this repo

The alert rules live in `dfinity-ops/k8s` and change separately. Land them after this canister is deployed; until then the series are absent and they simply never fire.

- `NRCRewardsCalculationStale` (page) — `time() - ..._success_timestamp_seconds > 129600`, guarded with `> 0` so a restarted canister does not page instantly.
- `NRCRewardsCalculationNeverSucceededSinceStart` (page) — gauge stuck at 0 for 6h.
- `NRCRewardsMessageInstructionsHigh` (page) — `..._max_message_instructions > 25e9`, half the per-message limit.
- `NRCRewardsMessageExceedsExecutionSlice` (ticket) — `> 2e9`, where slicing begins. Currently ~55% of that.
- Delete `NRCHighInstructionCount`.

## Reviewer notes

- **The underlying cost growth is real and not addressed here.** Two things drive it: the per-day registry key-family scans walk every revision the family has ever stored, which grows forever (~62% of the run today), and the per-day reward computation scales with the node fleet, which nearly doubled — 1,443 → 2,831 live node records between 2026-05-30 and 2026-08-12. The fleet term is why the curve accelerated, amplified by a 36-day ramp: each run sums 36 individual days, so an onboarding wave only reaches full weight 36 days later. A change that reads each key family once per calculation instead of once per day measures ~3.4× faster on a mainnet-shaped registry; it is parked rather than included here, so this PR stays a self-contained observability fix.
- `InstructionCounter` and the timestamp helper now return zero / use `current_time()` off-wasm, so `telemetry` is unit-testable. Behaviour on wasm is unchanged.
- One of the three new tests pins the exposed metric **names**, since the alert rules bind to those strings from a repository that cannot change in the same commit.

## Testing

- `cargo fmt --check` clean; `cargo clippy` clean under the CI flags for `ic-node-rewards-canister`.
- 38 unit tests pass (3 new).
- `bazel build //rs/node_rewards/canister:nrc :nrc-test` and all 5 affected bazel tests pass, including the three PocketIC integration tests that exercise the new code in real wasm.
- `./ci/scripts/rust-lint.sh` could not run to completion locally — `lifeline` needs `moc` and `devicemapper-sys`/`libcryptsetup-rs` need system dev packages absent from the dev host. Left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
