### PR TITLE
refactor: snapshot memory size validation

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -59,7 +59,8 @@ use ic_types::messages::{
 };
 use ic_types::{
     CanisterId, CanisterTimer, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, MAX_AGGREGATE_LOG_MEMORY_LIMIT,
-    NumBytes, NumInstructions, PrincipalId, SnapshotId, Time,
+    MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES, NumBytes,
+    NumInstructions, PrincipalId, SnapshotId, Time,
 };
 use ic_types_cycles::{
     CanisterCreation, CompoundCycles, Cycles, CyclesUseCase, Instructions, NominalCycles,
@@ -2392,6 +2393,34 @@ impl CanisterManager {
                         });
             }
 
+            // The snapshot's Wasm and stable memory must fit within the limits
+            // for the loaded module's execution mode.
+            let wasm_memory_limit = match new_execution_state.wasm_execution_mode {
+                WasmExecutionMode::Wasm32 => MAX_WASM_MEMORY_IN_BYTES,
+                WasmExecutionMode::Wasm64 => MAX_WASM64_MEMORY_IN_BYTES,
+            };
+            let snapshot_wasm_memory_bytes =
+                execution_snapshot.wasm_memory.size.get() as u64 * WASM_PAGE_SIZE_IN_BYTES as u64;
+            if snapshot_wasm_memory_bytes > wasm_memory_limit {
+                return Err(CanisterManagerError::CanisterSnapshotInconsistent {
+                    message: format!(
+                        "Snapshot Wasm memory ({snapshot_wasm_memory_bytes} bytes) exceeds the \
+                         limit allowed for the snapshot module's execution mode \
+                         ({wasm_memory_limit} bytes)."
+                    ),
+                });
+            }
+            let snapshot_stable_memory_bytes =
+                execution_snapshot.stable_memory.size.get() as u64 * WASM_PAGE_SIZE_IN_BYTES as u64;
+            if snapshot_stable_memory_bytes > MAX_STABLE_MEMORY_IN_BYTES {
+                return Err(CanisterManagerError::CanisterSnapshotInconsistent {
+                    message: format!(
+                        "Snapshot stable memory ({snapshot_stable_memory_bytes} bytes) exceeds the \
+                         limit allowed ({MAX_STABLE_MEMORY_IN_BYTES} bytes)."
+                    ),
+                });
+            }
+
             new_execution_state.exported_globals = execution_snapshot.exported_globals.clone();
 
             if canister_id == snapshot_canister_id {
@@ -2768,17 +2797,11 @@ impl CanisterManager {
         validate_controller(canister, &sender)?;
 
         // validate args:
-        let wasm_mode = canister
-            .execution_state
-            .as_ref()
-            .map(|x| x.wasm_execution_mode)
-            .unwrap_or_else(|| WasmExecutionMode::Wasm32);
-        let valid_args =
-            ValidatedSnapshotMetadata::validate(args.clone(), wasm_mode).map_err(|e| {
-                CanisterManagerError::CanisterSnapshotInconsistent {
-                    message: format!("Snapshot Metadata contains invalid data: {e:?}"),
-                }
-            })?;
+        let valid_args = ValidatedSnapshotMetadata::validate(args.clone()).map_err(|e| {
+            CanisterManagerError::CanisterSnapshotInconsistent {
+                message: format!("Snapshot Metadata contains invalid data: {e:?}"),
+            }
+        })?;
 
         let replace_snapshot_size = match args.replace_snapshot() {
             Some(replace_snapshot_id) => self.get_snapshot(canister, replace_snapshot_id)?.size(),

--- a/rs/replicated_state/src/canister_state/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_state/canister_snapshots.rs
@@ -2,7 +2,7 @@ use crate::{
     CanisterState, NumWasmPages, PageMap,
     canister_state::{
         WASM_PAGE_SIZE_IN_BYTES,
-        execution_state::{Memory, WasmExecutionMode},
+        execution_state::Memory,
         system_state::wasm_chunk_store::{self, ValidatedChunk, WasmChunkStore},
     },
     page_map::{Buffer, PageAllocatorFileDescriptor, PersistenceError},
@@ -14,8 +14,8 @@ use ic_management_canister_types_private::{
 };
 use ic_sys::PAGE_SIZE;
 use ic_types::{
-    CanisterId, CanisterTimer, MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES,
-    MAX_WASM64_MEMORY_IN_BYTES, NumBytes, SnapshotId, Time,
+    CanisterId, CanisterTimer, MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES, NumBytes,
+    SnapshotId, Time,
 };
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
@@ -515,7 +515,6 @@ pub struct ValidatedSnapshotMetadata {
 impl ValidatedSnapshotMetadata {
     pub fn validate(
         raw: UploadCanisterSnapshotMetadataArgs,
-        wasm_mode: WasmExecutionMode,
     ) -> Result<Self, MetadataValidationError> {
         if raw.wasm_module_size == 0 {
             return Err(MetadataValidationError::WasmModuleEmpty);
@@ -526,17 +525,8 @@ impl ValidatedSnapshotMetadata {
         if !(raw.wasm_memory_size as usize).is_multiple_of(WASM_PAGE_SIZE_IN_BYTES) {
             return Err(MetadataValidationError::WasmMemoryNotPageAligned);
         }
-        match wasm_mode {
-            WasmExecutionMode::Wasm32 => {
-                if raw.wasm_memory_size > MAX_WASM_MEMORY_IN_BYTES {
-                    return Err(MetadataValidationError::WasmMemoryTooLarge);
-                }
-            }
-            WasmExecutionMode::Wasm64 => {
-                if raw.wasm_memory_size > MAX_WASM64_MEMORY_IN_BYTES {
-                    return Err(MetadataValidationError::WasmMemoryTooLarge);
-                }
-            }
+        if raw.wasm_memory_size > MAX_WASM64_MEMORY_IN_BYTES {
+            return Err(MetadataValidationError::WasmMemoryTooLarge);
         }
         if !(raw.stable_memory_size as usize).is_multiple_of(WASM_PAGE_SIZE_IN_BYTES) {
             return Err(MetadataValidationError::StableMemoryNotPageAligned);


### PR DESCRIPTION
This PR defers canister snapshot memory size validation to when the canister snapshot is actually loaded.