### PR TITLE
feat: add `status_visibility` to `ic-management-canister-types`

### DIFF
--- a/packages/ic-management-canister-types/CHANGELOG.md
+++ b/packages/ic-management-canister-types/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the `PATCH` variant to the `HttpMethod` enum used by canister HTTPS outcalls (`http_request`). The variant is plumbed through the type but not yet enabled on replicated subnets.
+- Added `minimum_incoming_canister_call_cycles` field to `CanisterSettings` and `DefiniteCanisterSettings`.
+- Added `status_visibility` field to `CanisterSettings` and `DefiniteCanisterSettings`.
+  - Added the type `StatusVisibility`.
+
+### Changed
+
+- Doc: `CanisterSettings::wasm_memory_threshold` is capped at 2<sup>48</sup> (i.e., 256TB), not 2<sup>64</sup>-1.
 
 ## [0.8.0] - 2026-05-13
 

--- a/packages/ic-management-canister-types/src/lib.rs
+++ b/packages/ic-management-canister-types/src/lib.rs
@@ -63,6 +63,23 @@ pub enum SnapshotVisibility {
     AllowedViewers(Vec<Principal>),
 }
 
+/// # Status Visibility.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub enum StatusVisibility {
+    /// Controllers.
+    #[default]
+    #[serde(rename = "controllers")]
+    Controllers,
+    /// Public.
+    #[serde(rename = "public")]
+    Public,
+    /// Allowed viewers.
+    #[serde(rename = "allowed_viewers")]
+    AllowedViewers(Vec<Principal>),
+}
+
 /// # Environment Variable.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
@@ -148,6 +165,10 @@ pub struct CanisterSettings {
     ///
     /// Default value: [`SnapshotVisibility::Controllers`].
     pub snapshot_visibility: Option<SnapshotVisibility>,
+    /// Defines who is allowed to read the canister's status.
+    ///
+    /// Default value: [`StatusVisibility::Controllers`].
+    pub status_visibility: Option<StatusVisibility>,
     /// Indicates the upper limit on the WASM heap memory (bytes) consumption of the canister.
     ///
     /// Must be a number between 0 and 2<sup>48</sup>-1 (i.e 256TB), inclusively.
@@ -200,6 +221,8 @@ pub struct DefiniteCanisterSettings {
     pub log_memory_limit: Nat,
     /// Visibility of canister snapshots.
     pub snapshot_visibility: SnapshotVisibility,
+    /// Visibility of canister status.
+    pub status_visibility: StatusVisibility,
     /// Upper limit on the WASM heap memory (bytes) consumption of the canister.
     pub wasm_memory_limit: Nat,
     /// Threshold on the remaining wasm memory size of the canister in bytes.

--- a/packages/ic-management-canister-types/tests/ic.did
+++ b/packages/ic-management-canister-types/tests/ic.did
@@ -14,6 +14,12 @@ type snapshot_visibility = variant {
     allowed_viewers : vec principal;
 };
 
+type status_visibility = variant {
+    controllers;
+    public;
+    allowed_viewers : vec principal;
+};
+
 type environment_variable = record {
     name: text;
     value: text;
@@ -29,6 +35,7 @@ type canister_settings = record {
     log_visibility : opt log_visibility;
     log_memory_limit : opt nat;
     snapshot_visibility : opt snapshot_visibility;
+    status_visibility : opt status_visibility;
     wasm_memory_limit : opt nat;
     wasm_memory_threshold : opt nat;
     environment_variables : opt vec environment_variable;
@@ -44,6 +51,7 @@ type definite_canister_settings = record {
     log_visibility : log_visibility;
     log_memory_limit : nat;
     snapshot_visibility : snapshot_visibility;
+    status_visibility : status_visibility;
     wasm_memory_limit : nat;
     wasm_memory_threshold : nat;
     environment_variables : vec environment_variable;


### PR DESCRIPTION
The `status_visibility` canister setting (introduced in #10667) was only available in the internal `ic-management-canister-types-private` crate. Add it to the public crate as well: the `StatusVisibility` type, the fields on `CanisterSettings` and `DefiniteCanisterSettings`, and the corresponding entries in `tests/ic.did`.

Also complete the unreleased changelog, which was missing the `minimum_incoming_canister_call_cycles` field (#10398) and the tightened `wasm_memory_threshold` bound (#10574).