### PR TITLE
chore: update tarpc comment

### DIFF
--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1718,6 +1718,7 @@ crate.spec(
     features = [
         "full",
     ],
+    # Pinned to a fork because the published `tarpc` uses syn 3, while the rest of this repo (still) uses syn 2.
     git = "https://github.com/dfinity/tarpc",
     package = "tarpc",
     rev = "cddf1c64011d00f36016146e8447bef99531030c",

--- a/rs/crypto/internal/crypto_service_provider/Cargo.toml
+++ b/rs/crypto/internal/crypto_service_provider/Cargo.toml
@@ -52,9 +52,7 @@ slog = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 stubborn-io = "0.3.2"
-# Pinned to a fork because the published `tarpc` releases lag well behind on
-# `opentelemetry`. Switch back to crates.io once this is released:
-# https://github.com/google/tarpc/pull/565
+# Pinned to a fork because the published `tarpc` uses syn 3, while the rest of this repo (still) uses syn 2.
 tarpc = { git = "https://github.com/dfinity/tarpc", rev = "cddf1c64011d00f36016146e8447bef99531030c", features = [
     "full",
 ] }


### PR DESCRIPTION
We forked tarpc to bump opentelemetry crates. This change is now included upstream but we keep using the fork, because upstream switched to syn 3 (which we'll upgrade to after we've gotten rid of syn 1).

This updates the rationale in the manifests.