### PR TITLE
chore: bump priority-queue

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ccd372dba1df5020f88655da4545a04c71e6d5b2666f1179c3b3344aaadf5e96",
+  "checksum": "49f23508cb5f7f5588dfc22948a52cd7aa920ed8a09fa8b7d24083c0f596e53a",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -20250,7 +20250,7 @@
               "target": "pretty_assertions"
             },
             {
-              "id": "priority-queue 1.3.2",
+              "id": "priority-queue 2.7.0",
               "target": "priority_queue"
             },
             {
@@ -55084,14 +55084,14 @@
       ],
       "license_file": null
     },
-    "priority-queue 1.3.2": {
+    "priority-queue 2.7.0": {
       "name": "priority-queue",
-      "version": "1.3.2",
+      "version": "2.7.0",
       "package_url": "https://github.com/garro95/priority-queue",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/priority-queue/1.3.2/download",
-          "sha256": "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
+          "url": "https://static.crates.io/crates/priority-queue/2.7.0/download",
+          "sha256": "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
         }
       },
       "targets": [
@@ -55099,18 +55099,6 @@
           "Library": {
             "crate_name": "priority_queue",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -55127,19 +55115,21 @@
         ],
         "crate_features": {
           "common": [
-            "serde"
+            "default",
+            "serde",
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "indexmap 1.9.3",
-              "target": "indexmap"
+              "id": "equivalent 1.0.1",
+              "target": "equivalent"
             },
             {
-              "id": "priority-queue 1.3.2",
-              "target": "build_script_build"
+              "id": "indexmap 2.14.0",
+              "target": "indexmap"
             },
             {
               "id": "serde 1.0.228",
@@ -55148,30 +55138,10 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.3.2"
+        "edition": "2021",
+        "version": "2.7.0"
       },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "autocfg 1.5.0",
-              "target": "autocfg"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "LGPL-3.0 OR MPL-2.0",
+      "license": "LGPL-3.0-or-later OR MPL-2.0",
       "license_ids": [
         "LGPL-3.0",
         "MPL-2.0"
@@ -92074,7 +92044,7 @@
     "pprof 0.15.0",
     "predicates 3.1.2",
     "pretty_assertions 1.4.0",
-    "priority-queue 1.3.2",
+    "priority-queue 2.7.0",
     "proc-macro2 1.0.106",
     "procfs 0.17.0",
     "prometheus 0.14.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -9284,12 +9284,12 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "1.3.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
- "autocfg",
- "indexmap 1.9.3",
+ "equivalent",
+ "indexmap 2.14.0",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19844,12 +19844,13 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "1.4.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
- "autocfg",
- "indexmap 1.9.3",
+ "equivalent",
+ "indexmap 2.14.0",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -820,7 +820,7 @@ pprof = { git = "https://github.com/dfinity/pprof-rs", rev = "9159b45ecc3540d7fc
 ] }
 predicates = "3.1.2"
 pretty_assertions = "1.4.0"
-priority-queue = "1.3.1"
+priority-queue = "2.7.0"
 proc-macro2 = "1.0.89"
 procfs = { version = "^0.17", default-features = false }
 prometheus = { version = "0.14.0", features = ["process"] }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1222,7 +1222,7 @@ crate.spec(
         "serde",
     ],
     package = "priority-queue",
-    version = "^1.3.1",
+    version = "^2.7.0",
 )
 crate.spec(
     package = "proc-macro2",


### PR DESCRIPTION
The crate was very outdated and pulling a duplicate, old version of `indexmap`.