### PR TITLE
perf(key-manager): optimize some clones

### DIFF
--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -311,13 +311,13 @@ impl DkgKeyManager {
             let current_transcripts_with_load_deadlines = summary
                 .current_transcripts()
                 .values()
-                .map(|t| (current_interval_start, t.clone()));
+                .map(|t| (current_interval_start, t));
 
             // For next transcripts, we take the start of the next interval as a deadline.
             let next_transcripts_with_load_deadlines = summary
                 .next_transcripts()
                 .values()
-                .map(|t| (next_interval_start, t.clone()));
+                .map(|t| (next_interval_start, t));
 
             current_transcripts_with_load_deadlines.chain(next_transcripts_with_load_deadlines)
         };
@@ -334,6 +334,7 @@ impl DkgKeyManager {
 
             let crypto = self.crypto.clone();
             let logger = self.logger.clone();
+            let transcript = transcript.clone();
             let (tx, rx) = sync_channel(0);
             self.pending_transcript_loads
                 .insert(transcript.dkg_id.clone(), (deadline, rx));

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -303,50 +303,44 @@ impl DkgKeyManager {
     /// that CSP does not reload transcripts, which were successfully loaded
     /// before.
     fn load_transcripts_from_summary(&mut self, summary: &DkgSummary) {
-        let transcripts_to_load: Vec<_> = {
-            let current_interval_start = summary.height;
-            let next_interval_start = summary.get_next_start_height();
+        let current_interval_start = summary.height;
+        let next_interval_start = summary.get_next_start_height();
 
+        let transcripts_to_load = {
             // For current transcripts we take the current summary height as a deadline.
             let current_transcripts_with_load_deadlines = summary
                 .current_transcripts()
-                .iter()
-                .filter(|(_, t)| !self.pending_transcript_loads.contains_key(&t.dkg_id))
-                .map(|(_, t)| (current_interval_start, t.dkg_id.clone()));
+                .values()
+                .map(|t| (current_interval_start, t.clone()));
 
             // For next transcripts, we take the start of the next interval as a deadline.
             let next_transcripts_with_load_deadlines = summary
                 .next_transcripts()
-                .iter()
-                .filter(|(_, t)| !self.pending_transcript_loads.contains_key(&t.dkg_id))
-                .map(|(_, t)| (next_interval_start, t.dkg_id.clone()));
+                .values()
+                .map(|t| (next_interval_start, t.clone()));
 
-            current_transcripts_with_load_deadlines
-                .chain(next_transcripts_with_load_deadlines)
-                .collect()
+            current_transcripts_with_load_deadlines.chain(next_transcripts_with_load_deadlines)
         };
 
-        for (deadline, dkg_id) in transcripts_to_load.into_iter() {
+        for (deadline, transcript) in transcripts_to_load {
+            if self
+                .pending_transcript_loads
+                .contains_key(&transcript.dkg_id)
+            {
+                continue;
+            }
+
             let since = Instant::now();
 
             let crypto = self.crypto.clone();
             let logger = self.logger.clone();
-            let summary = summary.clone();
             let (tx, rx) = sync_channel(0);
             self.pending_transcript_loads
-                .insert(dkg_id.clone(), (deadline, rx));
+                .insert(transcript.dkg_id.clone(), (deadline, rx));
 
             std::thread::spawn(move || {
-                let transcript = summary
-                    .current_transcripts()
-                    .iter()
-                    .chain(summary.next_transcripts().iter())
-                    .find(|(_, t)| t.dkg_id == dkg_id)
-                    .expect("No transcript was found")
-                    .1;
-
                 let result = loop {
-                    let result = NiDkgAlgorithm::load_transcript(&*crypto, transcript);
+                    let result = NiDkgAlgorithm::load_transcript(&*crypto, &transcript);
                     let elapsed = since.elapsed().as_secs_f64();
 
                     match &result {
@@ -355,7 +349,7 @@ impl DkgKeyManager {
                             info!(
                                 logger,
                                 "Finished loading transcript {} after {}s",
-                                dkg_id_log_msg(&dkg_id),
+                                dkg_id_log_msg(&transcript.dkg_id),
                                 elapsed
                             );
                             break result;
@@ -366,7 +360,7 @@ impl DkgKeyManager {
                                 logger,
                                 "Finished loading public parts of transcript {} after {}s\
                                 (signing key unavailable since this node is not part of the committee)",
-                                dkg_id_log_msg(&dkg_id),
+                                dkg_id_log_msg(&transcript.dkg_id),
                                 elapsed
                             );
                             break result;
@@ -378,7 +372,7 @@ impl DkgKeyManager {
                                 logger,
                                 "Could only load public parts of transcript {} \
                                 (signing key unavailable: {:?})",
-                                dkg_id_log_msg(&dkg_id),
+                                dkg_id_log_msg(&transcript.dkg_id),
                                 val
                             );
                             break result;
@@ -390,7 +384,7 @@ impl DkgKeyManager {
                                 every_n_seconds => 5,
                                 logger,
                                 "Transcript {} couldn't be loaded: {:?} Retrying...",
-                                dkg_id_log_msg(&dkg_id),
+                                dkg_id_log_msg(&transcript.dkg_id),
                                 err
                             );
                         }
@@ -400,7 +394,7 @@ impl DkgKeyManager {
                             error!(
                                 logger,
                                 "Transcript {} couldn't be loaded: {:?}",
-                                dkg_id_log_msg(&dkg_id),
+                                dkg_id_log_msg(&transcript.dkg_id),
                                 err
                             );
                             break result;
@@ -442,18 +436,19 @@ impl DkgKeyManager {
                 .payload
                 .as_ref()
                 .as_summary()
+                .dkg
                 .clone(),
         );
 
         while let Some(summary) = dkg_summary {
-            let next_summary_height = summary.dkg.get_next_start_height();
-            for transcript in summary.dkg.into_transcripts() {
+            let next_summary_height = summary.get_next_start_height();
+            for transcript in summary.into_transcripts() {
                 transcripts_to_retain.insert(transcript);
             }
 
             dkg_summary = pool_reader
                 .get_finalized_block(next_summary_height)
-                .map(|b| b.payload.as_ref().as_summary().clone());
+                .map(|b| b.payload.as_ref().as_summary().dkg.clone());
         }
 
         let crypto = self.crypto.clone();

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -426,20 +426,17 @@ impl DkgKeyManager {
         // Create list of transcripts that we need to retain, which is all DKG
         // transcripts in the latest CUP and in all subsequent finalized summary blocks.
         let mut transcripts_to_retain: HashSet<NiDkgTranscript> = HashSet::new();
-        let mut dkg_summary = Some(
+        let mut next_summary_block = Some(
             pool_reader
                 .as_cache()
                 .catch_up_package()
                 .content
                 .block
-                .into_inner()
-                .payload
-                .as_ref()
-                .as_summary()
-                .dkg,
+                .into_inner(),
         );
 
-        while let Some(summary) = dkg_summary {
+        while let Some(summary_block) = next_summary_block {
+            let summary = &summary_block.payload.as_ref().as_summary().dkg;
             let next_summary_height = summary.get_next_start_height();
             for transcript in summary
                 .current_transcripts()
@@ -449,9 +446,7 @@ impl DkgKeyManager {
                 transcripts_to_retain.insert(transcript.clone());
             }
 
-            dkg_summary = pool_reader
-                .get_finalized_block(next_summary_height)
-                .map(|b| b.payload.as_ref().as_summary().dkg);
+            summary_block = pool_reader.get_finalized_block(next_summary_height);
         }
 
         let crypto = self.crypto.clone();

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -446,7 +446,7 @@ impl DkgKeyManager {
                 transcripts_to_retain.insert(transcript.clone());
             }
 
-            summary_block = pool_reader.get_finalized_block(next_summary_height);
+            next_summary_block = pool_reader.get_finalized_block(next_summary_height);
         }
 
         let crypto = self.crypto.clone();

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -436,19 +436,22 @@ impl DkgKeyManager {
                 .payload
                 .as_ref()
                 .as_summary()
-                .dkg
-                .clone(),
+                .dkg,
         );
 
         while let Some(summary) = dkg_summary {
             let next_summary_height = summary.get_next_start_height();
-            for transcript in summary.into_transcripts() {
-                transcripts_to_retain.insert(transcript);
+            for transcript in summary
+                .current_transcripts()
+                .values()
+                .chain(summary.next_transcripts().values())
+            {
+                transcripts_to_retain.insert(transcript.clone());
             }
 
             dkg_summary = pool_reader
                 .get_finalized_block(next_summary_height)
-                .map(|b| b.payload.as_ref().as_summary().dkg.clone());
+                .map(|b| b.payload.as_ref().as_summary().dkg);
         }
 
         let crypto = self.crypto.clone();

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -344,16 +344,6 @@ impl DkgSummary {
         &self.next_transcripts
     }
 
-    /// Return the set of transcripts (current and next) for all tags.
-    /// This function avoids expensive copying when transcripts are large.
-    pub fn into_transcripts(self) -> Vec<NiDkgTranscript> {
-        self.current_transcripts
-            .into_iter()
-            .chain(self.next_transcripts)
-            .map(|(_, t)| t)
-            .collect()
-    }
-
     /// Returns `true` if the provided height is included in the DKG interval
     /// corresponding to the current summary. Note that the summary block is
     /// considered to be part of the interval. For example, if the start height


### PR DESCRIPTION
This PR avoids/optimizes some clones in the DKG key manager:
- Simplify `load_transcripts_from_summary` to clone each transcript once and move each one individually to the respective thread that loads it, instead of cloning the entire summary each time and then iterating through it to find the corresponding transcript (which could even panic).
- In `delete_inactive_keys`, clone only the transcripts of interest, not the entire summaries, DKG (which can contain additional transcripts, like reshared ones and ones for remote subnets) and IDKG (useless here).