### PR TITLE
fix: use pigz from mirror

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,6 +59,23 @@ archive_override(
 # Misc tools
 
 bazel_dep(name = "pigz", version = "2.8.bcr.1")  # (parallel) gzip
+
+# The BCR `pigz` module fetches its source tarball from https://zlib.net, which
+# is currently down. Override it to fetch it from a mirror. Drop this override
+# once zlib.net is reachable again / the BCR entry uses a live URL.
+archive_override(
+    module_name = "pigz",
+    integrity = "sha256-64crTw4fDr5Zyfe9jFBsQgSJO6aoSS3jHfQW8NUXD9A=",
+    patch_strip = 0,
+    patches = [
+        "//bazel:pigz/patches/pigz.c.patch",
+        "//bazel:pigz/patches/add_build_file.patch",
+        "//bazel:pigz/patches/module_dot_bazel.patch",
+    ],
+    strip_prefix = "pigz-2.8",
+    urls = ["https://distfiles.macports.org/pigz/pigz-2.8.tar.gz"],
+)
+
 bazel_dep(name = "zstd", version = "1.5.7.bcr.1")  # zstd can change format across versions
 
 # QEMU, for the local system test backend. We only use the prebuilt (hermetic)

--- a/bazel/pigz/patches/add_build_file.patch
+++ b/bazel/pigz/patches/add_build_file.patch
@@ -1,0 +1,30 @@
+--- /dev/null	2023-06-26 14:23:42
++++ BUILD.bazel	2023-06-26 14:23:36
+@@ -0,0 +1,27 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary")
++
++_COPTS = ["-O3", "-Wall", "-Wextra", "-Wno-unknown-pragmas", "-Wcast-qual"]
++
++cc_binary(
++    name = "pigz",
++    srcs = [
++        "pigz.c",
++        "try.c",
++        "try.h",
++        "yarn.c",
++        "yarn.h",
++    ],
++    copts = _COPTS,
++    linkopts = [
++        "-lm",
++        "-lpthread",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@zopfli", "@zlib"],
++)
++
++alias(
++    name = "bin",
++    actual = ":pigz",
++    visibility = ["//visibility:public"],
++)

--- a/bazel/pigz/patches/module_dot_bazel.patch
+++ b/bazel/pigz/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- /dev/null	2023-06-26 13:35:45
++++ MODULE.bazel	2023-06-26 13:33:20
+@@ -0,0 +1,10 @@
++module(
++    name = "pigz",
++    version = "2.8.bcr.1",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.8")
++bazel_dep(name = "rules_cc", version = "0.0.17")
++bazel_dep(name = "zopfli", version = "1.0.3.bcr.2")
++bazel_dep(name = "zlib", version = "1.3")

--- a/bazel/pigz/patches/pigz.c.patch
+++ b/bazel/pigz/patches/pigz.c.patch
@@ -1,0 +1,11 @@
+--- pigz.c
++++ pigz.c
+@@ -429,7 +429,7 @@
+ #endif
+
+ #ifndef NOZOPFLI
+-#  include "zopfli/src/zopfli/deflate.h"    // ZopfliDeflatePart(),
++#  include "zopfli/deflate.h"               // ZopfliDeflatePart(),
+                                             // ZopfliInitOptions(),
+                                             // ZopfliOptions
+ #endif


### PR DESCRIPTION
https://zlib.net is currently down, meaning our (uncached) bazel builds are failing because we can't download the pigz source. We patch the bazel module to use a mirror instead.