### PR TITLE
refactor: install the canister memories in create_execution_state

### DIFF
--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -12,8 +12,8 @@ use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::wasmtime_embedder::system_api::{ExecutionParameters, InstructionLimits};
 use ic_error_types::RejectCode;
 use ic_execution_environment::{
-    CompilationCostHandling, ExecutionEnvironment, ExecutionServicesForTesting, RoundLimits,
-    as_round_instructions,
+    CompilationCostHandling, ExecutionEnvironment, ExecutionServicesForTesting, MemorySource,
+    RoundLimits, as_round_instructions,
 };
 use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
@@ -142,6 +142,7 @@ where
             UNIX_EPOCH,
             &mut round_limits,
             CompilationCostHandling::CountFullAmount,
+            MemorySource::Fresh,
         )
         .1
         .expect("Failed to create execution state");

--- a/rs/execution_environment/benches/management_canister/create_execution_state.rs
+++ b/rs/execution_environment/benches/management_canister/create_execution_state.rs
@@ -1,6 +1,8 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use ic_config::execution_environment::{SUBNET_CALLBACK_SOFT_LIMIT, SUBNET_MEMORY_RESERVATION};
-use ic_execution_environment::{CompilationCostHandling, RoundLimits, as_round_instructions};
+use ic_execution_environment::{
+    CompilationCostHandling, MemorySource, RoundLimits, as_round_instructions,
+};
 use ic_interfaces::execution_environment::SubnetAvailableMemory;
 use ic_test_utilities_execution_environment::ExecutionTestBuilder;
 use ic_test_utilities_types::ids::canister_test_id;
@@ -39,6 +41,7 @@ fn run_benchmark(
                     ic_types::time::UNIX_EPOCH,
                     &mut round_limits,
                     compilation_cost_handling,
+                    MemorySource::Fresh,
                 );
             },
             BatchSize::SmallInput,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -11,7 +11,7 @@ use crate::execution_environment::{
     RoundLimits,
 };
 use crate::execution_environment_metrics::ExecutionEnvironmentMetrics;
-use crate::hypervisor::Hypervisor;
+use crate::hypervisor::{Hypervisor, MemorySource};
 use crate::types::{IngressResponse, Response};
 use crate::util::{GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID};
 
@@ -2295,6 +2295,35 @@ impl CanisterManager {
             return Err(CanisterManagerError::LongExecutionAlreadyInProgress { canister_id });
         }
 
+        // Build the memories to restore up front, so that they can be handed to
+        // `create_execution_state` below instead of being installed after the
+        // fact. This is cheap: it only clones the storage of the snapshot's page
+        // maps and, for another canister's snapshot, allocates a fresh page
+        // allocator.
+        let (snapshot_wasm_memory, snapshot_stable_memory) = if canister_id == snapshot_canister_id
+        {
+            (
+                Memory::from(&execution_snapshot.wasm_memory),
+                Memory::from(&execution_snapshot.stable_memory),
+            )
+        } else {
+            let not_loadable = || CanisterManagerError::CanisterSnapshotNotLoadable {
+                canister_id,
+                snapshot_id,
+            };
+            let wasm_memory = Memory::try_from((
+                &execution_snapshot.wasm_memory,
+                Arc::clone(&self.fd_factory),
+            ))
+            .map_err(|_| not_loadable())?;
+            let stable_memory = Memory::try_from((
+                &execution_snapshot.stable_memory,
+                Arc::clone(&self.fd_factory),
+            ))
+            .map_err(|_| not_loadable())?;
+            (wasm_memory, stable_memory)
+        };
+
         // All basic checks have passed, prepay cycles for instructions.
         //
         // The Wasm execution mode is only used to pick the per-instruction rate
@@ -2339,6 +2368,10 @@ impl CanisterManager {
                     time,
                     round_limits,
                     compilation_cost_handling,
+                    MemorySource::Explicit {
+                        wasm_memory: snapshot_wasm_memory,
+                        stable_memory: snapshot_stable_memory,
+                    },
                 );
             debug_assert!(
                 instructions_for_execution <= prepaid_execution_instructions,
@@ -2423,38 +2456,6 @@ impl CanisterManager {
 
             new_execution_state.exported_globals = execution_snapshot.exported_globals.clone();
 
-            if canister_id == snapshot_canister_id {
-                new_execution_state.stable_memory = Memory::from(&execution_snapshot.stable_memory);
-                new_execution_state.wasm_memory = Memory::from(&execution_snapshot.wasm_memory);
-            } else {
-                let new_stable_memory = match Memory::try_from((
-                    &execution_snapshot.stable_memory,
-                    Arc::clone(&self.fd_factory),
-                )) {
-                    Ok(memory) => memory,
-                    Err(_) => {
-                        return Err(CanisterManagerError::CanisterSnapshotNotLoadable {
-                            canister_id,
-                            snapshot_id,
-                        });
-                    }
-                };
-                new_execution_state.stable_memory = new_stable_memory;
-
-                let new_wasm_memory = match Memory::try_from((
-                    &execution_snapshot.wasm_memory,
-                    Arc::clone(&self.fd_factory),
-                )) {
-                    Ok(memory) => memory,
-                    Err(_) => {
-                        return Err(CanisterManagerError::CanisterSnapshotNotLoadable {
-                            canister_id,
-                            snapshot_id,
-                        });
-                    }
-                };
-                new_execution_state.wasm_memory = new_wasm_memory;
-            }
             Some(new_execution_state)
         };
 

--- a/rs/execution_environment/src/execution/install.rs
+++ b/rs/execution_environment/src/execution/install.rs
@@ -8,10 +8,10 @@ use crate::canister_manager::types::{
 };
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
-    CanisterMemoryHandling, InstallCodeHelper, MemoryHandling, OriginalContext,
-    PausedInstallCodeHelper, finish_err,
+    InstallCodeHelper, OriginalContext, PausedInstallCodeHelper, finish_err,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
+use crate::hypervisor::MemorySource;
 use ic_base_types::PrincipalId;
 use ic_embedders::{
     wasm_executor::{CanisterStateChanges, PausedWasmExecution, WasmExecutionResult},
@@ -120,15 +120,12 @@ pub(crate) fn execute_install(
         round.time,
         round_limits,
         original.compilation_cost_handling,
+        // Install and re-install replace both the stable memory and the main
+        // memory with the initial memories of the new module.
+        MemorySource::Fresh,
     );
     helper.charge_for_compilation(instructions_from_compilation);
-    if let Err(err) = helper.replace_execution_state_and_allocations(
-        result,
-        CanisterMemoryHandling {
-            stable_memory_handling: MemoryHandling::Replace,
-            main_memory_handling: MemoryHandling::Replace,
-        },
-    ) {
+    if let Err(err) = helper.replace_execution_state_and_allocations(result) {
         let instructions_left = helper.instructions_left();
         return finish_err(
             clean_canister,

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -575,8 +575,8 @@ impl InstallCodeHelper {
 
     /// Replaces the execution state of the current canister with the newly
     /// created execution state. Which memories the new execution state carries
-    /// (the initial ones of the new module, the preserved ones of the old
-    /// execution state, or the ones of a snapshot) has already been decided by
+    /// (the initial ones of the new module or the preserved ones of the old
+    /// execution state) has already been decided by
     /// `Hypervisor::create_execution_state`.
     ///
     /// It also updates the compute and memory allocations with the requested

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -42,30 +42,6 @@ use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 #[cfg(test)]
 mod tests;
 
-/// Indicates whether the memory is kept or replaced with new (initial) memory.
-/// Applicable to both the stable memory and the main memory of a canister.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub(crate) enum MemoryHandling {
-    /// Retain the memory.
-    Keep,
-    /// Reset the memory.
-    Replace,
-}
-
-/// Specifies the handling of the canister's memories.
-/// * On install and re-install:
-///   - Replace both the stable memory and the main memory.
-/// * On upgrade:
-///   - For canisters with enhanced orthogonal persistence (Motoko):
-///     Retain both the main memory and the stable memory.
-///   - For all other canisters:
-///     Retain only the stable memory and erase the main memory.
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub(crate) struct CanisterMemoryHandling {
-    pub stable_memory_handling: MemoryHandling,
-    pub main_memory_handling: MemoryHandling,
-}
-
 /// The main steps of `install_code` execution that may fail with an error or
 /// change the canister state.
 #[derive(Clone, Debug)]
@@ -73,8 +49,14 @@ pub(crate) struct CanisterMemoryHandling {
 pub(crate) enum InstallCodeStep {
     ValidateInput,
     ReplaceExecutionStateAndAllocations {
+        /// The execution state as returned by
+        /// `Hypervisor::create_execution_state`, i.e. with the memories that
+        /// this `install_code` preserves (if any) already in place. Replaying
+        /// this step hence re-applies those memories as they were at the time
+        /// of the original execution rather than re-deriving them from the
+        /// replayed canister state; the two agree because replaying the
+        /// preceding steps is deterministic.
         maybe_execution_state: HypervisorResult<ExecutionState>,
-        memory_handling: CanisterMemoryHandling,
     },
     ClearCertifiedData,
     ClearLog,
@@ -591,21 +573,21 @@ impl InstallCodeHelper {
         Ok(())
     }
 
-    /// Replaces the execution state of the current canister with the freshly
-    /// created execution state. The stable memory and the main memory are
-    /// conditionally replaced based on the given `memory_handling`.
+    /// Replaces the execution state of the current canister with the newly
+    /// created execution state. Which memories the new execution state carries
+    /// (the initial ones of the new module, the preserved ones of the old
+    /// execution state, or the ones of a snapshot) has already been decided by
+    /// `Hypervisor::create_execution_state`.
     ///
     /// It also updates the compute and memory allocations with the requested
     /// values in `original` context.
     pub fn replace_execution_state_and_allocations(
         &mut self,
         maybe_execution_state: HypervisorResult<ExecutionState>,
-        memory_handling: CanisterMemoryHandling,
     ) -> Result<(), CanisterManagerError> {
         self.steps
             .push(InstallCodeStep::ReplaceExecutionStateAndAllocations {
                 maybe_execution_state: maybe_execution_state.clone(),
-                memory_handling,
             });
 
         let old_memory_usage = self.canister.memory_usage();
@@ -616,22 +598,11 @@ impl InstallCodeHelper {
             .as_ref()
             .map_or(NumBytes::new(0), |es| es.metadata.memory_usage());
 
-        // Replace the execution state and maybe the stable memory.
-        let mut execution_state =
+        // Replace the execution state, dropping the old one.
+        let execution_state =
             maybe_execution_state.map_err(|err| (self.canister.canister_id(), err))?;
 
         let new_wasm_custom_sections_memory_used = execution_state.metadata.memory_usage();
-
-        if let Some(old) = self.canister.execution_state.take() {
-            match memory_handling.stable_memory_handling {
-                MemoryHandling::Keep => execution_state.stable_memory = old.stable_memory,
-                MemoryHandling::Replace => {}
-            }
-            match memory_handling.main_memory_handling {
-                MemoryHandling::Keep => execution_state.wasm_memory = old.wasm_memory,
-                MemoryHandling::Replace => {}
-            }
-        };
 
         self.canister.execution_state = Some(execution_state);
 
@@ -832,10 +803,7 @@ impl InstallCodeHelper {
             InstallCodeStep::ValidateInput => self.validate_input(original),
             InstallCodeStep::ReplaceExecutionStateAndAllocations {
                 maybe_execution_state,
-                memory_handling,
-            } => {
-                self.replace_execution_state_and_allocations(maybe_execution_state, memory_handling)
-            }
+            } => self.replace_execution_state_and_allocations(maybe_execution_state),
             InstallCodeStep::ClearCertifiedData => {
                 self.clear_certified_data();
                 Ok(())

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -281,8 +281,9 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
 
     let module_hash = wasm_module.module_hash();
     // Stage 2: create a new execution state based on the new Wasm code, deactivate global timer, and bump canister version.
-    // Replace the execution state of the canister with a new execution state, but
-    // persist the stable memory (if it exists).
+    // Replace the execution state of the canister with a new execution state that
+    // persists the stable memory and, for canisters with enhanced orthogonal
+    // persistence, also the main memory.
     let memory_handling = CanisterMemoryHandling {
         stable_memory_handling: MemoryHandling::Keep,
         main_memory_handling: main_memory_handling(context.mode),

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -9,9 +9,10 @@ use crate::canister_manager::types::{
 };
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
-    CanisterMemoryHandling, InstallCodeHelper, OriginalContext, PausedInstallCodeHelper, finish_err,
+    InstallCodeHelper, OriginalContext, PausedInstallCodeHelper, finish_err,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
+use crate::hypervisor::{CanisterMemoryHandling, MemoryHandling, MemorySource};
 use ic_base_types::PrincipalId;
 use ic_embedders::{
     wasm_executor::{CanisterStateChanges, PausedWasmExecution, WasmExecutionResult},
@@ -30,8 +31,6 @@ use ic_replicated_state::{
 use ic_types::messages::{CanisterCall, RequestMetadata};
 use ic_types::methods::{FuncRef, SystemMethod, WasmMethod};
 use ic_types_cycles::{CompoundCycles, Instructions};
-
-use super::install_code::MemoryHandling;
 
 #[cfg(test)]
 mod tests;
@@ -284,41 +283,46 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
     // Stage 2: create a new execution state based on the new Wasm code, deactivate global timer, and bump canister version.
     // Replace the execution state of the canister with a new execution state, but
     // persist the stable memory (if it exists).
+    let memory_handling = CanisterMemoryHandling {
+        stable_memory_handling: MemoryHandling::Keep,
+        main_memory_handling: main_memory_handling(context.mode),
+    };
+    // Note that the memories to preserve are taken from the helper's canister,
+    // i.e. as they are after `canister_pre_upgrade()` has run, and not from the
+    // clean canister.
+    let new_memories = match helper.canister().execution_state.as_ref() {
+        Some(old) => MemorySource::Preserve {
+            old,
+            handling: memory_handling,
+        },
+        None => MemorySource::Fresh,
+    };
     let (instructions_from_compilation, result) = round.hypervisor.create_execution_state(
         wasm_module,
         canister_id,
         round.time,
         round_limits,
         original.compilation_cost_handling,
+        new_memories,
     );
 
     helper.charge_for_compilation(instructions_from_compilation);
 
-    let main_memory_handling = match determine_main_memory_handling(
-        context.mode,
-        &helper.canister().execution_state,
-        &result,
-    ) {
-        Ok(memory_handling) => memory_handling,
-        Err(err) => {
-            let instructions_left = helper.instructions_left();
-            return finish_err(
-                clean_canister,
-                instructions_left,
-                original,
-                round,
-                err,
-                helper.take_canister_log(),
-            );
-        }
-    };
+    if let Err(err) =
+        validate_wasm_memory_persistence(context.mode, &helper.canister().execution_state, &result)
+    {
+        let instructions_left = helper.instructions_left();
+        return finish_err(
+            clean_canister,
+            instructions_left,
+            original,
+            round,
+            err,
+            helper.take_canister_log(),
+        );
+    }
 
-    let memory_handling = CanisterMemoryHandling {
-        stable_memory_handling: MemoryHandling::Keep,
-        main_memory_handling,
-    };
-
-    if let Err(err) = helper.replace_execution_state_and_allocations(result, memory_handling) {
+    if let Err(err) = helper.replace_execution_state_and_allocations(result) {
         let instructions_left = helper.instructions_left();
         return finish_err(
             clean_canister,
@@ -890,17 +894,36 @@ impl PausedInstallCodeExecution for PausedPostUpgradeExecution {
     }
 }
 
-/// Determines main memory handling based on the `wasm_memory_persistence` upgrade options.
-/// Integrates two safety checks:
+/// Determines main memory handling based on the `wasm_memory_persistence` upgrade option.
+/// The choice only depends on the install mode; whether it is legitimate is checked
+/// separately by `validate_wasm_memory_persistence`, which needs the new execution
+/// state and hence can only run once that state has been created.
+fn main_memory_handling(install_mode: CanisterInstallModeV2) -> MemoryHandling {
+    match install_mode {
+        CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
+            wasm_memory_persistence: Some(WasmMemoryPersistence::Keep),
+            ..
+        })) => MemoryHandling::Keep,
+        CanisterInstallModeV2::Upgrade(None)
+        | CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
+            wasm_memory_persistence: None | Some(WasmMemoryPersistence::Replace),
+            ..
+        })) => MemoryHandling::Replace,
+        // These two modes cannot occur during an upgrade.
+        CanisterInstallModeV2::Install | CanisterInstallModeV2::Reinstall => unreachable!(),
+    }
+}
+
+/// Two safety checks on the `wasm_memory_persistence` upgrade option:
 /// - The `wasm_memory_persistence` upgrade option is not omitted in error, when
 ///   the old canister implementation uses enhanced orthogonal persistence.
 /// - The `wasm_memory_persistence: opt keep` option is not applied to a new canister
 ///   implementation that does not support enhanced orthogonal persistence.
-fn determine_main_memory_handling(
+fn validate_wasm_memory_persistence(
     install_mode: CanisterInstallModeV2,
     old_state: &Option<ExecutionState>,
     new_state_candidate: &HypervisorResult<ExecutionState>,
-) -> Result<MemoryHandling, CanisterManagerError> {
+) -> Result<(), CanisterManagerError> {
     let old_state_uses_orthogonal_persistence = || {
         old_state
             .as_ref()
@@ -922,7 +945,7 @@ fn determine_main_memory_handling(
                 let message = "Enhanced orthogonal persistence requires the `wasm_memory_persistence` upgrade option.".to_string();
                 return Err(CanisterManagerError::MissingUpgradeOptionError { message });
             }
-            Ok(MemoryHandling::Replace)
+            Ok(())
         }
         CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
             wasm_memory_persistence: Some(WasmMemoryPersistence::Keep),
@@ -933,12 +956,12 @@ fn determine_main_memory_handling(
                 let message = "The `wasm_memory_persistence: opt Keep` upgrade option requires that the new canister module supports enhanced orthogonal persistence.".to_string();
                 return Err(CanisterManagerError::InvalidUpgradeOptionError { message });
             }
-            Ok(MemoryHandling::Keep)
+            Ok(())
         }
         CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
             wasm_memory_persistence: Some(WasmMemoryPersistence::Replace),
             ..
-        })) => Ok(MemoryHandling::Replace),
+        })) => Ok(()),
         // These two modes cannot occur during an upgrade.
         CanisterInstallModeV2::Install | CanisterInstallModeV2::Reinstall => unreachable!(),
     }

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -282,8 +282,9 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
     let module_hash = wasm_module.module_hash();
     // Stage 2: create a new execution state based on the new Wasm code, deactivate global timer, and bump canister version.
     // Replace the execution state of the canister with a new execution state that
-    // persists the stable memory and, for canisters with enhanced orthogonal
-    // persistence, also the main memory.
+    // persists the stable memory and, if the `wasm_memory_persistence: opt keep`
+    // upgrade option is used (which requires enhanced orthogonal persistence),
+    // also the main memory.
     let memory_handling = CanisterMemoryHandling {
         stable_memory_handling: MemoryHandling::Keep,
         main_memory_handling: main_memory_handling(context.mode),

--- a/rs/execution_environment/src/execution/upgrade/tests.rs
+++ b/rs/execution_environment/src/execution/upgrade/tests.rs
@@ -444,11 +444,12 @@ fn upgrade_fails_on_long_pre_upgrade_hits_instructions_limit() {
 
 ////////////////////////////////////////////////////////////////////////
 // upgrade_stage_2_and_3a_create_execution_state_and_call_start()
-// 1. if let Err(err) = helper.replace_execution_state_and_allocations(..)
-// 2. if !execution_state.exports_method(Start)
-// 3. match execute_dts(..)
-//    3a. Finished
-//    3b. Paused
+// 1. if let Err(err) = validate_wasm_memory_persistence(..)
+// 2. if let Err(err) = helper.replace_execution_state_and_allocations(..)
+// 3. if !execution_state.exports_method(Start)
+// 4. match execute_dts(..)
+//    4a. Finished
+//    4b. Paused
 
 #[test]
 fn upgrade_fails_on_invalid_new_canister() {

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -19,7 +19,7 @@ use ic_interfaces_state_manager::StateReader;
 use ic_logger::ReplicaLogger;
 use ic_metrics::MetricsRegistry;
 use ic_metrics::buckets::{binary_buckets_with_zero, decimal_buckets_with_zero, linear_buckets};
-use ic_replicated_state::{ExecutionState, NetworkTopology, ReplicatedState, SystemState};
+use ic_replicated_state::{ExecutionState, Memory, NetworkTopology, ReplicatedState, SystemState};
 use ic_types::canister_log::CanisterLogMetrics;
 use ic_types::{
     CanisterId, DiskBytes, NumBytes, NumInstructions, SubnetId, Time, messages::RequestMetadata,
@@ -135,6 +135,56 @@ impl CanisterLogMetrics for HypervisorMetrics {
     }
 }
 
+/// Indicates whether the memory is kept or replaced with new (initial) memory.
+/// Applicable to both the stable memory and the main memory of a canister.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum MemoryHandling {
+    /// Retain the memory.
+    Keep,
+    /// Reset the memory.
+    Replace,
+}
+
+/// Specifies the handling of the canister's memories.
+/// * On install and re-install:
+///   - Replace both the stable memory and the main memory.
+/// * On upgrade:
+///   - For canisters with enhanced orthogonal persistence (Motoko):
+///     Retain both the main memory and the stable memory.
+///   - For all other canisters:
+///     Retain only the stable memory and erase the main memory.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct CanisterMemoryHandling {
+    pub stable_memory_handling: MemoryHandling,
+    pub main_memory_handling: MemoryHandling,
+}
+
+/// Specifies where the memories of a newly created execution state come from.
+///
+/// `Hypervisor::create_execution_state` always builds the initial memories of
+/// the new Wasm module (the module's declared minimum memory with its data
+/// segments applied); this type tells it what to do with them afterwards. It is
+/// a mandatory argument so that no caller can forget to restore the memories
+/// that the operation is supposed to preserve.
+#[derive(Debug)]
+// The `Explicit` variant is much larger than the others, but a `MemorySource`
+// is constructed once per operation and consumed right away.
+#[allow(clippy::large_enum_variant)]
+pub enum MemorySource<'a> {
+    /// Install and re-install: keep the initial memories of the new module.
+    Fresh,
+    /// Upgrade: carry over the memories of `old` as directed by `handling`.
+    Preserve {
+        old: &'a ExecutionState,
+        handling: CanisterMemoryHandling,
+    },
+    /// Snapshot restore: install the memories provided by the caller.
+    Explicit {
+        wasm_memory: Memory,
+        stable_memory: Memory,
+    },
+}
+
 #[doc(hidden)]
 pub struct Hypervisor {
     wasm_executor: Arc<dyn WasmExecutor>,
@@ -160,6 +210,7 @@ impl Hypervisor {
         last_install_timestamp: Time,
         round_limits: &mut RoundLimits,
         compilation_cost_handling: CompilationCostHandling,
+        new_memories: MemorySource<'_>,
     ) -> (NumInstructions, HypervisorResult<ExecutionState>) {
         // If a wasm instruction has no arguments then it can be represented as
         // a single byte. So taking the length of the wasm source is a
@@ -198,6 +249,29 @@ impl Hypervisor {
                 // creating execution states, so every install/upgrade/snapshot
                 // restore is forced to provide it.
                 execution_state.last_install_timestamp = Some(last_install_timestamp);
+                // Same for the memories: the embedder always creates the
+                // initial memories of the new module, which the caller may want
+                // to replace with the preserved (or snapshotted) ones.
+                match new_memories {
+                    MemorySource::Fresh => {}
+                    MemorySource::Preserve { old, handling } => {
+                        // Cloning a `Memory` is cheap: its page delta is a
+                        // persistent map and its sandbox handle is an `Arc`.
+                        if handling.stable_memory_handling == MemoryHandling::Keep {
+                            execution_state.stable_memory = old.stable_memory.clone();
+                        }
+                        if handling.main_memory_handling == MemoryHandling::Keep {
+                            execution_state.wasm_memory = old.wasm_memory.clone();
+                        }
+                    }
+                    MemorySource::Explicit {
+                        wasm_memory,
+                        stable_memory,
+                    } => {
+                        execution_state.wasm_memory = wasm_memory;
+                        execution_state.stable_memory = stable_memory;
+                    }
+                }
                 let total_cost = self.create_execution_state_base_cost
                     + compilation_cost_handling.adjusted_compilation_cost(compilation_cost);
                 round_limits.instructions -= as_round_instructions(total_cost);

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -169,7 +169,7 @@ pub struct CanisterMemoryHandling {
 // is constructed once per operation and consumed right away.
 #[allow(clippy::large_enum_variant)]
 pub enum MemorySource<'a> {
-    /// Install and re-install: keep the initial memories of the new module.
+    /// Install and re-install: use the newly installed module's initial memories.
     Fresh,
     /// Upgrade: carry over the memories of `old` as directed by `handling`.
     Preserve {

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -163,9 +163,7 @@ pub struct CanisterMemoryHandling {
 ///
 /// `Hypervisor::create_execution_state` always builds the initial memories of
 /// the new Wasm module (the module's declared minimum memory with its data
-/// segments applied); this type tells it what to do with them afterwards. It is
-/// a mandatory argument so that no caller can forget to restore the memories
-/// that the operation is supposed to preserve.
+/// segments applied); this type tells it what to do with them afterwards.
 #[derive(Debug)]
 // The `Explicit` variant is much larger than the others, but a `MemorySource`
 // is constructed once per operation and consumed right away.

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -149,10 +149,12 @@ pub enum MemoryHandling {
 /// * On install and re-install:
 ///   - Replace both the stable memory and the main memory.
 /// * On upgrade:
-///   - For canisters with enhanced orthogonal persistence (Motoko):
-///     Retain both the main memory and the stable memory.
-///   - For all other canisters:
-///     Retain only the stable memory and erase the main memory.
+///   - Always retain the stable memory.
+///   - Retain the main memory if and only if the `wasm_memory_persistence: opt keep`
+///     upgrade option is used, and erase it otherwise. That option is meant for
+///     canisters with enhanced orthogonal persistence (Motoko) and is only valid
+///     for those; such a canister may still opt into erasing its main memory by
+///     passing `wasm_memory_persistence: opt replace`.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct CanisterMemoryHandling {
     pub stable_memory_handling: MemoryHandling,

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -27,7 +27,9 @@ pub use execution_environment::{
     as_round_instructions, execute_canister,
 };
 pub use history::{IngressHistoryReaderImpl, IngressHistoryWriterImpl};
-pub use hypervisor::{Hypervisor, HypervisorMetrics};
+pub use hypervisor::{
+    CanisterMemoryHandling, Hypervisor, HypervisorMetrics, MemoryHandling, MemorySource,
+};
 use ic_base_types::PrincipalId;
 use ic_config::{execution_environment::Config, subnet_config::SubnetConfig};
 use ic_cycles_account_manager::CyclesAccountManager;


### PR DESCRIPTION
`Hypervisor::create_execution_state` always built the initial memories of the new Wasm module, and every caller then overwrote them afterwards: `install_code` swapped in the preserved memories in `InstallCodeHelper::replace_execution_state_and_allocations`, and `load_canister_snapshot` assigned the snapshot's memories directly. Which memories a new execution state ends up with was hence decided in three different places.

Make `create_execution_state` take a mandatory `MemorySource` describing where the memories come from (`Fresh` for install/reinstall, `Preserve` for upgrades, `Explicit` for snapshot restore) and apply it there, so it is the single place that assembles an execution state's memories.

The `wasm_memory_persistence` upgrade option only ever selected the main memory handling based on the install mode; the two enhanced orthogonal persistence checks in `determine_main_memory_handling` merely rejected otherwise valid combinations. Split it accordingly into the infallible `main_memory_handling`, which runs before the execution state is created, and `validate_wasm_memory_persistence`, which runs after it in the same position relative to the compilation charge as before.

`load_canister_snapshot` now builds the memories to restore before prepaying for the message. As a result a failure to load them (`CanisterSnapshotNotLoadable`) no longer charges the canister for compiling the snapshot's module and now takes precedence over `NotEnoughCycles`.