### PR TITLE
feat(cketh): give the sweeper address its own transaction pipeline

### DIFF
--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -343,7 +343,6 @@ rust_binary(
         "@crate_index//:ethers-core",
         "@crate_index//:ethnum",
         "@crate_index//:flate2",
-        "@crate_index//:hex",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:num-traits",
         "@crate_index//:rlp",

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -343,6 +343,7 @@ rust_binary(
         "@crate_index//:ethers-core",
         "@crate_index//:ethnum",
         "@crate_index//:flate2",
+        "@crate_index//:hex",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:num-traits",
         "@crate_index//:rlp",

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -151,6 +151,11 @@ type UpgradeArg = record {
 
     // Change the sweeper smart contract address.
     ethereum_sweeper_contract_address : opt text;
+
+    // Change the nonce of the next transaction sent from the dedicated sweeper address (its own
+    // nonce sequence, kept separate from the main address' so a stuck sweep cannot delay a
+    // withdrawal). Defaults to 0 at install.
+    next_sweeper_transaction_nonce : opt nat;
 };
 
 type MinterArg = variant { UpgradeArg : UpgradeArg; InitArg : InitArg };
@@ -611,6 +616,31 @@ type Event = record {
         };
         FinalizedTransaction : record {
             withdrawal_id : nat;
+            transaction_receipt : TransactionReceipt;
+        };
+        AcceptedSweepRequest : record {
+            sweep_id : nat;
+            destination : text;
+            amount : nat;
+            // Hex-encoded transaction call data (the delegate sweep call).
+            data : text;
+            max_transaction_fee : nat;
+            created_at : nat64;
+        };
+        CreatedSweeperTransaction : record {
+            sweep_id : nat;
+            transaction : UnsignedTransaction;
+        };
+        SignedSweeperTransaction : record {
+            sweep_id : nat;
+            raw_transaction : text;
+        };
+        ReplacedSweeperTransaction : record {
+            sweep_id : nat;
+            transaction : UnsignedTransaction;
+        };
+        FinalizedSweeperTransaction : record {
+            sweep_id : nat;
             transaction_receipt : TransactionReceipt;
         };
         ReimbursedEthWithdrawal : record {

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -114,6 +114,11 @@ type InitArg = record {
 
     // Address of the sweeper smart contract.
     ethereum_sweeper_contract_address : opt text;
+
+    // Nonce of the next transaction to be sent from the dedicated sweeper address (its own nonce
+    // sequence, kept separate from the main address' so a stuck sweep cannot delay a withdrawal).
+    // Defaults to 0, which is correct for a sweeper address that has never sent a transaction.
+    next_sweeper_transaction_nonce : opt nat;
 };
 
 type UpgradeArg = record {
@@ -154,7 +159,7 @@ type UpgradeArg = record {
 
     // Change the nonce of the next transaction sent from the dedicated sweeper address (its own
     // nonce sequence, kept separate from the main address' so a stuck sweep cannot delay a
-    // withdrawal). Defaults to 0 at install.
+    // withdrawal).
     next_sweeper_transaction_nonce : opt nat;
 };
 

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -627,8 +627,8 @@ type Event = record {
             sweep_id : nat;
             destination : text;
             amount : nat;
-            // Hex-encoded transaction call data (the delegate sweep call).
-            data : text;
+            // Transaction call data (the delegate sweep call).
+            data : blob;
             max_transaction_fee : nat;
             created_at : nat64;
         };

--- a/rs/ethereum/cketh/minter/src/dashboard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard/tests.rs
@@ -1155,6 +1155,7 @@ fn initial_state() -> State {
         last_scraped_block_number: candid::Nat::from(INITIAL_LAST_SCRAPED_BLOCK_NUMBER),
         evm_rpc_id: None,
         ethereum_sweeper_contract_address: None,
+        next_sweeper_transaction_nonce: None,
     })
     .expect("valid init args")
 }

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -521,6 +521,31 @@ pub mod events {
             withdrawal_id: Nat,
             transaction_receipt: TransactionReceipt,
         },
+        AcceptedSweepRequest {
+            sweep_id: Nat,
+            destination: String,
+            amount: Nat,
+            /// Hex-encoded transaction call data (the delegate sweep call).
+            data: String,
+            max_transaction_fee: Nat,
+            created_at: u64,
+        },
+        CreatedSweeperTransaction {
+            sweep_id: Nat,
+            transaction: UnsignedTransaction,
+        },
+        SignedSweeperTransaction {
+            sweep_id: Nat,
+            raw_transaction: String,
+        },
+        ReplacedSweeperTransaction {
+            sweep_id: Nat,
+            transaction: UnsignedTransaction,
+        },
+        FinalizedSweeperTransaction {
+            sweep_id: Nat,
+            transaction_receipt: TransactionReceipt,
+        },
         ReimbursedEthWithdrawal {
             reimbursed_in_block: Nat,
             withdrawal_id: Nat,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -525,8 +525,8 @@ pub mod events {
             sweep_id: Nat,
             destination: String,
             amount: Nat,
-            /// Hex-encoded transaction call data (the delegate sweep call).
-            data: String,
+            /// Transaction call data (the delegate sweep call).
+            data: ByteBuf,
             max_transaction_fee: Nat,
             created_at: u64,
         },

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -34,6 +34,8 @@ pub struct InitArg {
     pub evm_rpc_id: Option<Principal>,
     #[n(10)]
     pub ethereum_sweeper_contract_address: Option<String>,
+    #[cbor(n(11), with = "icrc_cbor::nat::option")]
+    pub next_sweeper_transaction_nonce: Option<Nat>,
 }
 
 impl TryFrom<InitArg> for State {
@@ -50,12 +52,18 @@ impl TryFrom<InitArg> for State {
             last_scraped_block_number,
             evm_rpc_id,
             ethereum_sweeper_contract_address,
+            next_sweeper_transaction_nonce,
         }: InitArg,
     ) -> Result<Self, Self::Error> {
         use std::str::FromStr;
 
         let initial_nonce = TransactionNonce::try_from(next_transaction_nonce)
             .map_err(|e| InvalidStateError::InvalidTransactionNonce(format!("ERROR: {e}")))?;
+        let initial_sweeper_nonce = next_sweeper_transaction_nonce
+            .map(TransactionNonce::try_from)
+            .transpose()
+            .map_err(|e| InvalidStateError::InvalidTransactionNonce(format!("ERROR: {e}")))?
+            .unwrap_or(TransactionNonce::ZERO);
         let minimum_withdrawal_amount = Wei::try_from(minimum_withdrawal_amount).map_err(|e| {
             InvalidStateError::InvalidMinimumWithdrawalAmount(format!("ERROR: {e}"))
         })?;
@@ -98,9 +106,7 @@ impl TryFrom<InitArg> for State {
             pending_withdrawal_principals: Default::default(),
             pending_deposit_principals: Default::default(),
             withdrawal_transactions: WithdrawalTransactions::new(initial_nonce),
-            // A freshly derived sweeper address has never sent a transaction, so its pipeline starts at
-            // nonce 0; existing minters set it via `UpgradeArg::next_sweeper_transaction_nonce`.
-            sweeper_transactions: TransactionPipeline::new(TransactionNonce::ZERO),
+            sweeper_transactions: TransactionPipeline::new(initial_sweeper_nonce),
             next_sweep_id: SweepId(0),
             cketh_ledger_id: ledger_id,
             cketh_minimum_withdrawal_amount: minimum_withdrawal_amount,

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -3,7 +3,7 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, TransactionNonce, Wei};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
-use crate::state::transactions::WithdrawalTransactions;
+use crate::state::transactions::{SweepId, TransactionPipeline, WithdrawalTransactions};
 use crate::state::{InvalidStateError, State};
 use crate::{EVM_RPC_ID_PRODUCTION, EVM_RPC_ID_STAGING};
 use candid::types::number::Nat;
@@ -98,6 +98,10 @@ impl TryFrom<InitArg> for State {
             pending_withdrawal_principals: Default::default(),
             pending_deposit_principals: Default::default(),
             withdrawal_transactions: WithdrawalTransactions::new(initial_nonce),
+            // A freshly derived sweeper address has never sent a transaction, so its pipeline starts at
+            // nonce 0; existing minters set it via `UpgradeArg::next_sweeper_transaction_nonce`.
+            sweeper_transactions: TransactionPipeline::new(TransactionNonce::ZERO),
+            next_sweep_id: SweepId(0),
             cketh_ledger_id: ledger_id,
             cketh_minimum_withdrawal_amount: minimum_withdrawal_amount,
             ethereum_block_height,

--- a/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
@@ -97,6 +97,16 @@ mod init {
 
         assert_matches!(
             State::try_from(InitArg {
+                next_sweeper_transaction_nonce: Some(Nat(BigUint::from_bytes_be(
+                    &ethnum::u256::MAX.to_be_bytes()
+                ) + 1_u8)),
+                ..valid_init_arg()
+            }),
+            Err(InvalidStateError::InvalidTransactionNonce(_))
+        );
+
+        assert_matches!(
+            State::try_from(InitArg {
                 last_scraped_block_number: Nat(BigUint::from_bytes_be(
                     &ethnum::u256::MAX.to_be_bytes(),
                 )),
@@ -137,6 +147,39 @@ mod init {
         assert_eq!(
             state.sweeper_contract_address,
             Some(Address::from_str("0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34").unwrap())
+        );
+    }
+
+    #[test]
+    fn should_start_sweeper_nonce_at_zero_when_unspecified() {
+        let state = State::try_from(InitArg {
+            next_sweeper_transaction_nonce: None,
+            ..valid_init_arg()
+        })
+        .expect("valid init args");
+
+        assert_eq!(
+            state.sweeper_transactions.next_transaction_nonce(),
+            TransactionNonce::ZERO
+        );
+    }
+
+    #[test]
+    fn should_use_given_sweeper_nonce_independently_of_the_main_one() {
+        let state = State::try_from(InitArg {
+            next_transaction_nonce: Nat::from(7_u8),
+            next_sweeper_transaction_nonce: Some(Nat::from(42_u8)),
+            ..valid_init_arg()
+        })
+        .expect("valid init args");
+
+        assert_eq!(
+            state.withdrawal_transactions.next_transaction_nonce(),
+            TransactionNonce::from(7_u8)
+        );
+        assert_eq!(
+            state.sweeper_transactions.next_transaction_nonce(),
+            TransactionNonce::from(42_u8)
         );
     }
 }

--- a/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
@@ -34,7 +34,7 @@ pub struct UpgradeArg {
     pub ethereum_sweeper_contract_address: Option<String>,
     /// Next transaction nonce of the dedicated sweeper address, on its own nonce sequence.
     /// Mirrors `next_transaction_nonce` for the main address.
-    #[cbor(n(12), with = "icrc_cbor::nat::option")]
+    #[cbor(n(11), with = "icrc_cbor::nat::option")]
     pub next_sweeper_transaction_nonce: Option<Nat>,
 }
 

--- a/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
@@ -32,6 +32,10 @@ pub struct UpgradeArg {
     pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,
     #[n(10)]
     pub ethereum_sweeper_contract_address: Option<String>,
+    /// Next transaction nonce of the dedicated sweeper address, on its own nonce sequence.
+    /// Mirrors `next_transaction_nonce` for the main address.
+    #[cbor(n(12), with = "icrc_cbor::nat::option")]
+    pub next_sweeper_transaction_nonce: Option<Nat>,
 }
 
 pub fn post_upgrade(upgrade_args: Option<UpgradeArg>) {

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -920,7 +920,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
                     amount: amount.into(),
-                    data: format!("0x{}", hex::encode(data)),
+                    data: ByteBuf::from(data),
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,
                 },

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -32,7 +32,7 @@ use ic_cketh_minter::state::audit::{Event, EventType, process_event};
 use ic_cketh_minter::state::eth_logs_scraping::{LogScrapingId, LogScrapingInfo};
 use ic_cketh_minter::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
-    ReimbursementRequest,
+    ReimbursementRequest, SweepRequest,
 };
 use ic_cketh_minter::state::{
     STATE, State, lazy_call_ecdsa_public_key, mutate_state, read_state, transactions,
@@ -907,6 +907,49 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     transaction_receipt,
                 } => EP::FinalizedTransaction {
                     withdrawal_id: withdrawal_id.get().into(),
+                    transaction_receipt: map_transaction_receipt(transaction_receipt),
+                },
+                EventType::AcceptedSweepRequest(SweepRequest {
+                    id,
+                    destination,
+                    amount,
+                    data,
+                    max_transaction_fee,
+                    created_at,
+                }) => EP::AcceptedSweepRequest {
+                    sweep_id: id.0.into(),
+                    destination: destination.to_string(),
+                    amount: amount.into(),
+                    data: format!("0x{}", hex::encode(data)),
+                    max_transaction_fee: max_transaction_fee.into(),
+                    created_at,
+                },
+                EventType::CreatedSweeperTransaction {
+                    sweep_id,
+                    transaction,
+                } => EP::CreatedSweeperTransaction {
+                    sweep_id: sweep_id.0.into(),
+                    transaction: map_unsigned_transaction(transaction),
+                },
+                EventType::SignedSweeperTransaction {
+                    sweep_id,
+                    transaction,
+                } => EP::SignedSweeperTransaction {
+                    sweep_id: sweep_id.0.into(),
+                    raw_transaction: transaction.raw_transaction_hex_string(),
+                },
+                EventType::ReplacedSweeperTransaction {
+                    sweep_id,
+                    transaction,
+                } => EP::ReplacedSweeperTransaction {
+                    sweep_id: sweep_id.0.into(),
+                    transaction: map_unsigned_transaction(transaction),
+                },
+                EventType::FinalizedSweeperTransaction {
+                    sweep_id,
+                    transaction_receipt,
+                } => EP::FinalizedSweeperTransaction {
+                    sweep_id: sweep_id.0.into(),
                     transaction_receipt: map_transaction_receipt(transaction_receipt),
                 },
                 EventType::ReimbursedEthWithdrawal(Reimbursed {

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -27,7 +27,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet, btree_map};
 use std::fmt::{Display, Formatter};
 use strum_macros::EnumIter;
-use transactions::WithdrawalTransactions;
+use transactions::{SweepId, SweeperTransactionPipeline, WithdrawalTransactions};
 
 pub mod audit;
 pub mod automatic_deposits;
@@ -76,6 +76,11 @@ pub struct State {
     pub minted_events: BTreeMap<EventSource, MintedEvent>,
     pub invalid_events: BTreeMap<EventSource, InvalidEventReason>,
     pub withdrawal_transactions: WithdrawalTransactions,
+    /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
+    /// its own nonce sequence, independent of the main-address withdrawal pipeline.
+    pub sweeper_transactions: SweeperTransactionPipeline,
+    /// Monotonic counter minting the next [`SweepId`] for the sweeper pipeline.
+    pub next_sweep_id: SweepId,
     pub skipped_blocks: BTreeMap<Address, BTreeSet<BlockNumber>>,
 
     /// Current balance of ETH held by the minter.
@@ -540,11 +545,18 @@ impl State {
             deposit_with_subaccount_helper_contract_address,
             last_deposit_with_subaccount_scraped_block_number,
             ethereum_sweeper_contract_address,
+            next_sweeper_transaction_nonce,
         } = upgrade_args;
         if let Some(nonce) = next_transaction_nonce {
             let nonce = TransactionNonce::try_from(nonce)
                 .map_err(|e| InvalidStateError::InvalidTransactionNonce(format!("ERROR: {e}")))?;
             self.withdrawal_transactions
+                .update_next_transaction_nonce(nonce);
+        }
+        if let Some(nonce) = next_sweeper_transaction_nonce {
+            let nonce = TransactionNonce::try_from(nonce)
+                .map_err(|e| InvalidStateError::InvalidTransactionNonce(format!("ERROR: {e}")))?;
+            self.sweeper_transactions
                 .update_next_transaction_nonce(nonce);
         }
         if let Some(amount) = minimum_withdrawal_amount {
@@ -663,7 +675,10 @@ impl State {
             other.sweeper_contract_address
         );
         ensure_eq!(self.sweeper_funding, other.sweeper_funding);
+        ensure_eq!(self.next_sweep_id, other.next_sweep_id);
 
+        self.sweeper_transactions
+            .is_equivalent_to(&other.sweeper_transactions)?;
         self.withdrawal_transactions
             .is_equivalent_to(&other.withdrawal_transactions)
     }

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -112,6 +112,44 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         } => {
             state.record_finalized_transaction(withdrawal_id, transaction_receipt);
         }
+        EventType::AcceptedSweepRequest(request) => {
+            state.next_sweep_id = request.id.next();
+            state.sweeper_transactions.record_request(request.clone());
+        }
+        EventType::CreatedSweeperTransaction {
+            sweep_id,
+            transaction,
+        } => {
+            state
+                .sweeper_transactions
+                .record_created_transaction(*sweep_id, transaction.clone());
+        }
+        EventType::SignedSweeperTransaction {
+            sweep_id: _,
+            transaction,
+        } => {
+            state
+                .sweeper_transactions
+                .record_signed_transaction(transaction.clone());
+        }
+        EventType::ReplacedSweeperTransaction {
+            sweep_id: _,
+            transaction,
+        } => {
+            state
+                .sweeper_transactions
+                .record_resubmit_transaction(transaction.clone());
+        }
+        EventType::FinalizedSweeperTransaction {
+            sweep_id,
+            transaction_receipt,
+        } => {
+            // The sweeper pipeline is never reimbursed and holds no ckETH balance, so unlike the main
+            // pipeline there is no reimbursement tail or balance update — just the finalize mechanics.
+            let _ = state
+                .sweeper_transactions
+                .record_finalized_transaction(*sweep_id, transaction_receipt);
+        }
         EventType::ReimbursedEthWithdrawal(Reimbursed {
             burn_in_block: withdrawal_id,
             reimbursed_in_block,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -93,6 +93,7 @@ impl GetEventsFile {
         use crate::endpoints::events::{
             AccessListItem as CandidAccessListItem, EventSource as CandidEventSource,
             ReimbursementIndex as CandidReimbursementIndex,
+            TransactionReceipt as CandidTransactionReceipt,
             TransactionStatus as CandidTransactionStatus,
         };
         use crate::eth_logs::EventSource;
@@ -128,6 +129,20 @@ impl GetEventsFile {
                     ledger_id,
                     ckerc20_ledger_burn_index: map_nat(ckerc20_ledger_burn_index),
                 },
+            }
+        }
+
+        fn map_transaction_receipt(receipt: CandidTransactionReceipt) -> TransactionReceipt {
+            TransactionReceipt {
+                block_hash: receipt.block_hash.parse().unwrap(),
+                block_number: receipt.block_number.try_into().unwrap(),
+                effective_gas_price: receipt.effective_gas_price.try_into().unwrap(),
+                gas_used: receipt.gas_used.try_into().unwrap(),
+                status: match receipt.status {
+                    CandidTransactionStatus::Success => TransactionStatus::Success,
+                    CandidTransactionStatus::Failure => TransactionStatus::Failure,
+                },
+                transaction_hash: receipt.transaction_hash.parse().unwrap(),
             }
         }
 
@@ -357,20 +372,7 @@ impl GetEventsFile {
                     transaction_receipt,
                 } => ET::FinalizedTransaction {
                     withdrawal_id: map_nat(withdrawal_id),
-                    transaction_receipt: TransactionReceipt {
-                        block_hash: transaction_receipt.block_hash.parse().unwrap(),
-                        block_number: transaction_receipt.block_number.try_into().unwrap(),
-                        effective_gas_price: transaction_receipt
-                            .effective_gas_price
-                            .try_into()
-                            .unwrap(),
-                        gas_used: transaction_receipt.gas_used.try_into().unwrap(),
-                        status: match transaction_receipt.status {
-                            CandidTransactionStatus::Success => TransactionStatus::Success,
-                            CandidTransactionStatus::Failure => TransactionStatus::Failure,
-                        },
-                        transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
-                    },
+                    transaction_receipt: map_transaction_receipt(transaction_receipt),
                 },
                 EventPayload::AcceptedSweepRequest {
                     sweep_id,
@@ -413,20 +415,7 @@ impl GetEventsFile {
                     transaction_receipt,
                 } => ET::FinalizedSweeperTransaction {
                     sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                    transaction_receipt: TransactionReceipt {
-                        block_hash: transaction_receipt.block_hash.parse().unwrap(),
-                        block_number: transaction_receipt.block_number.try_into().unwrap(),
-                        effective_gas_price: transaction_receipt
-                            .effective_gas_price
-                            .try_into()
-                            .unwrap(),
-                        gas_used: transaction_receipt.gas_used.try_into().unwrap(),
-                        status: match transaction_receipt.status {
-                            CandidTransactionStatus::Success => TransactionStatus::Success,
-                            CandidTransactionStatus::Failure => TransactionStatus::Failure,
-                        },
-                        transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
-                    },
+                    transaction_receipt: map_transaction_receipt(transaction_receipt),
                 },
                 EventPayload::ReimbursedEthWithdrawal {
                     reimbursed_in_block,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -7,7 +7,8 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::Wei;
 use crate::state::audit::{Event, replay_events_internal};
 use crate::state::transactions::{
-    Erc20WithdrawalRequest, Reimbursed, ReimbursementIndex, ReimbursementRequest,
+    Erc20WithdrawalRequest, Reimbursed, ReimbursementIndex, ReimbursementRequest, SweepId,
+    SweepRequest,
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
@@ -356,6 +357,62 @@ impl GetEventsFile {
                     transaction_receipt,
                 } => ET::FinalizedTransaction {
                     withdrawal_id: map_nat(withdrawal_id),
+                    transaction_receipt: TransactionReceipt {
+                        block_hash: transaction_receipt.block_hash.parse().unwrap(),
+                        block_number: transaction_receipt.block_number.try_into().unwrap(),
+                        effective_gas_price: transaction_receipt
+                            .effective_gas_price
+                            .try_into()
+                            .unwrap(),
+                        gas_used: transaction_receipt.gas_used.try_into().unwrap(),
+                        status: match transaction_receipt.status {
+                            CandidTransactionStatus::Success => TransactionStatus::Success,
+                            CandidTransactionStatus::Failure => TransactionStatus::Failure,
+                        },
+                        transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
+                    },
+                },
+                EventPayload::AcceptedSweepRequest {
+                    sweep_id,
+                    destination,
+                    amount,
+                    data,
+                    max_transaction_fee,
+                    created_at,
+                } => ET::AcceptedSweepRequest(SweepRequest {
+                    id: SweepId(sweep_id.0.to_u64().unwrap()),
+                    destination: destination.parse().unwrap(),
+                    amount: amount.try_into().unwrap(),
+                    data: hex::decode(data.strip_prefix("0x").unwrap_or(&data)).unwrap(),
+                    max_transaction_fee: max_transaction_fee.try_into().unwrap(),
+                    created_at,
+                }),
+                EventPayload::CreatedSweeperTransaction {
+                    sweep_id,
+                    transaction,
+                } => ET::CreatedSweeperTransaction {
+                    sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                    transaction: map_unsigned_transaction(transaction),
+                },
+                EventPayload::SignedSweeperTransaction {
+                    sweep_id,
+                    raw_transaction,
+                } => ET::SignedSweeperTransaction {
+                    sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                    transaction: map_signed_transaction(&raw_transaction),
+                },
+                EventPayload::ReplacedSweeperTransaction {
+                    sweep_id,
+                    transaction,
+                } => ET::ReplacedSweeperTransaction {
+                    sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                    transaction: map_unsigned_transaction(transaction),
+                },
+                EventPayload::FinalizedSweeperTransaction {
+                    sweep_id,
+                    transaction_receipt,
+                } => ET::FinalizedSweeperTransaction {
+                    sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
                     transaction_receipt: TransactionReceipt {
                         block_hash: transaction_receipt.block_hash.parse().unwrap(),
                         block_number: transaction_receipt.block_number.try_into().unwrap(),

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -385,7 +385,7 @@ impl GetEventsFile {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
                     amount: amount.try_into().unwrap(),
-                    data: hex::decode(data.strip_prefix("0x").unwrap_or(&data)).unwrap(),
+                    data: data.into_vec(),
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,
                 }),

--- a/rs/ethereum/cketh/minter/src/state/event.rs
+++ b/rs/ethereum/cketh/minter/src/state/event.rs
@@ -6,7 +6,7 @@ use crate::lifecycle::{init::InitArg, upgrade::UpgradeArg};
 use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, LedgerMintIndex};
 use crate::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
-    ReimbursementRequest,
+    ReimbursementRequest, SweepId, SweepRequest,
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{Eip1559TransactionRequest, SignedEip1559TransactionRequest};
@@ -186,6 +186,41 @@ pub enum EventType {
     /// The minter burned ckETH from its fee subaccount to top up the sweeper address with gas.
     #[n(27)]
     AcceptedSweeperFundingRequest(#[n(0)] EthWithdrawalRequest),
+    /// The minter enqueued a sweep to be sent from its dedicated sweeper address.
+    #[n(28)]
+    AcceptedSweepRequest(#[n(0)] SweepRequest),
+    /// The minter created a sweep transaction.
+    #[n(29)]
+    CreatedSweeperTransaction {
+        #[n(1)]
+        sweep_id: SweepId,
+        #[n(2)]
+        transaction: Eip1559TransactionRequest,
+    },
+    /// The minter signed a sweep transaction.
+    #[n(30)]
+    SignedSweeperTransaction {
+        #[n(1)]
+        sweep_id: SweepId,
+        #[n(2)]
+        transaction: SignedEip1559TransactionRequest,
+    },
+    /// The minter replaced a sweep transaction after a fee bump.
+    #[n(31)]
+    ReplacedSweeperTransaction {
+        #[n(1)]
+        sweep_id: SweepId,
+        #[n(2)]
+        transaction: Eip1559TransactionRequest,
+    },
+    /// The minter observed a sweep transaction being included in a finalized Ethereum block.
+    #[n(32)]
+    FinalizedSweeperTransaction {
+        #[n(1)]
+        sweep_id: SweepId,
+        #[n(2)]
+        transaction_receipt: TransactionReceipt,
+    },
 }
 
 /// Full snapshot of the ckERC20 deposit address registry. Carries the limits in

--- a/rs/ethereum/cketh/minter/src/state/event.rs
+++ b/rs/ethereum/cketh/minter/src/state/event.rs
@@ -192,33 +192,33 @@ pub enum EventType {
     /// The minter created a sweep transaction.
     #[n(29)]
     CreatedSweeperTransaction {
-        #[n(1)]
+        #[n(0)]
         sweep_id: SweepId,
-        #[n(2)]
+        #[n(1)]
         transaction: Eip1559TransactionRequest,
     },
     /// The minter signed a sweep transaction.
     #[n(30)]
     SignedSweeperTransaction {
-        #[n(1)]
+        #[n(0)]
         sweep_id: SweepId,
-        #[n(2)]
+        #[n(1)]
         transaction: SignedEip1559TransactionRequest,
     },
     /// The minter replaced a sweep transaction after a fee bump.
     #[n(31)]
     ReplacedSweeperTransaction {
-        #[n(1)]
+        #[n(0)]
         sweep_id: SweepId,
-        #[n(2)]
+        #[n(1)]
         transaction: Eip1559TransactionRequest,
     },
     /// The minter observed a sweep transaction being included in a finalized Ethereum block.
     #[n(32)]
     FinalizedSweeperTransaction {
-        #[n(1)]
+        #[n(0)]
         sweep_id: SweepId,
-        #[n(2)]
+        #[n(1)]
         transaction_receipt: TransactionReceipt,
     },
 }

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -712,9 +712,10 @@ prop_compose! {
         deposit_with_subaccount_helper_contract_address in proptest::option::of(arb_address()),
         last_deposit_with_subaccount_scraped_block_number in proptest::option::of(arb_nat()),
         sweeper_contract_address in proptest::option::of(arb_address()),
+        next_sweeper_transaction_nonce in proptest::option::of(arb_nat()),
     ) -> UpgradeArg {
         UpgradeArg {
-            next_sweeper_transaction_nonce: None,
+            next_sweeper_transaction_nonce,
             ethereum_contract_address: contract_address.map(|addr| addr.to_string()),
             ethereum_block_height,
             minimum_withdrawal_amount,

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -14,7 +14,8 @@ use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
 use crate::state::event::{Event, EventType};
 use crate::state::transactions::{
-    Erc20WithdrawalRequest, EthWithdrawalRequest, ReimbursementIndex,
+    Erc20WithdrawalRequest, EthWithdrawalRequest, ReimbursementIndex, SweepId,
+    SweeperTransactionPipeline,
 };
 use crate::state::{Erc20Balances, State};
 use crate::test_fixtures::{
@@ -711,6 +712,7 @@ prop_compose! {
         sweeper_contract_address in proptest::option::of(arb_address()),
     ) -> UpgradeArg {
         UpgradeArg {
+            next_sweeper_transaction_nonce: None,
             ethereum_contract_address: contract_address.map(|addr| addr.to_string()),
             ethereum_block_height,
             minimum_withdrawal_amount,
@@ -1165,6 +1167,8 @@ fn state_equivalence() {
     };
     let state = State {
         sweeper_funding: Default::default(),
+        sweeper_transactions: SweeperTransactionPipeline::new(TransactionNonce::ZERO),
+        next_sweep_id: SweepId(0),
         ethereum_network: EthereumNetwork::Mainnet,
         ecdsa_key_name: "test_key".to_string(),
         cketh_ledger_id: "apia6-jaaaa-aaaar-qabma-cai".parse().unwrap(),

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -681,6 +681,7 @@ prop_compose! {
         last_scraped_block_number in arb_nat(),
         evm_rpc_id in proptest::option::of(arb_principal()),
         sweeper_contract_address in proptest::option::of(arb_address()),
+        next_sweeper_transaction_nonce in proptest::option::of(arb_nat()),
     ) -> InitArg {
         InitArg {
             ethereum_network: EthereumNetwork::Sepolia,
@@ -693,6 +694,7 @@ prop_compose! {
             last_scraped_block_number,
             evm_rpc_id,
             ethereum_sweeper_contract_address: sweeper_contract_address.map(|addr| addr.to_string()),
+            next_sweeper_transaction_nonce,
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -439,7 +439,7 @@ impl fmt::Debug for Erc20WithdrawalRequest {
 ///    discarded. Paying the requester back is not the pipeline's concern — see
 ///    [`WithdrawalTransactions`].
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub(in crate::state) struct TransactionPipeline<R: PipelineRequest> {
+pub struct TransactionPipeline<R: PipelineRequest> {
     pending_requests: VecDeque<R>,
     // Processed requests (transaction created, sent, or finalized).
     processed_requests: BTreeMap<R::Id, R>,
@@ -450,7 +450,7 @@ pub(in crate::state) struct TransactionPipeline<R: PipelineRequest> {
 }
 
 /// The pipeline sending from the minter's main address, on which user withdrawals travel.
-pub(in crate::state) type MinterTransactionPipeline = TransactionPipeline<WithdrawalRequest>;
+pub type MinterTransactionPipeline = TransactionPipeline<WithdrawalRequest>;
 
 /// The pipeline sending from the minter's dedicated sweeper address.
 pub type SweeperTransactionPipeline = TransactionPipeline<SweepRequest>;
@@ -477,7 +477,7 @@ pub enum ResubmitTransactionError<Id> {
 /// How far a transaction has got through the pipeline. Carries the transaction itself, since
 /// every caller that asks the stage also wants the transaction at it.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub(in crate::state) enum TransactionStage<'a> {
+pub enum TransactionStage<'a> {
     Created(&'a Eip1559TransactionRequest),
     /// The most recently sent transaction, i.e. the one with the highest fee.
     Sent(&'a SignedTransactionRequest),

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -228,13 +228,15 @@ pub struct SweepRequest {
     /// This sweep's identity (the pipeline's alternate map key).
     #[n(0)]
     pub id: SweepId,
-    /// Address the sweep transaction is sent to (the delegated deposit EOA, later).
+    /// Address the sweep transaction is sent to: the sweeper contract, whose batch entry point
+    /// sweeps every delegated deposit address named in `data`.
     #[n(1)]
     pub destination: Address,
     /// ETH value moved by the transaction (zero for an ERC-20 sweep, which moves tokens via calldata).
     #[n(2)]
     pub amount: Wei,
-    /// Transaction call data (the delegate `sweepErc20` call, later; empty for a plain transfer).
+    /// Transaction call data: the sweeper contract's batch call, naming the deposit addresses to
+    /// sweep, the IC account each is credited to, and the tokens to move.
     #[n(3)]
     pub data: Vec<u8>,
     /// Ceiling on the transaction fee, used as the resubmission fee cap.

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -230,7 +230,9 @@ pub struct SweepRequest {
     #[n(2)]
     pub amount: Wei,
     /// Transaction call data: the sweeper contract's batch call, naming the deposit addresses to
-    /// sweep, the IC account each is credited to, and the tokens to move.
+    /// sweep, the IC account each is credited to, and the tokens to move. Its size is bounded by
+    /// the number of deposits the enqueuing side puts in one batch, which is where that limit
+    /// lives.
     #[n(3)]
     pub data: Vec<u8>,
     /// Ceiling on the transaction fee, used as the resubmission fee cap.

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -211,12 +211,6 @@ impl SweepId {
     }
 }
 
-impl fmt::Display for SweepId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -460,6 +460,19 @@ pub enum CreateTransactionError {
     },
 }
 
+/// Why a sweep could not be turned into a transaction.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum CreateSweepTransactionError {
+    /// The gas prepaid for this sweep cannot pay the current fee, so no transaction is created:
+    /// one priced within the allowance could not be mined, and would hold the sweeper's nonce
+    /// while the resubmission strategy refused to bump it past the same allowance.
+    InsufficientTransactionFee {
+        id: SweepId,
+        allowed_max_transaction_fee: Wei,
+        actual_max_transaction_fee: Wei,
+    },
+}
+
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ResubmitTransactionError<Id> {
     InsufficientTransactionFee {

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -194,6 +194,57 @@ pub struct Erc20WithdrawalRequest {
     pub created_at: u64,
 }
 
+/// Monotonic identity of a sweep, used as the sweeper pipeline's alternate map key. Unlike a
+/// withdrawal's `LedgerBurnIndex`, a sweep burns no ckETH, so its id is a plain counter.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Decode, Encode)]
+#[cbor(transparent)]
+pub struct SweepId(#[n(0)] pub u64);
+
+impl SweepId {
+    /// The id following this one, minted when a sweep is accepted.
+    pub fn next(self) -> Self {
+        SweepId(
+            self.0
+                .checked_add(1)
+                .expect("BUG: sweep id space exhausted"),
+        )
+    }
+}
+
+impl fmt::Display for SweepId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
+/// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
+/// and is never reimbursed.
+///
+/// For now this is a plain EIP-1559 transaction (type `0x02`); the EIP-7702 (`0x04`) first-time
+/// delegation and the sweep-queue-driven construction of the delegate call data are follow-ups.
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
+pub struct SweepRequest {
+    /// This sweep's identity (the pipeline's alternate map key).
+    #[n(0)]
+    pub id: SweepId,
+    /// Address the sweep transaction is sent to (the delegated deposit EOA, later).
+    #[n(1)]
+    pub destination: Address,
+    /// ETH value moved by the transaction (zero for an ERC-20 sweep, which moves tokens via calldata).
+    #[n(2)]
+    pub amount: Wei,
+    /// Transaction call data (the delegate `sweepErc20` call, later; empty for a plain transfer).
+    #[n(3)]
+    pub data: Vec<u8>,
+    /// Ceiling on the transaction fee, used as the resubmission fee cap.
+    #[n(4)]
+    pub max_transaction_fee: Wei,
+    /// The IC time at which the sweep was decided.
+    #[n(5)]
+    pub created_at: u64,
+}
+
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Decode, Encode)]
 pub enum ReimbursementIndex {
     #[n(0)]
@@ -368,9 +419,9 @@ impl fmt::Debug for Erc20WithdrawalRequest {
 }
 
 /// State machine holding Ethereum transactions issued by the minter from a **single sender
-/// address**, on that address' **own nonce sequence** — generic over the request type `R` so a
-/// second sender address can drive the same machinery on a nonce sequence of its own without
-/// interfering with user withdrawals (`R = WithdrawalRequest`, wrapped by [`WithdrawalTransactions`]).
+/// address**, on that address' **own nonce sequence** — generic over the request type `R` so the
+/// same machinery serves both the main-address withdrawal pipeline (`R = WithdrawalRequest`, aliased
+/// as [`WithdrawalTransactions`]) and the dedicated sweeper-address pipeline (`R = SweepRequest`).
 ///
 /// Overall the transaction lifecycle is as follows:
 /// 1. The request is enqueued and processed in a FIFO order.
@@ -398,6 +449,9 @@ pub(in crate::state) struct TransactionPipeline<R: PipelineRequest> {
 
 /// The pipeline sending from the minter's main address, on which user withdrawals travel.
 pub(in crate::state) type MinterTransactionPipeline = TransactionPipeline<WithdrawalRequest>;
+
+/// The pipeline sending from the minter's dedicated sweeper address.
+pub type SweeperTransactionPipeline = TransactionPipeline<SweepRequest>;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum CreateTransactionError {

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -196,10 +196,6 @@ impl PipelineRequest for SweepRequest {
         self.id
     }
 
-    fn created_at(&self) -> Option<u64> {
-        Some(self.created_at)
-    }
-
     fn resubmission_strategy(&self) -> ResubmissionStrategy {
         ResubmissionStrategy::GuaranteeEthAmount {
             allowed_max_transaction_fee: self.max_transaction_fee,

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{GasAmount, LedgerBurnIndex, TransactionNonce, Wei};
 use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy};
+use std::cmp::min;
 use std::convert::Infallible;
 use std::fmt;
 
@@ -228,13 +229,22 @@ impl PipelineRequest for SweepRequest {
             gas_limit > GasAmount::ZERO,
             "BUG: gas limit should be non-zero"
         );
-        let transaction_price = gas_fee_estimate.to_price(gas_limit);
+        // The fee is prepaid, so the whole allowance is allocated from the beginning: the sweep
+        // then survives a rising `base_fee_per_gas` without a resubmission, and can never cost
+        // more than the allowance the resubmission strategy would enforce anyway.
+        let max_fee_per_gas = self
+            .max_transaction_fee
+            .into_wei_per_gas(gas_limit)
+            .expect("BUG: gas_limit should be non-zero");
         Ok(Eip1559TransactionRequest {
             chain_id: ethereum_network.chain_id(),
             nonce,
-            max_priority_fee_per_gas: transaction_price.max_priority_fee_per_gas,
-            max_fee_per_gas: transaction_price.max_fee_per_gas,
-            gas_limit: transaction_price.gas_limit,
+            max_priority_fee_per_gas: min(
+                gas_fee_estimate.max_priority_fee_per_gas,
+                max_fee_per_gas,
+            ),
+            max_fee_per_gas,
+            gas_limit,
             destination: self.destination,
             amount: self.amount,
             data: self.data.clone(),

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -2,14 +2,12 @@
 //! and the minter's own implementation of it.
 
 use super::{
-    CreateTransactionError, EthWithdrawalRequest, SweepId, SweepRequest, TransactionCallData,
-    WithdrawalRequest,
+    CreateSweepTransactionError, CreateTransactionError, EthWithdrawalRequest, SweepId,
+    SweepRequest, TransactionCallData, WithdrawalRequest,
 };
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{GasAmount, LedgerBurnIndex, TransactionNonce, Wei};
 use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy};
-use std::cmp::min;
-use std::convert::Infallible;
 use std::fmt;
 
 /// A request that can flow through a `TransactionPipeline`: it carries an identity used as the
@@ -189,9 +187,7 @@ impl PipelineRequest for WithdrawalRequest {
 
 impl PipelineRequest for SweepRequest {
     type Id = SweepId;
-    /// A sweep pays its gas from the sweeper's own prepaid balance rather than out of the amount
-    /// moved, so there is no fee for it to fail to cover.
-    type Error = Infallible;
+    type Error = CreateSweepTransactionError;
 
     fn id(&self) -> SweepId {
         self.id
@@ -224,7 +220,7 @@ impl PipelineRequest for SweepRequest {
         gas_fee_estimate: GasFeeEstimate,
         gas_limit: GasAmount,
         ethereum_network: EthereumNetwork,
-    ) -> Result<Eip1559TransactionRequest, Infallible> {
+    ) -> Result<Eip1559TransactionRequest, CreateSweepTransactionError> {
         assert!(
             gas_limit > GasAmount::ZERO,
             "BUG: gas limit should be non-zero"
@@ -236,13 +232,20 @@ impl PipelineRequest for SweepRequest {
             .max_transaction_fee
             .into_wei_per_gas(gas_limit)
             .expect("BUG: gas_limit should be non-zero");
+        let min_max_fee_per_gas = gas_fee_estimate.min_max_fee_per_gas();
+        if min_max_fee_per_gas > max_fee_per_gas {
+            return Err(CreateSweepTransactionError::InsufficientTransactionFee {
+                id: self.id,
+                allowed_max_transaction_fee: self.max_transaction_fee,
+                actual_max_transaction_fee: min_max_fee_per_gas
+                    .transaction_cost(gas_limit)
+                    .unwrap_or(Wei::MAX),
+            });
+        }
         Ok(Eip1559TransactionRequest {
             chain_id: ethereum_network.chain_id(),
             nonce,
-            max_priority_fee_per_gas: min(
-                gas_fee_estimate.max_priority_fee_per_gas,
-                max_fee_per_gas,
-            ),
+            max_priority_fee_per_gas: gas_fee_estimate.max_priority_fee_per_gas,
             max_fee_per_gas,
             gas_limit,
             destination: self.destination,

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -215,6 +215,10 @@ impl PipelineRequest for SweepRequest {
             transaction.amount, self.amount,
             "BUG: sweep transaction amount should equal the request amount"
         );
+        assert_eq!(
+            transaction.data, self.data,
+            "BUG: sweep transaction should carry the request's call data"
+        );
     }
 
     fn create_transaction(

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -1,19 +1,25 @@
 //! What it takes for a request to travel a [`TransactionPipeline`](super::TransactionPipeline),
 //! and the minter's own implementation of it.
 
-use super::{CreateTransactionError, EthWithdrawalRequest, TransactionCallData, WithdrawalRequest};
+use super::{
+    CreateTransactionError, EthWithdrawalRequest, SweepId, SweepRequest, TransactionCallData,
+    WithdrawalRequest,
+};
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{GasAmount, LedgerBurnIndex, TransactionNonce, Wei};
 use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy};
+use std::convert::Infallible;
 use std::fmt;
 
 /// A request that can flow through a `TransactionPipeline`: it carries an identity used as the
 /// pipeline's alternate map key, and knows the EIP-1559 transaction it turns into.
 ///
-/// Implemented so far only by [`WithdrawalRequest`], the minter's main-address pipeline
-/// (`Id = LedgerBurnIndex`); a second sender address will bring a second implementation.
+/// Implemented by [`WithdrawalRequest`] — the minter's **main address** pipeline
+/// (`Id = LedgerBurnIndex`) — and by [`SweepRequest`] — the dedicated **sweeper address** pipeline
+/// (`Id = SweepId`), which burns no ckETH and is therefore never reimbursed.
 pub trait PipelineRequest {
-    /// The pipeline's alternate map key — a ckETH `LedgerBurnIndex` for withdrawals.
+    /// The pipeline's alternate map key: a ckETH `LedgerBurnIndex` for withdrawals, a `SweepId`
+    /// for sweeps.
     type Id: Copy + Ord + fmt::Debug;
 
     /// Why [`Self::create_transaction`] could not build a transaction. A request that always funds
@@ -177,5 +183,62 @@ impl PipelineRequest for WithdrawalRequest {
                 })
             }
         }
+    }
+}
+
+impl PipelineRequest for SweepRequest {
+    type Id = SweepId;
+    /// A sweep pays its gas from the sweeper's own prepaid balance rather than out of the amount
+    /// moved, so there is no fee for it to fail to cover.
+    type Error = Infallible;
+
+    fn id(&self) -> SweepId {
+        self.id
+    }
+
+    fn created_at(&self) -> Option<u64> {
+        Some(self.created_at)
+    }
+
+    fn resubmission_strategy(&self) -> ResubmissionStrategy {
+        ResubmissionStrategy::GuaranteeEthAmount {
+            allowed_max_transaction_fee: self.max_transaction_fee,
+        }
+    }
+
+    fn assert_created_transaction(&self, transaction: &Eip1559TransactionRequest) {
+        assert_eq!(
+            self.destination, transaction.destination,
+            "BUG: request and transaction destination mismatch"
+        );
+        assert_eq!(
+            transaction.amount, self.amount,
+            "BUG: sweep transaction amount should equal the request amount"
+        );
+    }
+
+    fn create_transaction(
+        &self,
+        nonce: TransactionNonce,
+        gas_fee_estimate: GasFeeEstimate,
+        gas_limit: GasAmount,
+        ethereum_network: EthereumNetwork,
+    ) -> Result<Eip1559TransactionRequest, Infallible> {
+        assert!(
+            gas_limit > GasAmount::ZERO,
+            "BUG: gas limit should be non-zero"
+        );
+        let transaction_price = gas_fee_estimate.to_price(gas_limit);
+        Ok(Eip1559TransactionRequest {
+            chain_id: ethereum_network.chain_id(),
+            nonce,
+            max_priority_fee_per_gas: transaction_price.max_priority_fee_per_gas,
+            max_fee_per_gas: transaction_price.max_fee_per_gas,
+            gas_limit: transaction_price.gas_limit,
+            destination: self.destination,
+            amount: self.amount,
+            data: self.data.clone(),
+            access_list: Default::default(),
+        })
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2906,10 +2906,13 @@ mod sweep_lane {
     use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
-    use crate::numeric::{GasAmount, TransactionNonce, Wei};
+    use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        Eip1559TransactionRequest, PipelineRequest, SweepId, SweepRequest, TransactionPipeline,
+        Eip1559TransactionRequest, PipelineRequest, ResubmitTransactionError, SweepId,
+        SweepRequest, TransactionPipeline,
     };
+    use crate::tx::GasFeeEstimate;
+    use assert_matches::assert_matches;
     use ic_ethereum_types::Address;
 
     const SWEEP_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
@@ -3012,6 +3015,98 @@ mod sweep_lane {
                 data: vec![0xff],
                 ..tx
             },
+        );
+    }
+
+    #[test]
+    fn should_allocate_the_whole_fee_allowance_to_a_sweep_transaction() {
+        let request = sweep_request(0);
+        let Ok(tx) = request.create_transaction(
+            TransactionNonce::ZERO,
+            gas_fee_estimate(),
+            SWEEP_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        );
+
+        assert_eq!(
+            tx.max_fee_per_gas,
+            request
+                .max_transaction_fee
+                .into_wei_per_gas(SWEEP_GAS_LIMIT)
+                .unwrap()
+        );
+        assert_eq!(
+            tx.max_fee_per_gas.transaction_cost(SWEEP_GAS_LIMIT),
+            Some(request.max_transaction_fee)
+        );
+        assert_eq!(
+            tx.max_priority_fee_per_gas,
+            gas_fee_estimate().max_priority_fee_per_gas
+        );
+    }
+
+    #[test]
+    fn should_keep_a_sweep_transaction_within_its_fee_allowance_when_the_estimate_spikes() {
+        let request = sweep_request(0);
+        let spiked_fee = GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::from(10_000_000_000_000_u64),
+            ..gas_fee_estimate()
+        };
+
+        let Ok(tx) = request.create_transaction(
+            TransactionNonce::ZERO,
+            spiked_fee,
+            SWEEP_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        );
+
+        assert_eq!(
+            tx.max_fee_per_gas.transaction_cost(SWEEP_GAS_LIMIT),
+            Some(request.max_transaction_fee)
+        );
+    }
+
+    #[test]
+    fn should_cap_the_priority_fee_at_the_fee_allowance() {
+        let request = SweepRequest {
+            max_transaction_fee: Wei::from(100_000_u64),
+            ..sweep_request(0)
+        };
+
+        let Ok(tx) = request.create_transaction(
+            TransactionNonce::ZERO,
+            gas_fee_estimate(),
+            SWEEP_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        );
+
+        assert_eq!(tx.max_fee_per_gas, WeiPerGas::ONE);
+        assert_eq!(tx.max_priority_fee_per_gas, tx.max_fee_per_gas);
+    }
+
+    #[test]
+    fn should_refuse_to_resubmit_a_sweep_beyond_its_fee_allowance() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+        let created = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+        pipeline.record_signed_transaction(sign_transaction(created));
+
+        let spiked_fee = GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::from(10_000_000_000_000_u64),
+            ..gas_fee_estimate()
+        };
+        let resubmitted = pipeline.create_resubmit_transactions(TransactionCount::ZERO, spiked_fee);
+
+        assert_matches!(
+            resubmitted.first().expect("BUG: nothing to resubmit"),
+            Err(ResubmitTransactionError::InsufficientTransactionFee {
+                id,
+                allowed_max_transaction_fee,
+                max_transaction_fee,
+                ..
+            }) if *id == SweepId(0)
+                && *allowed_max_transaction_fee == sweep_request(0).max_transaction_fee
+                && *max_transaction_fee > sweep_request(0).max_transaction_fee
         );
     }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2908,8 +2908,8 @@ mod sweep_lane {
     use crate::lifecycle::EthereumNetwork;
     use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        Eip1559TransactionRequest, PipelineRequest, ResubmitTransactionError, SweepId,
-        SweepRequest, TransactionPipeline,
+        CreateSweepTransactionError, Eip1559TransactionRequest, PipelineRequest,
+        ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline,
     };
     use crate::tx::GasFeeEstimate;
     use assert_matches::assert_matches;
@@ -2937,12 +2937,14 @@ mod sweep_lane {
         request: SweepRequest,
     ) -> Eip1559TransactionRequest {
         let id = request.id;
-        let Ok(tx) = request.create_transaction(
-            pipeline.next_transaction_nonce(),
-            gas_fee_estimate(),
-            SWEEP_GAS_LIMIT,
-            EthereumNetwork::Sepolia,
-        );
+        let tx = request
+            .create_transaction(
+                pipeline.next_transaction_nonce(),
+                gas_fee_estimate(),
+                SWEEP_GAS_LIMIT,
+                EthereumNetwork::Sepolia,
+            )
+            .expect("BUG: the fixture allowance covers the fixture fee");
         pipeline.record_created_transaction(id, tx);
         pipeline.created_tx.get_alt(&id).unwrap().as_ref().clone()
     }
@@ -3002,12 +3004,14 @@ mod sweep_lane {
     fn should_trap_when_the_created_transaction_carries_other_call_data() {
         let mut pipeline = sweeper_pipeline();
         pipeline.record_request(sweep_request(0));
-        let Ok(tx) = sweep_request(0).create_transaction(
-            pipeline.next_transaction_nonce(),
-            gas_fee_estimate(),
-            SWEEP_GAS_LIMIT,
-            EthereumNetwork::Sepolia,
-        );
+        let tx = sweep_request(0)
+            .create_transaction(
+                pipeline.next_transaction_nonce(),
+                gas_fee_estimate(),
+                SWEEP_GAS_LIMIT,
+                EthereumNetwork::Sepolia,
+            )
+            .expect("BUG: the fixture allowance covers the fixture fee");
 
         pipeline.record_created_transaction(
             SweepId(0),
@@ -3021,12 +3025,14 @@ mod sweep_lane {
     #[test]
     fn should_allocate_the_whole_fee_allowance_to_a_sweep_transaction() {
         let request = sweep_request(0);
-        let Ok(tx) = request.create_transaction(
-            TransactionNonce::ZERO,
-            gas_fee_estimate(),
-            SWEEP_GAS_LIMIT,
-            EthereumNetwork::Sepolia,
-        );
+        let tx = request
+            .create_transaction(
+                TransactionNonce::ZERO,
+                gas_fee_estimate(),
+                SWEEP_GAS_LIMIT,
+                EthereumNetwork::Sepolia,
+            )
+            .expect("BUG: the fixture allowance covers the fixture fee");
 
         assert_eq!(
             tx.max_fee_per_gas,
@@ -3046,42 +3052,57 @@ mod sweep_lane {
     }
 
     #[test]
-    fn should_keep_a_sweep_transaction_within_its_fee_allowance_when_the_estimate_spikes() {
+    fn should_refuse_to_create_a_sweep_the_allowance_cannot_pay_for() {
         let request = sweep_request(0);
         let spiked_fee = GasFeeEstimate {
             base_fee_per_gas: WeiPerGas::from(10_000_000_000_000_u64),
             ..gas_fee_estimate()
         };
 
-        let Ok(tx) = request.create_transaction(
+        let error = request.create_transaction(
             TransactionNonce::ZERO,
             spiked_fee,
             SWEEP_GAS_LIMIT,
             EthereumNetwork::Sepolia,
         );
 
-        assert_eq!(
-            tx.max_fee_per_gas.transaction_cost(SWEEP_GAS_LIMIT),
-            Some(request.max_transaction_fee)
+        assert_matches!(
+            error,
+            Err(CreateSweepTransactionError::InsufficientTransactionFee {
+                id,
+                allowed_max_transaction_fee,
+                actual_max_transaction_fee,
+            }) if id == request.id
+                && allowed_max_transaction_fee == request.max_transaction_fee
+                && actual_max_transaction_fee > request.max_transaction_fee
         );
     }
 
     #[test]
-    fn should_cap_the_priority_fee_at_the_fee_allowance() {
+    fn should_refuse_to_create_a_sweep_whose_allowance_the_priority_fee_alone_exceeds() {
         let request = SweepRequest {
             max_transaction_fee: Wei::from(100_000_u64),
             ..sweep_request(0)
         };
+        assert!(
+            gas_fee_estimate().max_priority_fee_per_gas
+                > request
+                    .max_transaction_fee
+                    .into_wei_per_gas(SWEEP_GAS_LIMIT)
+                    .unwrap()
+        );
 
-        let Ok(tx) = request.create_transaction(
+        let error = request.create_transaction(
             TransactionNonce::ZERO,
             gas_fee_estimate(),
             SWEEP_GAS_LIMIT,
             EthereumNetwork::Sepolia,
         );
 
-        assert_eq!(tx.max_fee_per_gas, WeiPerGas::ONE);
-        assert_eq!(tx.max_priority_fee_per_gas, tx.max_fee_per_gas);
+        assert_matches!(
+            error,
+            Err(CreateSweepTransactionError::InsufficientTransactionFee { .. })
+        );
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2995,6 +2995,27 @@ mod sweep_lane {
     }
 
     #[test]
+    #[should_panic(expected = "sweep transaction should carry the request's call data")]
+    fn should_trap_when_the_created_transaction_carries_other_call_data() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+        let Ok(tx) = sweep_request(0).create_transaction(
+            pipeline.next_transaction_nonce(),
+            gas_fee_estimate(),
+            SWEEP_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        );
+
+        pipeline.record_created_transaction(
+            SweepId(0),
+            Eip1559TransactionRequest {
+                data: vec![0xff],
+                ..tx
+            },
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "duplicate transaction id")]
     fn should_trap_on_a_duplicate_sweep_id() {
         let mut pipeline = sweeper_pipeline();

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2902,6 +2902,107 @@ pub mod arbitrary {
     }
 }
 
+mod sweep_lane {
+    use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
+    use crate::eth_rpc_client::responses::TransactionStatus;
+    use crate::lifecycle::EthereumNetwork;
+    use crate::numeric::{GasAmount, TransactionNonce, Wei};
+    use crate::state::transactions::{
+        Eip1559TransactionRequest, PipelineRequest, SweepId, SweepRequest, TransactionPipeline,
+    };
+    use ic_ethereum_types::Address;
+
+    const SWEEP_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+
+    fn sweep_request(id: u64) -> SweepRequest {
+        SweepRequest {
+            id: SweepId(id),
+            destination: Address::new([id as u8; 20]),
+            amount: Wei::ZERO,
+            data: vec![0xaa, 0xbb, 0xcc],
+            max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
+            created_at: 1_620_328_630_000_000_000,
+        }
+    }
+
+    fn sweeper_pipeline() -> TransactionPipeline<SweepRequest> {
+        TransactionPipeline::new(TransactionNonce::ZERO)
+    }
+
+    fn create_and_record_sweep_tx(
+        pipeline: &mut TransactionPipeline<SweepRequest>,
+        request: SweepRequest,
+    ) -> Eip1559TransactionRequest {
+        let id = request.id;
+        let Ok(tx) = request.create_transaction(
+            pipeline.next_transaction_nonce(),
+            gas_fee_estimate(),
+            SWEEP_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        );
+        pipeline.record_created_transaction(id, tx);
+        pipeline.created_tx.get_alt(&id).unwrap().as_ref().clone()
+    }
+
+    #[test]
+    fn should_create_a_sweep_transaction_on_the_lane_own_nonce() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+        assert_eq!(pipeline.next_transaction_nonce(), TransactionNonce::ZERO);
+
+        let tx = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+
+        assert_eq!(tx.nonce, TransactionNonce::ZERO);
+        assert_eq!(
+            pipeline.next_transaction_nonce(),
+            TransactionNonce::from(1_u64)
+        );
+        assert_eq!(tx.destination, sweep_request(0).destination);
+        assert_eq!(tx.amount, Wei::ZERO);
+        assert_eq!(tx.data, sweep_request(0).data);
+    }
+
+    #[test]
+    fn should_finalize_a_sweep() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+        let created = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+        let signed = sign_transaction(created);
+        pipeline.record_signed_transaction(signed.clone());
+
+        let receipt = transaction_receipt(&signed, TransactionStatus::Success);
+        let finalized = pipeline.record_finalized_transaction(SweepId(0), &receipt);
+
+        assert_eq!(finalized.transaction_hash(), &signed.hash());
+        assert!(pipeline.get_finalized_transaction(&SweepId(0)).is_some());
+    }
+
+    #[test]
+    fn should_advance_the_nonce_across_two_sweeps() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+        pipeline.record_request(sweep_request(1));
+
+        let first = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+        let second = create_and_record_sweep_tx(&mut pipeline, sweep_request(1));
+
+        assert_eq!(first.nonce, TransactionNonce::ZERO);
+        assert_eq!(second.nonce, TransactionNonce::from(1_u64));
+        assert_eq!(
+            pipeline.next_transaction_nonce(),
+            TransactionNonce::from(2_u64)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate transaction id")]
+    fn should_trap_on_a_duplicate_sweep_id() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(7));
+        pipeline.record_request(sweep_request(7));
+    }
+}
+
 fn cketh_withdrawal_request_with_index(ledger_burn_index: LedgerBurnIndex) -> EthWithdrawalRequest {
     use std::str::FromStr;
     EthWithdrawalRequest {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -69,6 +69,7 @@ pub fn valid_init_arg() -> InitArg {
         last_scraped_block_number: Default::default(),
         evm_rpc_id: Some(EVM_RPC_ID_STAGING),
         ethereum_sweeper_contract_address: None,
+        next_sweeper_transaction_nonce: None,
     }
 }
 

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -6,7 +6,8 @@ use ic_cketh_minter::checked_amount::CheckedAmountOf;
 use ic_cketh_minter::endpoints::events::{
     AccessListItem as CandidAccessListItem, Event as CandidEvent, EventSource as CandidEventSource,
     GetEventsResult, ReimbursementIndex as CandidReimbursementIndex,
-    TransactionStatus as CandidTransactionStatus, UnsignedTransaction,
+    TransactionReceipt as CandidTransactionReceipt, TransactionStatus as CandidTransactionStatus,
+    UnsignedTransaction,
 };
 use ic_cketh_minter::erc20::CkErc20Token;
 use ic_cketh_minter::eth_logs::{
@@ -69,6 +70,20 @@ fn map_reimbursement_index(index: CandidReimbursementIndex) -> ReimbursementInde
             ledger_id,
             ckerc20_ledger_burn_index: map_nat(ckerc20_ledger_burn_index),
         },
+    }
+}
+
+fn map_transaction_receipt(receipt: CandidTransactionReceipt) -> TransactionReceipt {
+    TransactionReceipt {
+        block_hash: receipt.block_hash.parse().unwrap(),
+        block_number: receipt.block_number.try_into().unwrap(),
+        effective_gas_price: receipt.effective_gas_price.try_into().unwrap(),
+        gas_used: receipt.gas_used.try_into().unwrap(),
+        status: match receipt.status {
+            CandidTransactionStatus::Success => TransactionStatus::Success,
+            CandidTransactionStatus::Failure => TransactionStatus::Failure,
+        },
+        transaction_hash: receipt.transaction_hash.parse().unwrap(),
     }
 }
 
@@ -304,20 +319,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 transaction_receipt,
             } => ET::FinalizedTransaction {
                 withdrawal_id: map_nat(withdrawal_id),
-                transaction_receipt: TransactionReceipt {
-                    block_hash: transaction_receipt.block_hash.parse().unwrap(),
-                    block_number: transaction_receipt.block_number.try_into().unwrap(),
-                    effective_gas_price: transaction_receipt
-                        .effective_gas_price
-                        .try_into()
-                        .unwrap(),
-                    gas_used: transaction_receipt.gas_used.try_into().unwrap(),
-                    status: match transaction_receipt.status {
-                        CandidTransactionStatus::Success => TransactionStatus::Success,
-                        CandidTransactionStatus::Failure => TransactionStatus::Failure,
-                    },
-                    transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
-                },
+                transaction_receipt: map_transaction_receipt(transaction_receipt),
             },
             EventPayload::AcceptedSweepRequest {
                 sweep_id,
@@ -360,20 +362,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 transaction_receipt,
             } => ET::FinalizedSweeperTransaction {
                 sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                transaction_receipt: TransactionReceipt {
-                    block_hash: transaction_receipt.block_hash.parse().unwrap(),
-                    block_number: transaction_receipt.block_number.try_into().unwrap(),
-                    effective_gas_price: transaction_receipt
-                        .effective_gas_price
-                        .try_into()
-                        .unwrap(),
-                    gas_used: transaction_receipt.gas_used.try_into().unwrap(),
-                    status: match transaction_receipt.status {
-                        CandidTransactionStatus::Success => TransactionStatus::Success,
-                        CandidTransactionStatus::Failure => TransactionStatus::Failure,
-                    },
-                    transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
-                },
+                transaction_receipt: map_transaction_receipt(transaction_receipt),
             },
             EventPayload::ReimbursedEthWithdrawal {
                 reimbursed_in_block,

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -18,7 +18,7 @@ use ic_cketh_minter::state::audit::EventType as ET;
 use ic_cketh_minter::state::event::Event;
 use ic_cketh_minter::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
-    ReimbursementRequest,
+    ReimbursementRequest, SweepId, SweepRequest,
 };
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
@@ -304,6 +304,62 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 transaction_receipt,
             } => ET::FinalizedTransaction {
                 withdrawal_id: map_nat(withdrawal_id),
+                transaction_receipt: TransactionReceipt {
+                    block_hash: transaction_receipt.block_hash.parse().unwrap(),
+                    block_number: transaction_receipt.block_number.try_into().unwrap(),
+                    effective_gas_price: transaction_receipt
+                        .effective_gas_price
+                        .try_into()
+                        .unwrap(),
+                    gas_used: transaction_receipt.gas_used.try_into().unwrap(),
+                    status: match transaction_receipt.status {
+                        CandidTransactionStatus::Success => TransactionStatus::Success,
+                        CandidTransactionStatus::Failure => TransactionStatus::Failure,
+                    },
+                    transaction_hash: transaction_receipt.transaction_hash.parse().unwrap(),
+                },
+            },
+            EventPayload::AcceptedSweepRequest {
+                sweep_id,
+                destination,
+                amount,
+                data,
+                max_transaction_fee,
+                created_at,
+            } => ET::AcceptedSweepRequest(SweepRequest {
+                id: SweepId(sweep_id.0.to_u64().unwrap()),
+                destination: destination.parse().unwrap(),
+                amount: amount.try_into().unwrap(),
+                data: hex::decode(data.strip_prefix("0x").unwrap_or(&data)).unwrap(),
+                max_transaction_fee: max_transaction_fee.try_into().unwrap(),
+                created_at,
+            }),
+            EventPayload::CreatedSweeperTransaction {
+                sweep_id,
+                transaction,
+            } => ET::CreatedSweeperTransaction {
+                sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                transaction: map_unsigned_transaction(transaction),
+            },
+            EventPayload::SignedSweeperTransaction {
+                sweep_id,
+                raw_transaction,
+            } => ET::SignedSweeperTransaction {
+                sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                transaction: map_signed_transaction(&raw_transaction),
+            },
+            EventPayload::ReplacedSweeperTransaction {
+                sweep_id,
+                transaction,
+            } => ET::ReplacedSweeperTransaction {
+                sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
+                transaction: map_unsigned_transaction(transaction),
+            },
+            EventPayload::FinalizedSweeperTransaction {
+                sweep_id,
+                transaction_receipt,
+            } => ET::FinalizedSweeperTransaction {
+                sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
                 transaction_receipt: TransactionReceipt {
                     block_hash: transaction_receipt.block_hash.parse().unwrap(),
                     block_number: transaction_receipt.block_number.try_into().unwrap(),

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -332,7 +332,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
                 amount: amount.try_into().unwrap(),
-                data: hex::decode(data.strip_prefix("0x").unwrap_or(&data)).unwrap(),
+                data: data.into_vec(),
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,
             }),

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -898,6 +898,7 @@ fn install_minter(env: &PocketIc, canisters: &CkEthCanisters, backend: &Ethereum
         last_scraped_block_number: backend.last_scraped_block_number(),
         evm_rpc_id: Some(canisters.evm_rpc_id),
         ethereum_sweeper_contract_address: None,
+        next_sweeper_transaction_nonce: None,
     };
     env.install_canister(
         canisters.minter_id,

--- a/rs/tests/cross_chain/ic_xc_cketh_test.rs
+++ b/rs/tests/cross_chain/ic_xc_cketh_test.rs
@@ -363,6 +363,7 @@ fn minter_init_args(ecdsa_key_id: &EcdsaKeyId, cketh_ledger: Principal) -> Minte
         last_scraped_block_number: Nat::from(0_u8),
         evm_rpc_id: None,
         ethereum_sweeper_contract_address: None,
+        next_sweeper_transaction_nonce: None,
     }
 }
 


### PR DESCRIPTION
## Why

The minter's dedicated sweeper address needs to send Ethereum transactions, and it must not share the main address' nonce sequence: a sweep stuck behind a fee-starved transaction would head-of-line-block every user withdrawal.

## What

A second instance of the transaction pipeline, for the sweeper address, on a nonce sequence of its own. A sweep burns no ckETH, so it is keyed by a plain counter rather than a ledger burn index, and is never reimbursed; it pays gas from the sweeper's prepaid balance, so it has no transaction fee it can fail to cover. Five audit events record the pipeline's transitions, with reconstruction, Candid mirrors and `.did`.

The sweeper's start nonce can be set from both lifecycle arguments. It is optional on install where the main address' equivalent is required, because install arguments are replayed from the event log and a required field would be missing from every event already written.

## Scope

The pipeline only. No timer drives it and nothing enqueues a sweep, so the new state stays empty: the sending task is [DEFI-2926](https://dfinity.atlassian.net/browse/DEFI-2926) in #11237, and EIP-7702 first-time delegation is #11250, stacked above. The sweep-queue source and prepaid-gas gating are still to come.

Sweeper *funding* — burning ckETH from the minter's fee subaccount to prepay that gas — is a separate stack (DEFI-2933) that meets this one only in the withdrawal pipeline, where its request variant has already landed. Hence the audit events here are numbered from `n28`, above the funding event master now owns.

## Candid compatibility

`CI_OVERRIDE_DIDC_CHECK` is set. The check flags the five cases this PR adds to the `Event` payload variant, since a variant returned to callers may not grow under Candid subtyping. It is the additive shape every new audit event has taken: existing cases keep their names and fields, and callers matching exhaustively on the old set see the new ones only for sweeper activity, which nothing enqueues yet. The new optional nonce field on the two argument types is compatible on its own.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


[DEFI-2917]: https://dfinity.atlassian.net/browse/DEFI-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ