### PR TITLE
chore: Manually implement serde for `Cycles` and CBOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15144,6 +15144,7 @@ dependencies = [
  "ic-heap-bytes",
  "ic-protobuf",
  "serde",
+ "serde_cbor",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "thousands",

--- a/rs/types/cycles/BUILD.bazel
+++ b/rs/types/cycles/BUILD.bazel
@@ -25,7 +25,10 @@ rust_library(
 rust_test(
     name = "cycles_test",
     crate = ":cycles",
-    deps = [],
+    deps = [
+        # Keep sorted.
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_doc(

--- a/rs/types/cycles/Cargo.toml
+++ b/rs/types/cycles/Cargo.toml
@@ -14,3 +14,6 @@ serde = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thousands = { workspace = true }
+
+[dev-dependencies]
+serde_cbor = { workspace = true }

--- a/rs/types/cycles/src/cycles.rs
+++ b/rs/types/cycles/src/cycles.rs
@@ -18,6 +18,13 @@ use thousands::Separable;
 ///
 /// NOTE: This is distinct from `NominalCycles` which should be used to update metrics
 /// related to cycles accounting.
+///
+/// NOTE: The derived `Serialize` impl is transparent, i.e. it emits the inner
+/// `u128`. CBOR (see `serde_cbor`) cannot represent integers above `u64::MAX`,
+/// so serializing a `Cycles` larger than that with `serde_cbor` *fails*. Types
+/// that hold a `Cycles` and are CBOR-encoded must therefore annotate the field
+/// with `#[serde(with = "ic_types_cycles::serde_as_u64_pair")]`, which encodes
+/// the full `u128` range as a pair of `u64`s.
 #[derive(
     Copy,
     Clone,
@@ -244,6 +251,27 @@ impl TryFrom<pbCyclesAccount> for Cycles {
 
     fn try_from(value: pbCyclesAccount) -> Result<Self, Self::Error> {
         try_from_le_bytes(value.cycles_balance)
+    }
+}
+
+/// Serializes [`Cycles`] as a `(high, low)` pair of `u64`s instead of as a bare
+/// `u128`, for use with `#[serde(with = "...")]`.
+///
+/// The derived, transparent `Serialize` impl emits a `u128`, which CBOR cannot
+/// represent beyond `u64::MAX`: `serde_cbor` fails with "The number can't be
+/// stored in CBOR". Any type holding a `Cycles` that is CBOR-encoded must use
+/// this module.
+pub mod serde_as_u64_pair {
+    use super::Cycles;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(cycles: &Cycles, serializer: S) -> Result<S::Ok, S::Error> {
+        cycles.into_parts().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Cycles, D::Error> {
+        let (high, low) = <(u64, u64)>::deserialize(deserializer)?;
+        Ok(Cycles::from_parts(high, low))
     }
 }
 

--- a/rs/types/cycles/src/cycles.rs
+++ b/rs/types/cycles/src/cycles.rs
@@ -287,6 +287,54 @@ fn try_from_le_bytes(bytes: Vec<u8>) -> Result<Cycles, ProxyDecodeError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::BTreeSet;
+
+    /// Holds a `Cycles` encoded via [`serde_as_u64_pair`], standing in for the
+    /// real types that must use it (e.g. `CanisterHttpPaymentReceipt`).
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct AsU64Pair(#[serde(with = "serde_as_u64_pair")] Cycles);
+
+    /// A handful of amounts either side of the `u64::MAX` boundary.
+    const AMOUNTS: [Cycles; 5] = [
+        Cycles::zero(),
+        Cycles::new(1),
+        Cycles::new(u64::MAX as u128),
+        Cycles::new(u64::MAX as u128 + 1),
+        Cycles::new(u128::MAX),
+    ];
+
+    /// The derived `Serialize` impl is transparent, i.e. it emits the inner
+    /// `u128`, and CBOR cannot represent integers above `u64::MAX`.
+    #[test]
+    fn cbor_cannot_encode_large_cycles_transparently() {
+        assert!(serde_cbor::to_vec(&Cycles::new(u64::MAX as u128)).is_ok());
+        assert!(serde_cbor::to_vec(&Cycles::new(u64::MAX as u128 + 1)).is_err());
+        assert!(serde_cbor::to_vec(&Cycles::new(u128::MAX)).is_err());
+    }
+
+    /// [`serde_as_u64_pair`] must round-trip the whole `Cycles` range through
+    /// CBOR. That is what makes it usable in CBOR-encoded signed bytes.
+    #[test]
+    fn serde_as_u64_pair_round_trips_through_cbor() {
+        for amount in AMOUNTS {
+            let bytes = serde_cbor::to_vec(&AsU64Pair(amount))
+                .unwrap_or_else(|err| panic!("failed to encode {amount}: {err}"));
+            let decoded: AsU64Pair = serde_cbor::from_slice(&bytes)
+                .unwrap_or_else(|err| panic!("failed to decode {amount}: {err}"));
+            assert_eq!(AsU64Pair(amount), decoded);
+        }
+    }
+
+    /// Distinct amounts must have distinct encodings: types signing over a
+    /// `Cycles` rely on [`serde_as_u64_pair`] to produce unambiguous bytes.
+    #[test]
+    fn serde_as_u64_pair_encodings_are_distinct() {
+        let encodings: BTreeSet<_> = AMOUNTS
+            .iter()
+            .map(|amount| serde_cbor::to_vec(&AsU64Pair(*amount)).unwrap())
+            .collect();
+        assert_eq!(encodings.len(), AMOUNTS.len());
+    }
 
     #[test]
     fn test_addition() {

--- a/rs/types/cycles/src/cycles.rs
+++ b/rs/types/cycles/src/cycles.rs
@@ -289,8 +289,7 @@ mod test {
     use super::*;
     use std::collections::BTreeSet;
 
-    /// Holds a `Cycles` encoded via [`serde_as_u64_pair`], standing in for the
-    /// real types that must use it (e.g. `CanisterHttpPaymentReceipt`).
+    /// Holds a `Cycles` encoded via [`serde_as_u64_pair`].
     #[derive(Debug, PartialEq, Deserialize, Serialize)]
     struct AsU64Pair(#[serde(with = "serde_as_u64_pair")] Cycles);
 

--- a/rs/types/cycles/src/lib.rs
+++ b/rs/types/cycles/src/lib.rs
@@ -6,7 +6,7 @@ mod cycles_use_case;
 mod nominal_cycles;
 
 pub use compound_cycles::CompoundCycles;
-pub use cycles::Cycles;
+pub use cycles::{Cycles, serde_as_u64_pair};
 pub use cycles_account_manager_subnet_config::CyclesAccountManagerSubnetConfig;
 pub use cycles_cost_schedule::CanisterCyclesCostSchedule;
 pub use cycles_use_case::{

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1117,6 +1117,11 @@ pub struct CanisterHttpPaymentReceipt {
     /// `per_replica_allowance - spent`. On free subnets it may exceed the (zero)
     /// allowance, since it is only used for cost accounting, but it may never
     /// exceed [`MAX_HTTP_OUTCALL_SPEND_FREE_SUBNET`].
+    ///
+    /// Encoded as a pair of `u64`s: this struct is part of the CBOR signed bytes
+    /// of [`CanisterHttpResponseReceipt`], and CBOR cannot represent a bare
+    /// `u128` above `u64::MAX`.
+    #[serde(with = "ic_types_cycles::serde_as_u64_pair")]
     pub spent: Cycles,
 }
 
@@ -1345,7 +1350,11 @@ impl PbArtifact for CanisterHttpResponseArtifact {
 
 #[cfg(test)]
 mod tests {
-    use crate::{messages::NO_DEADLINE, time::UNIX_EPOCH};
+    use crate::{
+        crypto::{CryptoHash, SignedBytesWithoutDomainSeparator},
+        messages::NO_DEADLINE,
+        time::UNIX_EPOCH,
+    };
 
     use super::*;
 
@@ -1359,6 +1368,59 @@ mod tests {
     use ic_types_test_utils::ids::node_test_id;
     use rstest::rstest;
     use strum::IntoEnumIterator;
+
+    /// Producing the signed bytes of a [`CanisterHttpResponseReceipt`] must never
+    /// panic, for any `spent` amount in the whole `Cycles` (`u128`) range.
+    ///
+    /// CBOR cannot represent a bare integer above `u64::MAX`, so a receipt holding
+    /// a transparently serialized `Cycles` used to panic while being signed or
+    /// verified.
+    #[test]
+    fn signed_bytes_of_exhaustive_receipts_do_not_panic() {
+        use crate::exhaustive::ExhaustiveSet;
+        use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
+
+        let mut rng = reproducible_rng();
+        let receipts = CanisterHttpResponseReceipt::exhaustive_set(&mut rng);
+        assert!(receipts.iter().any(|r| r.spent() > Cycles::from(u64::MAX)));
+
+        for receipt in receipts {
+            let mut bytes = Vec::new();
+            receipt.write_signed_bytes_without_domain_separator(&mut bytes);
+            assert!(!bytes.is_empty());
+        }
+    }
+
+    /// The signed bytes must distinguish receipts that differ only in `spent`,
+    /// including beyond `u64::MAX`.
+    #[test]
+    fn signed_bytes_are_injective_in_spent() {
+        let signed_bytes = |spent: Cycles| {
+            let mut bytes = Vec::new();
+            CanisterHttpResponseReceipt {
+                metadata: CanisterHttpResponseMetadata {
+                    id: CallbackId::new(1),
+                    content_hash: CryptoHashOf::new(CryptoHash(vec![0; 32])),
+                    content_size: 0,
+                    is_reject: false,
+                    replica_version: ReplicaVersion::default(),
+                },
+                payment_receipt: CanisterHttpPaymentReceipt { spent },
+            }
+            .write_signed_bytes_without_domain_separator(&mut bytes);
+            bytes
+        };
+
+        let amounts = [
+            Cycles::zero(),
+            Cycles::new(1),
+            Cycles::from(u64::MAX),
+            Cycles::from(u64::MAX) + Cycles::new(1),
+            Cycles::new(u128::MAX),
+        ];
+        let encodings: BTreeSet<_> = amounts.iter().map(|spent| signed_bytes(*spent)).collect();
+        assert_eq!(encodings.len(), amounts.len());
+    }
 
     #[test]
     fn test_request_arg_variable_size() {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1369,14 +1369,14 @@ mod tests {
     use rstest::rstest;
     use strum::IntoEnumIterator;
 
-    /// Producing the signed bytes of a [`CanisterHttpResponseReceipt`] must never
-    /// panic, for any `spent` amount in the whole `Cycles` (`u128`) range.
+    /// The signed bytes of a [`CanisterHttpResponseReceipt`] must round-trip, for
+    /// any `spent` amount in the whole `Cycles` (`u128`) range.
     ///
     /// CBOR cannot represent a bare integer above `u64::MAX`, so a receipt holding
     /// a transparently serialized `Cycles` used to panic while being signed or
     /// verified.
     #[test]
-    fn signed_bytes_of_exhaustive_receipts_do_not_panic() {
+    fn signed_bytes_of_exhaustive_receipts_round_trip() {
         use crate::exhaustive::ExhaustiveSet;
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 
@@ -1388,6 +1388,10 @@ mod tests {
             let mut bytes = Vec::new();
             receipt.write_signed_bytes_without_domain_separator(&mut bytes);
             assert!(!bytes.is_empty());
+
+            let decoded: CanisterHttpResponseReceipt = serde_cbor::from_slice(&bytes)
+                .unwrap_or_else(|err| panic!("failed to decode {receipt:?}: {err}"));
+            assert_eq!(receipt, decoded);
         }
     }
 


### PR DESCRIPTION
`serde_cbor` cannot represent a plain `u128` (that is greater than `u64::MAX`) and will fail when attempting to serialize one.

For the new pay-as-you-go pricing, cycles will be part of canister HTTP shares, which are cbor serialized in order to compute the signature. However, these values will always be far below `u64::MAX`.

Nevertheless, for consistency, this PR implements the `Serialize` and `Deserialize` traits manually as part of a new module, which falls back to a pair of `u64`.