### PR TITLE
fix(sns-wasm): actually overwrite existing SNS-specific upgrade path entries

### DIFF
--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -1940,7 +1940,7 @@ impl UpgradePath {
             .or_default()
             .entry(from)
         {
-            Entry::Occupied(occupied) => {
+            Entry::Occupied(mut occupied) => {
                 println!(
                     "Special Entry for {}  from {:?} to {:?} is being overwritten with new value {:?}",
                     sns_governance_canister_id,
@@ -1948,6 +1948,7 @@ impl UpgradePath {
                     occupied.get(),
                     to
                 );
+                occupied.insert(to);
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(to);
@@ -5645,5 +5646,46 @@ mod test {
                 }
             );
         }
+    }
+
+    #[test]
+    fn test_insert_sns_specific_upgrade_path_entry_overwrites_existing_entry() {
+        let sns_governance_canister_id = CanisterId::from_u64(1000);
+        let from_version = SnsVersion {
+            governance_wasm_hash: vec![1],
+            ..Default::default()
+        };
+        let first_to_version = SnsVersion {
+            governance_wasm_hash: vec![2],
+            ..Default::default()
+        };
+        let second_to_version = SnsVersion {
+            governance_wasm_hash: vec![3],
+            ..Default::default()
+        };
+
+        let mut upgrade_path = UpgradePath::default();
+        upgrade_path.insert_sns_specific_upgrade_path_entry(
+            from_version.clone(),
+            first_to_version.clone(),
+            sns_governance_canister_id,
+        );
+        assert_eq!(
+            upgrade_path.get_next_version(from_version.clone(), sns_governance_canister_id.get()),
+            Some(first_to_version)
+        );
+
+        // Run code under test: reconfigure the same `from_version` entry with a new target.
+        upgrade_path.insert_sns_specific_upgrade_path_entry(
+            from_version.clone(),
+            second_to_version.clone(),
+            sns_governance_canister_id,
+        );
+
+        // The entry must reflect the new target, not the stale first one.
+        assert_eq!(
+            upgrade_path.get_next_version(from_version, sns_governance_canister_id.get()),
+            Some(second_to_version)
+        );
     }
 }

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -17,4 +17,9 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* `insert_upgrade_path_entries` now actually replaces an SNS-specific
+  emergency upgrade step when called again for the same SNS and starting
+  version, instead of silently keeping the old step while reporting
+  success.
+
 ## Security

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -17,9 +17,9 @@ on the process that this file is part of, see
 
 ## Fixed
 
-* `insert_upgrade_path_entries` now actually replaces an SNS-specific
-  emergency upgrade step when called again for the same SNS and starting
-  version, instead of silently keeping the old step while reporting
-  success.
+* `insert_sns_specific_upgrade_path_entry` now actually replaces an
+  SNS-specific emergency upgrade step when called again for the same SNS
+  and starting version, instead of silently keeping the old step while
+  reporting success.
 
 ## Security


### PR DESCRIPTION
## Problem

`insert_sns_specific_upgrade_path_entry` is used to set a one-off emergency upgrade step for a specific SNS (e.g. "if this SNS is stuck at version A, send it to version B instead"). If you try to change that step later (e.g. because B turned out to be wrong, so it should now go to C), the function only logs that it is "being overwritten" but never actually writes the new value. The old entry stays in place, while the caller is told the request succeeded.

## Fix

Actually write the new value when overwriting an existing entry, the same way the sibling function `insert_upgrade_path_entry` already does a few lines below it.

## Testing

Added `test_insert_sns_specific_upgrade_path_entry_overwrites_existing_entry`, which inserts an entry, overwrites it with a different target, and checks that the second value is the one actually returned. This test fails on the old code and passes with the fix.