### PR TITLE
fix: account for install_code debit when loading a canister snapshot

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2372,6 +2372,16 @@ impl CanisterManager {
                 prepaid_execution_cycles - cycles_to_refund,
                 instructions_for_execution,
             );
+            // Loading a snapshot installs code on the canister (in particular,
+            // it compiles a Wasm module), so the instructions used count
+            // towards the `install_code` rate limit of the canister. Just like
+            // the consumed cycles, the debit is also recorded in
+            // `consumed_cycles` so that it survives the canister state
+            // rollback if a subsequent step fails.
+            if self.config.rate_limiting_of_instructions == FlagStatus::Enabled {
+                canister.scheduler_state.install_code_debit += instructions_for_execution;
+                consumed_cycles.add_install_code_debit(instructions_for_execution);
+            }
 
             let mut new_execution_state = match new_execution_state {
                 Ok(execution_state) => execution_state,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -311,6 +311,7 @@ impl RoundLimits {
 pub(crate) struct ConsumedCyclesForInstructions<'a> {
     consumed_cycles: CompoundCycles<Instructions>,
     instructions_used: NumInstructions,
+    install_code_debit: NumInstructions,
     cycles_account_manager: &'a CyclesAccountManager,
     log: &'a ReplicaLogger,
 }
@@ -324,6 +325,7 @@ impl<'a> ConsumedCyclesForInstructions<'a> {
         Self {
             consumed_cycles: CompoundCycles::new(Cycles::zero(), cost_schedule),
             instructions_used: NumInstructions::new(0),
+            install_code_debit: NumInstructions::new(0),
             cycles_account_manager,
             log,
         }
@@ -338,6 +340,20 @@ impl<'a> ConsumedCyclesForInstructions<'a> {
         self.instructions_used += instructions;
     }
 
+    /// Accumulates instructions that count towards the `install_code` rate
+    /// limit of the canister, i.e., instructions used by management operations
+    /// that install code on the canister (and thus compile a Wasm module).
+    ///
+    /// The debit is only applied if the management operation fails: on success
+    /// the operation itself is responsible for updating the canister's
+    /// `install_code_debit`.
+    ///
+    /// The caller is responsible for only accumulating instructions if
+    /// rate limiting of instructions is enabled.
+    pub(crate) fn add_install_code_debit(&mut self, instructions: NumInstructions) {
+        self.install_code_debit += instructions;
+    }
+
     pub(crate) fn apply(
         self,
         canister: &mut CanisterState,
@@ -345,6 +361,7 @@ impl<'a> ConsumedCyclesForInstructions<'a> {
         subnet_cycles_config: CyclesAccountManagerSubnetConfig,
         failed_charge: &IntCounter,
     ) {
+        canister.scheduler_state.install_code_debit += self.install_code_debit;
         let memory_usage = canister.memory_usage();
         let message_memory_usage = canister.message_memory_usage();
         let res = self.cycles_account_manager.consume_cycles_for_final_instructions(

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -1991,6 +1991,144 @@ fn load_canister_snapshot_charges_canister_cycles() {
     );
 }
 
+/// A tiny canister (and thus cheap to compile) that grows its stable memory
+/// by 1000 Wasm pages (~65MB) when its `grow` method is called.
+const GROW_STABLE_MEMORY_CANISTER_WAT: &str = r#"
+(module
+  (import "ic0" "msg_reply" (func $msg_reply))
+  (import "ic0" "stable64_grow" (func $stable64_grow (param i64) (result i64)))
+
+  (func $grow
+    (drop (call $stable64_grow (i64.const 1000)))
+    (call $msg_reply)
+  )
+
+  (memory $memory 1)
+  (export "canister_update grow" (func $grow))
+)"#;
+
+#[test]
+fn load_canister_snapshot_accounts_install_code_debit() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+
+    let subnet_type = SubnetType::Application;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_rate_limiting_of_instructions()
+        .build();
+
+    // Create a canister whose Wasm module is cheap to compile, ...
+    let wasm = wat::parse_str(GROW_STABLE_MEMORY_CANISTER_WAT).unwrap();
+    let canister_id = test
+        .canister_from_cycles_and_binary(CYCLES, wasm.clone())
+        .unwrap();
+    // ... but whose memory (and thus snapshot size) is large.
+    test.ingress(canister_id, "grow", vec![]).unwrap();
+
+    // Take a snapshot of the canister.
+    let args: TakeCanisterSnapshotArgs =
+        TakeCanisterSnapshotArgs::new(canister_id, None, None, None);
+    let result = test.subnet_message("take_canister_snapshot", args.encode());
+    let snapshot_id = CanisterSnapshotResponse::decode(&result.unwrap().bytes())
+        .unwrap()
+        .snapshot_id();
+
+    let instructions_for_snapshot_size = scheduler_config.canister_snapshot_baseline_instructions
+        + NumInstructions::new(test.canister_state(canister_id).snapshot_size_bytes().get());
+
+    // Reset the `install_code` debit accumulated when installing the canister.
+    test.canister_state_mut(canister_id)
+        .scheduler_state
+        .install_code_debit = NumInstructions::new(0);
+
+    // Loading the snapshot compiles the snapshot's Wasm module and thus
+    // increases the `install_code` debit of the canister.
+    let args: LoadCanisterSnapshotArgs =
+        LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
+    test.subnet_message("load_canister_snapshot", args.encode())
+        .unwrap();
+    let install_code_debit = test
+        .canister_state(canister_id)
+        .scheduler_state
+        .install_code_debit;
+    assert_gt!(install_code_debit, NumInstructions::new(0));
+    // Only the instructions used to compile the Wasm module are accounted for,
+    // i.e., the instructions charged for the snapshot size are not.
+    assert_lt!(install_code_debit, instructions_for_snapshot_size);
+
+    // Due to the `install_code` debit, a subsequent `install_code` is rate limited.
+    let error = test.upgrade_canister(canister_id, wasm).unwrap_err();
+    assert_eq!(error.code(), ErrorCode::CanisterInstallCodeRateLimited);
+}
+
+#[test]
+fn load_canister_snapshot_accounts_install_code_debit_on_failure() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_rate_limiting_of_instructions()
+        .build();
+
+    // Create canister.
+    let counter_canister_wasm = wat::parse_str(COUNTER_CANISTER_WAT).unwrap();
+    let canister_id = test
+        .canister_from_cycles_and_binary(CYCLES, counter_canister_wasm)
+        .unwrap();
+
+    // Create a snapshot from metadata containing an invalid Wasm module.
+    let wasm_module = vec![42; 1234];
+    let md_upload_args = UploadCanisterSnapshotMetadataArgs::new(
+        canister_id,
+        None,
+        wasm_module.len() as u64,
+        vec![],
+        1 << 16,
+        1 << 16,
+        vec![],
+        None,
+        None,
+    );
+    let WasmResult::Reply(bytes) = test
+        .subnet_message("upload_canister_snapshot_metadata", md_upload_args.encode())
+        .unwrap()
+    else {
+        panic!("expected WasmResult::Reply")
+    };
+    let snapshot_id = Decode!(&bytes, UploadCanisterSnapshotMetadataResponse)
+        .unwrap()
+        .get_snapshot_id();
+    let args = UploadCanisterSnapshotDataArgs::new(
+        canister_id,
+        snapshot_id,
+        CanisterSnapshotDataOffset::WasmModule { offset: 0 },
+        wasm_module,
+    );
+    test.subnet_message("upload_canister_snapshot_data", Encode!(&args).unwrap())
+        .unwrap();
+
+    // Reset the `install_code` debit accumulated when installing the canister.
+    test.canister_state_mut(canister_id)
+        .scheduler_state
+        .install_code_debit = NumInstructions::new(0);
+
+    // Loading the snapshot fails because its Wasm module cannot be compiled, ...
+    let args: LoadCanisterSnapshotArgs =
+        LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
+    let error = test
+        .subnet_message("load_canister_snapshot", args.encode())
+        .unwrap_err();
+    assert_eq!(error.code(), ErrorCode::CanisterInvalidWasm);
+
+    // ... but the instructions used for the compilation are still accounted for.
+    assert_gt!(
+        test.canister_state(canister_id)
+            .scheduler_state
+            .install_code_debit,
+        NumInstructions::new(0)
+    );
+}
+
 #[test]
 fn snapshot_must_include_globals() {
     let wat = r#"


### PR DESCRIPTION
Loading a canister snapshot compiles the snapshot's Wasm module just like `install_code` does, but the instructions used for the compilation were not accounted for in the canister's `install_code_debit`.

Now the instructions used to create the execution state are added to the canister's `install_code_debit` if rate limiting of instructions is enabled. The debit is also recorded in `ConsumedCyclesForInstructions` so that it survives the canister state rollback if a step after the compilation fails.