### PR TITLE
feat: make `canister_info` a query method of the management canister

### DIFF
--- a/packages/ic-management-canister-types/tests/candid_equality.rs
+++ b/packages/ic-management-canister-types/tests/candid_equality.rs
@@ -57,7 +57,7 @@ fn canister_status(_: CanisterStatusArgs) -> CanisterStatusResult {
     unimplemented!()
 }
 
-#[candid_method(update)]
+#[candid_method(query)]
 fn canister_info(_: CanisterInfoArgs) -> CanisterInfoResult {
     unimplemented!()
 }

--- a/packages/ic-management-canister-types/tests/ic.did
+++ b/packages/ic-management-canister-types/tests/ic.did
@@ -685,7 +685,7 @@ service ic : {
     http_request : (http_request_args) -> (http_request_result);
 
     // Public canister data
-    canister_info : (canister_info_args) -> (canister_info_result);
+    canister_info : (canister_info_args) -> (canister_info_result) query;
     canister_metadata : (canister_metadata_args) -> (canister_metadata_result);
 
     // Threshold ECDSA signature

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -20,7 +20,8 @@ use ic_interfaces::execution_environment::{
 };
 use ic_logger::{ReplicaLogger, error, fatal, info, warn};
 use ic_management_canister_types_private::{
-    CanisterIdRange, CanisterStatusType, EmptyBlob, ListCanistersResponse, Payload as _,
+    CanisterIdRange, CanisterInfoResponse, CanisterStatusType, EmptyBlob, ListCanistersResponse,
+    Payload as _,
 };
 use ic_registry_routing_table::canister_id_into_u64;
 use ic_registry_subnet_type::SubnetType;
@@ -445,6 +446,38 @@ pub(crate) fn validate_controller_or_subnet_admin(
             controller_provided: *sender,
         })
     }
+}
+
+/// Computes the response to the `canister_info` management canister method.
+///
+/// The method is not subject to any access control: the canister history is
+/// public information that any principal is allowed to retrieve. The size of
+/// the response is bounded by `MAX_CANISTER_HISTORY_CHANGES`, so producing it
+/// consumes no round instructions.
+///
+/// This is shared by the replicated path (an inter-canister call to
+/// `canister_info`) and the non-replicated path (see
+/// `crate::query_handler::subnet_query`) so that both return the same response.
+pub(crate) fn canister_info(
+    canister: &CanisterState,
+    num_requested_changes: Option<u64>,
+) -> CanisterInfoResponse {
+    let canister_history = canister.system_state.get_canister_history();
+    let total_num_changes = canister_history.get_total_num_changes();
+    let changes = canister_history
+        .get_changes(num_requested_changes.unwrap_or(0) as usize)
+        .map(|e| (*e.clone()).clone())
+        .collect();
+    let module_hash = canister
+        .execution_state
+        .as_ref()
+        .map(|es| es.wasm_binary.binary.module_hash().to_vec());
+    let controllers = canister
+        .controllers()
+        .iter()
+        .copied()
+        .collect::<Vec<PrincipalId>>();
+    CanisterInfoResponse::new(total_num_changes, changes, module_hash, controllers)
 }
 
 /// Computes the response to the `list_canisters` management canister method.

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -6,7 +6,7 @@ use crate::canister_manager::types::{
 };
 use crate::canister_settings::CanisterSettings;
 use crate::execution::call_or_task::execute_call_or_task;
-use crate::execution::common::{list_canisters, validate_controller};
+use crate::execution::common::{canister_info, list_canisters, validate_controller};
 use crate::execution::inspect_message;
 use crate::execution::response::execute_response;
 use crate::execution_environment_metrics::{
@@ -33,12 +33,12 @@ use ic_limits::MAX_PAIRED_PRE_SIGNATURES;
 use ic_logger::{ReplicaLogger, error, info, warn};
 use ic_management_canister_types_private::{
     CanisterChangeOrigin, CanisterHttpRequestArgs, CanisterIdRecord, CanisterInfoRequest,
-    CanisterInfoResponse, CanisterMetadataRequest, CanisterMetricsArgs, CanisterStatusType,
-    ClearChunkStoreArgs, CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs,
-    ECDSAPublicKeyResponse, EmptyBlob, FetchCanisterLogsRequest, FlexibleCanisterHttpRequestArgs,
-    IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
-    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
-    Payload as Ic00Payload, ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
+    CanisterMetadataRequest, CanisterMetricsArgs, CanisterStatusType, ClearChunkStoreArgs,
+    CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs, ECDSAPublicKeyResponse,
+    EmptyBlob, FetchCanisterLogsRequest, FlexibleCanisterHttpRequestArgs, IC_00,
+    InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
+    MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs, Payload as Ic00Payload,
+    ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
     ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
     ReshareChainKeyArgs, SchnorrAlgorithm, SchnorrPublicKeyArgs, SchnorrPublicKeyResponse,
     SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs, SignWithSchnorrAux,
@@ -2832,23 +2832,7 @@ impl ExecutionEnvironment {
         state: &ReplicatedState,
     ) -> Result<Vec<u8>, UserError> {
         let canister = get_canister(canister_id, state)?;
-        let canister_history = canister.system_state.get_canister_history();
-        let total_num_changes = canister_history.get_total_num_changes();
-        let changes = canister_history
-            .get_changes(num_requested_changes.unwrap_or(0) as usize)
-            .map(|e| (*e.clone()).clone())
-            .collect();
-        let module_hash = canister
-            .execution_state
-            .as_ref()
-            .map(|es| es.wasm_binary.binary.module_hash().to_vec());
-        let controllers = canister
-            .controllers()
-            .iter()
-            .copied()
-            .collect::<Vec<PrincipalId>>();
-        let res = CanisterInfoResponse::new(total_num_changes, changes, module_hash, controllers);
-        Ok(res.encode())
+        Ok(canister_info(canister, num_requested_changes).encode())
     }
 
     fn get_canister_metadata(

--- a/rs/execution_environment/src/query_handler/subnet_query.rs
+++ b/rs/execution_environment/src/query_handler/subnet_query.rs
@@ -7,12 +7,13 @@
 
 use crate::CanisterManager;
 use crate::canister_logs::fetch_canister_logs_response;
-use crate::execution::common::list_canisters;
+use crate::execution::common::{canister_info, list_canisters};
 use candid::Encode;
 use ic_base_types::PrincipalId;
 use ic_error_types::{ErrorCode, UserError};
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterMetricsArgs, FetchCanisterLogsRequest, Payload, QueryMethod,
+    CanisterIdRecord, CanisterInfoRequest, CanisterMetricsArgs, FetchCanisterLogsRequest, Payload,
+    QueryMethod,
 };
 use ic_replicated_state::{CanisterState, ReplicatedState};
 use ic_types::{CanisterId, NumInstructions};
@@ -58,6 +59,12 @@ pub(super) fn execute_subnet_query(
                 ready_for_migration,
                 state.get_own_subnet_admins(),
             )?;
+            Ok((Encode!(&response).unwrap(), NumInstructions::new(0)))
+        }
+        QueryMethod::CanisterInfo => {
+            let args = CanisterInfoRequest::decode(payload)?;
+            let canister = get_canister(state, args.canister_id())?;
+            let response = canister_info(canister, args.num_requested_changes());
             Ok((Encode!(&response).unwrap(), NumInstructions::new(0)))
         }
         QueryMethod::ListCanisters => list_canisters(state, &caller, payload),

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -4,10 +4,10 @@ use ic_base_types::{CanisterId, NumSeconds, PrincipalId};
 use ic_config::execution_environment::INSTRUCTION_OVERHEAD_PER_QUERY_CALL;
 use ic_error_types::{ErrorCode, UserError};
 use ic_management_canister_types_private::{
-    CanisterIdRange, CanisterIdRecord, CanisterMetricsArgs, CanisterMetricsResult,
-    CanisterSettingsArgsBuilder, CanisterStatusResultV2, CanisterStatusType,
-    FetchCanisterLogsRequest, FetchCanisterLogsResponse, ListCanistersResponse, LogVisibilityV2,
-    Payload,
+    CanisterIdRange, CanisterIdRecord, CanisterInfoRequest, CanisterInfoResponse,
+    CanisterMetricsArgs, CanisterMetricsResult, CanisterSettingsArgsBuilder,
+    CanisterStatusResultV2, CanisterStatusType, FetchCanisterLogsRequest,
+    FetchCanisterLogsResponse, ListCanistersResponse, LogVisibilityV2, Payload,
 };
 use ic_registry_resource_limits::ResourceLimits;
 use ic_test_utilities::universal_canister::{call_args, wasm};
@@ -1559,6 +1559,42 @@ fn composite_query_call_to_management_canister_canister_status() {
             .balance()
             .get()
     );
+}
+
+#[test]
+fn composite_query_call_to_management_canister_canister_info() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_a = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    // Canister B is controlled by the test user, not by canister A.
+    let canister_b = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+
+    let payload = CanisterInfoRequest::new(canister_b, Some(10)).encode();
+    let reply = test
+        .non_replicated_query(
+            canister_a,
+            "composite_query",
+            ic00_composite_query("canister_info", payload.clone()),
+        )
+        .unwrap();
+
+    // `canister_info` is not subject to any access control, so canister A can
+    // retrieve the info of canister B and gets the same response as a query
+    // sent by the user directly to the management canister.
+    let expected = test
+        .non_replicated_query(CanisterId::ic_00(), "canister_info", payload)
+        .unwrap();
+    let info = Decode!(&reply.bytes(), CanisterInfoResponse).unwrap();
+    assert_eq!(
+        info,
+        Decode!(&expected.bytes(), CanisterInfoResponse).unwrap()
+    );
+    assert_eq!(info.controllers(), vec![test.user_id().get()]);
+    assert_eq!(
+        info.changes().len() as u64,
+        info.total_num_changes(),
+        "the whole canister history is expected to fit into the response"
+    );
+    assert_gt!(info.total_num_changes(), 0);
 }
 
 #[test]

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -75,6 +75,27 @@ fn get_canister_info(
     }
 }
 
+/// Retrieves the canister info by sending a query call to the management
+/// canister on behalf of the given sender.
+fn query_canister_info(
+    env: &StateMachine,
+    sender: PrincipalId,
+    canister_id: CanisterId,
+    num_requested_changes: Option<u64>,
+) -> Result<CanisterInfoResponse, UserError> {
+    let wasm_result = env.query_as(
+        sender,
+        ic00::IC_00,
+        Method::CanisterInfo,
+        CanisterInfoRequest::new(canister_id, num_requested_changes).encode(),
+    )?;
+    match wasm_result {
+        WasmResult::Reply(bytes) => Ok(CanisterInfoResponse::decode(&bytes[..])
+            .expect("failed to decode canister_info response")),
+        WasmResult::Reject(reason) => panic!("canister_info query rejected: {reason}"),
+    }
+}
+
 fn canister_id_from_wasm_result(wasm_result: WasmResult) -> CanisterId {
     match wasm_result {
         WasmResult::Reply(bytes) => CanisterIdRecord::decode(&bytes[..])
@@ -1044,6 +1065,21 @@ fn canister_info_retrieval() {
     assert_eq!(canister_info.changes(), reference_change_entries);
     assert_eq!(canister_info.module_hash(), None);
     assert_eq!(canister_info.controllers(), vec![user_id1, user_id2]);
+
+    // while ingress messages are rejected, any principal can retrieve canister
+    // information via query calls (neither the anonymous user nor `user_id3`
+    // is a controller of the canister) and gets the same response as a canister
+    // calling `canister_info` in replicated mode
+    let user_id3 = user_test_id(9).get();
+    for num_requested_changes in [None, Some(2), Some(4), Some(666)] {
+        let expected = get_canister_info(&env, ucan, canister_id, num_requested_changes).unwrap();
+        for sender in [anonymous_user, user_id1, user_id3] {
+            assert_eq!(
+                query_canister_info(&env, sender, canister_id, num_requested_changes).unwrap(),
+                expected
+            );
+        }
+    }
 }
 
 #[test]

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -3758,6 +3758,7 @@ impl Payload<'_> for ListCanistersResponse {}
 pub enum QueryMethod {
     FetchCanisterLogs,
     CanisterStatus,
+    CanisterInfo,
     ListCanisters,
     CanisterMetrics,
 }

--- a/rs/types/management_canister_types/tests/candid_equality.rs
+++ b/rs/types/management_canister_types/tests/candid_equality.rs
@@ -91,7 +91,7 @@ fn canister_status(_: CanisterStatusArgs) -> CanisterStatusResult {
     unreachable!()
 }
 
-#[candid_method(update)]
+#[candid_method(query)]
 fn canister_info(_: CanisterInfoArgs) -> CanisterInfoResult {
     unreachable!()
 }

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -677,7 +677,7 @@ service ic : {
     start_canister : (start_canister_args) -> ();
     stop_canister : (stop_canister_args) -> ();
     canister_status : (canister_status_args) -> (canister_status_result);
-    canister_info : (canister_info_args) -> (canister_info_result);
+    canister_info : (canister_info_args) -> (canister_info_result) query;
     canister_metadata : (canister_metadata_args) -> (canister_metadata_result);
     delete_canister : (delete_canister_args) -> ();
     deposit_cycles : (deposit_cycles_args) -> ();


### PR DESCRIPTION
`canister_info` can now be invoked as a non-replicated query call, both by end users sending a query call to the management canister via the public HTTP handler and by canisters making a composite query call.

The method is not subject to any access control: the canister history is public information that any principal is allowed to retrieve. Ingress (update) messages to `canister_info` keep being rejected and calling it via an inter-canister call is unaffected.

Implementation notes:
- The computation of the response is factored out of `ExecutionEnvironment` into the shared `canister_info` helper in `execution::common` so that the replicated and the non-replicated path return the same response.
- The size of the response is bounded by `MAX_CANISTER_HISTORY_CHANGES`, so producing it consumes no round instructions.
- `canister_info` is declared as a query method in `ic.did`.