### PR TITLE
fix(canister_logging): reject a log_memory_limit below one page

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -59,8 +59,8 @@ use ic_types::messages::{
 };
 use ic_types::{
     CanisterId, CanisterTimer, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, MAX_AGGREGATE_LOG_MEMORY_LIMIT,
-    MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES, NumBytes,
-    NumInstructions, PrincipalId, SnapshotId, Time,
+    MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES,
+    MIN_AGGREGATE_LOG_MEMORY_LIMIT, NumBytes, NumInstructions, PrincipalId, SnapshotId, Time,
 };
 use ic_types_cycles::{
     CanisterCreation, CompoundCycles, Cycles, CyclesUseCase, Instructions, NominalCycles,
@@ -578,6 +578,15 @@ impl CanisterManager {
                 return Err(CanisterManagerError::CanisterLogMemoryLimitIsTooHigh {
                     bytes: requested_limit,
                     limit: max_limit,
+                });
+            }
+            // A zero limit disables canister logging; any other limit must be
+            // at least the minimum ring buffer data capacity.
+            let min_limit = NumBytes::new(MIN_AGGREGATE_LOG_MEMORY_LIMIT as u64);
+            if requested_limit.get() != 0 && requested_limit < min_limit {
+                return Err(CanisterManagerError::CanisterLogMemoryLimitIsTooLow {
+                    bytes: requested_limit,
+                    limit: min_limit,
                 });
             }
             // Resizing reads all stored log records from the old ring buffer and

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -85,8 +85,8 @@ use ic_test_utilities_types::{
     messages::{IngressBuilder, RequestBuilder},
 };
 use ic_types::{
-    CanisterId, CanisterTimer, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
-    SubnetId, UserId,
+    CanisterId, CanisterTimer, ComputeAllocation, MIN_AGGREGATE_LOG_MEMORY_LIMIT, MemoryAllocation,
+    NumBytes, NumInstructions, SubnetId, UserId,
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{CanisterCall, StopCanisterCallId, StopCanisterContext},
     time::UNIX_EPOCH,
@@ -5824,6 +5824,113 @@ fn create_canister_heap_delta_log_memory_limit_explicit() {
     .unwrap();
 
     assert_eq!(test.state().metadata.heap_delta_estimate, NumBytes::from(0));
+}
+
+// A non-zero log_memory_limit below the minimum is rejected on canister creation.
+#[test]
+fn create_canister_with_too_low_log_memory_limit_fails() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+
+    let mut test = ExecutionTestBuilder::new().build();
+    for limit in [1, MIN_AGGREGATE_LOG_MEMORY_LIMIT as u64 - 1] {
+        test.create_canister_with_settings(
+            CYCLES,
+            CanisterSettingsArgsBuilder::new()
+                .with_log_memory_limit(limit)
+                .build(),
+        )
+        .unwrap_err()
+        .assert_contains(
+            ErrorCode::CanisterRejectedMessage,
+            &format!(
+                "The canister log memory limit {limit} is too low. \
+                It must be either zero or at least {MIN_AGGREGATE_LOG_MEMORY_LIMIT}."
+            ),
+        );
+        assert_eq!(test.state().num_canisters(), 0);
+    }
+}
+
+// A non-zero log_memory_limit below the minimum is rejected on update_settings,
+// leaving the previous limit in place.
+#[test]
+fn update_settings_with_too_low_log_memory_limit_fails() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+    const MIB: u64 = 1024 * 1024;
+
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_id = test
+        .create_canister_with_settings(
+            CYCLES,
+            CanisterSettingsArgsBuilder::new()
+                .with_log_memory_limit(MIB)
+                .build(),
+        )
+        .unwrap();
+
+    for limit in [1, MIN_AGGREGATE_LOG_MEMORY_LIMIT as u64 - 1] {
+        let args = UpdateSettingsArgs {
+            canister_id: canister_id.get(),
+            settings: CanisterSettingsArgsBuilder::new()
+                .with_log_memory_limit(limit)
+                .build(),
+            sender_canister_version: None,
+        }
+        .encode();
+        test.subnet_message(Method::UpdateSettings, args)
+            .unwrap_err()
+            .assert_contains(
+                ErrorCode::CanisterRejectedMessage,
+                &format!(
+                    "The canister log memory limit {limit} is too low. \
+                    It must be either zero or at least {MIN_AGGREGATE_LOG_MEMORY_LIMIT}."
+                ),
+            );
+        assert_eq!(
+            test.canister_state(canister_id).log_memory_limit(),
+            NumBytes::new(MIB)
+        );
+    }
+}
+
+// The minimum log_memory_limit is accepted and applied as is.
+#[test]
+fn update_settings_with_minimum_log_memory_limit_succeeds() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+    const MIB: u64 = 1024 * 1024;
+    let min_limit = MIN_AGGREGATE_LOG_MEMORY_LIMIT as u64;
+
+    let mut test = ExecutionTestBuilder::new().build();
+    let canister_id = test
+        .create_canister_with_settings(
+            CYCLES,
+            CanisterSettingsArgsBuilder::new()
+                .with_log_memory_limit(MIB)
+                .build(),
+        )
+        .unwrap();
+
+    let args = UpdateSettingsArgs {
+        canister_id: canister_id.get(),
+        settings: CanisterSettingsArgsBuilder::new()
+            .with_log_memory_limit(min_limit)
+            .build(),
+        sender_canister_version: None,
+    }
+    .encode();
+    test.subnet_message(Method::UpdateSettings, args).unwrap();
+
+    assert_eq!(
+        test.canister_state(canister_id).log_memory_limit(),
+        NumBytes::new(min_limit)
+    );
+    assert_eq!(
+        test.canister_state(canister_id)
+            .system_state
+            .log_memory_store
+            .byte_capacity() as u64,
+        min_limit
+    );
 }
 
 #[test]

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -498,6 +498,10 @@ pub(crate) enum CanisterManagerError {
         bytes: NumBytes,
         limit: NumBytes,
     },
+    CanisterLogMemoryLimitIsTooLow {
+        bytes: NumBytes,
+        limit: NumBytes,
+    },
     CanisterSnapshotAccessDenied {
         caller: PrincipalId,
         method_name: String,
@@ -774,6 +778,12 @@ impl AsErrorHelp for CanisterManagerError {
             },
             CanisterManagerError::CanisterLogMemoryLimitIsTooHigh { .. } => ErrorHelp::UserError {
                 suggestion: "Set a lower canister log memory limit.".to_string(),
+                doc_link: "".to_string(),
+            },
+            CanisterManagerError::CanisterLogMemoryLimitIsTooLow { .. } => ErrorHelp::UserError {
+                suggestion: "Set a higher canister log memory limit, \
+                or zero to disable canister logging."
+                    .to_string(),
                 doc_link: "".to_string(),
             },
         }
@@ -1215,6 +1225,13 @@ impl From<CanisterManagerError> for UserError {
                 ErrorCode::CanisterRejectedMessage,
                 format!(
                     "The canister log memory limit {bytes} is too high. It must be at most {limit}."
+                ),
+            ),
+            CanisterLogMemoryLimitIsTooLow { bytes, limit } => Self::new(
+                ErrorCode::CanisterRejectedMessage,
+                format!(
+                    "The canister log memory limit {bytes} is too low. \
+                    It must be either zero or at least {limit}."
                 ),
             ),
             FetchCanisterLogsAccessDenied { caller } => Self::new(

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -22,6 +22,19 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+/// Returns the ring buffer data capacity to use for a non-zero log memory limit.
+///
+/// Non-zero limits below `DATA_CAPACITY_MIN` are rejected when canister settings
+/// are validated, so the clamping here is only a safety net for the release
+/// build; in debug builds such a limit trips the assertion instead.
+fn data_capacity_for_limit(limit: usize) -> usize {
+    debug_assert!(
+        limit >= DATA_CAPACITY_MIN,
+        "non-zero log memory limit {limit} is below the minimum {DATA_CAPACITY_MIN}"
+    );
+    limit.max(DATA_CAPACITY_MIN)
+}
+
 /// Canister log storage backed by a PageMap-based ring buffer.
 ///
 /// Using PageMap allows log data to be stored outside the heap and
@@ -256,7 +269,7 @@ impl LogMemoryStore {
             return NumBytes::new(0);
         }
         // Mirror resize_impl's capacity clamping exactly.
-        let target_capacity = (limit.get() as usize).max(DATA_CAPACITY_MIN);
+        let target_capacity = data_capacity_for_limit(limit.get() as usize);
         NumBytes::new(self.virtual_memory_for_data_capacity(target_capacity) as u64)
     }
 
@@ -290,7 +303,7 @@ impl LogMemoryStore {
             // Limit zero deallocates — work only if allocated.
             return self.maybe_page_map.is_some();
         }
-        let target_limit = limit.max(DATA_CAPACITY_MIN);
+        let target_limit = data_capacity_for_limit(limit);
         let current_capacity = self.get_header().map(|h| h.data_capacity.get() as usize);
         current_capacity != Some(target_limit)
     }
@@ -318,7 +331,7 @@ impl LogMemoryStore {
             self.deallocate();
             return;
         }
-        let target_limit = limit.max(DATA_CAPACITY_MIN);
+        let target_limit = data_capacity_for_limit(limit);
         let current_capacity = self.get_header().map(|h| h.data_capacity.get() as usize);
 
         // Determine the PageMap strategy and create a new ring buffer.

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
@@ -6,7 +6,9 @@ use crate::canister_state::system_state::log_memory_store::{
 };
 use crate::page_map::PageMap;
 use ic_management_canister_types_private::{CanisterLogRecord, DataSize, FetchCanisterLogsFilter};
-use ic_types::canister_log::MAX_FETCH_CANISTER_LOGS_RESULT_BYTES;
+use ic_types::canister_log::{
+    MAX_FETCH_CANISTER_LOGS_RESULT_BYTES, MIN_AGGREGATE_LOG_MEMORY_LIMIT,
+};
 use more_asserts::assert_le;
 
 // PageMap file layout.
@@ -48,8 +50,13 @@ const _: () = assert!(5 * DATA_SEGMENT_SIZE_MAX <= RESULT_MAX_SIZE.get());
 /// Log memory limit can be zero to disable logging,
 /// but when it is non-zero it must be at least this value
 /// to properly account for the size of at least one OS page.
+/// Non-zero limits below this value are rejected when canister settings are
+/// validated.
 pub(super) const DATA_CAPACITY_MIN: usize = VIRTUAL_PAGE_SIZE;
 const _: () = assert!(VIRTUAL_PAGE_SIZE <= DATA_CAPACITY_MIN); // data capacity must be at least one page.
+// The user-facing minimum log memory limit matches the ring buffer's minimum
+// data capacity, so that an accepted non-zero limit is applied as is.
+const _: () = assert!(MIN_AGGREGATE_LOG_MEMORY_LIMIT == DATA_CAPACITY_MIN);
 
 pub(super) struct RingBuffer {
     io: StructIO,

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
@@ -16,8 +16,7 @@ use more_asserts::{assert_gt, assert_lt};
 const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
 
-/// Minimal non-zero log memory limit.
-/// Must be rounded up to at least one OS page.
+/// Minimal non-zero log memory limit: at least one OS page.
 const TEST_MINIMAL_LOG_MEMORY_LIMIT: NumBytes = NumBytes::new(4 * KIB);
 
 /// Default log memory limit.
@@ -122,14 +121,12 @@ fn test_canister_creation_initially_default_size() {
 fn test_canister_minimal_log_memory_limit() {
     let mut canister = MockCanister::create_canister();
 
-    // Small non-zero value.
+    // Smallest allowed non-zero value: exactly one OS page.
     canister.update_settings(CanisterSettings {
-        log_memory_limit: Some(NumBytes::new(1)),
+        log_memory_limit: Some(TEST_MINIMAL_LOG_MEMORY_LIMIT),
         ..Default::default()
     });
 
-    // Small non-zero value must be rounded up to at
-    // least one OS page.
     assert_eq!(canister.fetch_canister_logs().len(), 0);
     assert_eq!(
         canister.log_memory_usage(),

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -138,9 +138,20 @@ fn test_appending_to_uninitialized_store_updates_next_idx() {
 fn test_minimal_allowed_capacity() {
     let mut s = LogMemoryStore::new();
 
-    s.resize_for_testing(1); // Set a small limit.
+    s.resize_for_testing(EXPECTED_DATA_CAPACITY_MIN); // Set the smallest allowed limit.
 
     assert_eq!(s.byte_capacity(), EXPECTED_DATA_CAPACITY_MIN);
+}
+
+// Non-zero limits below the minimum are rejected when canister settings are
+// validated, so reaching the store with one is a bug.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "non-zero log memory limit 1 is below the minimum 4096")]
+fn test_resize_below_minimal_allowed_capacity_panics() {
+    let mut s = LogMemoryStore::new();
+
+    s.resize_for_testing(1);
 }
 
 #[test]
@@ -593,9 +604,9 @@ fn test_decreasing_capacity_drops_oldest_records_but_preserves_recent() {
 #[test]
 fn test_small_capacity_indexing() {
     let mut s = LogMemoryStore::new();
-    // Set a very small capacity, smaller than 146 bytes (INDEX_ENTRY_COUNT_MAX).
-    // 146 entries. If capacity is 100. 100 / 146 = 0.
-    s.resize_for_testing(100);
+    // Set the smallest allowed capacity, so that each of the 146 index entries
+    // (INDEX_ENTRY_COUNT_MAX) covers a segment of just 4096 / 146 = 28 bytes.
+    s.resize_for_testing(EXPECTED_DATA_CAPACITY_MIN);
 
     let mut delta = CanisterLog::new_delta_with_next_index(0, 100);
     // Add multiple records.
@@ -648,12 +659,11 @@ fn test_multiple_records_in_same_segment() {
 }
 
 #[test]
-fn test_very_small_capacity_single_byte() {
+fn test_minimal_allowed_capacity_single_record() {
     let mut s = LogMemoryStore::new();
-    // Set capacity to 1 byte - this will be clamped to DATA_CAPACITY_MIN (4096 bytes).
-    s.resize_for_testing(1);
+    // Set capacity to DATA_CAPACITY_MIN (4096 bytes).
+    s.resize_for_testing(EXPECTED_DATA_CAPACITY_MIN);
 
-    // Verify byte capacity was clamped to minimum.
     assert_eq!(s.byte_capacity(), 4096);
 
     let mut delta = CanisterLog::new_delta_with_next_index(0, 4096);
@@ -976,11 +986,6 @@ fn assert_memory_usage_for_limit(limit: usize) {
 #[test]
 fn memory_usage_for_limit_zero_limit() {
     assert_memory_usage_for_limit(0);
-}
-
-#[test]
-fn memory_usage_for_limit_below_minimum() {
-    assert_memory_usage_for_limit(1); // below DATA_CAPACITY_MIN
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -609,24 +609,26 @@ fn test_small_capacity_indexing() {
     s.resize_for_testing(EXPECTED_DATA_CAPACITY_MIN);
 
     let mut delta = CanisterLog::new_delta_with_next_index(0, 100);
-    // Add multiple records.
+    // Add multiple records, each larger than a single 28-byte segment.
     // Header overhead is 8+8+4 = 20 bytes.
-    // Content "a" is 1 byte.
-    // Total 21 bytes per record.
-    delta.add_record(0, b"a".to_vec());
-    delta.add_record(1, b"b".to_vec());
+    // Content is 10 bytes.
+    // Total 30 bytes per record.
+    let content_a = b"aaaaaaaaaa".to_vec();
+    let content_b = b"bbbbbbbbbb".to_vec();
+    delta.add_record(0, content_a.clone());
+    delta.add_record(1, content_b.clone());
 
     s.append_delta_log(&mut delta);
 
     assert!(!s.is_empty());
-    // 21 * 2 = 42 bytes used.
-    assert_eq!(s.bytes_used(), 42);
+    // 30 * 2 = 60 bytes used.
+    assert_eq!(s.bytes_used(), 60);
 
     // Try to read it back.
     let records = s.records(None);
     assert_eq!(records.len(), 2, "Should return 2 records");
-    assert_eq!(records[0].content, b"a");
-    assert_eq!(records[1].content, b"b");
+    assert_eq!(records[0].content, content_a);
+    assert_eq!(records[1].content, content_b);
 }
 
 #[test]

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -12,6 +12,13 @@ const MIB: usize = 1024 * KIB;
 /// The maximum size of an aggregate canister log buffer.
 pub const MAX_AGGREGATE_LOG_MEMORY_LIMIT: usize = 2 * MIB;
 
+/// The minimum non-zero size of an aggregate canister log buffer.
+///
+/// A limit of zero disables logging altogether; any other limit must be at
+/// least this value, which is the log memory store's minimum ring buffer data
+/// capacity of one OS page.
+pub const MIN_AGGREGATE_LOG_MEMORY_LIMIT: usize = 4 * KIB;
+
 /// The default size of an aggregate canister log buffer.
 pub const DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT: usize = 4 * KIB;
 
@@ -27,6 +34,7 @@ pub const MAX_DELTA_LOG_MEMORY_LIMIT: usize = 2 * MIB;
 pub const MAX_FETCH_CANISTER_LOGS_RESULT_BYTES: usize = 2_000_000;
 
 // Compile-time assertions to ensure the constants are within valid ranges.
+const _: () = assert!(MIN_AGGREGATE_LOG_MEMORY_LIMIT <= DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT);
 const _: () = assert!(DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT <= MAX_AGGREGATE_LOG_MEMORY_LIMIT);
 const _: () = assert!(MAX_DELTA_LOG_MEMORY_LIMIT <= MAX_AGGREGATE_LOG_MEMORY_LIMIT);
 // A `fetch_canister_logs` response is the returned records (trimmed to

--- a/rs/types/types/src/lib.rs
+++ b/rs/types/types/src/lib.rs
@@ -89,7 +89,7 @@ pub mod exhaustive;
 
 pub use crate::canister_log::{
     CanisterLog, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, MAX_AGGREGATE_LOG_MEMORY_LIMIT,
-    MAX_DELTA_LOG_MEMORY_LIMIT,
+    MAX_DELTA_LOG_MEMORY_LIMIT, MIN_AGGREGATE_LOG_MEMORY_LIMIT,
 };
 pub use crate::replica_version::ReplicaVersion;
 pub use crate::time::Time;


### PR DESCRIPTION
A non-zero `log_memory_limit` below 4096 was silently rounded up to one OS page (`DATA_CAPACITY_MIN`) by the log memory store, so a canister asking for e.g. 100 bytes was given, and charged for, a 4 KiB data region. Reject such a limit instead of quietly changing it: `update_settings` and `create_canister` now fail with `CanisterLogMemoryLimitIsTooLow`. A zero limit still disables canister logging, and the existing upper bound is unchanged.

The new `MIN_AGGREGATE_LOG_MEMORY_LIMIT` sits next to the existing aggregate log limits, with a compile-time assertion tying it to the ring buffer's `DATA_CAPACITY_MIN` so the accepted minimum and the storage granularity cannot drift apart.

The clamping in the store is kept as a release-build safety net, but is now funnelled through a single `data_capacity_for_limit` helper guarded by a `debug_assert!`, so a sub-minimum limit reaching the store is caught in tests rather than silently rounded. Store tests that exercised the clamp are updated to the minimum, and a new test pins the assertion itself.