### PR TITLE
chore: simplify memory retrieval on upgrade and clarify preserving the memories on upgrade

### DIFF
--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -292,12 +292,17 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
     // Note that the memories to preserve are taken from the helper's canister,
     // i.e. as they are after `canister_pre_upgrade()` has run, and not from the
     // clean canister.
-    let new_memories = match helper.canister().execution_state.as_ref() {
-        Some(old) => MemorySource::Preserve {
-            old,
-            handling: memory_handling,
-        },
-        None => MemorySource::Fresh,
+    // Stage 1 rejects an upgrade of a canister without an execution state with
+    // `WasmModuleNotFound` and no step in between can remove it, so the old
+    // execution state is present here.
+    let old = helper
+        .canister()
+        .execution_state
+        .as_ref()
+        .expect("upgrading a canister without an execution state");
+    let new_memories = MemorySource::Preserve {
+        old,
+        handling: memory_handling,
     };
     let (instructions_from_compilation, result) = round.hypervisor.create_execution_state(
         wasm_module,

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -255,8 +255,11 @@ impl Hypervisor {
                 match new_memories {
                     MemorySource::Fresh => {}
                     MemorySource::Preserve { old, handling } => {
-                        // Cloning a `Memory` is cheap: its page delta is a
-                        // persistent map and its sandbox handle is an `Arc`.
+                        // Cloning a `Memory` is cheap: cloning its page delta,
+                        // a persistent map, only clones the root node of its
+                        // tree, whose subtrees are `Arc`s, and its checkpoint
+                        // files, page allocator and sandbox handle are `Arc`s
+                        // as well.
                         if handling.stable_memory_handling == MemoryHandling::Keep {
                             execution_state.stable_memory = old.stable_memory.clone();
                         }


### PR DESCRIPTION
An upgrade of a canister without an execution state is rejected with `WasmModuleNotFound` in stage 1 and no step in between can remove the execution state, so stage 2 always has the old execution state whose memories are to be preserved. Replace the (unreachable) `MemorySource::Fresh` fallback, which would silently reset the stable memory, with an `expect` documenting that invariant.

Note that we also expect an execution state to be present when resuming DTS of a response callback execution so this panic site is not new of its kind.

Also spell out in `Hypervisor::create_execution_state` why cloning a `Memory` is cheap.