### PR TITLE
feat: Delete canister directory via `UnflushedCheckpointOp::DeleteCanister`

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1362,13 +1362,9 @@ impl CanisterManager {
         // - its state is permanently deleted, and
         // - its cycles are discarded.
 
-        // Remove the canister from `ReplicatedState`; and record the removal, so that
-        // the canister's directory is also deleted from the tip.
+        // Remove the canister from `ReplicatedState`. This also records the removal, so
+        // that the canister's directory is deleted from the tip.
         let canister_to_delete = state.remove_canister(&canister_id_to_delete).unwrap();
-        state
-            .metadata
-            .unflushed_checkpoint_ops
-            .delete_canister(canister_id_to_delete);
         let canister_memory_allocated_bytes = canister_to_delete.memory_allocated_bytes();
 
         round_limits.subnet_available_memory.increment(

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1362,8 +1362,13 @@ impl CanisterManager {
         // - its state is permanently deleted, and
         // - its cycles are discarded.
 
-        // Remove the canister from `ReplicatedState`.
+        // Remove the canister from `ReplicatedState`; and record the removal, so that
+        // the canister's directory is also deleted from the tip.
         let canister_to_delete = state.remove_canister(&canister_id_to_delete).unwrap();
+        state
+            .metadata
+            .unflushed_checkpoint_ops
+            .delete_canister(canister_id_to_delete);
         let canister_memory_allocated_bytes = canister_to_delete.memory_allocated_bytes();
 
         round_limits.subnet_available_memory.increment(

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -2055,8 +2055,8 @@ fn delete_canister_records_unflushed_checkpoint_op() {
     let _ = test.stop_canister(canister_id);
     test.process_stopping_canisters();
 
-    // Ignore any checkpoint ops accumulated while creating and stopping the canister.
-    test.state_mut().metadata.unflushed_checkpoint_ops.take();
+    // Creating and stopping a canister does not require any checkpoint ops.
+    assert!(test.state().metadata.unflushed_checkpoint_ops.is_empty());
 
     test.delete_canister(canister_id).unwrap();
 

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -56,6 +56,7 @@ use ic_replicated_state::{
     CallContextManager, CallOrigin, CanisterState, CanisterStatus, ReplicatedState,
     canister_state::system_state::wasm_chunk_store::{self, ChunkValidationResult},
     metadata_state::{
+        UnflushedCheckpointOp,
         subnet_call_context_manager::InstallCodeCallId,
         testing::{NetworkTopologyTesting, SystemMetadataTesting},
     },
@@ -2042,6 +2043,27 @@ fn canister_status_of_deleted_canister() {
     assert!(
         err.description()
             .contains(&format!("Canister {canister_id} not found"))
+    );
+}
+
+#[test]
+fn delete_canister_records_unflushed_checkpoint_op() {
+    let mut test = ExecutionTestBuilder::new().build();
+
+    let canister_id = test.create_canister(*INITIAL_CYCLES);
+
+    let _ = test.stop_canister(canister_id);
+    test.process_stopping_canisters();
+
+    // Ignore any checkpoint ops accumulated while creating and stopping the canister.
+    test.state_mut().metadata.unflushed_checkpoint_ops.take();
+
+    test.delete_canister(canister_id).unwrap();
+
+    // Deleting the canister requires deleting its directory from the tip.
+    assert_eq!(
+        test.state_mut().metadata.unflushed_checkpoint_ops.take(),
+        vec![UnflushedCheckpointOp::DeleteCanister(canister_id)]
     );
 }
 

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -2321,7 +2321,7 @@ impl UnflushedCheckpointOps {
 
     /// Records the deletion of a canister. Private to the crate because the only way
     /// of permanently removing a canister is `ReplicatedState::remove_canister()`,
-    /// which already records the operation.
+    /// which calls this on the caller's behalf.
     pub(crate) fn delete_canister(&mut self, canister_id: CanisterId) {
         self.operations
             .push(UnflushedCheckpointOp::DeleteCanister(canister_id));

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -2319,7 +2319,10 @@ impl UnflushedCheckpointOps {
         ));
     }
 
-    pub fn delete_canister(&mut self, canister_id: CanisterId) {
+    /// Records the deletion of a canister. Private to the crate because the only way
+    /// of permanently removing a canister is `ReplicatedState::remove_canister()`,
+    /// which already records the operation.
+    pub(crate) fn delete_canister(&mut self, canister_id: CanisterId) {
         self.operations
             .push(UnflushedCheckpointOp::DeleteCanister(canister_id));
     }

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -2270,6 +2270,8 @@ pub enum UnflushedCheckpointOp {
     LoadSnapshot(CanisterId, SnapshotId),
     /// A canister was renamed.
     RenameCanister(CanisterId, CanisterId),
+    /// A canister was deleted.
+    DeleteCanister(CanisterId),
 }
 
 /// A collection of unflushed checkpoint operations in the order that they were applied to the state.
@@ -2315,6 +2317,11 @@ impl UnflushedCheckpointOps {
             old_canister_id,
             new_canister_id,
         ));
+    }
+
+    pub fn delete_canister(&mut self, canister_id: CanisterId) {
+        self.operations
+            .push(UnflushedCheckpointOp::DeleteCanister(canister_id));
     }
 }
 

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -592,10 +592,18 @@ impl ReplicatedState {
     }
 
     /// Permanently removes the canister and its scheduling priority from the subnet
-    /// schedule.
+    /// schedule; and records the removal as an unflushed checkpoint operation, so that
+    /// the canister's directory is also deleted from the tip.
+    ///
+    /// Use `take_canister_state()` instead if the canister is only temporarily removed
+    /// from the state (e.g. to work around borrow checker limitations).
     pub fn remove_canister(&mut self, canister_id: &CanisterId) -> Option<Arc<CanisterState>> {
         self.metadata.subnet_schedule.remove(canister_id);
-        self.canister_states.remove(canister_id)
+        let canister_state = self.canister_states.remove(canister_id)?;
+        self.metadata
+            .unflushed_checkpoint_ops
+            .delete_canister(*canister_id);
+        Some(canister_state)
     }
 
     /// Returns a reference to the canister states.

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1255,6 +1255,13 @@ fn split() {
     assert_eq!(expected, state_b);
 }
 
+/// Drops a canister from the state the same way `online_split()` does, i.e. without
+/// recording an `UnflushedCheckpointOp::DeleteCanister`.
+fn drop_canister(state: &mut ReplicatedState, canister_id: &CanisterId) {
+    state.take_canister_state(canister_id).unwrap();
+    state.metadata.subnet_schedule.remove(canister_id);
+}
+
 #[test]
 fn online_split() {
     // We will be splitting subnet A into A' and B.
@@ -1374,7 +1381,7 @@ fn online_split() {
     // Start off with the original state (plus new routing table).
     let mut expected = fixture.state.clone();
     // Only `CANISTER_1` should be left.
-    expected.remove_canister(&CANISTER_2);
+    drop_canister(&mut expected, &CANISTER_2);
     // The input schedules of `CANISTER_1` should have been repartitioned.
     let mut canister_state_arc = expected.take_canister_state(&CANISTER_1).unwrap();
     let canister_state = Arc::make_mut(&mut canister_state_arc);
@@ -1407,7 +1414,7 @@ fn online_split() {
     // New subnet ID.
     expected.metadata.own_subnet_id = SUBNET_B;
     // Only `CANISTER_2` should be hosted.
-    expected.remove_canister(&CANISTER_1);
+    drop_canister(&mut expected, &CANISTER_1);
     // The input schedules of `CANISTER_2` should have been repartitioned.
     let mut canister_state_arc = expected.take_canister_state(&CANISTER_2).unwrap();
     let canister_state = Arc::make_mut(&mut canister_state_arc);

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -542,7 +542,7 @@ impl TipHandler {
         canister_id: CanisterId,
     ) -> Result<(), LayoutError> {
         let tip = self.tip(height)?;
-        tip.canister(&canister_id)?.delete_dir()
+        tip.delete_canister_dir(&canister_id)
     }
 
     /// Moves the entire canister directory from one canister id to another.
@@ -1813,13 +1813,16 @@ impl<Permissions: AccessPolicy> CheckpointLayout<Permissions> {
         &self,
         canister_id: &CanisterId,
     ) -> Result<CanisterLayout<Permissions>, LayoutError> {
-        CanisterLayout::new(
-            self.0
-                .root
-                .join(CANISTER_STATES_DIR)
-                .join(hex::encode(canister_id.get_ref().as_slice())),
-            self,
-        )
+        CanisterLayout::new(self.canister_path(canister_id), self)
+    }
+
+    /// The path of the given canister's directory. As opposed to `canister()`, this
+    /// does not create the directory.
+    fn canister_path(&self, canister_id: &CanisterId) -> PathBuf {
+        self.0
+            .root
+            .join(CANISTER_STATES_DIR)
+            .join(hex::encode(canister_id.get_ref().as_slice()))
     }
 
     /// Lists all snapshots in the checkpoint.
@@ -2043,6 +2046,23 @@ where
             message: "Failed to sync checkpoint directory for the creation of the state sync checkpoint marker".to_string(),
             io_err: err,
         })
+    }
+
+    /// Removes the entire directory of the given canister.
+    ///
+    /// This is a no-op if the canister has no directory, e.g. because it was created
+    /// and deleted without any of its `PageMap`s having been flushed.
+    pub fn delete_canister_dir(&self, canister_id: &CanisterId) -> Result<(), LayoutError> {
+        let canister_path = self.canister_path(canister_id);
+        match std::fs::remove_dir_all(&canister_path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(LayoutError::IoError {
+                path: canister_path,
+                message: "Cannot remove canister.".to_string(),
+                io_err: err,
+            }),
+        }
     }
 }
 
@@ -2418,25 +2438,6 @@ impl<Permissions: AccessPolicy> CanisterLayout<Permissions> {
             name_stem: LOG_MEMORY_STORE.into(),
             permissions_tag: PhantomData,
             _checkpoint: self.checkpoint.clone(),
-        }
-    }
-}
-
-impl<P> CanisterLayout<P>
-where
-    P: WritePolicy,
-{
-    /// Removes the entire directory of the canister. Does nothing if the directory
-    /// does not exist.
-    pub fn delete_dir(&self) -> Result<(), LayoutError> {
-        match std::fs::remove_dir_all(self.raw_path()) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(LayoutError::IoError {
-                path: self.raw_path(),
-                message: "Cannot remove canister.".to_string(),
-                io_err: err,
-            }),
         }
     }
 }

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -532,6 +532,19 @@ impl TipHandler {
         Ok(())
     }
 
+    /// Deletes the directory of the given canister from tip.
+    ///
+    /// This is a no-op if the canister has no directory in tip, e.g. because it was
+    /// created and deleted without any of its `PageMap`s having been flushed.
+    pub fn delete_canister_directory(
+        &mut self,
+        height: Height,
+        canister_id: CanisterId,
+    ) -> Result<(), LayoutError> {
+        let tip = self.tip(height)?;
+        tip.canister(&canister_id)?.delete_dir()
+    }
+
     /// Moves the entire canister directory from one canister id to another.
     pub fn move_canister_directory(
         &mut self,
@@ -2405,6 +2418,25 @@ impl<Permissions: AccessPolicy> CanisterLayout<Permissions> {
             name_stem: LOG_MEMORY_STORE.into(),
             permissions_tag: PhantomData,
             _checkpoint: self.checkpoint.clone(),
+        }
+    }
+}
+
+impl<P> CanisterLayout<P>
+where
+    P: WritePolicy,
+{
+    /// Removes the entire directory of the canister. Does nothing if the directory
+    /// does not exist.
+    pub fn delete_dir(&self) -> Result<(), LayoutError> {
+        match std::fs::remove_dir_all(self.raw_path()) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(LayoutError::IoError {
+                path: self.raw_path(),
+                message: "Cannot remove canister.".to_string(),
+                io_err: err,
+            }),
         }
     }
 }

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -828,6 +828,48 @@ fn test_all_existing_wasm_files() {
 }
 
 #[test]
+fn test_delete_canister_dir() {
+    let tmp = tmpdir("checkpoint");
+    let checkpoint_layout: CheckpointLayout<RwPolicy<()>> =
+        CheckpointLayout::new_untracked(tmp.path().to_owned(), Height::new(0)).unwrap();
+
+    // Deleting a canister without a directory is a no-op.
+    checkpoint_layout
+        .delete_canister_dir(&canister_test_id(42))
+        .unwrap();
+    assert!(checkpoint_layout.canister_ids().unwrap().is_empty());
+
+    // Create directories for two canisters, one of them with a wasm file.
+    let canister_layout = checkpoint_layout.canister(&canister_test_id(42)).unwrap();
+    File::create(canister_layout.wasm().path()).unwrap();
+    let _ = checkpoint_layout.canister(&canister_test_id(43)).unwrap();
+    assert_eq!(
+        checkpoint_layout.canister_ids().unwrap(),
+        vec![canister_test_id(42), canister_test_id(43)]
+    );
+
+    // Deleting a canister removes its directory with all its contents, but leaves
+    // the other canister alone.
+    checkpoint_layout
+        .delete_canister_dir(&canister_test_id(42))
+        .unwrap();
+    assert!(!canister_layout.raw_path().exists());
+    assert_eq!(
+        checkpoint_layout.canister_ids().unwrap(),
+        vec![canister_test_id(43)]
+    );
+
+    // Deleting the same canister again is a no-op.
+    checkpoint_layout
+        .delete_canister_dir(&canister_test_id(42))
+        .unwrap();
+    assert_eq!(
+        checkpoint_layout.canister_ids().unwrap(),
+        vec![canister_test_id(43)]
+    );
+}
+
+#[test]
 fn wasm_can_be_serialized_to_and_loaded_from_a_file() {
     let wasm_in_memory = CanisterModule::new(vec![0x00, 0x61, 0x73, 0x6d]);
     let wasm_hash = wasm_in_memory.module_hash();

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -106,6 +106,10 @@ pub(crate) enum TipRequest {
     },
     /// Filter canisters and snapshots in tip. Remove ones not present in the sets.
     ///
+    /// Canisters deleted during execution are removed from tip via
+    /// `UnflushedCheckpointOp::DeleteCanister`, so this only needs to catch canisters
+    /// dropped without a corresponding operation, i.e. during subnet splitting.
+    ///
     /// State: `tip_folder_state.has_filtered_canisters = true`
     FilterTipCanisters {
         height: Height,
@@ -819,7 +823,7 @@ fn switch_to_checkpoint(
 }
 
 /// Update the tip directory files with the most recent checkpoint operations.
-/// `operations` is an ordered list of all created/restored snapshots and renamed canisters since the last flush.
+/// `operations` is an ordered list of all created/restored snapshots and renamed or deleted canisters since the last flush.
 fn flush_unflushed_checkpoint_ops(
     log: &ReplicaLogger,
     tip_handler: &mut TipHandler,
@@ -837,6 +841,9 @@ fn flush_unflushed_checkpoint_ops(
             }
             UnflushedCheckpointOp::RenameCanister(src, dst) => {
                 tip_handler.move_canister_directory(height, src, dst)?;
+            }
+            UnflushedCheckpointOp::DeleteCanister(canister_id) => {
+                tip_handler.delete_canister_directory(height, canister_id)?;
             }
         }
     }

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8507,15 +8507,16 @@ fn deleted_canister_is_removed_from_tip() {
             state_manager.commit_and_certify(state, CertificationScope::Full, None);
             state_manager.flush_tip_channel();
 
+            let (height, mut state) = state_manager.take_tip();
             let tip = CheckpointLayout::<ReadOnly>::new_untracked(
                 state_manager.state_layout().raw_path().join("tip"),
-                Height(0),
+                height,
             )
             .unwrap();
             assert_eq!(tip.canister_ids().unwrap(), vec![canister_id]);
 
-            let (_height, mut state) = state_manager.take_tip();
             delete_canister(&mut state, canister_id);
+            assert!(!state.system_metadata().unflushed_checkpoint_ops.is_empty());
 
             // Trigger a flush either at the checkpoint or by committing exactly
             // `NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY` rounds before the checkpoint.
@@ -8537,6 +8538,7 @@ fn deleted_canister_is_removed_from_tip() {
 
             // The canister directory is gone from the tip, even without a checkpoint.
             assert!(tip.canister_ids().unwrap().is_empty());
+            // And the checkpoint op has been flushed.
             let (_height, state) = state_manager.take_tip();
             assert!(state.system_metadata().unflushed_checkpoint_ops.is_empty());
         });

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8480,6 +8480,71 @@ fn can_rename_canister() {
     can_rename_canister_impl(CertificationScope::Full);
 }
 
+/// Simplified version of canister deletion that only does the parts relevant to the state manager.
+fn delete_canister(state: &mut ReplicatedState, canister_id: CanisterId) {
+    state.remove_canister(&canister_id).unwrap();
+    state
+        .metadata
+        .unflushed_checkpoint_ops
+        .delete_canister(canister_id);
+}
+
+#[test]
+fn deleted_canister_is_removed_from_tip() {
+    fn deleted_canister_is_removed_from_tip_impl(certification_scope: CertificationScope) {
+        state_manager_test(|_metrics, state_manager| {
+            let canister_id = canister_test_id(100);
+
+            // Install a canister and give it some initial state.
+            let (_height, mut state) = state_manager.take_tip();
+            insert_dummy_canister(&mut state, canister_id);
+            let canister_state = state.canister_state_make_mut(&canister_id).unwrap();
+            let execution_state = canister_state.execution_state.as_mut().unwrap();
+            execution_state
+                .wasm_memory
+                .page_map
+                .update(&[(PageIndex::new(0), &[1_u8; PAGE_SIZE])]);
+            state_manager.commit_and_certify(state, CertificationScope::Full, None);
+            state_manager.flush_tip_channel();
+
+            let tip = CheckpointLayout::<ReadOnly>::new_untracked(
+                state_manager.state_layout().raw_path().join("tip"),
+                Height(0),
+            )
+            .unwrap();
+            assert_eq!(tip.canister_ids().unwrap(), vec![canister_id]);
+
+            let (_height, mut state) = state_manager.take_tip();
+            delete_canister(&mut state, canister_id);
+
+            // Trigger a flush either at the checkpoint or by committing exactly
+            // `NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY` rounds before the checkpoint.
+            if certification_scope == CertificationScope::Full {
+                state_manager.commit_and_certify(state, certification_scope.clone(), None);
+            } else {
+                state_manager.commit_and_certify(
+                    state,
+                    certification_scope.clone(),
+                    Some(BatchSummary {
+                        next_checkpoint_height: Height(
+                            2 + NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY,
+                        ),
+                        current_interval_length: Height(500),
+                    }),
+                );
+            }
+            state_manager.flush_tip_channel();
+
+            // The canister directory is gone from the tip, even without a checkpoint.
+            assert!(tip.canister_ids().unwrap().is_empty());
+            let (_height, state) = state_manager.take_tip();
+            assert!(state.system_metadata().unflushed_checkpoint_ops.is_empty());
+        });
+    }
+    deleted_canister_is_removed_from_tip_impl(CertificationScope::Metadata);
+    deleted_canister_is_removed_from_tip_impl(CertificationScope::Full);
+}
+
 #[test_strategy::proptest(ProptestConfig { cases: 20, ..ProptestConfig::default() })]
 fn stream_store_encode_decode(
     #[strategy(arb_stream(

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8258,6 +8258,14 @@ fn restore_chunk_store_from_snapshot() {
     assert!(env.execute_ingress(canister_id, "read", vec![],).is_err(),);
 }
 
+/// Drops a canister from the state the same way `online_split()` does, i.e. without
+/// recording an `UnflushedCheckpointOp::DeleteCanister`: canisters dropped during a
+/// subnet split are removed from tip by `FilterTipCanisters` instead.
+fn drop_canister(state: &mut ReplicatedState, canister_id: &CanisterId) {
+    state.take_canister_state(canister_id).unwrap();
+    state.metadata.subnet_schedule.remove(canister_id);
+}
+
 #[test]
 fn can_split_with_inflight_restore_snapshot() {
     // We will be splitting subnet A into A' and B.
@@ -8340,11 +8348,11 @@ fn can_split_with_inflight_restore_snapshot() {
             if subnet_id == SUBNET_A {
                 other_subnet_id = SUBNET_B;
                 // `SUBNET_A` should only host `CANISTER_1` (and preserve its snapshot).
-                expected.remove_canister(&CANISTER_2);
+                drop_canister(&mut expected, &CANISTER_2);
             } else if subnet_id == SUBNET_B {
                 other_subnet_id = SUBNET_A;
                 // `SUBNET_B` should only host `CANISTER_2`.
-                expected.remove_canister(&CANISTER_1);
+                drop_canister(&mut expected, &CANISTER_1);
             } else {
                 unreachable!("Unexpected subnet ID: {:?}", subnet_id);
             }
@@ -8480,15 +8488,6 @@ fn can_rename_canister() {
     can_rename_canister_impl(CertificationScope::Full);
 }
 
-/// Simplified version of canister deletion that only does the parts relevant to the state manager.
-fn delete_canister(state: &mut ReplicatedState, canister_id: CanisterId) {
-    state.remove_canister(&canister_id).unwrap();
-    state
-        .metadata
-        .unflushed_checkpoint_ops
-        .delete_canister(canister_id);
-}
-
 #[test]
 fn deleted_canister_is_removed_from_tip() {
     fn deleted_canister_is_removed_from_tip_impl(certification_scope: CertificationScope) {
@@ -8510,7 +8509,7 @@ fn deleted_canister_is_removed_from_tip() {
             .unwrap();
             assert_eq!(tip.canister_ids().unwrap(), vec![canister_id]);
 
-            delete_canister(&mut state, canister_id);
+            state.remove_canister(&canister_id).unwrap();
             assert!(!state.system_metadata().unflushed_checkpoint_ops.is_empty());
 
             // Trigger a flush either at the checkpoint or by committing exactly

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8495,15 +8495,10 @@ fn deleted_canister_is_removed_from_tip() {
         state_manager_test(|_metrics, state_manager| {
             let canister_id = canister_test_id(100);
 
-            // Install a canister and give it some initial state.
+            // Install a canister and checkpoint the state, so that the canister has a
+            // directory in the tip.
             let (_height, mut state) = state_manager.take_tip();
             insert_dummy_canister(&mut state, canister_id);
-            let canister_state = state.canister_state_make_mut(&canister_id).unwrap();
-            let execution_state = canister_state.execution_state.as_mut().unwrap();
-            execution_state
-                .wasm_memory
-                .page_map
-                .update(&[(PageIndex::new(0), &[1_u8; PAGE_SIZE])]);
             state_manager.commit_and_certify(state, CertificationScope::Full, None);
             state_manager.flush_tip_channel();
 


### PR DESCRIPTION
Introduce a new `UnflushedCheckpointOp::DeleteCanister` recorded when a canister is deleted during execution. The tip thread applies it in `flush_unflushed_checkpoint_ops`, removing the canister's directory from tip at the next flush (i.e., every round) instead of only at the next checkpoint, and in order relative to the other checkpoint operations.

`FilterTipCanisters` is retained as is: canisters dropped without a corresponding operation, i.e. during subnet splitting, are still removed from tip when creating a checkpoint.