### PR TITLE
fix(system-tests): enable detect-zeroes on the Local backend's boot disk

### DIFF
--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -1209,11 +1209,24 @@ impl LocalBackend {
 
         // Primary boot disk (qcow2 overlay), then any extra (raw) disks. Disks go
         // on later root ports so they never take the NICs' bus numbers.
+        //
+        // `detect-zeroes=unmap` keeps upgrade tests from filling the host's disk.
+        // A GuestOS upgrade `dd`s the whole update image onto the inactive slot
+        // (see `manageboot.sh`), and that image is mostly holes: ~11 GiB of
+        // `boot.img` + `root.img` for ~1.2 GiB of content. Without zero
+        // detection every one of those zero blocks allocates a qcow2 cluster, so
+        // a single 4-node upgrade/downgrade test — which writes both slots on
+        // every node — grows its overlays by ~87 GiB. Paired with the
+        // `discard=unmap` on the same drive, zero writes instead become unmaps,
+        // bringing that down to ~11 GiB. That is safe over a backing
+        // file: the overlay is qcow2 v3 (`compat=1.1`), so qcow2 records a *zero
+        // cluster* rather than deallocating, and reads keep returning zeros
+        // instead of falling through to the base image.
         let rp = root_port!();
         arg!(
             "-drive",
             format!(
-                "if=none,id=disk0,file={},format=qcow2,cache=none,discard=unmap",
+                "if=none,id=disk0,file={},format=qcow2,cache=none,discard=unmap,detect-zeroes=unmap",
                 primary_disk.display()
             )
         );

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -1023,6 +1023,15 @@ impl LocalBackend {
                 .arg("raw")
                 .arg("-b")
                 .arg(&base)
+                // Pin the qcow2 version instead of inheriting `qemu-img`'s
+                // default, because `detect-zeroes=unmap` on the `-drive` below
+                // depends on it: only v3 (`compat=1.1`) can record a *zero
+                // cluster*, which is what makes a zeroed range read back as
+                // zeros rather than falling through to the backing file. On v2
+                // qcow2 would have to write the zeros out instead, silently
+                // giving up the space saving.
+                .arg("-o")
+                .arg("compat=1.1")
                 .arg(&primary_disk);
             // Grow the overlay's virtual size to `min_gib`, but only when it
             // exceeds the base image's size (the base is raw, so its byte length
@@ -1219,9 +1228,9 @@ impl LocalBackend {
         // every node — grows its overlays by ~87 GiB. Paired with the
         // `discard=unmap` on the same drive, zero writes instead become unmaps,
         // bringing that down to ~11 GiB. That is safe over a backing
-        // file: the overlay is qcow2 v3 (`compat=1.1`), so qcow2 records a *zero
-        // cluster* rather than deallocating, and reads keep returning zeros
-        // instead of falling through to the base image.
+        // file because the overlay is created with `compat=1.1` above: qcow2 v3
+        // records a *zero cluster* rather than deallocating, so reads keep
+        // returning zeros instead of falling through to the base image.
         let rp = root_port!();
         arg!(
             "-drive",


### PR DESCRIPTION
## Why

The `_local` variants of the upgrade/downgrade system-tests have been failing on **CI RBE Evaluation / Bazel Test All on RBE** since 2026-08-14 (`upgrade_downgrade_old_nns_subnet_test_local` fails all 3 attempts; the other 6 in the family flake). They pass on Farm via ci-main `_colocate` and on the daily `local-system-tests` job, so it is specific to the RBE workers.

The Namespace worker runs out of disk. The driver's own logger dies first, so the failure surfaces as an unrelated-looking panic:

```
thread '<unnamed>' panicked at slog-2.7.0/src/lib.rs:1944:33:
slog::Fuse Drain: Os { code: 28, kind: StorageFull, message: "No space left on device" }
```

That kills the slog-async worker; the next log call from the main thread then goes through the outer `Fuse` and escalates to `Fatal(BrokenPipe, "The logger thread terminated")`, attributed to whatever the test happened to be doing (usually `start_vm`). `No space left on device` is present in every failing attempt of both affected runs.

## What fills the disk

A GuestOS upgrade `dd`s the update image onto the inactive slot with no `conv=sparse` ([`manageboot.sh`](https://github.com/dfinity/ic/blob/master/ic-os/components/upgrade/manageboot/manageboot.sh#L248-L255)), so it writes every byte of a mostly hole-y image. Measured on the images `upgrade_downgrade_nns_subnet_test` actually boots (`@mainnet_app_images`):

| | apparent | allocated |
|---|---|---|
| extracted base `disk.img` (`image_cache/<key>.img`) | 50 GiB | 1.2 GiB |
| update payload `boot.img` + `root.img` | 11 GiB | 1.2 GiB |

The qcow2 overlay had `discard=unmap` but no zero detection, so each of those zero blocks allocated a cluster. An upgrade/downgrade test writes **both** slots on every node:

```
10.9 GiB x 2 upgrades x 4 nodes  =  87 GiB
+ base 1.2 GiB + inputs 0.85 GiB ~= 89 GiB per test action
```

At `cpu: 7` against a ~32 vCPU worker four of these co-schedule, so ~360 GiB is demanded from a 288 GB (268 GiB) disk. Even three does not fit.

## The change

Adding `detect-zeroes=unmap` to the primary drive turns those zero writes into unmaps, bringing a 4-node test from ~89 GiB to ~11 GiB — four co-scheduled tests then fit in ~44 GiB.

This is safe over a backing file. `qemu-img create` produces qcow2 v3 (`compat: 1.1`), so qcow2 records a *zero cluster* rather than deallocating, and reads keep returning zeros instead of falling through to the base image. Verified with the bundled QEMU 11.0.0 against a deliberately non-zero backing file, with `qemu-img`'s own sparse detection disabled (`-S 0`) so the only zero-elision is the drive's:

| | overlay allocated | reads back all-zero | leaks backing data |
|---|---|---|---|
| without `detect-zeroes` | 8.3M | yes | no |
| with `detect-zeroes=unmap` | **260K** | **yes** | **no** |

The extra (raw) disks are left untouched — those are the small padded config images, so there is nothing to reclaim there.

## Not fixed here

Two related items, deliberately out of scope:

1. **The logger escalates a host write failure into a misleading panic.** `new_file_logger` / `new_stdout_logger` `.fuse()` the inner drain, so any write error panics the async worker. Worth making `ENOSPC` fail with an explicit message instead.
2. **Nothing bounds a `_local` test's disk footprint.** Only `cpu` is reserved. This change buys a ~8x margin, but a declared disk reservation (or a lower `cpus_oversubscription_factor`) is what stops it recurring.

## Testing

- `cargo check --all-targets --all-features -p ic-system-test-driver` — clean
- `cargo fmt` — no changes beyond this diff
- `./ci/scripts/rust-lint.sh` — exit 0
- Bazel build/test of the affected targets was **not** run locally: the only targets within depth 2 of `local_backend.rs` are `//rs/tests/driver:ic-system-test-driver`, `//rs/tests/driver:generic_workload_engine` and `//rs/tests/idx:test_e2e_scenarios`, and the change only takes effect in the `_local` system tests, which need 20-30 vCPUs of QEMU each. Relying on CI to exercise those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)