### PR TITLE
feat: Add replicated state metric for the total value of pending anonymous refunds

### DIFF
--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -810,15 +810,34 @@ fn replicated_state_metrics_subnet_queue_messages() {
 #[test]
 fn replicated_state_metrics_pending_refunds() {
     const NAME: &str = "replicated_state_pending_refunds";
+    const CYCLES_NAME: &str = "replicated_state_pending_refunds_cycles";
 
     let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
-    assert_eq!(Some(0), fetch_int_gauge(&observe(&state), NAME));
+    let registry = observe(&state);
+    assert_eq!(Some(0), fetch_int_gauge(&registry, NAME));
+    assert_eq!(Some(0.), fetch_gauge(&registry, CYCLES_NAME));
 
     state.add_refund(canister_test_id(1), Cycles::new(13));
-    assert_eq!(Some(1), fetch_int_gauge(&observe(&state), NAME));
+    let registry = observe(&state);
+    assert_eq!(Some(1), fetch_int_gauge(&registry, NAME));
+    assert_eq!(Some(13.), fetch_gauge(&registry, CYCLES_NAME));
+
+    // A second refund, to a different canister.
+    state.add_refund(canister_test_id(2), Cycles::new(29));
+    let registry = observe(&state);
+    assert_eq!(Some(2), fetch_int_gauge(&registry, NAME));
+    assert_eq!(Some(42.), fetch_gauge(&registry, CYCLES_NAME));
+
+    // Taking the larger refund only leaves the smaller one behind.
+    state.take_refunds(|refund| refund.recipient() == canister_test_id(2));
+    let registry = observe(&state);
+    assert_eq!(Some(1), fetch_int_gauge(&registry, NAME));
+    assert_eq!(Some(13.), fetch_gauge(&registry, CYCLES_NAME));
 
     state.take_refunds(|_| true);
-    assert_eq!(Some(0), fetch_int_gauge(&observe(&state), NAME));
+    let registry = observe(&state);
+    assert_eq!(Some(0), fetch_int_gauge(&registry, NAME));
+    assert_eq!(Some(0.), fetch_gauge(&registry, CYCLES_NAME));
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/queues/refunds.rs
+++ b/rs/replicated_state/src/canister_state/queues/refunds.rs
@@ -24,6 +24,10 @@ pub struct RefundPool {
     // Refund amounts, by recipient.
     #[validate_eq(Ignore)]
     amounts: BTreeMap<CanisterId, Cycles>,
+
+    /// Transient: total amount of pooled cycles.
+    #[validate_eq(Ignore)]
+    total: Cycles,
 }
 
 impl RefundPool {
@@ -31,6 +35,7 @@ impl RefundPool {
         Self {
             refunds: BTreeSet::new(),
             amounts: BTreeMap::new(),
+            total: Cycles::zero(),
         }
     }
 
@@ -59,7 +64,10 @@ impl RefundPool {
         // Add the updated amount to the priority queue.
         assert!(self.refunds.insert(Refund::anonymous(receiver, amount)));
 
+        self.total += cycles;
+
         debug_assert_eq!(self.amounts.len(), self.refunds.len());
+        debug_assert_eq!(self.compute_total(), self.total);
     }
 
     /// Retains only the refunds for which the predicate `f` returns `true`.
@@ -69,6 +77,8 @@ impl RefundPool {
             self.refunds
                 .contains(&Refund::anonymous(*receiver, *amount))
         });
+        // Retaining is `O(n)` anyway, so just recompute the total.
+        self.total = self.compute_total();
 
         debug_assert_eq!(self.amounts.len(), self.refunds.len());
     }
@@ -87,11 +97,15 @@ impl RefundPool {
         self.refunds.is_empty()
     }
 
+    /// Returns the total amount of pooled cycles.
+    pub fn total(&self) -> Cycles {
+        self.total
+    }
+
     /// Computes the total amount of pooled cycles.
     ///
     /// Complexity: `O(n)`
-    #[cfg(debug_assertions)]
-    pub(crate) fn compute_total(&self) -> Cycles {
+    fn compute_total(&self) -> Cycles {
         self.refunds
             .iter()
             .fold(Cycles::zero(), |acc, r| acc + r.amount())

--- a/rs/replicated_state/src/canister_state/queues/refunds/tests.rs
+++ b/rs/replicated_state/src/canister_state/queues/refunds/tests.rs
@@ -27,10 +27,12 @@ fn test_add_single_refund() {
     let cycles = Cycles::new(1000);
 
     assert!(pool.is_empty());
+    assert_eq!(pool.total(), Cycles::zero());
 
     pool.add(canister_id, cycles);
 
     assert_eq!(pool.len(), 1);
+    assert_eq!(pool.total(), cycles);
     assert_eq!(
         &[refund(canister_id, cycles)],
         collect_iter(&pool).as_slice()
@@ -44,12 +46,14 @@ fn test_add_multiple_refunds() {
     let cycles = Cycles::new(1000);
 
     assert!(pool.is_empty());
+    assert_eq!(pool.total(), Cycles::zero());
 
     pool.add(canister_id, cycles);
     pool.add(canister_id, cycles);
     pool.add(canister_id, cycles);
 
     assert_eq!(pool.len(), 1);
+    assert_eq!(pool.total(), cycles * 3_u64);
     assert_eq!(
         &[refund(canister_id, cycles * 3_u64)],
         collect_iter(&pool).as_slice()
@@ -70,6 +74,7 @@ fn test_add_multiple_refunds_with_same_amount() {
 
     // They should be sorted by canister ID (lowest first).
     assert_eq!(pool.len(), 3);
+    assert_eq!(pool.total(), Cycles::new(3000));
     assert_eq!(
         &[
             refund(canister_id1, Cycles::new(1000)),
@@ -93,6 +98,7 @@ fn test_add_zero_cycles() {
     let mut pool = RefundPool::new();
     pool.add(CanisterId::from(1), Cycles::new(0));
     assert_eq!(pool.len(), 0);
+    assert_eq!(pool.total(), Cycles::zero());
     assert!(pool.is_empty());
 }
 
@@ -108,6 +114,7 @@ fn test_add_changes_priority() {
 
     // They should be sorted by amount (highest first).
     assert_eq!(pool.len(), 2);
+    assert_eq!(pool.total(), Cycles::new(1500));
     assert_eq!(
         &[
             refund(canister_id2, Cycles::new(1000)),
@@ -121,6 +128,7 @@ fn test_add_changes_priority() {
 
     // The (still 2) refunds should now be sorted accordingly.
     assert_eq!(pool.len(), 2);
+    assert_eq!(pool.total(), Cycles::new(2500));
     assert_eq!(
         &[
             refund(canister_id1, Cycles::new(1500)),
@@ -147,13 +155,21 @@ fn test_retain() {
     pool.add(canister_id2, Cycles::new(2000));
 
     assert_eq!(pool.len(), 2);
+    assert_eq!(pool.total(), Cycles::new(3000));
 
     // Retain only canister_id1.
     pool.retain(|refund| refund.recipient() == canister_id1);
 
     assert_eq!(pool.len(), 1);
+    assert_eq!(pool.total(), Cycles::new(1000));
     assert_eq!(
         &[refund(canister_id1, Cycles::new(1000))],
         collect_iter(&pool).as_slice()
     );
+
+    // Retain nothing.
+    pool.retain(|_| false);
+
+    assert!(pool.is_empty());
+    assert_eq!(pool.total(), Cycles::zero());
 }

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -2374,7 +2374,7 @@ impl SystemState {
     ) -> Cycles {
         self.cycles_balance
             + self.queues.attached_cycles()
-            + refunds.map(RefundPool::compute_total).unwrap_or_default()
+            + refunds.map(RefundPool::total).unwrap_or_default()
             + extra_cycles.unwrap_or_default()
     }
 

--- a/rs/replicated_state/src/metrics.rs
+++ b/rs/replicated_state/src/metrics.rs
@@ -71,6 +71,7 @@ pub struct ReplicatedStateMetrics {
     canisters_with_old_open_call_contexts: IntGaugeVec,
     subnet_call_contexts: IntGaugeVec,
     pending_refunds: IntGauge,
+    pending_refunds_cycles: Gauge,
     total_canister_balance: Gauge,
     total_canister_reserved_balance: Gauge,
     canister_paused_execution: Histogram,
@@ -236,6 +237,10 @@ impl ReplicatedStateMetrics {
             pending_refunds: metrics_registry.int_gauge(
                 "replicated_state_pending_refunds",
                 "Number of pending anonymous refunds, i.e. refunds accumulated at the subnet level, not yet routed into streams.",
+            ),
+            pending_refunds_cycles: metrics_registry.gauge(
+                "replicated_state_pending_refunds_cycles",
+                "Total value in Cycles of pending anonymous refunds, i.e. refunds accumulated at the subnet level, not yet routed into streams.",
             ),
             total_canister_balance: metrics_registry.gauge(
                 "scheduler_canister_balance_cycles_total",
@@ -689,6 +694,8 @@ impl ReplicatedStateMetrics {
         }
 
         self.pending_refunds.set(state.refunds().len() as i64);
+        self.pending_refunds_cycles
+            .set(state.refunds().total().get() as f64);
 
         self.canisters_not_in_routing_table
             .set(canisters_not_in_routing_table);

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1740,7 +1740,7 @@ impl ReplicatedState {
             + stream_cycles
             + dropped_message_cycles
             + self.subnet_queues.attached_cycles()
-            + self.refunds.compute_total()
+            + self.refunds.total()
     }
 
     /// Validates that the subnet's total cycle balance including cycles attached to


### PR DESCRIPTION
Adds `replicated_state_pending_refunds_cycles`, the total value in cycles of the refunds in the subnet-level refund pool, complementing the existing `replicated_state_pending_refunds` count.

In order to avoid summing up the whole pool on every round, `RefundPool` now maintains the total incrementally, in a new transient field (recomputed on `retain()`, which is `O(n)` anyway; validated against a full recount in debug builds), just like `IngressHistoryState`'s `state_counts`. As a result, the debug-only balance checks can use the maintained total instead of recomputing it.