### PR TITLE
fix(CI): verify that commit-sha is the head of pr-number in ci-kickoff-manual

### DIFF
--- a/.github/workflows/ci-kickoff-manual.yml
+++ b/.github/workflows/ci-kickoff-manual.yml
@@ -17,8 +17,8 @@ on:
         type: boolean
 
 jobs:
-  get-pr-refs:
-    name: Get PR Refs
+  verify-inputs-and-get-pr-refs:
+    name: Verify Inputs and Get PR Refs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,27 +27,70 @@ jobs:
       base-ref: ${{ steps.fetch.outputs.base_ref }}
       head-ref: ${{ steps.fetch.outputs.head_ref }}
     steps:
-      - name: Fetch PR Base Ref
+      - name: Verify Commit Belongs to PR and Fetch PR Refs
         id: fetch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ inputs.pr-number }}
+          COMMIT_SHA: ${{ inputs.commit-sha }}
         with:
           script: |
-            const prNumber = parseInt('${{ inputs.pr-number }}', 10);
-            if (isNaN(prNumber)) {
-              core.setFailed('Invalid pr-number input');
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pr-number input: ${process.env.PR_NUMBER}`);
               return;
             }
+            const sha = (process.env.COMMIT_SHA || '').toLowerCase();
+            if (!/^[0-9a-f]{40}$/.test(sha)) {
+              core.setFailed('commit-sha must be a full 40-character commit SHA');
+              return;
+            }
+
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber
             });
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${prNumber} is ${pr.state}, refusing to run CI on it`);
+              return;
+            }
+
+            // GitHub returns at most 250 commits here; for larger PRs only the
+            // head commit can be verified this way.
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+            const shas = new Set(commits.map(c => c.sha.toLowerCase()));
+
+            if (!shas.has(sha)) {
+              if (pr.commits > commits.length) {
+                core.setFailed(
+                  `PR #${prNumber} has ${pr.commits} commits, more than the ${commits.length} ` +
+                  `the API returns, so ${sha} could not be verified. Re-run with the PR head ` +
+                  `commit ${pr.head.sha}.`);
+              } else {
+                core.setFailed(`Commit ${sha} is not part of PR #${prNumber} ` +
+                               `(head is ${pr.head.sha})`);
+              }
+              return;
+            }
+
+            if (sha !== pr.head.sha.toLowerCase()) {
+              core.warning(`Commit ${sha} is not the current head of PR #${prNumber} ` +
+                           `(${pr.head.sha}) — running CI on an older commit of the PR`);
+            }
+
             core.info(`PR #${prNumber} base ref: ${pr.base.ref}, head ref: ${pr.head.ref}`);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('head_ref', pr.head.ref);
 
   ci-main:
     name: CI Main
+    needs: [verify-inputs-and-get-pr-refs]
     uses: ./.github/workflows/ci-main.yml
     secrets: inherit
     with:
@@ -61,13 +104,13 @@ jobs:
 
   ci-pr-only:
     name: CI PR Only
-    needs: [get-pr-refs]
+    needs: [verify-inputs-and-get-pr-refs]
     uses: ./.github/workflows/ci-pr-only.yml
     secrets: inherit
     with:
       commit-sha: ${{ inputs.commit-sha }}
-      base-ref: ${{ needs.get-pr-refs.outputs.base-ref }}
-      head-ref: ${{ needs.get-pr-refs.outputs.head-ref }}
+      base-ref: ${{ needs.verify-inputs-and-get-pr-refs.outputs.base-ref }}
+      head-ref: ${{ needs.verify-inputs-and-get-pr-refs.outputs.head-ref }}
       pr-number: ${{ inputs.pr-number }}
     permissions:
       contents: read
@@ -114,6 +157,7 @@ jobs:
   post-comment-with-ci-link:
     name: Post Comment with CI Link
     runs-on: ubuntu-latest
+    needs: [verify-inputs-and-get-pr-refs]
     permissions:
       contents: read
       pull-requests: write
@@ -134,6 +178,7 @@ jobs:
   notify-slack-new-workflow-run:
     name: Notify Slack for new External Contributor Workflow Run
     runs-on: ubuntu-latest
+    needs: [verify-inputs-and-get-pr-refs]
     steps:
       - name: Post to a Slack channel
         id: slack

--- a/.github/workflows/ci-kickoff-manual.yml
+++ b/.github/workflows/ci-kickoff-manual.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       base-ref: ${{ steps.fetch.outputs.base_ref }}
       head-ref: ${{ steps.fetch.outputs.head_ref }}
+      head-repo: ${{ steps.fetch.outputs.head_repo }}
     steps:
       - name: Verify Commit Is PR Head and Fetch PR Refs
         id: fetch
@@ -67,9 +68,15 @@ jobs:
               return;
             }
 
-            core.info(`PR #${prNumber} base ref: ${pr.base.ref}, head ref: ${pr.head.ref}`);
+            // Empty if the fork was deleted after the PR was opened. Jobs that
+            // push to the head branch compare this against github.repository and
+            // skip the push unless the branch lives in this repository.
+            const headRepo = pr.head.repo ? pr.head.repo.full_name : '';
+            core.info(`PR #${prNumber} base ref: ${pr.base.ref}, ` +
+                      `head ref: ${pr.head.ref}, head repo: ${headRepo}`);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_repo', headRepo);
 
   ci-main:
     name: CI Main
@@ -94,6 +101,7 @@ jobs:
       commit-sha: ${{ inputs.commit-sha }}
       base-ref: ${{ needs.verify-inputs-and-get-pr-refs.outputs.base-ref }}
       head-ref: ${{ needs.verify-inputs-and-get-pr-refs.outputs.head-ref }}
+      head-repo: ${{ needs.verify-inputs-and-get-pr-refs.outputs.head-repo }}
       pr-number: ${{ inputs.pr-number }}
     permissions:
       contents: read

--- a/.github/workflows/ci-kickoff-manual.yml
+++ b/.github/workflows/ci-kickoff-manual.yml
@@ -34,8 +34,17 @@ jobs:
         env:
           PR_NUMBER: ${{ inputs.pr-number }}
           COMMIT_SHA: ${{ inputs.commit-sha }}
+          CONFIRM: ${{ inputs.confirm }}
         with:
           script: |
+            // For boolean workflow_dispatch inputs, 'required: true' does not
+            // enforce that the box is ticked, so check it here.
+            if (process.env.CONFIRM !== 'true') {
+              core.setFailed('confirm must be checked: it acknowledges that you reviewed ' +
+                             'the PR at the specified commit');
+              return;
+            }
+
             // Match on the raw string: Number() would also accept forms like
             // '0x10', '1e3' or ' 12 ', which would target a different PR.
             if (!/^[1-9][0-9]*$/.test(process.env.PR_NUMBER || '')) {

--- a/.github/workflows/ci-kickoff-manual.yml
+++ b/.github/workflows/ci-kickoff-manual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       commit-sha:
-        description: 'The commit SHA to run the workflow on'
+        description: 'The commit SHA to run the workflow on (must be the head commit of the PR)'
         required: true
         default: ''
       pr-number:
@@ -27,7 +27,7 @@ jobs:
       base-ref: ${{ steps.fetch.outputs.base_ref }}
       head-ref: ${{ steps.fetch.outputs.head_ref }}
     steps:
-      - name: Verify Commit Belongs to PR and Fetch PR Refs
+      - name: Verify Commit Is PR Head and Fetch PR Refs
         id: fetch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -58,32 +58,13 @@ jobs:
               return;
             }
 
-            // GitHub returns at most 250 commits here; for larger PRs only the
-            // head commit can be verified this way.
-            const commits = await github.paginate(github.rest.pulls.listCommits, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100
-            });
-            const shas = new Set(commits.map(c => c.sha.toLowerCase()));
-
-            if (!shas.has(sha)) {
-              if (pr.commits > commits.length) {
-                core.setFailed(
-                  `PR #${prNumber} has ${pr.commits} commits, more than the ${commits.length} ` +
-                  `the API returns, so ${sha} could not be verified. Re-run with the PR head ` +
-                  `commit ${pr.head.sha}.`);
-              } else {
-                core.setFailed(`Commit ${sha} is not part of PR #${prNumber} ` +
-                               `(head is ${pr.head.sha})`);
-              }
-              return;
-            }
-
+            // Require the head commit: the confirm checkbox states the PR was
+            // reviewed at this commit, and an older commit of the PR would run
+            // CI on code that is no longer what the PR proposes to merge.
             if (sha !== pr.head.sha.toLowerCase()) {
-              core.warning(`Commit ${sha} is not the current head of PR #${prNumber} ` +
-                           `(${pr.head.sha}) — running CI on an older commit of the PR`);
+              core.setFailed(`Commit ${sha} is not the head of PR #${prNumber} ` +
+                             `(head is ${pr.head.sha}). Re-run with the head commit.`);
+              return;
             }
 
             core.info(`PR #${prNumber} base ref: ${pr.base.ref}, head ref: ${pr.head.ref}`);

--- a/.github/workflows/ci-kickoff-manual.yml
+++ b/.github/workflows/ci-kickoff-manual.yml
@@ -35,11 +35,13 @@ jobs:
           COMMIT_SHA: ${{ inputs.commit-sha }}
         with:
           script: |
-            const prNumber = Number(process.env.PR_NUMBER);
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid pr-number input: ${process.env.PR_NUMBER}`);
+            // Match on the raw string: Number() would also accept forms like
+            // '0x10', '1e3' or ' 12 ', which would target a different PR.
+            if (!/^[1-9][0-9]*$/.test(process.env.PR_NUMBER || '')) {
+              core.setFailed(`pr-number must be a positive decimal integer, got: ${process.env.PR_NUMBER}`);
               return;
             }
+            const prNumber = Number(process.env.PR_NUMBER);
             const sha = (process.env.COMMIT_SHA || '').toLowerCase();
             if (!/^[0-9a-f]{40}$/.test(sha)) {
               core.setFailed('commit-sha must be a full 40-character commit SHA');
@@ -164,16 +166,23 @@ jobs:
     steps:
       - name: Add PR Comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ inputs.pr-number }}
+          COMMIT_SHA: ${{ inputs.commit-sha }}
         with:
           script: |
-            let message = 'Run on ${{ inputs.commit-sha }} URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n'
+            // Both inputs were validated by verify-inputs-and-get-pr-refs, which
+            // this job depends on.
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+                           `/actions/runs/${context.runId}`;
+            const message = `Run on ${process.env.COMMIT_SHA} URL: ${runUrl}\n\n`;
 
-            github.rest.issues.createComment({
-              issue_number: ${{ inputs.pr-number }},
+            await github.rest.issues.createComment({
+              issue_number: Number(process.env.PR_NUMBER),
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: message
-            })
+            });
 
   notify-slack-new-workflow-run:
     name: Notify Slack for new External Contributor Workflow Run

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ${{ github.event.pull_request.head.ref }}
         type: string
+      head-repo:
+        description: The repository the head branch of the PR lives in ("owner/repo")
+        required: false
+        default: ${{ github.event.pull_request.head.repo.full_name }}
+        type: string
       pr-number:
         description: 'The PR number'
         required: false
@@ -63,6 +68,9 @@ jobs:
     runs-on: *dind-small-setup
     container: *container-setup
     timeout-minutes: 30
+    env: &pr-branch-env
+      HEAD_REF: ${{ inputs.head-ref }}
+      HEAD_REPO: ${{ inputs.head-repo }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -120,7 +128,17 @@ jobs:
                 git config --global user.email "infra+github-automation@dfinity.org"
                 git config --global user.name "IDX GitHub Automation"
                 git commit -m "Automatically fixing code for linting and formatting issues"
-                git push origin HEAD:'${{ inputs.head-ref }}'
+                # Only push when the PR's head branch lives in this repository. On the
+                # ci-kickoff-manual path the PR can come from a fork, in which case
+                # "origin" is still this repository and the push would create a branch
+                # named after the fork's branch here instead of updating the PR.
+                if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                    git push origin HEAD:"$HEAD_REF"
+                else
+                    echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \
+                         "'$GITHUB_REPOSITORY': not pushing. Apply the diff below instead:"
+                    git --no-pager diff --cached
+                fi
 
                 # Because the buildifier made changes, fail the PR
                 EXIT_STATUS=1
@@ -163,6 +181,7 @@ jobs:
     name: Lock Generate
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env: *pr-branch-env
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -209,7 +228,17 @@ jobs:
               git config --global user.email "infra+github-automation@dfinity.org"
               git config --global user.name "IDX GitHub Automation"
               git commit -m "Automatically updated Cargo*.lock"
-              git push origin HEAD:'${{ inputs.head-ref }}'
+              # Only push when the PR's head branch lives in this repository. On the
+              # ci-kickoff-manual path the PR can come from a fork, in which case
+              # "origin" is still this repository and the push would create a branch
+              # named after the fork's branch here instead of updating the PR.
+              if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                  git push origin HEAD:"$HEAD_REF"
+              else
+                  echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \
+                       "'$GITHUB_REPOSITORY': not pushing. Apply the diff below instead:"
+                  git --no-pager diff --cached
+              fi
 
               # Because the lockfiles need updating, fail the PR
               EXIT_STATUS=1
@@ -222,6 +251,7 @@ jobs:
     runs-on: *dind-small-setup
     container: *container-setup
     timeout-minutes: 10
+    env: *pr-branch-env
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -259,7 +289,17 @@ jobs:
               git config --global user.email "infra+github-automation@dfinity.org"
               git config --global user.name "IDX GitHub Automation"
               git commit -m "Automatically updated config type fixtures"
-              git push origin HEAD:'${{ inputs.head-ref }}'
+              # Only push when the PR's head branch lives in this repository. On the
+              # ci-kickoff-manual path the PR can come from a fork, in which case
+              # "origin" is still this repository and the push would create a branch
+              # named after the fork's branch here instead of updating the PR.
+              if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                  git push origin HEAD:"$HEAD_REF"
+              else
+                  echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \
+                       "'$GITHUB_REPOSITORY': not pushing. Apply the diff below instead:"
+                  git --no-pager diff --cached
+              fi
 
               # Because the fixtures need updating, fail the PR
               EXIT_STATUS=1

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -124,15 +124,15 @@ jobs:
             git add --all
             git status
             if ! git diff --cached --quiet; then
-                # There are some changes staged
-                git config --global user.email "infra+github-automation@dfinity.org"
-                git config --global user.name "IDX GitHub Automation"
-                git commit -m "Automatically fixing code for linting and formatting issues"
-                # Only push when the PR's head branch lives in this repository. On the
-                # ci-kickoff-manual path the PR can come from a fork, in which case
-                # "origin" is still this repository and the push would create a branch
-                # named after the fork's branch here instead of updating the PR.
+                # There are some changes staged. Only commit and push them when the PR's
+                # head branch lives in this repository: on the ci-kickoff-manual path the
+                # PR can come from a fork, in which case "origin" is still this repository
+                # and the push would create a branch named after the fork's branch here
+                # instead of updating the PR. Show the diff for the contributor instead.
                 if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                    git config --global user.email "infra+github-automation@dfinity.org"
+                    git config --global user.name "IDX GitHub Automation"
+                    git commit -m "Automatically fixing code for linting and formatting issues"
                     git push origin HEAD:"$HEAD_REF"
                 else
                     echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \
@@ -224,15 +224,15 @@ jobs:
           git add Cargo.lock Cargo.Bazel.*.lock
           git status
           if ! git diff --cached --quiet; then
-              # There are some changes staged
-              git config --global user.email "infra+github-automation@dfinity.org"
-              git config --global user.name "IDX GitHub Automation"
-              git commit -m "Automatically updated Cargo*.lock"
-              # Only push when the PR's head branch lives in this repository. On the
-              # ci-kickoff-manual path the PR can come from a fork, in which case
-              # "origin" is still this repository and the push would create a branch
-              # named after the fork's branch here instead of updating the PR.
+              # There are some changes staged. Only commit and push them when the PR's
+              # head branch lives in this repository: on the ci-kickoff-manual path the
+              # PR can come from a fork, in which case "origin" is still this repository
+              # and the push would create a branch named after the fork's branch here
+              # instead of updating the PR. Show the diff for the contributor instead.
               if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                  git config --global user.email "infra+github-automation@dfinity.org"
+                  git config --global user.name "IDX GitHub Automation"
+                  git commit -m "Automatically updated Cargo*.lock"
                   git push origin HEAD:"$HEAD_REF"
               else
                   echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \
@@ -285,15 +285,15 @@ jobs:
           git add rs/ic_os/config/types/compatibility_tests/fixtures
           git status
           if ! git diff --cached --quiet; then
-              # There are some changes staged
-              git config --global user.email "infra+github-automation@dfinity.org"
-              git config --global user.name "IDX GitHub Automation"
-              git commit -m "Automatically updated config type fixtures"
-              # Only push when the PR's head branch lives in this repository. On the
-              # ci-kickoff-manual path the PR can come from a fork, in which case
-              # "origin" is still this repository and the push would create a branch
-              # named after the fork's branch here instead of updating the PR.
+              # There are some changes staged. Only commit and push them when the PR's
+              # head branch lives in this repository: on the ci-kickoff-manual path the
+              # PR can come from a fork, in which case "origin" is still this repository
+              # and the push would create a branch named after the fork's branch here
+              # instead of updating the PR. Show the diff for the contributor instead.
               if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+                  git config --global user.email "infra+github-automation@dfinity.org"
+                  git config --global user.name "IDX GitHub Automation"
+                  git commit -m "Automatically updated config type fixtures"
                   git push origin HEAD:"$HEAD_REF"
               else
                   echo "Head branch '$HEAD_REF' lives in '$HEAD_REPO', not in" \


### PR DESCRIPTION
The `ci-kickoff-manual` workflow takes a `commit-sha` and a `pr-number` input, with the intention that the commit belongs to that PR. Nothing checked this.

A mismatch would run CI on unrelated code while reporting commit statuses and PR comments against the PR, and — because the auto-fix jobs in `ci-pr-only.yml` do `git push origin HEAD:'${{ inputs.head-ref }}'` — would let did-check / buf-format / cargo-lock fixups derived from a foreign tree be pushed onto the PR's head branch.

## Changes

- `get-pr-refs` already fetches the PR, so it is extended to verify that `commit-sha` is the **head commit** of the PR, and renamed to `verify-inputs-and-get-pr-refs`.
- It also rejects a `pr-number` that isn't a positive decimal integer or a `commit-sha` that isn't a full 40-hex SHA, and refuses non-open PRs.
- Neither `github-script` step interpolates the inputs into its JS body any more — both the verification job and `post-comment-with-ci-link` read them from `env:`, removing a script-injection surface. The remaining `${{ inputs.* }}` uses are in `with:` / `ref:` positions, where the gate above guarantees the values are a 40-hex SHA and a decimal integer.
- The `confirm` checkbox is now enforced: for boolean `workflow_dispatch` inputs `required: true` only means the field is present, not that it is ticked, so the acknowledgement that the PR was reviewed at this commit was optional in practice.
- Every job now depends on the verification. Previously only `ci-pr-only` did, so a verification failure did not stop `ci-main`, the PR comment, or the Slack notification — a failed job does not cancel independent jobs.

## Don't push autofixes to a branch named after a fork's branch

Follow-up on a review comment, in the same area: the pushing jobs in `ci-pr-only.yml` (`autofix`, `lock-generate`, `generate-config-fixtures`) do `git push origin HEAD:<head-ref>`. `actions/checkout` defaults to `repository: github.repository`, so `origin` is always this repository, while `head-ref` is `pr.head.ref` — an unqualified branch name.

On the `pull_request` path that is fine: `ci-kickoff.yml` only calls `ci-pr-only` when `head.repo.full_name == github.repository`. On the `ci-kickoff-manual` path — which exists for external contributions — `head-ref` is the *fork's* branch name, so the push creates a branch of that name **here** instead of updating the PR. It uses the `PR_CREATION_BOT` app token, so the job's `contents: read` does not restrain it. Two notable cases: a fork branch called `main`/`master` is rejected by the branch ruleset (so the job just fails), and a fork branch called `dev-gh-*` would land on a name that is a `push` trigger for Kickoff, running CI Main with secrets on unreviewed code.

The fix gates the push rather than the jobs:

- `ci-pr-only.yml` takes a new `head-repo` input, defaulting to `github.event.pull_request.head.repo.full_name` and supplied on the manual path from the `pulls.get` response the verification job already has (empty if the fork was deleted, which fails closed).
- The three jobs commit and push only when it equals `github.repository`; otherwise they print the staged diff and still exit non-zero. The commit is created only on the pushing path, so the printed diff is the patch the contributor actually has to apply (a `git diff --cached` after committing would print nothing).

Guarding the jobs with `if: github.event_name == 'pull_request' && …` instead would work, but `autofix` is the only place the `//pre-commit:*` checks run (`shfmt`, `ruff`, `buf`, `buf-breaking`, `do-not-merge`, `buildifier`, `gazelle`, `rustfmt`), so external PRs would get a green `ci-pr-only-status` with no lint gate at all. Gating the push keeps those checks gating exactly the PRs that need them most, and leaves the contributor an actionable diff in the log.

`head-ref` and `head-repo` are also passed to the scripts through the environment now instead of being interpolated: git allows single quotes in branch names, so `HEAD:'${{ inputs.head-ref }}'` was itself a fork-controlled shell-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
