### PR TITLE
fix: Correctly report the updated config version

### DIFF
--- a/ic-os/components/hostos/update-config/update-config.service
+++ b/ic-os/components/hostos/update-config/update-config.service
@@ -4,6 +4,7 @@ RequiresMountsFor=/boot/config
 Before=node_exporter.service
 Before=guestos.target
 Before=log-config.service
+Before=custom-metrics.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
A race means that sometimes the metric is reported before the config is updated. This should fix that up.

---

We're planning to drop these changes anyway, so this won't really make a difference, but this way the removal will be complete in case we bring the feature back.