### PR TITLE
refactor(cketh): rename EthTransactions to WithdrawalTransactions and hide its fields

### DIFF
--- a/rs/ethereum/cketh/minter/src/dashboard.rs
+++ b/rs/ethereum/cketh/minter/src/dashboard.rs
@@ -337,7 +337,7 @@ impl DashboardTemplate {
             .collect();
 
         let mut withdrawal_requests: Vec<_> = state
-            .eth_transactions
+            .withdrawal_transactions
             .withdrawal_requests_iter()
             .cloned()
             .map(|request| match request {
@@ -369,7 +369,7 @@ impl DashboardTemplate {
         withdrawal_requests.sort_unstable_by_key(|req| Reverse(req.cketh_ledger_burn_index));
 
         let mut pending_transactions: Vec<_> = state
-            .eth_transactions
+            .withdrawal_transactions
             .transactions_to_sign_iter()
             .map(|(_nonce, ledger_burn_index, tx)| {
                 let (destination, value, token_symbol) = to_dashboard_transaction(tx, state);
@@ -382,25 +382,29 @@ impl DashboardTemplate {
                 }
             })
             .collect();
-        pending_transactions.extend(state.eth_transactions.sent_transactions_iter().flat_map(
-            |(_nonce, ledger_burn_index, txs)| {
-                txs.into_iter().map(|tx| {
-                    let (destination, value, token_symbol) = to_dashboard_transaction(tx, state);
-                    DashboardPendingTransaction {
-                        ledger_burn_index: *ledger_burn_index,
-                        destination,
-                        value,
-                        token_symbol,
-                        status: RetrieveEthStatus::TxSent(EthTransaction::from(tx)),
-                    }
-                })
-            },
-        ));
+        pending_transactions.extend(
+            state
+                .withdrawal_transactions
+                .sent_transactions_iter()
+                .flat_map(|(_nonce, ledger_burn_index, txs)| {
+                    txs.into_iter().map(|tx| {
+                        let (destination, value, token_symbol) =
+                            to_dashboard_transaction(tx, state);
+                        DashboardPendingTransaction {
+                            ledger_burn_index: *ledger_burn_index,
+                            destination,
+                            value,
+                            token_symbol,
+                            status: RetrieveEthStatus::TxSent(EthTransaction::from(tx)),
+                        }
+                    })
+                }),
+        );
         pending_transactions
             .sort_unstable_by_key(|pending_tx| Reverse(pending_tx.ledger_burn_index));
 
         let mut finalized_transactions: Vec<_> = state
-            .eth_transactions
+            .withdrawal_transactions
             .finalized_transactions_iter()
             .map(|(_tx_nonce, index, tx)| {
                 let (destination, value, token_symbol) = to_dashboard_transaction(tx, state);
@@ -428,7 +432,7 @@ impl DashboardTemplate {
         );
 
         let mut reimbursed_transactions: Vec<_> = state
-            .eth_transactions
+            .withdrawal_transactions
             .reimbursed_transactions_iter()
             .map(|(index, result)| {
                 let (cketh_ledger_burn_index, token_symbol) = match index {
@@ -488,7 +492,7 @@ impl DashboardTemplate {
             sweeper_contract_address: state.sweeper_contract_address,
             log_scrapings: state.log_scrapings.clone(),
             cketh_ledger_id: state.cketh_ledger_id,
-            next_transaction_nonce: state.eth_transactions.next_transaction_nonce(),
+            next_transaction_nonce: state.withdrawal_transactions.next_transaction_nonce(),
             minimum_withdrawal_amount: state.cketh_minimum_withdrawal_amount,
             first_synced_block: state.first_scraped_block_number,
             last_observed_block: state.last_observed_block_number,

--- a/rs/ethereum/cketh/minter/src/guard/mod.rs
+++ b/rs/ethereum/cketh/minter/src/guard/mod.rs
@@ -30,7 +30,7 @@ impl RequestsGuardedByPrincipal for PendingWithdrawalRequests {
     }
 
     fn pending_requests_count(state: &State) -> usize {
-        state.eth_transactions.withdrawal_requests_len()
+        state.withdrawal_transactions.withdrawal_requests_len()
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/guard/tests.rs
+++ b/rs/ethereum/cketh/minter/src/guard/tests.rs
@@ -69,7 +69,7 @@ mod retrieve_eth_guard {
 
         fn record_withdrawal_request(ledger_burn_index: LedgerBurnIndex) {
             mutate_state(|s| {
-                s.eth_transactions
+                s.withdrawal_transactions
                     .record_withdrawal_request(EthWithdrawalRequest {
                         withdrawal_amount: Wei::ONE,
                         destination: Address::ZERO,

--- a/rs/ethereum/cketh/minter/src/lifecycle/init.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/init.rs
@@ -3,7 +3,7 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, TransactionNonce, Wei};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
-use crate::state::transactions::EthTransactions;
+use crate::state::transactions::WithdrawalTransactions;
 use crate::state::{InvalidStateError, State};
 use crate::{EVM_RPC_ID_PRODUCTION, EVM_RPC_ID_STAGING};
 use candid::types::number::Nat;
@@ -97,7 +97,7 @@ impl TryFrom<InitArg> for State {
             ecdsa_key_name,
             pending_withdrawal_principals: Default::default(),
             pending_deposit_principals: Default::default(),
-            eth_transactions: EthTransactions::new(initial_nonce),
+            withdrawal_transactions: WithdrawalTransactions::new(initial_nonce),
             cketh_ledger_id: ledger_id,
             cketh_minimum_withdrawal_amount: minimum_withdrawal_amount,
             ethereum_block_height,

--- a/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/tests.rs
@@ -131,7 +131,7 @@ mod init {
             Wei::new(10_000_000_000_000_000)
         );
         assert_eq!(
-            state.eth_transactions.next_transaction_nonce(),
+            state.withdrawal_transactions.next_transaction_nonce(),
             TransactionNonce::ZERO
         );
         assert_eq!(

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -423,7 +423,10 @@ async fn withdraw_eth(
 #[update]
 async fn retrieve_eth_status(block_index: u64) -> RetrieveEthStatus {
     let ledger_burn_index = LedgerBurnIndex::new(block_index);
-    read_state(|s| s.eth_transactions.transaction_status(&ledger_burn_index))
+    read_state(|s| {
+        s.withdrawal_transactions
+            .transaction_status(&ledger_burn_index)
+    })
 }
 
 #[query]
@@ -431,7 +434,7 @@ async fn withdrawal_status(parameter: WithdrawalSearchParameter) -> Vec<Withdraw
     use transactions::WithdrawalRequest::*;
     let parameter = transactions::WithdrawalSearchParameter::try_from(parameter).unwrap();
     read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .withdrawal_status(&parameter)
             .into_iter()
             .map(|(request, status, tx)| WithdrawalDetail {
@@ -1132,7 +1135,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 
                 let now_nanos = ic_cdk::api::time();
                 let age_nanos = now_nanos.saturating_sub(
-                    s.eth_transactions
+                    s.withdrawal_transactions
                         .oldest_incomplete_withdrawal_timestamp()
                         .unwrap_or(now_nanos),
                 );

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -26,7 +26,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet, btree_map};
 use std::fmt::{Display, Formatter};
 use strum_macros::EnumIter;
-use transactions::EthTransactions;
+use transactions::WithdrawalTransactions;
 
 pub mod audit;
 pub mod automatic_deposits;
@@ -73,7 +73,7 @@ pub struct State {
     pub events_to_mint: BTreeMap<EventSource, ReceivedEvent>,
     pub minted_events: BTreeMap<EventSource, MintedEvent>,
     pub invalid_events: BTreeMap<EventSource, InvalidEventReason>,
-    pub eth_transactions: EthTransactions,
+    pub withdrawal_transactions: WithdrawalTransactions,
     pub skipped_blocks: BTreeMap<Address, BTreeSet<BlockNumber>>,
 
     /// Current balance of ETH held by the minter.
@@ -362,7 +362,8 @@ impl State {
             "BUG: unsupported ERC-20 token {}",
             request.erc20_contract_address
         );
-        self.eth_transactions.record_withdrawal_request(request);
+        self.withdrawal_transactions
+            .record_withdrawal_request(request);
     }
 
     pub fn record_finalized_transaction(
@@ -370,7 +371,7 @@ impl State {
         withdrawal_id: &LedgerBurnIndex,
         receipt: &TransactionReceipt,
     ) {
-        self.eth_transactions
+        self.withdrawal_transactions
             .record_finalized_transaction(*withdrawal_id, receipt.clone());
         self.update_balance_upon_withdrawal(withdrawal_id, receipt);
     }
@@ -399,11 +400,11 @@ impl State {
     ) {
         let tx_fee = receipt.effective_transaction_fee();
         let tx = self
-            .eth_transactions
+            .withdrawal_transactions
             .get_finalized_transaction(withdrawal_id)
             .expect("BUG: missing finalized transaction");
         let withdrawal_request = self
-            .eth_transactions
+            .withdrawal_transactions
             .get_processed_withdrawal_request(withdrawal_id)
             .expect("BUG: missing withdrawal request");
         let charged_tx_fee = match withdrawal_request {
@@ -520,7 +521,8 @@ impl State {
         if let Some(nonce) = next_transaction_nonce {
             let nonce = TransactionNonce::try_from(nonce)
                 .map_err(|e| InvalidStateError::InvalidTransactionNonce(format!("ERROR: {e}")))?;
-            self.eth_transactions.update_next_transaction_nonce(nonce);
+            self.withdrawal_transactions
+                .update_next_transaction_nonce(nonce);
         }
         if let Some(amount) = minimum_withdrawal_amount {
             let minimum_withdrawal_amount = Wei::try_from(amount).map_err(|e| {
@@ -631,8 +633,8 @@ impl State {
             other.sweeper_contract_address
         );
 
-        self.eth_transactions
-            .is_equivalent_to(&other.eth_transactions)
+        self.withdrawal_transactions
+            .is_equivalent_to(&other.withdrawal_transactions)
     }
 
     pub fn eth_balance(&self) -> &EthBalance {

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -71,14 +71,14 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         }
         EventType::AcceptedEthWithdrawalRequest(request) => {
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_withdrawal_request(request.clone());
         }
         EventType::AcceptedSweeperFundingRequest(request) => {
             // Named explicitly: the payload converts to `CkEth` on its own, which would make the
             // funding reimbursable.
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_withdrawal_request(WithdrawalRequest::SweeperFunding(request.clone()));
         }
         EventType::CreatedTransaction {
@@ -86,7 +86,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             transaction,
         } => {
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_created_transaction(*withdrawal_id, transaction.clone());
         }
         EventType::SignedTransaction {
@@ -94,7 +94,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             transaction,
         } => {
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_signed_transaction(transaction.clone());
         }
         EventType::ReplacedTransaction {
@@ -102,7 +102,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             transaction,
         } => {
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_resubmit_transaction(transaction.clone());
         }
         EventType::FinalizedTransaction {
@@ -117,12 +117,14 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             reimbursed_amount: _,
             transaction_hash: _,
         }) => {
-            state.eth_transactions.record_finalized_reimbursement(
-                ReimbursementIndex::CkEth {
-                    ledger_burn_index: *withdrawal_id,
-                },
-                *reimbursed_in_block,
-            );
+            state
+                .withdrawal_transactions
+                .record_finalized_reimbursement(
+                    ReimbursementIndex::CkEth {
+                        ledger_burn_index: *withdrawal_id,
+                    },
+                    *reimbursed_in_block,
+                );
         }
         EventType::SkippedBlockForContract {
             contract_address,
@@ -141,17 +143,19 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             ckerc20_ledger_id,
             reimbursed,
         } => {
-            state.eth_transactions.record_finalized_reimbursement(
-                ReimbursementIndex::CkErc20 {
-                    cketh_ledger_burn_index: *cketh_ledger_burn_index,
-                    ledger_id: *ckerc20_ledger_id,
-                    ckerc20_ledger_burn_index: reimbursed.burn_in_block,
-                },
-                reimbursed.reimbursed_in_block,
-            );
+            state
+                .withdrawal_transactions
+                .record_finalized_reimbursement(
+                    ReimbursementIndex::CkErc20 {
+                        cketh_ledger_burn_index: *cketh_ledger_burn_index,
+                        ledger_id: *ckerc20_ledger_id,
+                        ckerc20_ledger_burn_index: reimbursed.burn_in_block,
+                    },
+                    reimbursed.reimbursed_in_block,
+                );
         }
         EventType::FailedErc20WithdrawalRequest(cketh_reimbursement_request) => {
-            state.eth_transactions.record_reimbursement_request(
+            state.withdrawal_transactions.record_reimbursement_request(
                 ReimbursementIndex::CkEth {
                     ledger_burn_index: cketh_reimbursement_request.ledger_burn_index,
                 },
@@ -163,7 +167,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         }
         EventType::QuarantinedReimbursement { index } => {
             state
-                .eth_transactions
+                .withdrawal_transactions
                 .record_quarantined_reimbursement(index.clone());
         }
         EventType::SyncedDepositWithSubaccountToBlock { block_number } => {

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -435,7 +435,7 @@ mod upgrade {
         state.upgrade(upgrade_arg).expect("valid upgrade args");
 
         assert_eq!(
-            state.eth_transactions.next_transaction_nonce(),
+            state.withdrawal_transactions.next_transaction_nonce(),
             TransactionNonce::from(15_u64)
         );
         assert_eq!(
@@ -888,9 +888,9 @@ fn state_equivalence() {
     use crate::EVM_RPC_ID_PRODUCTION;
     use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
     use crate::map::MultiKeyMap;
-    use crate::state::transactions::{
-        EthTransactions, EthWithdrawalRequest, Reimbursed, ReimbursementRequest,
-    };
+    use crate::state::transactions::WithdrawalRequest;
+    use crate::state::transactions::tests::WithdrawalTransactionsBuilder;
+    use crate::state::transactions::{EthWithdrawalRequest, Reimbursed, ReimbursementRequest};
     use crate::state::{InvalidEventReason, MintedEvent};
     use crate::timed_sized_map::Timestamp;
     use crate::tx::{
@@ -900,6 +900,7 @@ fn state_equivalence() {
     use ic_cdk_management_canister::EcdsaPublicKeyResult;
     use icrc_ledger_types::icrc1::account::Account;
     use maplit::{btreemap, btreeset};
+    use std::collections::VecDeque;
 
     fn source(txhash: &str, index: u64) -> EventSource {
         EventSource {
@@ -937,84 +938,55 @@ fn state_equivalence() {
         ledger_burn_index: LedgerBurnIndex::new(20),
         ..withdrawal_request1.clone()
     };
-    let eth_transactions = EthTransactions {
-        pending_withdrawal_requests: vec![
-            withdrawal_request1.clone().into(),
-            withdrawal_request2.clone().into(),
-        ]
-        .into_iter()
-        .collect(),
-        processed_withdrawal_requests: btreemap! {
-            LedgerBurnIndex::new(4) => EthWithdrawalRequest {
-                withdrawal_amount: Wei::new(1_000_000_000_000),
-                ledger_burn_index: LedgerBurnIndex::new(4),
-                destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52".parse().unwrap(),
-                from: "ezu3d-2mifu-k3bh4-oqhrj-mbrql-5p67r-pp6pr-dbfra-unkx5-sxdtv-rae"
+    let pending_withdrawal_requests: VecDeque<WithdrawalRequest> = vec![
+        withdrawal_request1.clone().into(),
+        withdrawal_request2.clone().into(),
+    ]
+    .into_iter()
+    .collect();
+    let processed_withdrawal_requests = btreemap! {
+        LedgerBurnIndex::new(4) => EthWithdrawalRequest {
+            withdrawal_amount: Wei::new(1_000_000_000_000),
+            ledger_burn_index: LedgerBurnIndex::new(4),
+            destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52".parse().unwrap(),
+            from: "ezu3d-2mifu-k3bh4-oqhrj-mbrql-5p67r-pp6pr-dbfra-unkx5-sxdtv-rae"
+                .parse()
+                .unwrap(),
+            from_subaccount: None,
+            created_at: Some(1699527697000000000),
+        }.into(),
+       withdrawal_request1.ledger_burn_index  => withdrawal_request1.clone().into(),
+    };
+    let created_tx = singleton_map(
+        2,
+        4,
+        TransactionRequest {
+            transaction: Eip1559TransactionRequest {
+                chain_id: 1,
+                nonce: TransactionNonce::new(2),
+                max_priority_fee_per_gas: WeiPerGas::new(100_000_000),
+                max_fee_per_gas: WeiPerGas::new(100_000_000),
+                gas_limit: GasAmount::new(21_000),
+                destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52"
                     .parse()
                     .unwrap(),
-                from_subaccount: None,
-                created_at: Some(1699527697000000000),
-            }.into(),
-           withdrawal_request1.ledger_burn_index  => withdrawal_request1.clone().into(),
-        },
-        created_tx: singleton_map(
-            2,
-            4,
-            TransactionRequest {
-                transaction: Eip1559TransactionRequest {
-                    chain_id: 1,
-                    nonce: TransactionNonce::new(2),
-                    max_priority_fee_per_gas: WeiPerGas::new(100_000_000),
-                    max_fee_per_gas: WeiPerGas::new(100_000_000),
-                    gas_limit: GasAmount::new(21_000),
-                    destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52"
-                        .parse()
-                        .unwrap(),
-                    amount: Wei::new(1_000_000_000_000),
-                    data: vec![],
-                    access_list: Default::default(),
-                },
-                resubmission: ResubmissionStrategy::ReduceEthAmount {
-                    withdrawal_amount: Wei::new(1_000_000_000_000),
-                },
+                amount: Wei::new(1_000_000_000_000),
+                data: vec![],
+                access_list: Default::default(),
             },
-        ),
-        sent_tx: singleton_map(
-            1,
-            3,
-            vec![SignedTransactionRequest {
-                transaction: SignedEip1559TransactionRequest::from((
-                    Eip1559TransactionRequest {
-                        chain_id: 1,
-                        nonce: TransactionNonce::new(1),
-                        max_priority_fee_per_gas: WeiPerGas::new(100_000_000),
-                        max_fee_per_gas: WeiPerGas::new(100_000_000),
-                        gas_limit: GasAmount::new(21_000),
-                        destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52"
-                            .parse()
-                            .unwrap(),
-                        amount: Wei::new(1_000_000_000_000),
-                        data: vec![],
-                        access_list: Default::default(),
-                    },
-                    TransactionSignature {
-                        signature_y_parity: true,
-                        r: Default::default(),
-                        s: Default::default(),
-                    },
-                )),
-                resubmission: ResubmissionStrategy::ReduceEthAmount {
-                    withdrawal_amount: Wei::new(1_000_000_000_000),
-                },
-            }],
-        ),
-        finalized_tx: singleton_map(
-            0,
-            2,
-            SignedEip1559TransactionRequest::from((
+            resubmission: ResubmissionStrategy::ReduceEthAmount {
+                withdrawal_amount: Wei::new(1_000_000_000_000),
+            },
+        },
+    );
+    let sent_tx = singleton_map(
+        1,
+        3,
+        vec![SignedTransactionRequest {
+            transaction: SignedEip1559TransactionRequest::from((
                 Eip1559TransactionRequest {
                     chain_id: 1,
-                    nonce: TransactionNonce::new(0),
+                    nonce: TransactionNonce::new(1),
                     max_priority_fee_per_gas: WeiPerGas::new(100_000_000),
                     max_fee_per_gas: WeiPerGas::new(100_000_000),
                     gas_limit: GasAmount::new(21_000),
@@ -1030,44 +1002,81 @@ fn state_equivalence() {
                     r: Default::default(),
                     s: Default::default(),
                 },
-            ))
-            .try_finalize(TransactionReceipt {
-                block_hash: "0x9e1e2124a453e7b5afaabe42fb66fffb12d4b1053403d2f487d250007f3cb550"
+            )),
+            resubmission: ResubmissionStrategy::ReduceEthAmount {
+                withdrawal_amount: Wei::new(1_000_000_000_000),
+            },
+        }],
+    );
+    let finalized_tx = singleton_map(
+        0,
+        2,
+        SignedEip1559TransactionRequest::from((
+            Eip1559TransactionRequest {
+                chain_id: 1,
+                nonce: TransactionNonce::new(0),
+                max_priority_fee_per_gas: WeiPerGas::new(100_000_000),
+                max_fee_per_gas: WeiPerGas::new(100_000_000),
+                gas_limit: GasAmount::new(21_000),
+                destination: "0xA776Cc20DFdCCF0c3ba89cB9Fb0f10Aba5b98f52"
                     .parse()
                     .unwrap(),
-                block_number: BlockNumber::new(400_000),
-                effective_gas_price: WeiPerGas::new(100_000_000),
-                gas_used: GasAmount::new(21_000),
-                status: TransactionStatus::Success,
-                transaction_hash:
-                    "0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d"
-                        .parse()
-                        .unwrap(),
-            })
-            .expect("valid receipt"),
-        ),
-        next_nonce: TransactionNonce::new(3),
-        maybe_reimburse: btreeset! { LedgerBurnIndex::new(4) },
-        reimbursement_requests: btreemap! {
-            ReimbursementIndex::CkEth { ledger_burn_index: LedgerBurnIndex::new(3) } => ReimbursementRequest {
-                transaction_hash: Some("0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d"
+                amount: Wei::new(1_000_000_000_000),
+                data: vec![],
+                access_list: Default::default(),
+            },
+            TransactionSignature {
+                signature_y_parity: true,
+                r: Default::default(),
+                s: Default::default(),
+            },
+        ))
+        .try_finalize(TransactionReceipt {
+            block_hash: "0x9e1e2124a453e7b5afaabe42fb66fffb12d4b1053403d2f487d250007f3cb550"
                 .parse()
-                .unwrap()),
-                ledger_burn_index: LedgerBurnIndex::new(3),
-                reimbursed_amount: CkTokenAmount::new(100_000_000_000),
-                to: "ezu3d-2mifu-k3bh4-oqhrj-mbrql-5p67r-pp6pr-dbfra-unkx5-sxdtv-rae".parse().unwrap(),
-                to_subaccount: None,
-            }
-        },
-        reimbursed: btreemap! {
-           ReimbursementIndex::CkEth { ledger_burn_index: LedgerBurnIndex::new(6) } => Ok(Reimbursed {
-                transaction_hash: Some("0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d".parse().unwrap()),
-                reimbursed_in_block: LedgerMintIndex::new(150),
-                reimbursed_amount: CkTokenAmount::new(10_000_000_000_000),
-                burn_in_block: LedgerBurnIndex::new(6),
-            }),
-        },
+                .unwrap(),
+            block_number: BlockNumber::new(400_000),
+            effective_gas_price: WeiPerGas::new(100_000_000),
+            gas_used: GasAmount::new(21_000),
+            status: TransactionStatus::Success,
+            transaction_hash: "0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d"
+                .parse()
+                .unwrap(),
+        })
+        .expect("valid receipt"),
+    );
+    let next_nonce = TransactionNonce::new(3);
+    let maybe_reimburse = btreeset! { LedgerBurnIndex::new(4) };
+    let reimbursement_requests = btreemap! {
+        ReimbursementIndex::CkEth { ledger_burn_index: LedgerBurnIndex::new(3) } => ReimbursementRequest {
+            transaction_hash: Some("0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d"
+            .parse()
+            .unwrap()),
+            ledger_burn_index: LedgerBurnIndex::new(3),
+            reimbursed_amount: CkTokenAmount::new(100_000_000_000),
+            to: "ezu3d-2mifu-k3bh4-oqhrj-mbrql-5p67r-pp6pr-dbfra-unkx5-sxdtv-rae".parse().unwrap(),
+            to_subaccount: None,
+        }
     };
+    let reimbursed = btreemap! {
+       ReimbursementIndex::CkEth { ledger_burn_index: LedgerBurnIndex::new(6) } => Ok(Reimbursed {
+            transaction_hash: Some("0x06afc3c693dc2ba2c19b5c287c4dddce040d766bea5fd13c8a7268b04aa94f2d".parse().unwrap()),
+            reimbursed_in_block: LedgerMintIndex::new(150),
+            reimbursed_amount: CkTokenAmount::new(10_000_000_000_000),
+            burn_in_block: LedgerBurnIndex::new(6),
+        }),
+    };
+    let builder = WithdrawalTransactionsBuilder::default()
+        .with_pending_withdrawal_requests(pending_withdrawal_requests)
+        .with_processed_withdrawal_requests(processed_withdrawal_requests)
+        .with_created_tx(created_tx)
+        .with_sent_tx(sent_tx)
+        .with_finalized_tx(finalized_tx)
+        .with_next_nonce(next_nonce)
+        .with_maybe_reimburse(maybe_reimburse)
+        .with_reimbursement_requests(reimbursement_requests)
+        .with_reimbursed(reimbursed);
+    let withdrawal_transactions = builder.clone().build();
     let mut ckerc20_tokens = DedupMultiKeyMap::default();
     ckerc20_tokens
         .try_insert(
@@ -1158,7 +1167,7 @@ fn state_equivalence() {
         invalid_events: btreemap! {
             source("0x05c6ec45699c9a6a4b1a4ea2058b0cee852ea2f19b18fb8313c04bf8156efde4", 11) => InvalidEventReason::InvalidDeposit("failed to decode principal from bytes 0x00333c125dc9f41abaf2b8b85d49fdc7ff75b2a4000000000000000000000000".to_string()),
         },
-        eth_transactions: eth_transactions.clone(),
+        withdrawal_transactions: withdrawal_transactions.clone(),
         pending_withdrawal_principals: Default::default(),
         pending_deposit_principals: Default::default(),
         active_tasks: Default::default(),
@@ -1281,15 +1290,17 @@ fn state_equivalence() {
     assert_eq!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                pending_withdrawal_requests: vec![
-                    withdrawal_request2.clone().into(),
-                    withdrawal_request1.clone().into()
-                ]
-                .into_iter()
-                .collect(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_pending_withdrawal_requests(
+                    vec![
+                        withdrawal_request2.clone().into(),
+                        withdrawal_request1.clone().into()
+                    ]
+                    .into_iter()
+                    .collect()
+                )
+                .build(),
             ..state.clone()
         },),
         "changing the order of withdrawal requests should result in an equivalent state",
@@ -1298,10 +1309,12 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                pending_withdrawal_requests: vec![withdrawal_request1.into()].into_iter().collect(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_pending_withdrawal_requests(
+                    vec![withdrawal_request1.into()].into_iter().collect()
+                )
+                .build(),
             ..state.clone()
         }),
         "changing the withdrawal requests should break equivalence"
@@ -1310,10 +1323,7 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                sent_tx: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder.clone().with_sent_tx(Default::default()).build(),
             ..state.clone()
         }),
         "changing the transactions should break equivalence"
@@ -1322,10 +1332,7 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                created_tx: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder.clone().with_created_tx(Default::default()).build(),
             ..state.clone()
         }),
         "changing the transactions should break equivalence"
@@ -1334,10 +1341,10 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                finalized_tx: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_finalized_tx(Default::default())
+                .build(),
             ..state.clone()
         }),
         "changing the transactions should break equivalence"
@@ -1346,10 +1353,10 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                maybe_reimburse: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_maybe_reimburse(Default::default())
+                .build(),
             ..state.clone()
         }),
         "changing the reimbursement data should break equivalence"
@@ -1358,10 +1365,10 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                reimbursement_requests: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_reimbursement_requests(Default::default())
+                .build(),
             ..state.clone()
         }),
         "changing the reimbursement data should break equivalence"
@@ -1370,10 +1377,7 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                reimbursed: Default::default(),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder.clone().with_reimbursed(Default::default()).build(),
             ..state.clone()
         }),
         "changing the reimbursement data should break equivalence"
@@ -1382,10 +1386,10 @@ fn state_equivalence() {
     assert_ne!(
         Ok(()),
         state.is_equivalent_to(&State {
-            eth_transactions: EthTransactions {
-                next_nonce: TransactionNonce::new(1000),
-                ..eth_transactions.clone()
-            },
+            withdrawal_transactions: builder
+                .clone()
+                .with_next_nonce(TransactionNonce::new(1000))
+                .build(),
             ..state.clone()
         }),
         "changing the next nonce should break equivalence"
@@ -1465,7 +1469,7 @@ mod sweeper_funding {
         );
 
         let request = state
-            .eth_transactions
+            .withdrawal_transactions
             .withdrawal_requests_iter()
             .next()
             .expect("BUG: the funding request was not recorded");

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests;
+pub(in crate::state) mod tests;
 
 use crate::endpoints::{EthTransaction, RetrieveEthStatus, TxFinalizedStatus, WithdrawalStatus};
 use crate::eth_logs::LedgerSubaccount;
@@ -392,22 +392,18 @@ impl fmt::Debug for Erc20WithdrawalRequest {
 /// 6. If a given transaction fails the minter will reimburse the user who requested the
 ///    withdrawal with the corresponding amount minus fees.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub struct EthTransactions {
-    pub(in crate::state) pending_withdrawal_requests: VecDeque<WithdrawalRequest>,
+pub struct WithdrawalTransactions {
+    pending_withdrawal_requests: VecDeque<WithdrawalRequest>,
     // Processed withdrawal requests (transaction created, sent, or finalized).
-    pub(in crate::state) processed_withdrawal_requests:
-        BTreeMap<LedgerBurnIndex, WithdrawalRequest>,
-    pub(in crate::state) created_tx:
-        MultiKeyMap<TransactionNonce, LedgerBurnIndex, TransactionRequest>,
-    pub(in crate::state) sent_tx:
-        MultiKeyMap<TransactionNonce, LedgerBurnIndex, Vec<SignedTransactionRequest>>,
-    pub(in crate::state) finalized_tx:
-        MultiKeyMap<TransactionNonce, LedgerBurnIndex, FinalizedEip1559Transaction>,
-    pub(in crate::state) next_nonce: TransactionNonce,
+    processed_withdrawal_requests: BTreeMap<LedgerBurnIndex, WithdrawalRequest>,
+    created_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, TransactionRequest>,
+    sent_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, Vec<SignedTransactionRequest>>,
+    finalized_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, FinalizedEip1559Transaction>,
+    next_nonce: TransactionNonce,
 
-    pub(in crate::state) maybe_reimburse: BTreeSet<LedgerBurnIndex>,
-    pub(in crate::state) reimbursement_requests: BTreeMap<ReimbursementIndex, ReimbursementRequest>,
-    pub(in crate::state) reimbursed: BTreeMap<ReimbursementIndex, ReimbursedResult>,
+    maybe_reimburse: BTreeSet<LedgerBurnIndex>,
+    reimbursement_requests: BTreeMap<ReimbursementIndex, ReimbursementRequest>,
+    reimbursed: BTreeMap<ReimbursementIndex, ReimbursedResult>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -429,7 +425,7 @@ pub enum ResubmitTransactionError {
     },
 }
 
-impl EthTransactions {
+impl WithdrawalTransactions {
     pub fn new(next_nonce: TransactionNonce) -> Self {
         Self {
             pending_withdrawal_requests: VecDeque::new(),

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -7,7 +7,7 @@ use crate::numeric::{
     BlockNumber, Erc20Value, GasAmount, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas,
 };
 use crate::state::transactions::{
-    Erc20WithdrawalRequest, EthTransactions, EthWithdrawalRequest, WithdrawalRequest,
+    Erc20WithdrawalRequest, EthWithdrawalRequest, WithdrawalRequest, WithdrawalTransactions,
     create_transaction,
 };
 use crate::tx::{
@@ -30,14 +30,16 @@ const DEFAULT_CKERC20_MAX_FEE_PER_GAS: WeiPerGas =
 const DEFAULT_ERC20_CONTRACT_ADDRESS: &str = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const DEFAULT_CKERC20_LEDGER_ID: &str = "sa4so-piaaa-aaaar-qacnq-cai";
 
-mod eth_transactions {
+mod withdrawal_transactions {
     use crate::endpoints::{EthTransaction, RetrieveEthStatus};
     use crate::numeric::{LedgerBurnIndex, TransactionNonce};
     use crate::state::transactions::tests::{
         cketh_withdrawal_request_with_index, create_and_record_transaction, gas_fee_estimate,
         sign_transaction, transaction_receipt,
     };
-    use crate::state::transactions::{EthTransactions, TransactionStatus, WithdrawalRequest};
+    use crate::state::transactions::{
+        TransactionStatus, WithdrawalRequest, WithdrawalTransactions,
+    };
 
     mod record_withdrawal_request {
         use super::*;
@@ -51,7 +53,7 @@ mod eth_transactions {
         #[test]
         fn should_record_withdrawal_request() {
             fn test<R: Into<WithdrawalRequest> + Clone>(withdrawal_request: R) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 transactions.record_withdrawal_request(withdrawal_request.clone());
 
                 assert_eq!(
@@ -75,7 +77,7 @@ mod eth_transactions {
                 withdrawal_request: R,
                 duplicate_index: S,
             ) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 transactions.record_withdrawal_request(withdrawal_request.clone());
 
                 expect_panic_with_message(
@@ -143,13 +145,13 @@ mod eth_transactions {
 
         #[test]
         fn should_be_empty_when_no_withdrawal_requests() {
-            let transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             assert_eq!(transactions.withdrawal_requests_batch(5), vec![]);
         }
 
         #[test]
         fn should_retrieve_the_first_withdrawal_requests() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let withdrawal_requests: [WithdrawalRequest; 5] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -167,7 +169,7 @@ mod eth_transactions {
         proptest! {
             #[test]
             fn should_retrieve_all_withdrawal_requests_in_order(batch_size in 3..100_usize) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let mut rng = reproducible_rng();
                 let withdrawal_requests: [WithdrawalRequest; 3] =
                     create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -180,7 +182,7 @@ mod eth_transactions {
 
         #[test]
         fn should_limit_batch_size_when_too_many_pending_transactions() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let withdrawal_requests: [WithdrawalRequest; 1000] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -229,7 +231,7 @@ mod eth_transactions {
         }
 
         fn create_and_record_pending_transaction<R: Into<WithdrawalRequest>>(
-            transactions: &mut EthTransactions,
+            transactions: &mut WithdrawalTransactions,
             withdrawal_request: R,
             to_sign: bool,
         ) {
@@ -243,13 +245,13 @@ mod eth_transactions {
 
     mod reschedule_withdrawal_request {
         use crate::numeric::TransactionNonce;
-        use crate::state::transactions::EthTransactions;
+        use crate::state::transactions::WithdrawalTransactions;
         use crate::state::transactions::tests::create_and_record_ck_withdrawal_requests;
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 
         #[test]
         fn should_reschedule_withdrawal_request() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [first_request, second_request, third_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -303,7 +305,7 @@ mod eth_transactions {
             cketh_withdrawal_request_with_index, create_and_record_ck_withdrawal_requests,
             create_and_record_transaction, create_ck_withdrawal_requests, gas_fee_estimate,
         };
-        use crate::state::transactions::{EthTransactions, create_transaction};
+        use crate::state::transactions::{WithdrawalTransactions, create_transaction};
         use crate::test_fixtures::expect_panic_with_message;
         use crate::tx::Eip1559TransactionRequest;
         use crate::withdraw::{
@@ -317,7 +319,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_when_withdrawal_request_not_found() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] = create_ck_withdrawal_requests(&mut rng);
             let tx = create_transaction(
@@ -338,7 +340,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_when_mismatch_with_cketh_withdrawal_request() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_request = cketh_withdrawal_request_with_index(LedgerBurnIndex::new(15));
             transactions.record_withdrawal_request(withdrawal_request.clone());
             let correct_tx = create_transaction(
@@ -386,7 +388,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_when_mismatch_with_ckerc20_withdrawal_request() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_request = ckerc20_withdrawal_request_with_index(
                 LedgerBurnIndex::new(3),
                 LedgerBurnIndex::new(7),
@@ -437,7 +439,7 @@ mod eth_transactions {
                 let current_nonce = TransactionNonce::from(current_nonce);
                 let wrong_nonce = current_nonce.checked_add(TransactionNonce::from(nonce_drift)).unwrap();
                 prop_assert_ne!(current_nonce, wrong_nonce);
-                let mut transactions = EthTransactions::new(current_nonce);
+                let mut transactions = WithdrawalTransactions::new(current_nonce);
                 let mut rng = reproducible_rng();
                 let [withdrawal_request] = create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
                 let tx_with_wrong_nonce = create_transaction(
@@ -458,7 +460,7 @@ mod eth_transactions {
 
         #[test]
         fn should_create_and_record_cketh_transaction() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let transaction_price = gas_fee_estimate();
             for i in 0..100_u64 {
                 let ledger_burn_index = LedgerBurnIndex::new(15 + i);
@@ -500,7 +502,7 @@ mod eth_transactions {
 
         #[test]
         fn should_create_and_record_ckerc20_transactions() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let gas_fee_estimate = gas_fee_estimate();
             for i in 0..100_u64 {
                 let cketh_ledger_burn_index = LedgerBurnIndex::new(3 * i);
@@ -581,7 +583,7 @@ mod eth_transactions {
 
         #[test]
         fn should_consume_withdrawal_request_when_creating_transaction() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -603,7 +605,7 @@ mod eth_transactions {
             create_and_record_ck_withdrawal_requests, create_and_record_transaction,
             gas_fee_estimate, sign_transaction, signed_transaction_with_nonce,
         };
-        use crate::state::transactions::{EthTransactions, WithdrawalRequest};
+        use crate::state::transactions::{WithdrawalRequest, WithdrawalTransactions};
         use crate::test_fixtures::expect_panic_with_message;
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
         use proptest::{prop_assume, proptest};
@@ -611,14 +613,14 @@ mod eth_transactions {
         #[test]
         #[should_panic(expected = "missing created transaction")]
         fn should_fail_when_created_transaction_not_found() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             transactions
                 .record_signed_transaction(signed_transaction_with_nonce(TransactionNonce::ZERO));
         }
 
         #[test]
         fn should_record_signed_transactions() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let withdrawal_requests: [WithdrawalRequest; 100] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -649,7 +651,7 @@ mod eth_transactions {
             fn should_fail_when_signed_transaction_does_not_match_created_transaction(
                 bad_tx in arb_signed_eip_1559_transaction_request_with_nonce(TransactionNonce::ZERO)
             ) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let mut rng = reproducible_rng();
                 let [withdrawal_request] =
                     create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -669,7 +671,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_to_re_sign_without_resubmit() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -698,14 +700,14 @@ mod eth_transactions {
             create_and_record_transaction, double_and_increment, gas_fee_estimate,
         };
         use crate::state::transactions::{
-            EthTransactions, ResubmitTransactionError, WithdrawalRequest,
+            ResubmitTransactionError, WithdrawalRequest, WithdrawalTransactions,
         };
         use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate};
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 
         #[test]
         fn should_be_empty_when_no_sent_transactions() {
-            let transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let resubmitted_txs = transactions
                 .create_resubmit_transactions(TransactionCount::ZERO, gas_fee_estimate());
 
@@ -714,7 +716,7 @@ mod eth_transactions {
 
         #[test]
         fn should_be_empty_when_all_sent_transactions_already_mined() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let withdrawal_requests: [WithdrawalRequest; 100] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -746,7 +748,7 @@ mod eth_transactions {
 
         #[test]
         fn should_be_empty_when_initial_max_fee_per_gas_covers_new_fee() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let withdrawal_requests: [WithdrawalRequest; 100] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -857,7 +859,7 @@ mod eth_transactions {
                 test: &ParameterizedTest,
                 withdrawal_request: R,
             ) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let withdrawal_request = withdrawal_request.into();
                 let cketh_ledger_burn_index = withdrawal_request.cketh_ledger_burn_index();
                 transactions.record_withdrawal_request(withdrawal_request.clone());
@@ -905,7 +907,7 @@ mod eth_transactions {
 
         #[test]
         fn should_resubmit_multiple_cketh_transactions() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_requests: [WithdrawalRequest; 100] =
                 create_and_record_cketh_withdrawal_requests(&mut transactions);
             let initial_price = GasFeeEstimate {
@@ -956,7 +958,7 @@ mod eth_transactions {
 
         #[test]
         fn should_not_resubmit_ckerc20_transactions_unless_max_priority_fee_increases() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_requests: [WithdrawalRequest; 100] =
                 create_and_record_ckerc20_withdrawal_requests(&mut transactions);
             let initial_price = GasFeeEstimate {
@@ -1051,7 +1053,7 @@ mod eth_transactions {
             create_and_record_transaction, gas_fee_estimate, sign_transaction,
         };
         use crate::state::transactions::{
-            EthTransactions, WithdrawalRequest, equal_ignoring_fee_and_amount,
+            WithdrawalRequest, WithdrawalTransactions, equal_ignoring_fee_and_amount,
         };
         use crate::test_fixtures::expect_panic_with_message;
         use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate};
@@ -1060,7 +1062,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_when_no_sent_tx() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1085,7 +1087,7 @@ mod eth_transactions {
                 withdrawal_request: R,
                 create_transactions_with_increasing_fees: F,
             ) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let withdrawal_request = withdrawal_request.into();
                 let cketh_ledger_burn_index = withdrawal_request.cketh_ledger_burn_index();
                 transactions.record_withdrawal_request(withdrawal_request.clone());
@@ -1166,7 +1168,7 @@ mod eth_transactions {
             fn should_fail_when_mismatch_with_already_sent(
                 wrong_resent_tx in arb_signed_eip_1559_transaction_request_with_nonce(TransactionNonce::ZERO)
             ) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let mut rng = reproducible_rng();
                 let [withdrawal_request] =
                     create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1192,7 +1194,7 @@ mod eth_transactions {
         #[test]
         fn should_replace_existing_resubmitted_transaction() {
             fn test<R: Into<WithdrawalRequest>>(withdrawal_request: R) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let initial_price = GasFeeEstimate {
                     base_fee_per_gas: WeiPerGas::from(10_u8),
                     max_priority_fee_per_gas: WeiPerGas::from(2_u8),
@@ -1279,7 +1281,7 @@ mod eth_transactions {
 
     mod transactions_to_send_batch {
         use crate::numeric::{TransactionCount, TransactionNonce};
-        use crate::state::transactions::EthTransactions;
+        use crate::state::transactions::WithdrawalTransactions;
         use crate::state::transactions::tests::arbitrary::arb_checked_amount_of;
         use crate::state::transactions::tests::{
             create_and_record_ck_withdrawal_requests, create_and_record_signed_transaction,
@@ -1292,7 +1294,7 @@ mod eth_transactions {
         proptest! {
             #[test]
             fn should_be_empty_when_no_transactions_to_send(latest_tx_count in arb_checked_amount_of()) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let mut rng = reproducible_rng();
                 assert_transactions_to_send_iter_is_empty(&transactions, latest_tx_count);
 
@@ -1311,7 +1313,7 @@ mod eth_transactions {
 
         #[test]
         fn should_contain_only_last_transactions() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [first_withdrawal_request, second_withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1362,7 +1364,7 @@ mod eth_transactions {
         }
 
         fn assert_transactions_to_send_iter_is_empty(
-            transactions: &EthTransactions,
+            transactions: &WithdrawalTransactions,
             latest_tx_count: TransactionCount,
         ) {
             assert_eq!(
@@ -1381,7 +1383,7 @@ mod eth_transactions {
             create_and_record_ck_withdrawal_requests, create_and_record_signed_transaction,
             resubmit_transaction_with_bumped_price,
         };
-        use crate::state::transactions::{EthTransactions, WithdrawalRequest};
+        use crate::state::transactions::{WithdrawalRequest, WithdrawalTransactions};
         use crate::tx::SignedEip1559TransactionRequest;
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
         use proptest::proptest;
@@ -1390,7 +1392,7 @@ mod eth_transactions {
         proptest! {
             #[test]
             fn should_be_empty_when_no_transaction_to_finalize(finalized_tx_count in arb_checked_amount_of()) {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
                 let mut rng = reproducible_rng();
                 assert_eq!(
                     transactions.sent_transactions_to_finalize(&finalized_tx_count),
@@ -1421,7 +1423,7 @@ mod eth_transactions {
         #[test]
         fn should_contain_transactions_to_finalize() {
             fn send_transaction(
-                transactions: &mut EthTransactions,
+                transactions: &mut WithdrawalTransactions,
                 withdrawal_request: WithdrawalRequest,
             ) -> SignedEip1559TransactionRequest {
                 let created_tx = create_and_record_transaction(
@@ -1432,7 +1434,7 @@ mod eth_transactions {
                 create_and_record_signed_transaction(transactions, created_tx.clone())
             }
 
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [first_withdrawal, second_withdrawal, third_withdrawal] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1492,8 +1494,8 @@ mod eth_transactions {
             create_and_record_transaction, dummy_signature, gas_fee_estimate, transaction_receipt,
         };
         use crate::state::transactions::{
-            Erc20WithdrawalRequest, EthTransactions, ReimbursementIndex, ReimbursementRequest,
-            TransactionStatus, WithdrawalRequest,
+            Erc20WithdrawalRequest, ReimbursementIndex, ReimbursementRequest, TransactionStatus,
+            WithdrawalRequest, WithdrawalTransactions,
         };
         use crate::test_fixtures::expect_panic_with_message;
         use crate::tx::{GasFeeEstimate, SignedEip1559TransactionRequest};
@@ -1502,7 +1504,7 @@ mod eth_transactions {
 
         #[test]
         fn should_fail_when_sent_transaction_not_found() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1548,7 +1550,7 @@ mod eth_transactions {
 
         #[test]
         fn should_record_cketh_finalized_transaction_and_not_reimburse() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let cketh_ledger_burn_index = LedgerBurnIndex::new(15);
             let withdrawal_request: WithdrawalRequest =
                 cketh_withdrawal_request_with_index(cketh_ledger_burn_index).into();
@@ -1575,7 +1577,7 @@ mod eth_transactions {
 
         #[test]
         fn should_not_reimburse_unused_transaction_fee_when_ckerc20_withdrawal_successful() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let cketh_ledger_burn_index = LedgerBurnIndex::new(7);
             let ckerc20_ledger_burn_index = LedgerBurnIndex::new(7);
             let withdrawal_request = ckerc20_withdrawal_request_with_index(
@@ -1606,7 +1608,7 @@ mod eth_transactions {
 
         #[test]
         fn should_not_reimburse_when_ckerc20_witdrawal_used_up_transaction_fee() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let cketh_ledger_burn_index = LedgerBurnIndex::new(7);
             let ckerc20_ledger_burn_index = LedgerBurnIndex::new(7);
             let withdrawal_request = Erc20WithdrawalRequest {
@@ -1643,7 +1645,7 @@ mod eth_transactions {
 
         #[test]
         fn should_reimburse_tokens_when_ckerc20_withdrawal_fails() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let cketh_ledger_burn_index = LedgerBurnIndex::new(7);
             let ckerc20_ledger_burn_index = LedgerBurnIndex::new(7);
             let withdrawal_request = ckerc20_withdrawal_request_with_index(
@@ -1691,7 +1693,7 @@ mod eth_transactions {
         #[test]
         fn should_record_finalized_transaction_and_reimburse_unused_tx_fee_when_cketh_withdrawal_fails()
          {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_request = cketh_withdrawal_request_with_index(LedgerBurnIndex::new(15));
             transactions.record_withdrawal_request(withdrawal_request.clone());
             let cketh_ledger_burn_index = withdrawal_request.ledger_burn_index;
@@ -1741,7 +1743,7 @@ mod eth_transactions {
 
         #[test]
         fn should_record_finalized_transaction() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1772,7 +1774,7 @@ mod eth_transactions {
 
         #[test]
         fn should_clean_up_failed_resubmitted_transactions_when_finalizing() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] =
                 create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -1811,14 +1813,16 @@ mod eth_transactions {
         use crate::eth_rpc_client::responses::TransactionStatus;
         use crate::numeric::TransactionNonce;
         use crate::state::transactions::tests::create_ck_withdrawal_requests;
-        use crate::state::transactions::tests::eth_transactions::withdrawal_flow;
-        use crate::state::transactions::{EthTransactions, ReimbursedError, ReimbursementIndex};
+        use crate::state::transactions::tests::withdrawal_transactions::withdrawal_flow;
+        use crate::state::transactions::{
+            ReimbursedError, ReimbursementIndex, WithdrawalTransactions,
+        };
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
         use maplit::{btreemap, btreeset};
 
         #[test]
         fn should_quarantine_reimbursement() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] = create_ck_withdrawal_requests(&mut rng);
             let reimbursement_index = ReimbursementIndex::try_from(&withdrawal_request)
@@ -1848,16 +1852,16 @@ mod eth_transactions {
         use crate::numeric::{LedgerBurnIndex, LedgerMintIndex, TransactionNonce};
         use crate::state::transactions::tests::{
             ckerc20_withdrawal_request_with_index, cketh_withdrawal_request_with_index,
-            create_ck_withdrawal_requests, eth_transactions::withdrawal_flow,
+            create_ck_withdrawal_requests, withdrawal_transactions::withdrawal_flow,
         };
         use crate::state::transactions::{
-            EthTransactions, ReimbursementIndex, TransactionStatus, WithdrawalRequest,
-            WithdrawalSearchParameter, WithdrawalStatus,
+            ReimbursementIndex, TransactionStatus, WithdrawalRequest, WithdrawalSearchParameter,
+            WithdrawalStatus, WithdrawalTransactions,
         };
         use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 
         pub fn assert_withdrawal_status(
-            transactions: &EthTransactions,
+            transactions: &WithdrawalTransactions,
             request: &WithdrawalRequest,
             withdrawal_status: Vec<WithdrawalStatus>,
         ) {
@@ -1906,7 +1910,7 @@ mod eth_transactions {
 
         #[test]
         fn should_have_finalized_success_status() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] = create_ck_withdrawal_requests(&mut rng);
             let cketh_ledger_burn_index = withdrawal_request.cketh_ledger_burn_index();
@@ -1934,7 +1938,7 @@ mod eth_transactions {
 
         #[test]
         fn should_have_finalized_reimbursed_status_for_cketh_withdrawal() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_request = cketh_withdrawal_request_with_index(LedgerBurnIndex::new(15));
             let cketh_ledger_burn_index = withdrawal_request.ledger_burn_index;
             let receipt = withdrawal_flow(
@@ -1989,7 +1993,7 @@ mod eth_transactions {
 
         #[test]
         fn should_have_finalized_reimbursed_status_for_ckerc20_withdrawal() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let withdrawal_request = ckerc20_withdrawal_request_with_index(
                 LedgerBurnIndex::new(15),
                 LedgerBurnIndex::new(7),
@@ -2040,7 +2044,7 @@ mod eth_transactions {
 
         #[test]
         fn should_have_status_pending_reimbursement_for_quarantined_reimbursement() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let mut rng = reproducible_rng();
             let [withdrawal_request] = create_ck_withdrawal_requests(&mut rng);
             let reimbursement_index = ReimbursementIndex::try_from(&withdrawal_request)
@@ -2062,7 +2066,7 @@ mod eth_transactions {
     }
 
     pub fn withdrawal_flow<T: Into<WithdrawalRequest>>(
-        transactions: &mut EthTransactions,
+        transactions: &mut WithdrawalTransactions,
         withdrawal_request: T,
         status: TransactionStatus,
     ) -> super::TransactionReceipt {
@@ -2175,7 +2179,7 @@ mod eth_transactions {
 
         #[test]
         fn should_never_enter_maybe_reimburse() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let funding = sweeper_funding_request();
 
             transactions.record_withdrawal_request(funding.clone());
@@ -2196,7 +2200,7 @@ mod eth_transactions {
         #[test]
         fn should_not_reimburse_a_failed_funding() {
             for status in [TransactionStatus::Success, TransactionStatus::Failure] {
-                let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+                let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
 
                 let _receipt =
                     withdrawal_flow(&mut transactions, sweeper_funding_request(), status);
@@ -2213,7 +2217,7 @@ mod eth_transactions {
 
         #[test]
         fn should_still_reimburse_a_failed_user_withdrawal() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
 
             let _receipt = withdrawal_flow(
                 &mut transactions,
@@ -2285,7 +2289,7 @@ mod eth_transactions {
 
         #[test]
         fn should_cap_resubmission_at_the_funded_amount() {
-            let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+            let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
             let funding = sweeper_funding_payload();
             let request = WithdrawalRequest::SweeperFunding(funding.clone());
             transactions.record_withdrawal_request(request.clone());
@@ -2329,13 +2333,13 @@ mod oldest_incomplete_withdrawal_timestamp {
 
     #[test]
     fn should_return_none_when_no_requests() {
-        let transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         assert_eq!(None, transactions.oldest_incomplete_withdrawal_timestamp());
     }
 
     #[test]
     fn should_return_created_at_of_one_request() {
-        let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         let mut rng = reproducible_rng();
         let [withdrawal_request] =
             create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -2348,7 +2352,7 @@ mod oldest_incomplete_withdrawal_timestamp {
 
     #[test]
     fn should_return_the_min_of_two_requests() {
-        let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         let mut rng = reproducible_rng();
         let [mut first_request, mut second_request] = create_ck_withdrawal_requests(&mut rng);
         set_created_at(&mut first_request, 10);
@@ -2364,7 +2368,7 @@ mod oldest_incomplete_withdrawal_timestamp {
 
     #[test]
     fn should_work_for_requests_with_transactions() {
-        let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         let mut rng = reproducible_rng();
         let [withdrawal_request] =
             create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -2382,7 +2386,7 @@ mod oldest_incomplete_withdrawal_timestamp {
 
     #[test]
     fn should_return_the_min_of_requests_in_all_states() {
-        let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         let mut rng = reproducible_rng();
         let [mut first_request, mut second_request] = create_ck_withdrawal_requests(&mut rng);
         set_created_at(&mut first_request, 10);
@@ -2400,7 +2404,7 @@ mod oldest_incomplete_withdrawal_timestamp {
 
     #[test]
     fn should_ignore_finalized_requests() {
-        let mut transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let mut transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         let mut rng = reproducible_rng();
         let [withdrawal_request] =
             create_and_record_ck_withdrawal_requests(&mut transactions, &mut rng);
@@ -2650,14 +2654,14 @@ mod withdrawal_flow {
     use super::arbitrary::{arb_checked_amount_of, arb_gas_fee_estimate, arb_withdrawal_request};
     use crate::numeric::TransactionNonce;
     use crate::state::transactions::tests::sign_transaction;
-    use crate::state::transactions::{EthTransactions, EthereumNetwork, create_transaction};
+    use crate::state::transactions::{EthereumNetwork, WithdrawalTransactions, create_transaction};
     use crate::withdraw::estimate_gas_limit;
     use proptest::proptest;
     use std::cell::RefCell;
 
     #[test]
     fn should_not_panic() {
-        let transactions = EthTransactions::new(TransactionNonce::ZERO);
+        let transactions = WithdrawalTransactions::new(TransactionNonce::ZERO);
         //required because proptest closure cannot take mutable args.
         let wrapped_txs = RefCell::new(transactions);
 
@@ -2966,7 +2970,7 @@ fn gas_fee_estimate() -> GasFeeEstimate {
 
 /// Create a mix of ckETH and ckERC20 withdrawal requests and record them.
 fn create_and_record_ck_withdrawal_requests<const N: usize, R: Rng>(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
     rng: &mut R,
 ) -> [WithdrawalRequest; N] {
     let requests = create_ck_withdrawal_requests(rng);
@@ -2978,7 +2982,7 @@ fn create_and_record_ck_withdrawal_requests<const N: usize, R: Rng>(
 
 /// Create ckETH withdrawal requests and record them.
 fn create_and_record_cketh_withdrawal_requests<const N: usize>(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
 ) -> [WithdrawalRequest; N] {
     let requests = create_cketh_withdrawal_requests();
     for request in &requests {
@@ -2989,7 +2993,7 @@ fn create_and_record_cketh_withdrawal_requests<const N: usize>(
 
 /// Create ckERC20 withdrawal requests and record them.
 fn create_and_record_ckerc20_withdrawal_requests<const N: usize>(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
 ) -> [WithdrawalRequest; N] {
     let requests = create_ckerc20_withdrawal_requests();
     for request in &requests {
@@ -3048,7 +3052,7 @@ fn create_ckerc20_withdrawal_requests<const N: usize>() -> [WithdrawalRequest; N
 }
 
 fn create_and_record_transaction<R: Into<WithdrawalRequest>>(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
     withdrawal_request: R,
     gas_fee_estimate: GasFeeEstimate,
 ) -> Eip1559TransactionRequest {
@@ -3072,7 +3076,7 @@ fn create_and_record_transaction<R: Into<WithdrawalRequest>>(
 }
 
 fn create_and_record_signed_transaction(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
     created_tx: Eip1559TransactionRequest,
 ) -> SignedEip1559TransactionRequest {
     let signed_tx = sign_transaction(created_tx);
@@ -3081,7 +3085,7 @@ fn create_and_record_signed_transaction(
 }
 
 fn resubmit_transaction_with_bumped_price(
-    transactions: &mut EthTransactions,
+    transactions: &mut WithdrawalTransactions,
     created_tx: Eip1559TransactionRequest,
 ) -> SignedEip1559TransactionRequest {
     use crate::tx::SignableTransaction;
@@ -3143,4 +3147,126 @@ pub fn increase_by_10_percent<T>(amount: CheckedAmountOf<T>) -> CheckedAmountOf<
                 .expect("BUG: must be Some() because divisor is non-zero"),
         )
         .unwrap_or(CheckedAmountOf::MAX)
+}
+
+use crate::map::MultiKeyMap;
+use crate::state::transactions::{ReimbursedResult, ReimbursementIndex, ReimbursementRequest};
+use crate::tx::{FinalizedEip1559Transaction, SignedTransactionRequest, TransactionRequest};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// Assembles a [`WithdrawalTransactions`] field by field, so a test can build a state the public
+/// API would take many steps to reach — then clone the builder and vary one field to check what
+/// that field alone changes.
+#[derive(Clone)]
+pub(in crate::state) struct WithdrawalTransactionsBuilder {
+    pending_withdrawal_requests: VecDeque<WithdrawalRequest>,
+    processed_withdrawal_requests: BTreeMap<LedgerBurnIndex, WithdrawalRequest>,
+    created_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, TransactionRequest>,
+    sent_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, Vec<SignedTransactionRequest>>,
+    finalized_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, FinalizedEip1559Transaction>,
+    next_nonce: TransactionNonce,
+    maybe_reimburse: BTreeSet<LedgerBurnIndex>,
+    reimbursement_requests: BTreeMap<ReimbursementIndex, ReimbursementRequest>,
+    reimbursed: BTreeMap<ReimbursementIndex, ReimbursedResult>,
+}
+
+impl Default for WithdrawalTransactionsBuilder {
+    fn default() -> Self {
+        Self {
+            pending_withdrawal_requests: Default::default(),
+            processed_withdrawal_requests: Default::default(),
+            created_tx: Default::default(),
+            sent_tx: Default::default(),
+            finalized_tx: Default::default(),
+            next_nonce: TransactionNonce::ZERO,
+            maybe_reimburse: Default::default(),
+            reimbursement_requests: Default::default(),
+            reimbursed: Default::default(),
+        }
+    }
+}
+
+impl WithdrawalTransactionsBuilder {
+    pub(in crate::state) fn with_pending_withdrawal_requests(
+        mut self,
+        pending_withdrawal_requests: VecDeque<WithdrawalRequest>,
+    ) -> Self {
+        self.pending_withdrawal_requests = pending_withdrawal_requests;
+        self
+    }
+
+    pub(in crate::state) fn with_processed_withdrawal_requests(
+        mut self,
+        processed_withdrawal_requests: BTreeMap<LedgerBurnIndex, WithdrawalRequest>,
+    ) -> Self {
+        self.processed_withdrawal_requests = processed_withdrawal_requests;
+        self
+    }
+
+    pub(in crate::state) fn with_created_tx(
+        mut self,
+        created_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, TransactionRequest>,
+    ) -> Self {
+        self.created_tx = created_tx;
+        self
+    }
+
+    pub(in crate::state) fn with_sent_tx(
+        mut self,
+        sent_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, Vec<SignedTransactionRequest>>,
+    ) -> Self {
+        self.sent_tx = sent_tx;
+        self
+    }
+
+    pub(in crate::state) fn with_finalized_tx(
+        mut self,
+        finalized_tx: MultiKeyMap<TransactionNonce, LedgerBurnIndex, FinalizedEip1559Transaction>,
+    ) -> Self {
+        self.finalized_tx = finalized_tx;
+        self
+    }
+
+    pub(in crate::state) fn with_next_nonce(mut self, next_nonce: TransactionNonce) -> Self {
+        self.next_nonce = next_nonce;
+        self
+    }
+
+    pub(in crate::state) fn with_maybe_reimburse(
+        mut self,
+        maybe_reimburse: BTreeSet<LedgerBurnIndex>,
+    ) -> Self {
+        self.maybe_reimburse = maybe_reimburse;
+        self
+    }
+
+    pub(in crate::state) fn with_reimbursement_requests(
+        mut self,
+        reimbursement_requests: BTreeMap<ReimbursementIndex, ReimbursementRequest>,
+    ) -> Self {
+        self.reimbursement_requests = reimbursement_requests;
+        self
+    }
+
+    pub(in crate::state) fn with_reimbursed(
+        mut self,
+        reimbursed: BTreeMap<ReimbursementIndex, ReimbursedResult>,
+    ) -> Self {
+        self.reimbursed = reimbursed;
+        self
+    }
+
+    pub(in crate::state) fn build(self) -> WithdrawalTransactions {
+        WithdrawalTransactions {
+            pending_withdrawal_requests: self.pending_withdrawal_requests,
+            processed_withdrawal_requests: self.processed_withdrawal_requests,
+            created_tx: self.created_tx,
+            sent_tx: self.sent_tx,
+            finalized_tx: self.finalized_tx,
+            next_nonce: self.next_nonce,
+            maybe_reimburse: self.maybe_reimburse,
+            reimbursement_requests: self.reimbursement_requests,
+            reimbursed: self.reimbursed,
+        }
+    }
 }

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -55,7 +55,7 @@ pub async fn process_reimbursement() {
     };
 
     let reimbursements: Vec<(ReimbursementIndex, ReimbursementRequest)> = read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .reimbursement_requests_iter()
             .map(|(index, request)| (index.clone(), request.clone()))
             .collect()
@@ -161,7 +161,7 @@ pub async fn process_retrieve_eth_requests() {
         }
     };
 
-    if read_state(|s| !s.eth_transactions.has_pending_requests()) {
+    if read_state(|s| !s.withdrawal_transactions.has_pending_requests()) {
         return;
     }
 
@@ -183,7 +183,7 @@ pub async fn process_retrieve_eth_requests() {
     send_transactions_batch(latest_transaction_count).await;
     finalize_transactions_batch().await;
 
-    if read_state(|s| s.eth_transactions.has_pending_requests()) {
+    if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
         ic_cdk_timers::set_timer(
             crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
             async { process_retrieve_eth_requests().await },
@@ -211,7 +211,7 @@ async fn resubmit_transactions_batch(
     latest_transaction_count: Option<TransactionCount>,
     gas_fee_estimate: &GasFeeEstimate,
 ) {
-    if read_state(|s| s.eth_transactions.is_sent_tx_empty()) {
+    if read_state(|s| s.withdrawal_transactions.is_sent_tx_empty()) {
         return;
     }
     let latest_transaction_count = match latest_transaction_count {
@@ -221,7 +221,7 @@ async fn resubmit_transactions_batch(
         }
     };
     let transactions_to_resubmit = read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .create_resubmit_transactions(latest_transaction_count, gas_fee_estimate.clone())
     });
     for result in transactions_to_resubmit {
@@ -250,12 +250,12 @@ async fn resubmit_transactions_batch(
 
 fn create_transactions_batch(gas_fee_estimate: GasFeeEstimate) {
     for request in read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .withdrawal_requests_batch(WITHDRAWAL_REQUESTS_BATCH_SIZE)
     }) {
         log!(DEBUG, "[create_transactions_batch]: processing {request:?}",);
         let ethereum_network = read_state(State::ethereum_network);
-        let nonce = read_state(|s| s.eth_transactions.next_transaction_nonce());
+        let nonce = read_state(|s| s.withdrawal_transactions.next_transaction_nonce());
         let gas_limit = estimate_gas_limit(&request);
         match create_transaction(
             &request,
@@ -289,7 +289,10 @@ fn create_transactions_batch(gas_fee_estimate: GasFeeEstimate) {
                     INFO,
                     "[create_transactions_batch]: Withdrawal request with burn index {ledger_burn_index} has insufficient amount {withdrawal_amount:?} to cover transaction fees: {max_transaction_fee:?}. Request moved back to end of queue."
                 );
-                mutate_state(|s| s.eth_transactions.reschedule_withdrawal_request(request));
+                mutate_state(|s| {
+                    s.withdrawal_transactions
+                        .reschedule_withdrawal_request(request)
+                });
             }
         };
     }
@@ -306,7 +309,7 @@ pub fn estimate_gas_limit(withdrawal_request: &WithdrawalRequest) -> GasAmount {
 
 async fn sign_transactions_batch() {
     let transactions_batch: Vec<_> = read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .transactions_to_sign_batch(TRANSACTIONS_TO_SIGN_BATCH_SIZE)
     });
     log!(DEBUG, "Signing transactions {transactions_batch:?}");
@@ -354,7 +357,7 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
         }
     };
     let transactions_to_send: Vec<_> = read_state(|s| {
-        s.eth_transactions
+        s.withdrawal_transactions
             .transactions_to_send_batch(latest_transaction_count, TRANSACTIONS_TO_SEND_BATCH_SIZE)
     });
 
@@ -393,14 +396,14 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
 }
 
 async fn finalize_transactions_batch() {
-    if read_state(|s| s.eth_transactions.is_sent_tx_empty()) {
+    if read_state(|s| s.withdrawal_transactions.is_sent_tx_empty()) {
         return;
     }
 
     match finalized_transaction_count().await {
         Ok(finalized_tx_count) => {
             let txs_to_finalize = read_state(|s| {
-                s.eth_transactions
+                s.withdrawal_transactions
                     .sent_transactions_to_finalize(&finalized_tx_count)
             });
             let expected_finalized_withdrawal_ids: BTreeSet<_> =


### PR DESCRIPTION
Part of [DEFI-2917](https://dfinity.atlassian.net/browse/DEFI-2917) (deposit-from-CEX), the first of a stack preparing the minter to send Ethereum transactions from a second address. Pure refactoring: no behaviour change, and no test loses or gains coverage.

Wide but shallow — a rename across twelve files plus one genuine change. The substantive work sits in the PRs above.

## What

- **Renames `EthTransactions` to `WithdrawalTransactions`.** The name has to give way: a second sender address is coming, and its transactions are equally "Eth transactions". What distinguishes this one is that it carries user withdrawals.
- **Makes the fields private.** No production code ever read one — the visibility existed solely so `state::tests` could assemble a populated value and vary one field at a time to exercise `is_equivalent_to`. A builder in `transactions::tests` covers that without exposing the fields. It does nothing but collect them, so what a test builds is still spelled out at the test; and since varying a field is what the test is for, each case clones the builder and changes only the field it is probing rather than restating the other eight:

```rust
withdrawal_transactions: builder.clone().with_sent_tx(Default::default()).build(),
```

`state_equivalence` keeps every assertion it had, in place.

## Note on visibility

`transactions::tests` is `pub(in crate::state)` so `state::tests` can name the builder. A plain associated function would not need that — method resolution does not go through the module path — but a builder is a type, and types need a reachable path. The fields themselves stay private, which is the point of the change.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


[DEFI-2917]: https://dfinity.atlassian.net/browse/DEFI-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ