### PR TITLE
fix: set LANG=C.UTF-8 in the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
   "postStartCommand": "/ic/ci/container/init.sh",
   "containerEnv": {
     "CARGO_TARGET_DIR": "/home/ubuntu/.cache/cargo",
-    "USER": "${localEnv:USER}"
+    "USER": "${localEnv:USER}",
+    "LANG": "C.UTF-8"
   },
   "mounts": [
     {


### PR DESCRIPTION
Entering a terminal in the VS Code dev container greeted you with:

```
bash: warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8): No such file or directory
bash: warning: setlocale: LC_COLLATE: cannot change locale (en_US.UTF-8): No such file or directory
...
```

Cause, in three steps:

1. The dev container image ships only the `C`, `C.UTF-8` and `POSIX` locales (`locale -a`), and nothing in it sets `LANG`.
2. Because `LANG` is empty, VS Code's `terminal.integrated.detectLocale` (default `"auto"`) injects `LANG=en_US.UTF-8` into every terminal it spawns — confirmed on a live terminal process, whose `/proc/<pid>/environ` carries it while none of its ancestors (vscode-server, code-server, pid 1) do.
3. `LANG` alone doesn't upset bash, but bash-completion copies it into the individual categories — `/usr/share/bash-completion/bash_completion:355`: `local LC_COLLATE=C LC_CTYPE=${LC_ALL:-${LC_CTYPE:-${LANG-}}} LC_ALL=`. Assigning a nonexistent locale to `LC_CTYPE`/`LC_COLLATE` inside a running shell is what prints the warning, twice per call (set + restore).

Setting a UTF-8 locale that actually exists fixes both halves: the locale resolves, and `detectLocale` leaves `LANG` alone because it already ends in `.utf-8`. `C.UTF-8` is the same value `ci/container/container-run.sh` already passes, so CLI and dev container shells now agree.

Rejected alternatives: `"terminal.integrated.detectLocale": "off"` fixes it per-user only and leaves shells in the non-UTF-8 `POSIX` locale; generating `en_US.UTF-8` in the image needs a `ci/container/Dockerfile` change plus an image rebuild for no gain over `C.UTF-8`.

## Testing

Reproduced and verified in the container:

```
$ env -i LANG=en_US.UTF-8 bash --norc -c 'source /usr/share/bash-completion/bash_completion; COMP_WORDS=(ls ""); COMP_CWORD=1; _filedir'
...warning: setlocale: LC_CTYPE: cannot change locale (en_US.UTF-8)...
...warning: setlocale: LC_COLLATE: cannot change locale (en_US.UTF-8)...
$ env -i LANG=C.UTF-8 bash --norc -c '...same...'   # silent
```

`Dev Containers: Rebuild Container` with this change applied: warnings gone.

Note `containerEnv` is applied at container creation, so picking this up requires a rebuild (or reopen), not just a window reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
