### PR TITLE
fix: make `ci/container/container-run.sh` work when the checkout is a git worktree

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -10,7 +10,11 @@ if [ "${BUILD_IC_NESTED:-}" == 1 ]; then
 fi
 export BUILD_IC_NESTED=1
 
-export ROOT_DIR="$(git rev-parse --show-toplevel)"
+# Assign, then export: `export X="$(...)"` swallows the command
+# substitution's exit status, so a failing git would leave X empty and
+# `set -e` would not notice.
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+export ROOT_DIR
 
 # This script needs to be run inside the ic-build container
 # If it isn't, we drop into the correct container.
@@ -105,7 +109,8 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-export VERSION="$(git rev-parse HEAD)"
+VERSION="$(git rev-parse HEAD)"
+export VERSION
 
 BAZEL_TARGETS=()
 

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -227,13 +227,16 @@ if [ -f "${REPO_ROOT}/.git" ]; then
                 # worktree's *host* path, and those paths do not exist in the
                 # container (this checkout lives at $WORKDIR, the others are not
                 # mounted at all), so git considers every worktree prunable here.
-                # That is harmless for reading, but `git gc` -- which git runs
-                # automatically after commit/fetch/... -- prunes worktrees as
-                # part of its job and would delete the host's admin directories.
-                # Turn auto gc off; an explicit `git gc` remains the user's call.
+                # That is harmless for reading, but `git gc` prunes worktrees as
+                # part of its job -- and git runs gc automatically after
+                # commit/fetch/... -- so it would delete the host's admin
+                # directories. Disable worktree pruning itself rather than gc as
+                # a whole: object maintenance keeps working, and an explicit
+                # `git gc` is safe too. (`git worktree prune` ignores this
+                # setting, so still don't run that one in here.)
                 -e GIT_CONFIG_COUNT=1
-                -e GIT_CONFIG_KEY_0=gc.auto
-                -e GIT_CONFIG_VALUE_0=0
+                -e GIT_CONFIG_KEY_0=gc.worktreePruneExpire
+                -e GIT_CONFIG_VALUE_0=never
             )
             ;;
     esac

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -205,6 +205,40 @@ RUNTIME_RUN_ARGS=(
     --mount type=tmpfs,target="/tmp/containers" # expected by ic-os build
 )
 
+# When the checkout is a linked git worktree, its `.git` is a *file* holding an
+# absolute path to an admin directory under the main checkout's `.git`, i.e. a
+# path outside the checkout. Mounting only the checkout leaves that pointer
+# dangling, so every `git` call inside the container fails -- including the
+# `$(git rev-parse --show-toplevel)` that several ci scripts rely on. Mount the
+# main checkout's `.git` at the very same absolute path so the pointer resolves.
+if [ -f "${REPO_ROOT}/.git" ]; then
+    GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+    GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)" # may be relative
+    case "$GIT_COMMON_DIR" in
+        "$REPO_ROOT" | "$REPO_ROOT"/*)
+            : # inside the checkout already, covered by the mount above
+            ;;
+        *)
+            eprintln "Checkout is a git worktree, also mounting '$GIT_COMMON_DIR'"
+            RUNTIME_RUN_ARGS+=(
+                --mount type=bind,source="${GIT_COMMON_DIR}",target="${GIT_COMMON_DIR}"
+
+                # Each worktree admin directory holds a back-pointer to its
+                # worktree's *host* path, and those paths do not exist in the
+                # container (this checkout lives at $WORKDIR, the others are not
+                # mounted at all), so git considers every worktree prunable here.
+                # That is harmless for reading, but `git gc` -- which git runs
+                # automatically after commit/fetch/... -- prunes worktrees as
+                # part of its job and would delete the host's admin directories.
+                # Turn auto gc off; an explicit `git gc` remains the user's call.
+                -e GIT_CONFIG_COUNT=1
+                -e GIT_CONFIG_KEY_0=gc.auto
+                -e GIT_CONFIG_VALUE_0=0
+            )
+            ;;
+    esac
+fi
+
 # Privilege/isolation flags required by the IC-OS guest build, per runtime.
 if [ "$RUNTIME" = docker ]; then
     # Under docker the IC-OS build runs (rootless) podman *inside* this

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -219,6 +219,24 @@ if [ -f "${REPO_ROOT}/.git" ]; then
             : # inside the checkout already, covered by the mount above
             ;;
         *)
+            # Mounting at the same absolute path only helps if the pointer *is*
+            # absolute. With `worktree.useRelativePaths` (git >= 2.48) `.git`
+            # holds a path relative to the checkout, which inside the container
+            # resolves against $WORKDIR no matter where the admin directory is
+            # mounted, and so keeps dangling. Say so instead of handing over a
+            # container in which git does not work.
+            GITDIR_POINTER="$(sed -n 's/^gitdir: //p' "${REPO_ROOT}/.git")"
+            case "$GITDIR_POINTER" in
+                /*) ;;
+                *)
+                    eprintln "'${REPO_ROOT}/.git' points at '$GITDIR_POINTER', a path relative to the checkout."
+                    eprintln "The checkout is mounted at '$WORKDIR' in the container, so that path cannot be made to resolve there."
+                    eprintln "Re-point it absolutely, e.g. from the main checkout:"
+                    eprintln "> git -c worktree.useRelativePaths=false worktree repair '$REPO_ROOT'"
+                    exit 1
+                    ;;
+            esac
+
             eprintln "Checkout is a git worktree, also mounting '$GIT_COMMON_DIR'"
             RUNTIME_RUN_ARGS+=(
                 --mount type=bind,source="${GIT_COMMON_DIR}",target="${GIT_COMMON_DIR}"

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -205,12 +205,17 @@ RUNTIME_RUN_ARGS=(
     --mount type=tmpfs,target="/tmp/containers" # expected by ic-os build
 )
 
-# When the checkout is a linked git worktree, its `.git` is a *file* holding an
-# absolute path to an admin directory under the main checkout's `.git`, i.e. a
-# path outside the checkout. Mounting only the checkout leaves that pointer
+# Where `.git` is a *file* rather than a directory it holds a path to the real
+# git directory -- typically a linked git worktree, whose `.git` names an admin
+# directory under the main checkout's `.git`, but a `--separate-git-dir` clone
+# or a submodule looks the same. Mounting only the checkout leaves that pointer
 # dangling, so every `git` call inside the container fails -- including the
 # `$(git rev-parse --show-toplevel)` that several ci scripts rely on. Mount the
-# main checkout's `.git` at the very same absolute path so the pointer resolves.
+# git directory at the very same absolute path so the pointer resolves.
+#
+# Note that for a worktree this hands the container read-write access to the
+# main checkout's entire git directory, where for a plain clone only the
+# checkout itself is exposed.
 if [ -f "${REPO_ROOT}/.git" ]; then
     GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
     GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)" # may be relative
@@ -237,7 +242,7 @@ if [ -f "${REPO_ROOT}/.git" ]; then
                     ;;
             esac
 
-            eprintln "Checkout is a git worktree, also mounting '$GIT_COMMON_DIR'"
+            eprintln "Git directory lies outside the checkout, also mounting '$GIT_COMMON_DIR'"
             RUNTIME_RUN_ARGS+=(
                 --mount type=bind,source="${GIT_COMMON_DIR}",target="${GIT_COMMON_DIR}"
 

--- a/ci/container/get-image-tag.sh
+++ b/ci/container/get-image-tag.sh
@@ -2,7 +2,9 @@
 
 set -eEuo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Assign first: `cd "$(...)"` would silently `cd ""` (exit 0) if git failed.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 
 INPUT_FILES=(
     ci/container/Dockerfile

--- a/ci/scripts/rust-lint.sh
+++ b/ci/scripts/rust-lint.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-cd "${CI_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+# Note the assignment: `cd "$(git rev-parse ...)"` would `cd ""` and *succeed*
+# (bash returns 0 for a null directory operand) if git failed, silently turning
+# this script into a no-op that lints nothing and exits 0. An assignment, in
+# contrast, takes the command substitution's exit status, so `set -e` fires.
+REPO_ROOT="${CI_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
 
 cargo fmt -- --check
 

--- a/ci/scripts/rust-lint.sh
+++ b/ci/scripts/rust-lint.sh
@@ -2,9 +2,11 @@
 set -xeuo pipefail
 
 # Note the assignment: `cd "$(git rev-parse ...)"` would `cd ""` and *succeed*
-# (bash returns 0 for a null directory operand) if git failed, silently turning
-# this script into a no-op that lints nothing and exits 0. An assignment, in
-# contrast, takes the command substitution's exit status, so `set -e` fires.
+# (bash returns 0 for a null directory operand) if git failed, leaving the shell
+# wherever it happened to be and linting that instead -- so a run that never
+# located the repository would still look like a successful lint of it. An
+# assignment, in contrast, takes the command substitution's exit status, so
+# `set -e` fires.
 REPO_ROOT="${CI_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
Running `./ci/container/container-run.sh` from a linked git worktree gave a container in which git did not work at all, and the ci scripts that locate the repository with git did not notice.

**The container could not use git.** In a linked worktree `.git` is a file pointing at an admin directory under the main checkout's `.git` — an absolute path outside the checkout. Only the checkout was mounted, so that pointer dangled and every `git` call inside the container failed. `container-run.sh` now also mounts that directory at the same absolute path, which fixes every git-dependent script at once rather than one script at a time. Plain clones are unaffected. A worktree whose pointer is *relative* (git's `worktree.useRelativePaths`) cannot be made to resolve this way, so that case is reported and refused instead of silently handed over.

That mount makes all worktrees look prunable inside the container, since their back-pointers name host paths that are not mounted. Reading is unaffected, but `git gc` prunes worktrees it considers stale as part of its job, and would delete the host's admin directories — including those of worktrees you are not even using here. Worktree pruning is therefore switched off for the container, rather than gc as a whole: the repository still gets its object maintenance, and an explicit `git gc` is safe too.

**The failures were silent.** `cd ""` returns 0 in bash and does not move the shell, and a command substitution inside `${X:-...}` does not trip errexit, so a script whose `git rev-parse --show-toplevel` failed carried on against whatever directory it happened to be in and still exited 0; `export X="$(...)"` swallows the substitution's exit status the same way. The affected scripts now assign first and then `cd`/`export`, so `set -e` fires. A sweep found no other instances.

Only local developer tooling changes — CI sets `CI_PROJECT_DIR` and never hit this. Note that the VS Code dev container (`.devcontainer/devcontainer.json`) is still affected: its mounts are static, so it cannot pick up the main checkout's git directory the way this script does.
