### PR TITLE
chore(system-tests): lower cpus_oversubscription_factor from 4 to 3

### DIFF
--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -45,7 +45,7 @@ def system_test(
         logs = True,
         vm_allocation_mode = None,
         cpus = None,
-        cpus_oversubscription_factor = 4,
+        cpus_oversubscription_factor = 3,
         **kwargs):
     """Declares a system-test.
 


### PR DESCRIPTION
We observed a few RBE workers running Out Of Memory which I expect is because we're running too many system-tests on them. System-tests don't specify their required memory so it can indeed happen they use too much. So let's overload workers slightly less by reducing `cpus_oversubscription_factor` from 4 to 3.