### PR TITLE
feat: declare mainnet binaries as bazel dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1290,6 +1290,33 @@ mainnet_icos_images(
     path = "//:mainnet-icos-revisions.json",
 )
 
+mainnet_icos_binaries = use_repo_rule("//bazel:mainnet-icos-binaries.bzl", "mainnet_icos_binaries")
+
+# Mainnet release binaries, published for the same revisions as the mainnet ICOS
+# images above. Declaring them as Bazel dependencies (instead of having the tests
+# download them from the CDN while they run) is what allows the system-tests that
+# use them to also run on the network-isolated local backend. See the
+# mainnet_binaries_runtime_deps dicts in //rs/tests:common.bzl.
+mainnet_icos_binaries(
+    name = "mainnet_nns_binaries",
+    parts = [
+        "guestos",
+        "subnets",
+        "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe",
+    ],
+    path = "//:mainnet-icos-revisions.json",
+)
+
+mainnet_icos_binaries(
+    name = "mainnet_app_binaries",
+    parts = [
+        "guestos",
+        "subnets",
+        "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe",
+    ],
+    path = "//:mainnet-icos-revisions.json",
+)
+
 mainnet_icos_versions = use_repo_rule("//bazel:mainnet-icos-versions.bzl", "mainnet_icos_versions")
 
 mainnet_icos_versions(

--- a/bazel/mainnet-icos-binaries.bzl
+++ b/bazel/mainnet-icos-binaries.bzl
@@ -1,0 +1,123 @@
+"""
+This module defines Bazel targets for the release binaries that were published
+for the mainnet versions of the ICOS images.
+
+System-tests that need to run a binary built at a version currently deployed on
+mainnet used to download it from the CDN while the test was running, which
+pinned those tests to the Farm backend: the local backend runs in a
+network-isolated sandbox. Declaring the binaries as Bazel dependencies instead
+makes them available offline, so the `_local` variants can run too.
+"""
+
+def binary_download_url(git_commit_id, name):
+    """URL of the gzipped release binary `name` published for `git_commit_id`.
+
+    `https://download.dfinity.systems/ic/{rev}/release/{name}.gz` holds a
+    byte-identical copy, but that prefix is legacy (see `bundle-legacy` in
+    //publish/binaries/BUILD.bazel). We use the canonical prefix, which is also
+    the directory whose SHA256SUMS ci/src/mainnet_revisions/mainnet_revisions.py
+    reads to record the hashes verified below -- the two must agree.
+
+    Args:
+      git_commit_id: the revision the binary was published for.
+      name: the name of the binary, e.g. "ic-replay".
+
+    Returns:
+      The download URL.
+    """
+    return "https://download.dfinity.systems/ic/{git_commit_id}/binaries/x86_64-linux/{name}.gz".format(
+        git_commit_id = git_commit_id,
+        name = name,
+    )
+
+# One genrule per binary, decompressing the downloaded artifact and making it
+# executable.
+#
+# The genrule is called `gunzip_{name}` and not `{name}` because a target may not
+# have the same name as one of its own outputs. Naming the *output* `{name}`
+# keeps the public label `@repo//:{name}` short and, more importantly, gives the
+# file the exact basename the tests need: run_systest.sh symlinks runtime
+# dependencies as `<hash>-<basename>` and `ic-backup` looks its binaries up by
+# name under `binaries/<version>/`.
+#
+# `gunzip -c > $@` creates a non-executable file and genrules don't mark their
+# outputs executable, hence the explicit `chmod +x`.
+_GUNZIP_GENRULE = """
+genrule(
+    name = "gunzip_{name}",
+    srcs = ["{name}.gz"],
+    outs = ["{name}"],
+    cmd = "gunzip -c $< > $@ && chmod +x $@",
+    executable = True,
+    target_compatible_with = ["@platforms//os:linux"],
+)
+"""
+
+def _mainnet_icos_binaries_impl(repository_ctx):
+    """Repository rule for the release binaries of a mainnet ICOS version.
+
+    Every binary recorded for the selected version is downloaded (pinned by the
+    sha256 from the same revisions JSON) as `<name>.gz` and decompressed into an
+    executable `<name>` which is exported as `@<repo>//:<name>`.
+    """
+
+    parts = list(repository_ctx.attr.parts)
+
+    # The path to the mainnet icos info
+    json_path = repository_ctx.attr.path
+    repository_ctx.watch(json_path)  # recreate the repo if the data changes
+
+    # Read and decode mainnet data
+    info = json.decode(repository_ctx.read(json_path))
+    for part in parts:
+        info = info[part]
+
+    if "binaries" not in info:
+        fail(("No 'binaries' recorded for {parts} in {path}. Regenerate it by running " +
+              "`python3 ci/src/mainnet_revisions/mainnet_revisions.py --dry-run icos`.").format(
+            parts = "/".join(parts),
+            path = json_path,
+        ))
+
+    git_commit_id = info["version"]
+    binaries = info["binaries"]
+
+    # Sorting keeps the generated BUILD file independent of the JSON key order.
+    names = sorted(binaries.keys())
+
+    for name in names:
+        # Pass the sha256 of each binary so the download can be served from the
+        # local repository cache / Remote Asset API CAS instead of re-fetched
+        # from the CDN.
+        repository_ctx.download(
+            binary_download_url(git_commit_id, name),
+            "{name}.gz".format(name = name),
+            sha256 = binaries[name],
+        )
+
+    BUILD = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files({GZS})
+""".format(GZS = str([name + ".gz" for name in names])) + "".join([
+        _GUNZIP_GENRULE.format(name = name)
+        for name in names
+    ])
+    repository_ctx.file("BUILD.bazel", content = BUILD)
+
+    # This repo is reproducible: the downloads are pinned by sha256 and
+    # everything else is derived from the watched revisions JSON and the rule
+    # attributes. Declaring this makes the repo eligible for Bazel 9's repo
+    # contents cache ({repository_cache}/contents), so the binaries are shared
+    # across output bases/workspaces (e.g. persisted CI runner caches) instead of
+    # being re-downloaded on every fetch. Without this return value the repo is
+    # never contents-cached.
+    return repository_ctx.repo_metadata(reproducible = True)
+
+mainnet_icos_binaries = repository_rule(
+    implementation = _mainnet_icos_binaries_impl,
+    attrs = {
+        "parts": attr.string_list(mandatory = True, doc = "Will be used to index into the mainnet icos revisions JSON file."),
+        "path": attr.label(mandatory = True, doc = "The path to the mainnet icos revisions."),
+    },
+)

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -21,13 +21,7 @@ SAVED_VERSIONS_CANISTERS_FILE = "mainnet-canister-revisions.json"
 # Release binaries (published on the CDN under `.../binaries/x86_64-linux/` as
 # `<name>.gz`) whose sha256 we record for every mainnet revision. They are exposed
 # to Bazel by //bazel:mainnet-icos-binaries.bzl and consumed by system-tests that
-# have to run a binary built at a mainnet version:
-#   * ic-replay, sandbox_launcher, canister_sandbox, compiler_sandbox
-#       -> //rs/tests/consensus/backup:backup_manager_{upgrade,downgrade}_test
-#   * types-test
-#       -> //rs/tests/consensus/orchestrator:cup_compatibility_test
-#   * replicated-state-test, state-layout-test
-#       -> //rs/tests/message_routing:queues_compatibility_test
+# have to run a binary built at a mainnet version.
 # Keep sorted; this determines the key order in the generated JSON.
 MAINNET_BINARIES = [
     "canister_sandbox",
@@ -38,12 +32,6 @@ MAINNET_BINARIES = [
     "state-layout-test",
     "types-test",
 ]
-
-# Fields every saved record must have. Listing them (rather than checking a single
-# field) means that when a new field is introduced, records that are already on the
-# current version are still rewritten once, so the new field gets backfilled instead
-# of only appearing on the next version bump.
-REQUIRED_RECORD_FIELDS = ("setupos_disk_img_hash", "binaries")
 
 
 class Command(Enum):
@@ -478,7 +466,7 @@ def get_binary_hashes(version: str) -> dict:
 
 def is_record_up_to_date(existing: dict, version: str) -> bool:
     """Whether `existing` is on `version` and already has every field we record."""
-    return existing.get("version", "") == version and all(f in existing for f in REQUIRED_RECORD_FIELDS)
+    return existing.get("version", "") == version and all(f in existing for f in ("setupos_disk_img_hash", "binaries"))
 
 
 def get_logger(level) -> logging.Logger:

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -18,6 +18,33 @@ app_subnet_id = "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe
 PUBLIC_DASHBOARD_API = "https://ic-api.internetcomputer.org"
 SAVED_VERSIONS_CANISTERS_FILE = "mainnet-canister-revisions.json"
 
+# Release binaries (published on the CDN under `.../binaries/x86_64-linux/` as
+# `<name>.gz`) whose sha256 we record for every mainnet revision. They are exposed
+# to Bazel by //bazel:mainnet-icos-binaries.bzl and consumed by system-tests that
+# have to run a binary built at a mainnet version:
+#   * ic-replay, sandbox_launcher, canister_sandbox, compiler_sandbox
+#       -> //rs/tests/consensus/backup:backup_manager_{upgrade,downgrade}_test
+#   * types-test
+#       -> //rs/tests/consensus/orchestrator:cup_compatibility_test
+#   * replicated-state-test, state-layout-test
+#       -> //rs/tests/message_routing:queues_compatibility_test
+# Keep sorted; this determines the key order in the generated JSON.
+MAINNET_BINARIES = [
+    "canister_sandbox",
+    "compiler_sandbox",
+    "ic-replay",
+    "replicated-state-test",
+    "sandbox_launcher",
+    "state-layout-test",
+    "types-test",
+]
+
+# Fields every saved record must have. Listing them (rather than checking a single
+# field) means that when a new field is introduced, records that are already on the
+# current version are still rewritten once, so the new field gets backfilled instead
+# of only appearing on the next version bump.
+REQUIRED_RECORD_FIELDS = ("setupos_disk_img_hash", "binaries")
+
 
 class Command(Enum):
     ICOS = 1
@@ -36,6 +63,10 @@ class VersionInfo:
     # via the NNS, so this is read from the CDN SHA256SUMS file.
     setupos_hash: str
     setupos_dev_hash: str
+    # SHA256 of each of MAINNET_BINARIES as published (gzipped) on the CDN under
+    # `binaries/x86_64-linux/`, read from that directory's SHA256SUMS. Consumed by
+    # //bazel:mainnet-icos-binaries.bzl.
+    binaries: dict
 
 
 def sync_main_branch_and_checkout_branch(
@@ -171,7 +202,18 @@ def get_replica_version_info(replica_version: str) -> VersionInfo:
     setupos_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
     setupos_dev_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
-    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
+    binaries = get_binary_hashes(version)
+
+    return VersionInfo(
+        version,
+        hash,
+        dev_hash,
+        launch_measurements,
+        dev_measurements,
+        setupos_hash,
+        setupos_dev_hash,
+        binaries,
+    )
 
 
 def get_latest_replica_version_info() -> VersionInfo:
@@ -207,7 +249,18 @@ def get_latest_replica_version_info() -> VersionInfo:
     setupos_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img/SHA256SUMS", "disk-img.tar.zst")
     setupos_dev_hash = download_and_read_sha256sums(f"{setupos_base}/disk-img-dev/SHA256SUMS", "disk-img.tar.zst")
 
-    return VersionInfo(version, hash, dev_hash, launch_measurements, dev_measurements, setupos_hash, setupos_dev_hash)
+    binaries = get_binary_hashes(version)
+
+    return VersionInfo(
+        version,
+        hash,
+        dev_hash,
+        launch_measurements,
+        dev_measurements,
+        setupos_hash,
+        setupos_dev_hash,
+        binaries,
+    )
 
 
 def get_latest_hostos_version_info(logger: logging.Logger) -> VersionInfo:
@@ -249,6 +302,7 @@ def get_latest_hostos_version_info(logger: logging.Logger) -> VersionInfo:
         replica_info.dev_measurements,
         replica_info.setupos_hash,
         replica_info.setupos_dev_hash,
+        replica_info.binaries,
     )
 
 
@@ -263,7 +317,7 @@ def update_saved_subnet_revision(repo_root: pathlib.Path, logger: logging.Logger
         data = json.load(f)
 
     existing = data.get("guestos", {}).get("subnets", {}).get(subnet, {})
-    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
+    if is_record_up_to_date(existing, replica_info.version):
         logger.info("Subnet revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -273,6 +327,7 @@ def update_saved_subnet_revision(repo_root: pathlib.Path, logger: logging.Logger
         "update_img_hash_dev": replica_info.dev_hash,
         "setupos_disk_img_hash": replica_info.setupos_hash,
         "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
+        "binaries": replica_info.binaries,
         "launch_measurements": replica_info.launch_measurements,
         "launch_measurements_dev": replica_info.dev_measurements,
     }
@@ -296,7 +351,7 @@ def update_saved_replica_revision(repo_root: pathlib.Path, logger: logging.Logge
         data = json.load(f)
 
     existing = data.get("guestos", {}).get("latest_release", {})
-    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
+    if is_record_up_to_date(existing, replica_info.version):
         logger.info("Latest revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -306,6 +361,7 @@ def update_saved_replica_revision(repo_root: pathlib.Path, logger: logging.Logge
         "update_img_hash_dev": replica_info.dev_hash,
         "setupos_disk_img_hash": replica_info.setupos_hash,
         "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
+        "binaries": replica_info.binaries,
         "launch_measurements": replica_info.launch_measurements,
         "launch_measurements_dev": replica_info.dev_measurements,
     }
@@ -327,7 +383,7 @@ def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger
         data = json.load(f)
 
     existing = data.get("hostos", {}).get("latest_release", {})
-    if existing.get("version", "") == replica_info.version and "setupos_disk_img_hash" in existing:
+    if is_record_up_to_date(existing, replica_info.version):
         logger.info("Hostos revision already updated to version %s. Skipping update.", replica_info.version)
         return
 
@@ -338,6 +394,7 @@ def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger
             "update_img_hash_dev": replica_info.dev_hash,
             "setupos_disk_img_hash": replica_info.setupos_hash,
             "setupos_disk_img_hash_dev": replica_info.setupos_dev_hash,
+            "binaries": replica_info.binaries,
             "launch_measurements": replica_info.launch_measurements,
             "launch_measurements_dev": replica_info.dev_measurements,
         }
@@ -383,16 +440,45 @@ def download_and_read_file(url: str):
             return json.loads(f.read().decode())
 
 
-def download_and_read_sha256sums(url: str, filename: str) -> str:
-    """Download a SHA256SUMS file and return the hex sha256 recorded for `filename`."""
+def download_sha256sums(url: str) -> dict:
+    """Download a SHA256SUMS file and return a mapping from filename to its hex sha256."""
     with tempfile.NamedTemporaryFile() as tmp_file:
         urllib.request.urlretrieve(url, tmp_file.name)
         with open(tmp_file.name, "r", encoding="utf-8") as f:
-            for line in f:
-                parts = line.split()
-                if len(parts) == 2 and parts[1] == filename:
-                    return parts[0]
-    raise Exception(f"No sha256 for {filename} in {url}")
+            return {p[1]: p[0] for p in (line.split() for line in f) if len(p) == 2}
+
+
+def download_and_read_sha256sums(url: str, filename: str) -> str:
+    """Download a SHA256SUMS file and return the hex sha256 recorded for `filename`."""
+    sha256 = download_sha256sums(url).get(filename)
+    if sha256 is None:
+        raise Exception(f"No sha256 for {filename} in {url}")
+    return sha256
+
+
+def get_binary_hashes(version: str) -> dict:
+    """
+    Return {binary name: sha256 of <name>.gz} for MAINNET_BINARIES at `version`.
+
+    Read from the SHA256SUMS of the very directory that
+    //bazel:mainnet-icos-binaries.bzl downloads the binaries from, so the recorded
+    hash and the verified download can never refer to different copies.
+
+    Raises if a binary is missing: failing the updater's own PR is much better than
+    recording nothing and breaking `bazel build` for everyone once the repository
+    rule can no longer find it.
+    """
+    url = f"https://download.dfinity.systems/ic/{version}/binaries/x86_64-linux/SHA256SUMS"
+    sums = download_sha256sums(url)
+    missing = [name for name in MAINNET_BINARIES if f"{name}.gz" not in sums]
+    if missing:
+        raise Exception(f"No sha256 for {', '.join(missing)} in {url}")
+    return {name: sums[f"{name}.gz"] for name in MAINNET_BINARIES}
+
+
+def is_record_up_to_date(existing: dict, version: str) -> bool:
+    """Whether `existing` is on `version` and already has every field we record."""
+    return existing.get("version", "") == version and all(f in existing for f in REQUIRED_RECORD_FIELDS)
 
 
 def get_logger(level) -> logging.Logger:

--- a/mainnet-icos-revisions.json
+++ b/mainnet-icos-revisions.json
@@ -7,6 +7,15 @@
         "update_img_hash_dev": "752a1309bc4be13a89acc5ae40f0cd9432d84b5020cba83952bbea85b8d3b027",
         "setupos_disk_img_hash": "cd003d2725de0248801b7572ae08adc8184f7311c93ed301c04507724e06dc9e",
         "setupos_disk_img_hash_dev": "5e82713d768fac0b8bafdde2dbaca91c66e0e1bac45f495d8168af0b9d529a1d",
+        "binaries": {
+          "canister_sandbox": "01898d9fa3c40d0aebd84930289bad1db5ec90a442aedcb4fd3dbab9eb7f426a",
+          "compiler_sandbox": "d8ba643ed70843d2d0e8cecde52a54ccf07ca22c417caf3b6ba6c0f35ff429da",
+          "ic-replay": "a668289276dcee2d693f9215dbf35176028d63f06b78443f481d209872aca17c",
+          "replicated-state-test": "58f3254c71beb7fe001f7046c660f398507a233bbdeb2e09f87a71a7eb441f27",
+          "sandbox_launcher": "5fe1e6d01515981f8f1bafa992d20131e57820cca44ce83f6d2f68d0f27921b4",
+          "state-layout-test": "224ba5a9ab6d2d6da570fae906cc39a1e9a98a114516c7d08ab9ed636ab437cd",
+          "types-test": "23e9a456614380a7edf15d1d6afdf87a3ec1a019dcc57e232542cf08805e5c44"
+        },
         "launch_measurements": {
           "guest_launch_measurements": [
             {
@@ -142,6 +151,15 @@
         "update_img_hash_dev": "3924d5e9c86822b367cbfdbaab48c667f2a32bee3ab65e5772d54c32e6a829ed",
         "setupos_disk_img_hash": "5c488a88730dd52c2cf3186d10517b8e86cfbc445f47e850a07479632d466390",
         "setupos_disk_img_hash_dev": "18330bb4c6fcf94977fb7e8576e0d781864777406a8b33b47153f15fbef4e454",
+        "binaries": {
+          "canister_sandbox": "2a2e8891dc8837b02b1bf00972b71e5e8393fc5334ac611638071bc151b37cfc",
+          "compiler_sandbox": "050bdee43705e3d66fc64fa95918d122625cb3a8539c4a00e30461788fe97afb",
+          "ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5",
+          "replicated-state-test": "106b3fc2af013b33e251ead603152c22cef7ac12584c207bc223bcd4e0c081fc",
+          "sandbox_launcher": "e888b39bb3917002bd9843252469af5d3094aa4409d5b0c758ecf8d2b7a72c5e",
+          "state-layout-test": "f7603af64891a3f9d72efa8b12de51f9bf121e0bda974b45ffcbcf793bfa39ea",
+          "types-test": "c30d337312392ea63ac0be5403547ebe884b24aab716343891e6ed2442b83973"
+        },
         "launch_measurements": {
           "guest_launch_measurements": [
             {
@@ -284,6 +302,15 @@
       "update_img_hash_dev": "3924d5e9c86822b367cbfdbaab48c667f2a32bee3ab65e5772d54c32e6a829ed",
       "setupos_disk_img_hash": "5c488a88730dd52c2cf3186d10517b8e86cfbc445f47e850a07479632d466390",
       "setupos_disk_img_hash_dev": "18330bb4c6fcf94977fb7e8576e0d781864777406a8b33b47153f15fbef4e454",
+      "binaries": {
+        "canister_sandbox": "2a2e8891dc8837b02b1bf00972b71e5e8393fc5334ac611638071bc151b37cfc",
+        "compiler_sandbox": "050bdee43705e3d66fc64fa95918d122625cb3a8539c4a00e30461788fe97afb",
+        "ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5",
+        "replicated-state-test": "106b3fc2af013b33e251ead603152c22cef7ac12584c207bc223bcd4e0c081fc",
+        "sandbox_launcher": "e888b39bb3917002bd9843252469af5d3094aa4409d5b0c758ecf8d2b7a72c5e",
+        "state-layout-test": "f7603af64891a3f9d72efa8b12de51f9bf121e0bda974b45ffcbcf793bfa39ea",
+        "types-test": "c30d337312392ea63ac0be5403547ebe884b24aab716343891e6ed2442b83973"
+      },
       "launch_measurements": {
         "guest_launch_measurements": [
           {
@@ -427,6 +454,15 @@
       "update_img_hash_dev": "d887710aaf9ecee67d0a50fe74b3476141515de128f6ffd1156f07ba7b053582",
       "setupos_disk_img_hash": "5c488a88730dd52c2cf3186d10517b8e86cfbc445f47e850a07479632d466390",
       "setupos_disk_img_hash_dev": "18330bb4c6fcf94977fb7e8576e0d781864777406a8b33b47153f15fbef4e454",
+      "binaries": {
+        "canister_sandbox": "2a2e8891dc8837b02b1bf00972b71e5e8393fc5334ac611638071bc151b37cfc",
+        "compiler_sandbox": "050bdee43705e3d66fc64fa95918d122625cb3a8539c4a00e30461788fe97afb",
+        "ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5",
+        "replicated-state-test": "106b3fc2af013b33e251ead603152c22cef7ac12584c207bc223bcd4e0c081fc",
+        "sandbox_launcher": "e888b39bb3917002bd9843252469af5d3094aa4409d5b0c758ecf8d2b7a72c5e",
+        "state-layout-test": "f7603af64891a3f9d72efa8b12de51f9bf121e0bda974b45ffcbcf793bfa39ea",
+        "types-test": "c30d337312392ea63ac0be5403547ebe884b24aab716343891e6ed2442b83973"
+      },
       "launch_measurements": {
         "guest_launch_measurements": [
           {

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -15,6 +15,66 @@ MAINNET_ENV = {
     "MAINNET_APP_GUESTOS_REVISION_ENV": MAINNET_APP["version"],
 }
 
+def mainnet_binaries_runtime_deps(repo, prefix, binaries):
+    """Runtime dependencies on binaries published for a mainnet revision.
+
+    These come from @mainnet_{nns,app}_binaries (see
+    //bazel:mainnet-icos-binaries.bzl) instead of being downloaded from the CDN by
+    the test itself, which is what lets the `_local` (network-isolated) variants of
+    the consuming tests run.
+
+    Only depend on the binaries a test actually uses: every runtime dependency ends
+    up in the test's runfiles (and, for colocated tests, in the tarball copied to
+    the driver's UVM), so an unused one costs both disk and time.
+
+    Args:
+      repo: the repository holding the binaries, e.g. "mainnet_nns_binaries".
+      prefix: env var prefix identifying the revision, e.g. "MAINNET_NNS".
+      binaries: names of the binaries to depend on.
+
+    Returns:
+      A dict from env var name (e.g. "MAINNET_NNS_IC_REPLAY_PATH") to label.
+    """
+    return {
+        "{}_{}_PATH".format(prefix, name.upper().replace("-", "_")): "@{}//:{}".format(repo, name)
+        for name in binaries
+    }
+
+# Used by //rs/tests/consensus/backup: `ic-backup` replays a subnet's artifacts
+# with the `ic-replay` (and sandbox binaries) of the version that produced them.
+MAINNET_NNS_REPLAY_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
+    "mainnet_nns_binaries",
+    "MAINNET_NNS",
+    [
+        "canister_sandbox",
+        "compiler_sandbox",
+        "ic-replay",
+        "sandbox_launcher",
+    ],
+)
+
+# Used by //rs/tests/consensus/orchestrator:cup_compatibility_test.
+MAINNET_TYPES_TEST_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
+    "mainnet_nns_binaries",
+    "MAINNET_NNS",
+    ["types-test"],
+) | mainnet_binaries_runtime_deps(
+    "mainnet_app_binaries",
+    "MAINNET_APP",
+    ["types-test"],
+)
+
+# Used by //rs/tests/message_routing:queues_compatibility_test.
+MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
+    "mainnet_nns_binaries",
+    "MAINNET_NNS",
+    ["replicated-state-test", "state-layout-test"],
+) | mainnet_binaries_runtime_deps(
+    "mainnet_app_binaries",
+    "MAINNET_APP",
+    ["replicated-state-test", "state-layout-test"],
+)
+
 NNS_CANISTER_WASM_PROVIDERS = {
     "registry-canister_test": {
         "tip-of-branch": "//rs/registry/canister:registry-canister-test",

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -18,11 +18,6 @@ MAINNET_ENV = {
 def mainnet_binaries_runtime_deps(repo, prefix, binaries):
     """Runtime dependencies on binaries published for a mainnet revision.
 
-    These come from @mainnet_{nns,app}_binaries (see
-    //bazel:mainnet-icos-binaries.bzl) instead of being downloaded from the CDN by
-    the test itself, which is what lets the `_local` (network-isolated) variants of
-    the consuming tests run.
-
     Only depend on the binaries a test actually uses: every runtime dependency ends
     up in the test's runfiles (and, for colocated tests, in the tarball copied to
     the driver's UVM), so an unused one costs both disk and time.
@@ -40,8 +35,6 @@ def mainnet_binaries_runtime_deps(repo, prefix, binaries):
         for name in binaries
     }
 
-# Used by //rs/tests/consensus/backup: `ic-backup` replays a subnet's artifacts
-# with the `ic-replay` (and sandbox binaries) of the version that produced them.
 MAINNET_NNS_REPLAY_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
     "mainnet_nns_binaries",
     "MAINNET_NNS",
@@ -53,7 +46,6 @@ MAINNET_NNS_REPLAY_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
     ],
 )
 
-# Used by //rs/tests/consensus/orchestrator:cup_compatibility_test.
 MAINNET_TYPES_TEST_RUNTIME_DEPS = mainnet_binaries_runtime_deps(
     "mainnet_nns_binaries",
     "MAINNET_NNS",


### PR DESCRIPTION
Note this PR is at the bottom of a stack of https://github.com/dfinity/ic/pull/11187 and https://github.com/dfinity/ic/pull/11188.

Several system-tests need to run a binary built at a version currently deployed on mainnet, and download it from `download.dfinity.systems` **while the test is running**. That pins them to the Farm backend — the `_local` backend runs in a network-isolated sandbox — and it means the binary is used without verifying its sha256 (`file_sync_helper::download_binary` passes `None` as the expected hash).

This PR adds the mechanism; the tests are converted in the PRs stacked on top.

### Where the hashes live

In `mainnet-icos-revisions.json`, as a `binaries` map next to the `version` they belong to, rather than in a new file. The binaries have to match the *exact* GuestOS revision a test boots — `ic-backup` looks up `binaries/<version the node reports>/<name>` — so a separate file updated by a separate bot PR could drift for a cron cycle and the backup tests would silently fall back to a download. One record keeps the update atomic. It also needs no CI-policy changes: `mainnet-*-revisions.json` is already covered by `BOT_APPROVED_FILES`, `CODEOWNERS` and `auto-approve.yml`.

### The pieces

* `mainnet_revisions.py` reads the hashes from the CDN's `binaries/x86_64-linux/SHA256SUMS` — the very directory the repository rule downloads from, so the recorded hash and the verified download can't refer to different copies. It raises when a binary is missing, so that fails the updater's own PR rather than `bazel build` for everyone.
* The "already up to date" guard now checks every field we record (`REQUIRED_RECORD_FIELDS`) instead of just one, so existing entries are backfilled on the next run instead of only picking the new field up on the next version bump. This is what generated the +36 lines in the JSON here.
* `bazel/mainnet-icos-binaries.bzl` downloads each recorded binary pinned by that sha256 and decompresses it into an executable file, exported as `@mainnet_{nns,app}_binaries//:<name>`.
* `rs/tests/common.bzl` turns those into per-purpose `runtime_deps` dicts.

### Notes for review

* Both repos download every binary in the map (~99 MB total), even though `@mainnet_app_binaries` only needs three of them. That keeps the JSON the single source of truth instead of duplicating the list in `MODULE.bazel`; the unused ones are only *downloaded*, never *built*, since their genrules never enter a test's `data`. If fetch size ever matters, the escape hatch is a `binaries` filter attribute — two lines.
* The genrule is `gunzip_{name}` with output `{name}` because a target may not share its name with its own output (same reason `//publish/binaries` uses `{name}_cleaned`). The output basename matters: `run_systest.sh` symlinks runtime deps as `<hash>-<basename>` and `ic-backup` looks its binaries up by name.
* Decompression is a genrule rather than `repository_ctx.execute(["gunzip", ...])` so that `repo_metadata(reproducible = True)` stays honest — repo content depends only on the watched JSON and the rule attributes.

### Verification

```
bazel build @mainnet_nns_binaries//... @mainnet_app_binaries//...   # 14 targets, all mode 0555
ic-replay --help / types-test --list                                 # run
python3 ci/src/mainnet_revisions/mainnet_revisions.py --dry-run icos  # 2nd run: all 4 records skip, empty diff
```