### PR TITLE
test: run the mainnet compatibility tests on the local backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,6 @@ dependencies = [
  "ic-nns-constants",
  "ic-nns-governance-api",
  "ic-protobuf",
- "ic-recovery",
  "ic-registry-keys",
  "ic-registry-nns-data-provider",
  "ic-registry-subnet-features",
@@ -2470,7 +2469,6 @@ dependencies = [
  "reqwest",
  "serde_cbor",
  "slog",
- "tempfile",
  "tokio",
  "url",
 ]
@@ -17580,7 +17578,6 @@ dependencies = [
  "ic-agent",
  "ic-base-types",
  "ic-management-canister-types 0.8.0",
- "ic-recovery",
  "ic-registry-subnet-type",
  "ic-system-test-driver",
  "ic-types",

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rs/tests:common.bzl", "DEFAULT_VCPUS_PER_VM", "MAINNET_ENV", "MESSAGE_CANISTER_RUNTIME_DEPS", "MIN_LOCAL_CPUS")
+load("//rs/tests:common.bzl", "DEFAULT_VCPUS_PER_VM", "MAINNET_ENV", "MAINNET_TYPES_TEST_RUNTIME_DEPS", "MESSAGE_CANISTER_RUNTIME_DEPS", "MIN_LOCAL_CPUS")
 load("//rs/tests:system_tests.bzl", "system_test", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -78,27 +78,18 @@ system_test_nns(
 
 system_test(
     name = "cup_compatibility_test",
-    # TODO: support this test on the local backend (drop `backend = "farm"`).
-    # The test downloads the mainnet `types-test` tool from:
-    # https://download.dfinity.systems/ic/{hash}/release/types-test.gz
-    # which requires external network access which is only available on the farm backend.
-    # Provide this dependency as a bazel dependency. Also see the same TODO in:
-    # rs/tests/consensus/orchestrator/cup_compatibility_test.rs.
-    backend = "farm",
     cpus = MIN_LOCAL_CPUS,  # Empty setup (|_| ()), no VMs deployed.
     env = MAINNET_ENV,
-    runtime_deps = {
+    guestos = False,  # The setup is `|_| ()` so no GuestOS image is ever booted.
+    runtime_deps = MAINNET_TYPES_TEST_RUNTIME_DEPS | {
         "TYPES_TEST_PATH": "//rs/types/types:types_test",
     },
     deps = [
         # Keep sorted.
-        "//rs/recovery",
-        "//rs/tests/consensus/utils",
         "//rs/tests/driver:ic-system-test-driver",
         "//rs/types/types",
         "@crate_index//:anyhow",
         "@crate_index//:slog",
-        "@crate_index//:tempfile",
     ],
 )
 

--- a/rs/tests/consensus/orchestrator/Cargo.toml
+++ b/rs/tests/consensus/orchestrator/Cargo.toml
@@ -16,7 +16,6 @@ ic-nns-common = { path = "../../../nns/common" }
 ic-nns-constants = { path = "../../../nns/constants" }
 ic-nns-governance-api = { path = "../../../nns/governance/api" }
 ic-protobuf = { path = "../../../protobuf" }
-ic-recovery = { path = "../../../recovery" }
 ic-registry-keys = { path = "../../../registry/keys" }
 ic-registry-nns-data-provider = { path = "../../../registry/nns_data_provider" }
 ic-registry-subnet-features = { path = "../../../registry/subnet_features" }
@@ -30,7 +29,6 @@ registry-canister = { path = "../../../registry/canister" }
 reqwest = { workspace = true }
 serde_cbor = { workspace = true }
 slog = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 

--- a/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
+++ b/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
@@ -21,18 +21,15 @@ or violation of integrity.
 end::catalog[] */
 
 use anyhow::Result;
-use ic_recovery::file_sync_helper::download_binary;
 use ic_system_test_driver::driver::test_env_api::{
-    READY_WAIT_TIMEOUT, RETRY_BACKOFF, get_mainnet_application_subnet_revision,
-    get_mainnet_nns_revision,
+    get_dependency_path_from_env, get_mainnet_application_subnet_revision, get_mainnet_nns_revision,
 };
 use ic_system_test_driver::driver::{group::SystemTestGroup, test_env::TestEnv};
 use ic_system_test_driver::systest;
-use ic_system_test_driver::util::block_on;
 use ic_types::ReplicaVersion;
 use slog::{Logger, error, info};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 const SANITY_CHECK_ARTIFACTS_COUNT: usize = 46;
@@ -100,33 +97,27 @@ and the custom `ExhaustiveSet` implementation is removed at the same time.
     }
 }
 
-/// TODO: Instead of downloading the mainnet binary, declare it as a bazel
-/// dependency such that it is downloaded ahead of time. This should be done
-/// once the following blockers are resolved:
-/// 1. It is possible to declare a dependency that can download and extract
-///    g-zipped archives, and make them executable.
-/// 2. There is a way to automatically update the version of this dependency,
-///    Ideally such that it is in sync with mainnet-icos-revisions.json
-fn download_mainnet_binary(version: &ReplicaVersion, log: &Logger, target_dir: &Path) -> PathBuf {
-    block_on(ic_system_test_driver::retry_with_msg_async!(
-        "download mainnet binary",
-        log,
-        READY_WAIT_TIMEOUT,
-        RETRY_BACKOFF,
-        || async { Ok(download_binary(log, version, "types-test".into(), target_dir,).await?) }
-    ))
-    .expect("Failed to Download")
-}
-
 fn nns_version_test(env: TestEnv) {
-    test(env, &get_mainnet_nns_revision().unwrap())
+    test(
+        env,
+        &get_mainnet_nns_revision().unwrap(),
+        "MAINNET_NNS_TYPES_TEST_PATH",
+    )
 }
 
 fn application_subnet_version_test(env: TestEnv) {
-    test(env, &get_mainnet_application_subnet_revision().unwrap())
+    test(
+        env,
+        &get_mainnet_application_subnet_revision().unwrap(),
+        "MAINNET_APP_TYPES_TEST_PATH",
+    )
 }
 
-fn test(env: TestEnv, mainnet_version: &ReplicaVersion) {
+/// `mainnet_test_env_var` names the runtime dependency holding the `types-test`
+/// binary built at `mainnet_version` (see `runtime_deps` in BUILD.bazel).
+/// `mainnet_version` itself is only used for logging: which binary we get is
+/// determined by the bazel dependency, not resolved from the version at runtime.
+fn test(env: TestEnv, mainnet_version: &ReplicaVersion, mainnet_test_env_var: &str) {
     let log = env.logger();
 
     info!(log, "Continuing with mainnet version {mainnet_version}");
@@ -137,9 +128,8 @@ fn test(env: TestEnv, mainnet_version: &ReplicaVersion) {
         fs::remove_dir_all(&output_dir)
             .expect("Should have all the permissions to remove the existing directory");
     }
-    let branch_test = PathBuf::from(&std::env::var("TYPES_TEST_PATH").unwrap());
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let mainnet_test = download_mainnet_binary(mainnet_version, &log, tmp_dir.path());
+    let branch_test = get_dependency_path_from_env("TYPES_TEST_PATH");
+    let mainnet_test = get_dependency_path_from_env(mainnet_test_env_var);
 
     info!(log, "Creating artifacts with mainnet version...");
     call_unit_test(&log, &mainnet_test, Action::Serialize);

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rs/tests:common.bzl", "DEFAULT_VCPUS_PER_VM", "MAINNET_ENV", "MIN_LOCAL_CPUS", "UNIVERSAL_CANISTER_RUNTIME_DEPS")
+load("//rs/tests:common.bzl", "DEFAULT_VCPUS_PER_VM", "MAINNET_ENV", "MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS", "MIN_LOCAL_CPUS", "UNIVERSAL_CANISTER_RUNTIME_DEPS")
 load("//rs/tests:system_tests.bzl", "system_test", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -141,31 +141,17 @@ system_test_nns(
 
 system_test(
     name = "queues_compatibility_test",
-    # TODO: support this test on the local backend (drop `backend = "farm"`).
-    # The test downloads the mainnet `replicated-state-test` / `state-layout-test`
-    # binaries from an external URL, which doesn't work on the local backend
-    # because we don't allow network access for local tests:
-    #
-    #   thread 'main' panicked at rs/tests/message_routing/queues_compatibility_test.rs:102:6:
-    #   Failed to Download: ... Error: error sending request for url
-    #     (https://download.dfinity.systems/ic/<version>/release/replicated-state-test.gz)
-    #
-    # To support this locally the mainnet test binaries would have to be provided
-    # via a bazel dependency instead of being downloaded from the CDN.
-    backend = "farm",
-    cpus = MIN_LOCAL_CPUS,  # setup is `|_| ()`, no Farm VMs deployed.
+    cpus = MIN_LOCAL_CPUS,  # setup is `|_| ()`, no VMs deployed.
     env = MAINNET_ENV,
-    runtime_deps = {
+    guestos = False,  # The setup is `|_| ()` so no GuestOS image is ever booted.
+    runtime_deps = MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS | {
         "REPLICATED_STATE_TEST_BINARY_PATH": "//rs/replicated_state:replicated_state_test_binary",
         "STATE_LAYOUT_TEST_BINARY_PATH": "//rs/state_layout:state_layout_test_binary",
     },
     deps = [
-        "//rs/recovery",
         "//rs/tests/driver:ic-system-test-driver",
         "//rs/types/types",
         "@crate_index//:anyhow",
-        "@crate_index//:serde",
-        "@crate_index//:serde_json",
         "@crate_index//:slog",
         "@crate_index//:tempfile",
     ],

--- a/rs/tests/message_routing/Cargo.toml
+++ b/rs/tests/message_routing/Cargo.toml
@@ -14,7 +14,6 @@ dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-management-canister-types = { workspace = true }
-ic-recovery = { path = "../../recovery" }
 ic-registry-subnet-type = { path = "../../registry/subnet_type" }
 ic-system-test-driver = { path = "../driver" }
 ic-types = { path = "../../types/types" }

--- a/rs/tests/message_routing/queues_compatibility_test.rs
+++ b/rs/tests/message_routing/queues_compatibility_test.rs
@@ -8,7 +8,8 @@
 //! 2. We add a test that uses:
 //!
 //!    a. the binary from the commit that matches the latest mainnet versions, as
-//!    defined in mainnet-icos-revisions.json, (the binary is downloaded from S3)
+//!    defined in mainnet-icos-revisions.json (the binary is a bazel dependency,
+//!    see MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS in rs/tests/common.bzl)
 //!
 //!    b. the binary from the current commit
 //!
@@ -25,22 +26,15 @@
 //! a bit hacky, but gets around the annoying Rust test code visibility limitations,
 //! allowing the test serializers/deserializers to use unit test code from
 //! replicated_state.
-//!
-//! Implemented as a system test since binary downloads from the CDN don't
-//! work from plain Rust tests for some reason, and debugging/fixing this seems
-//! neither fun nor profitable.
 
 use anyhow::Result;
 use slog::{Logger, info};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
 
-use ic_recovery::file_sync_helper::download_binary;
 use ic_system_test_driver::driver::{group::SystemTestGroup, test_env::TestEnv, test_env_api::*};
 use ic_system_test_driver::systest;
-use ic_system_test_driver::util::block_on;
 use ic_types::ReplicaVersion;
 
 fn run_unit_test(
@@ -82,26 +76,6 @@ fn run_unit_test(
     output
 }
 
-fn download_mainnet_binary(
-    binary_name: &str,
-    version: &ReplicaVersion,
-    target_dir: &Path,
-    log: &Logger,
-) -> PathBuf {
-    block_on(ic_system_test_driver::retry_with_msg_async!(
-        "download mainnet binary",
-        log,
-        Duration::from_secs(30),
-        RETRY_BACKOFF,
-        || async {
-            download_binary(log, version, binary_name.into(), target_dir)
-                .await
-                .map_err(|e| e.into())
-        }
-    ))
-    .expect("Failed to Download")
-}
-
 /// Check that the artifacts produced by the `test_module` of `from_binary` can be ingested by
 /// the `test_module` of the `to_binary`
 ///
@@ -137,7 +111,12 @@ enum TestType {
     #[allow(dead_code)]
     SelfTestOnly,
     Bidirectional {
-        published_binary: String,
+        /// Env var holding the published ("mainnet") test binary, which is a bazel
+        /// runtime dependency built at `mainnet_version` (see
+        /// MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS in rs/tests/common.bzl).
+        published_binary_env_var: String,
+        /// Only used for logging: which binary we get is determined by the bazel
+        /// dependency, not resolved from the version at runtime.
         mainnet_version: ReplicaVersion,
     },
 }
@@ -160,11 +139,11 @@ impl TestCase {
     pub fn run(&self, logger: &Logger) {
         match &self.test_type {
             TestType::Bidirectional {
-                published_binary,
+                published_binary_env_var,
                 mainnet_version,
             } => {
                 self.self_test(logger);
-                self.bidirectional_test(mainnet_version, published_binary, logger)
+                self.bidirectional_test(mainnet_version, published_binary_env_var, logger)
             }
             TestType::SelfTestOnly => {
                 self.self_test(logger);
@@ -192,24 +171,17 @@ impl TestCase {
     fn bidirectional_test(
         &self,
         mainnet_version: &ReplicaVersion,
-        published_binary_name: &str,
+        published_binary_env_var: &str,
         logger: &Logger,
     ) {
-        let download_dir = tempfile::tempdir().unwrap();
-        let download_dir_path = download_dir.path();
-        let published_binary = download_mainnet_binary(
-            published_binary_name,
-            mainnet_version,
-            download_dir_path,
-            logger,
-        );
+        let published_binary = get_dependency_path_from_env(published_binary_env_var);
         let test_binary = get_dependency_path_from_env(&self.test_binary_env_var);
         info!(
             logger,
-            "Testing module {} with the mainnet commit {} and published binary {}",
+            "Testing module {} with the mainnet commit {} and published binary {:?}",
             self.test_module,
             mainnet_version,
-            published_binary_name,
+            published_binary,
         );
         for (direction, from, to) in [
             ("upgrade", &published_binary, &test_binary),
@@ -236,51 +208,53 @@ fn test(env: TestEnv) {
         mainnet_application_subnet_version
     );
 
-    let mainnet_versions = [mainnet_nns_version, mainnet_application_subnet_version];
+    // The published binaries of both mainnet versions are bazel runtime
+    // dependencies, named `<prefix>_<binary>` where `<prefix>` identifies the
+    // mainnet version. See MAINNET_QUEUES_COMPATIBILITY_RUNTIME_DEPS in
+    // rs/tests/common.bzl.
+    let mainnet_versions = [
+        ("MAINNET_NNS", mainnet_nns_version),
+        ("MAINNET_APP", mainnet_application_subnet_version),
+    ];
 
-    let tests = mainnet_versions.iter().flat_map(|v| {
+    let tests = mainnet_versions.iter().flat_map(|(prefix, version)| {
         [
-            TestCase::new(
-                TestType::Bidirectional {
-                    published_binary: "replicated-state-test".to_string(),
-                    mainnet_version: v.clone(),
-                },
+            (
+                "REPLICATED_STATE_TEST_PATH",
                 "REPLICATED_STATE_TEST_BINARY_PATH",
                 "canister_state::queues::tests::mainnet_compatibility_tests::basic_test",
             ),
-            TestCase::new(
-                TestType::Bidirectional {
-                    published_binary: "replicated-state-test".to_string(),
-                    mainnet_version: v.clone(),
-                },
+            (
+                "REPLICATED_STATE_TEST_PATH",
                 "REPLICATED_STATE_TEST_BINARY_PATH",
                 "canister_state::queues::tests::mainnet_compatibility_tests::best_effort_test",
             ),
-            TestCase::new(
-                TestType::Bidirectional {
-                    published_binary: "replicated-state-test".to_string(),
-                    mainnet_version: v.clone(),
-                },
+            (
+                "REPLICATED_STATE_TEST_PATH",
                 "REPLICATED_STATE_TEST_BINARY_PATH",
                 "canister_state::queues::tests::mainnet_compatibility_tests::input_order_test",
             ),
-            TestCase::new(
-                TestType::Bidirectional {
-                    published_binary: "replicated-state-test".to_string(),
-                    mainnet_version: v.clone(),
-                },
+            (
+                "REPLICATED_STATE_TEST_PATH",
                 "REPLICATED_STATE_TEST_BINARY_PATH",
                 "canister_state::queues::tests::mainnet_compatibility_tests::refunds_test",
             ),
-            TestCase::new(
-                TestType::Bidirectional {
-                    published_binary: "state-layout-test".to_string(),
-                    mainnet_version: v.clone(),
-                },
+            (
+                "STATE_LAYOUT_TEST_PATH",
                 "STATE_LAYOUT_TEST_BINARY_PATH",
                 "state_layout::tests::mainnet_compatibility_tests::task_queue_compatibility_test",
             ),
         ]
+        .map(|(published_binary, test_binary_env_var, test_module)| {
+            TestCase::new(
+                TestType::Bidirectional {
+                    published_binary_env_var: format!("{prefix}_{published_binary}"),
+                    mainnet_version: version.clone(),
+                },
+                test_binary_env_var,
+                test_module,
+            )
+        })
     });
 
     for t in tests {


### PR DESCRIPTION
`cup_compatibility_test` and `queues_compatibility_test` compare artifacts produced by the branch binaries against the ones produced by the binaries of the versions running on mainnet, which they downloaded from `download.dfinity.systems` while running. Take those from `@mainnet_{nns,app}_binaries` instead and drop `backend = "farm"`.

Also verifies their sha256, which the downloads did not, and drops 12 downloads per test run to 0.

### `guestos = False`

Both tests deploy no VMs — their setup is `|_| ()` — but `guestos` defaults to `True`, so they were pulling in the multi-GB GuestOS disk and update images, and the local backend `sha256sum`s every one of them on each run. Precedent: `//rs/tests/node:root_tests`. It's a separate commit so it can be reverted on its own.

### Verification

Both `_local` variants pass in ~1.5s:

```
//rs/tests/consensus/orchestrator:cup_compatibility_test_local   PASSED in 1.5s
//rs/tests/message_routing:queues_compatibility_test_local       PASSED in 1.4s
```

and the logs confirm the work actually happened rather than being skipped:

* cup ran both versions (`798712972b1e…` for the NNS subnet, `59c42492cd6e…` for the application subnet), 48 artifacts created and deserialized in each direction;
* queues ran all 10 bidirectional blocks, 5 per version, against two distinct `replicated-state-test` and two distinct `state-layout-test` binaries;
* neither log mentions `download.dfinity.systems`.

`cargo fmt --check` and clippy with CI's `--deny warnings --deny clippy::all` flags are clean for both crates. The Farm variants still build.

### Incidental cleanups

`//rs/recovery` and `tempfile` drop out of `cup_compatibility_test`, `//rs/recovery` out of `queues_compatibility_test`, plus `//rs/tests/consensus/utils`, `@crate_index//:serde` and `@crate_index//:serde_json`, which were already unused before this change. Line 140's `PathBuf::from(&std::env::var(...).unwrap())` becomes `get_dependency_path_from_env`, matching every other system test.

### Future Work

Consider whether these tests can become regular rust_tests instead of system-tests.