### PR TITLE
perf: Correct limit of derivation path length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7817,6 +7817,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "slog",
+ "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",

--- a/rs/crypto/BUILD.bazel
+++ b/rs/crypto/BUILD.bazel
@@ -56,6 +56,7 @@ rust_library(
         "@crate_index//:rustls",
         "@crate_index//:serde",
         "@crate_index//:slog",
+        "@crate_index//:static_assertions",
         "@crate_index//:strum",
         "@crate_index//:tempfile",
         "@crate_index//:tokio",

--- a/rs/crypto/Cargo.toml
+++ b/rs/crypto/Cargo.toml
@@ -48,6 +48,7 @@ rand_chacha = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 slog = { workspace = true }
+static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = { workspace = true }

--- a/rs/crypto/src/sign/canister_threshold_sig.rs
+++ b/rs/crypto/src/sign/canister_threshold_sig.rs
@@ -1,4 +1,6 @@
-use ic_crypto_internal_threshold_sig_canister_threshold_sig::IDkgTranscriptInternal;
+use ic_crypto_internal_threshold_sig_canister_threshold_sig::{
+    DerivationPath, IDkgTranscriptInternal,
+};
 use ic_types::crypto::canister_threshold_sig::MasterPublicKey;
 use ic_types::crypto::canister_threshold_sig::idkg::IDkgTranscript;
 use ic_types::crypto::canister_threshold_sig::idkg::IDkgTranscriptType::{Masked, Unmasked};
@@ -12,6 +14,16 @@ pub(crate) mod test_utils;
 mod tests;
 
 pub use idkg::{MegaKeyFromRegistryError, retrieve_mega_public_key_from_registry};
+
+// Before a derivation path reaches threshold key derivation, exactly one element
+// is prepended to it: the caller's principal when signing, and the target canister
+// id for the public key APIs.
+//
+// Were the two bounds equal, then a request at the maximum length would be rejected.
+static_assertions::const_assert_eq!(
+    ic_management_canister_types_private::MAXIMUM_DERIVATION_PATH_LENGTH + 1,
+    DerivationPath::MAXIMUM_DERIVATION_PATH_LENGTH
+);
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum MasterPublicKeyExtractionError {

--- a/rs/execution_environment/benches/management_canister/ecdsa.rs
+++ b/rs/execution_environment/benches/management_canister/ecdsa.rs
@@ -110,7 +110,7 @@ fn ecdsa_public_key_benchmark(c: &mut Criterion) {
             expect_error(
                 result,
                 ErrorCode::CanisterCalledTrap,
-                "Deserialize error: The number of elements exceeds maximum allowed 255",
+                "Deserialize error: The number of elements exceeds maximum allowed 254",
             )
         },
     );
@@ -123,7 +123,7 @@ fn ecdsa_public_key_benchmark(c: &mut Criterion) {
             expect_error(
                 result,
                 ErrorCode::CanisterCalledTrap,
-                "Deserialize error: The number of elements exceeds maximum allowed 255",
+                "Deserialize error: The number of elements exceeds maximum allowed 254",
             );
         },
     );
@@ -165,7 +165,7 @@ fn sign_with_ecdsa_benchmark(c: &mut Criterion) {
             expect_error(
                 result,
                 ErrorCode::CanisterCalledTrap,
-                "Deserialize error: The number of elements exceeds maximum allowed 255",
+                "Deserialize error: The number of elements exceeds maximum allowed 254",
             );
         },
     );
@@ -178,7 +178,7 @@ fn sign_with_ecdsa_benchmark(c: &mut Criterion) {
             expect_error(
                 result,
                 ErrorCode::CanisterCalledTrap,
-                "Deserialize error: The number of elements exceeds maximum allowed 255",
+                "Deserialize error: The number of elements exceeds maximum allowed 254",
             );
         },
     );

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -53,11 +53,16 @@ pub const HASH_LENGTH: usize = 32;
 ///
 /// The extended public key format uses a byte to represent the derivation
 /// level of a key, thus BIP32 derivations with more than 255 path elements
-/// are not interoperable with other software.
+/// are not interoperable with other software. This cap applies to the *full*
+/// path seen by threshold crypto, which the replica derives from the path
+/// supplied here by prepending exactly one element: the caller's principal
+/// for `sign_with_ecdsa`/`sign_with_schnorr`, and the target canister id for
+/// `ecdsa_public_key`/`schnorr_public_key`. One slot is therefore reserved
+/// for that prefix, leaving 254 for the caller.
 ///
 /// See https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format
 /// for details
-const MAXIMUM_DERIVATION_PATH_LENGTH: usize = 255;
+pub const MAXIMUM_DERIVATION_PATH_LENGTH: usize = 254;
 
 /// Limit the amount of work for skipping unneeded data on the wire when parsing Candid.
 /// The value of 10_000 follows the Candid recommendation.


### PR DESCRIPTION
The extended public key format uses one byte to represent the derivation level of a key, thus BIP32 derivations with more than 255 path elements are not interoperable with other software (see [here](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format)).

The crypto layer itself prepends one element, leaving 254 to the caller, while larger requests are rejected.

With this PR we therefore limit the path length to 254 elements, such that the request may already be rejected during deserialization.