### PR TITLE
feat: Do not route canister messages from a cooling down subnet

### DIFF
--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -480,6 +480,9 @@ impl StreamBuilderImpl {
                 // Destination subnet found.
                 Some(dst_subnet_id) => {
                     let is_loopback_stream = self.subnet_id == dst_subnet_id;
+                    let dst_subnet_topology = network_topology.subnets().get(&dst_subnet_id);
+                    let dst_subnet_type = dst_subnet_topology
+                        .map_or(SubnetType::Application, |topology| topology.subnet_type);
 
                     // No messages from canister output queues are routed while either
                     // this subnet (the source) or the destination subnet is cooling down;
@@ -488,7 +491,7 @@ impl StreamBuilderImpl {
                     // cooling down anymore, rather than rejecting or dropping it.
                     if !is_from_subnet_queues
                         && (own_subnet_is_cooling_down
-                            || network_topology.is_cooling_down(&dst_subnet_id))
+                            || dst_subnet_topology.is_some_and(|topology| topology.cooling_down))
                     {
                         self.metrics.cooling_down_skipped_queues.inc();
                         output_iter.exclude_queue();
@@ -496,15 +499,7 @@ impl StreamBuilderImpl {
                     }
 
                     let dst_stream_entry = streams.entry(dst_subnet_id);
-                    if !is_loopback_stream
-                        && is_at_limit(
-                            &dst_stream_entry,
-                            network_topology
-                                .subnets()
-                                .get(&dst_subnet_id)
-                                .map_or(SubnetType::Application, |topology| topology.subnet_type),
-                        )
-                    {
+                    if !is_loopback_stream && is_at_limit(&dst_stream_entry, dst_subnet_type) {
                         // Stream full, skip all other messages to this destination.
                         output_iter.exclude_queue();
                         continue;
@@ -513,11 +508,8 @@ impl StreamBuilderImpl {
                     // We will route (or reject) the message, pop it.
                     let mut msg = validated_next(&mut output_iter, &msg);
 
-                    let is_engine_dst = !is_loopback_stream
-                        && network_topology
-                            .subnets()
-                            .get(&dst_subnet_id)
-                            .is_some_and(|t| t.subnet_type == SubnetType::CloudEngine);
+                    let is_engine_dst =
+                        !is_loopback_stream && dst_subnet_type == SubnetType::CloudEngine;
                     let is_engine_src =
                         !is_loopback_stream && own_subnet_type == SubnetType::CloudEngine;
 

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -412,7 +412,7 @@ impl StreamBuilderImpl {
         // Tests whether a stream is over the message count limit, byte limit or (if
         // directed at a system subnet) over `2 * system_subnet_stream_msg_limit`.
         let is_at_limit = |stream: &btree_map::Entry<SubnetId, Stream>,
-                           destination_subnet_type: SubnetType|
+                           destination_subnet_type: Option<SubnetType>|
          -> bool {
             let stream = match stream {
                 btree_map::Entry::Occupied(occupied_entry) => occupied_entry.get(),
@@ -431,7 +431,7 @@ impl StreamBuilderImpl {
             // At limit if system subnet limit is hit. This is only enforced for non-local
             // streams to system subnets (i.e., excluding the loopback stream on system
             // subnets). And only applies to canister messages, not refunds.
-            destination_subnet_type == SubnetType::System
+            destination_subnet_type == Some(SubnetType::System)
                 && stream_messages_len - stream.refund_count()
                     >= 2 * self.system_subnet_stream_msg_limit
         };
@@ -481,8 +481,7 @@ impl StreamBuilderImpl {
                 Some(dst_subnet_id) => {
                     let is_loopback_stream = self.subnet_id == dst_subnet_id;
                     let dst_subnet_topology = network_topology.subnets().get(&dst_subnet_id);
-                    let dst_subnet_type = dst_subnet_topology
-                        .map_or(SubnetType::Application, |topology| topology.subnet_type);
+                    let dst_subnet_type = dst_subnet_topology.map(|topology| topology.subnet_type);
 
                     // No messages from canister output queues are routed while either
                     // this subnet (the source) or the destination subnet is cooling down;
@@ -509,7 +508,7 @@ impl StreamBuilderImpl {
                     let mut msg = validated_next(&mut output_iter, &msg);
 
                     let is_engine_dst =
-                        !is_loopback_stream && dst_subnet_type == SubnetType::CloudEngine;
+                        !is_loopback_stream && dst_subnet_type == Some(SubnetType::CloudEngine);
                     let is_engine_src =
                         !is_loopback_stream && own_subnet_type == SubnetType::CloudEngine;
 

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -42,8 +42,8 @@ struct StreamBuilderMetrics {
     pub routed_payload_sizes: Histogram,
     /// Misrouted messages currently in streams, by remote subnet.
     pub stream_misrouted_messages: IntGaugeVec,
-    /// Canister output queues skipped because their destination subnet was
-    /// cooling down.
+    /// Canister output queues skipped because this subnet or their destination
+    /// subnet was cooling down.
     pub cooling_down_skipped_queues: IntCounter,
     /// Critical error for payloads above the maximum supported size.
     pub critical_error_payload_too_large: IntCounter,
@@ -132,9 +132,9 @@ impl StreamBuilderMetrics {
         );
         let cooling_down_skipped_queues = metrics_registry.int_counter(
             METRIC_COOLING_DOWN_SKIPPED_QUEUES,
-            "Canister output queues skipped because their destination subnet was cooling down. \
-            Counted once per queue per round, so the same queue is counted repeatedly for as \
-            long as the destination subnet keeps cooling down.",
+            "Canister output queues skipped because this subnet or their destination subnet \
+            was cooling down. Counted once per queue per round, so the same queue is counted \
+            repeatedly for as long as either subnet keeps cooling down.",
         );
         let critical_error_payload_too_large =
             metrics_registry.error_counter(CRITICAL_ERROR_PAYLOAD_TOO_LARGE);
@@ -456,6 +456,7 @@ impl StreamBuilderImpl {
         // No canister can have the subnet's own principal as its canister ID, so this
         // identifies the messages taken from the subnet's own output queues.
         let own_subnet_as_canister_id = CanisterId::from(self.subnet_id);
+        let own_subnet_is_cooling_down = network_topology.is_cooling_down(&self.subnet_id);
 
         let mut requests_to_reject = Vec::new();
         let mut oversized_requests = Vec::new();
@@ -480,11 +481,15 @@ impl StreamBuilderImpl {
                 Some(dst_subnet_id) => {
                     let is_loopback_stream = self.subnet_id == dst_subnet_id;
 
-                    // A cooling down destination subnet must not be sent any messages
-                    // from canister output queues. Retain the message (along with
-                    // everything behind it in the same queue) until the destination stops
-                    // cooling down, rather than rejecting or dropping it.
-                    if !is_from_subnet_queues && network_topology.is_cooling_down(&dst_subnet_id) {
+                    // No messages from canister output queues are routed while either
+                    // this subnet (the source) or the destination subnet is cooling down;
+                    // not even into the loopback stream. Retain the message (along with
+                    // everything behind it in the same queue) until neither subnet is
+                    // cooling down anymore, rather than rejecting or dropping it.
+                    if !is_from_subnet_queues
+                        && (own_subnet_is_cooling_down
+                            || network_topology.is_cooling_down(&dst_subnet_id))
+                    {
                         self.metrics.cooling_down_skipped_queues.inc();
                         output_iter.exclude_queue();
                         continue;

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -1167,7 +1167,7 @@ mod cooling_down {
     /// The sender of all messages in the tests below, hosted by `LOCAL_SUBNET`.
     const SENDER_CANISTER: CanisterId = CanisterId::from_u64(0);
     /// The destination canister, hosted by the cooling down subnet (which is
-    /// `LOCAL_SUBNET` itself in `new_loopback_cooling_down_fixture()`).
+    /// `LOCAL_SUBNET` itself in `new_local_cooling_down_fixture()`).
     const COOLING_DOWN_CANISTER: CanisterId = CanisterId::from_u64(1);
     /// A canister hosted by `OTHER_SUBNET`.
     const OTHER_CANISTER: CanisterId = CanisterId::from_u64(2);
@@ -1203,9 +1203,11 @@ mod cooling_down {
     }
 
     /// Same as `new_cooling_down_fixture()`, except that `COOLING_DOWN_CANISTER` is
-    /// hosted by `LOCAL_SUBNET` and it is `LOCAL_SUBNET` that is cooling down; i.e.
-    /// the messages to `COOLING_DOWN_CANISTER` would go into the loopback stream.
-    fn new_loopback_cooling_down_fixture(
+    /// hosted by `LOCAL_SUBNET` and it is `LOCAL_SUBNET` that is cooling down. I.e.
+    /// `LOCAL_SUBNET` is both the source subnet of all messages below and the
+    /// destination subnet of the messages to `COOLING_DOWN_CANISTER` (which would go
+    /// into the loopback stream); while `OTHER_SUBNET` is not cooling down.
+    fn new_local_cooling_down_fixture(
         log: &ReplicaLogger,
     ) -> (StreamBuilderImpl, ReplicatedState, MetricsRegistry) {
         let (stream_builder, mut state, metrics_registry) = new_fixture(log);
@@ -1364,6 +1366,9 @@ mod cooling_down {
     /// attached. Every combination is exercised twice: with a remote subnet cooling
     /// down; and with `LOCAL_SUBNET` itself cooling down, i.e. the loopback stream is
     /// not exempt either.
+    ///
+    /// See `build_streams_retains_messages_from_cooling_down_subnet()` for the
+    /// mirror image, i.e. a cooling down source subnet.
     #[test]
     fn build_streams_retains_messages_to_cooling_down_subnet() {
         for cooling_down_subnet in [COOLING_DOWN_SUBNET, LOCAL_SUBNET] {
@@ -1374,7 +1379,7 @@ mod cooling_down {
                     with_test_replica_logger(|log| {
                         let (stream_builder, mut provided_state, metrics_registry) =
                             if cooling_down_subnet == LOCAL_SUBNET {
-                                new_loopback_cooling_down_fixture(&log)
+                                new_local_cooling_down_fixture(&log)
                             } else {
                                 new_cooling_down_fixture(&log)
                             };
@@ -1457,6 +1462,66 @@ mod cooling_down {
             assert_eq!(1, fetch_cooling_down_skipped_queues(&metrics_registry));
             assert_eq_critical_errors(0, 0, 0, &metrics_registry);
         });
+    }
+
+    /// Tests that a canister message from a canister on a cooling down subnet is
+    /// retained in the sending canister's output queue -- rather than routed,
+    /// rejected or dropped -- even though the destination subnet is not cooling
+    /// down; and that it is routed as soon as the source subnet stops cooling down.
+    ///
+    /// Covers the full matrix of: request vs. response; unbounded-wait vs.
+    /// bounded-wait; and with no cycles vs. 1T cycles attached; addressed to a
+    /// canister on a subnet that is not cooling down and to that subnet itself (i.e.
+    /// its management canister); as well as to a local canister and to `LOCAL_SUBNET`
+    /// itself, i.e. the loopback stream is not exempt either (which is also covered
+    /// by `build_streams_retains_messages_to_cooling_down_subnet()`, the source and
+    /// the destination subnet being one and the same for a loopback message).
+    #[test]
+    fn build_streams_retains_messages_from_cooling_down_subnet() {
+        for (receiver, dst_subnet) in [
+            (OTHER_CANISTER, OTHER_SUBNET),
+            (CanisterId::from(OTHER_SUBNET), OTHER_SUBNET),
+            (COOLING_DOWN_CANISTER, LOCAL_SUBNET),
+            (CanisterId::from(LOCAL_SUBNET), LOCAL_SUBNET),
+        ] {
+            for msg in cooling_down_message_matrix(receiver) {
+                with_test_replica_logger(|log| {
+                    let (stream_builder, mut provided_state, metrics_registry) =
+                        new_local_cooling_down_fixture(&log);
+                    provided_state
+                        .put_canister_states(canister_states_with_outputs(vec![msg.clone()]));
+
+                    let mut result_state = stream_builder.build_streams(provided_state);
+
+                    // Nothing was routed into the stream to the destination subnet; the
+                    // message is still in the sender's output queue; and no reject response
+                    // was generated for it.
+                    assert_no_messages_routed(&result_state, dst_subnet);
+                    assert_eq!(
+                        vec![msg.clone()],
+                        output_queue_contents(&result_state, SENDER_CANISTER, receiver)
+                    );
+                    assert!(
+                        !result_state
+                            .canister_state(&SENDER_CANISTER)
+                            .unwrap()
+                            .has_input()
+                    );
+
+                    assert_routed_messages_eq(MetricVec::new(), &metrics_registry);
+                    assert_eq!(1, fetch_cooling_down_skipped_queues(&metrics_registry));
+                    assert_eq_critical_errors(0, 0, 0, &metrics_registry);
+
+                    // And it is routed as soon as the source subnet stops cooling down.
+                    clear_cooling_down(&mut result_state, LOCAL_SUBNET);
+                    let result_state = stream_builder.build_streams(result_state);
+                    assert_eq!(
+                        vec![StreamMessage::from(msg)],
+                        routed_messages(&result_state, dst_subnet)
+                    );
+                });
+            }
+        }
     }
 }
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -33,8 +33,7 @@ message SubnetTopology {
   repeated types.v1.MasterPublicKeyId chain_keys_held = 6;
   registry.subnet.v1.CanisterCyclesCostSchedule canister_cycles_cost_schedule = 7;
   repeated types.v1.PrincipalId subnet_admins = 8;
-  // Whether the subnet is "cooling down", i.e. quiescing: it inducts no ingress
-  // messages.
+  // Whether the subnet is "cooling down", i.e. quiescing.
   //
   // See `ic_replicated_state::SubnetTopology::cooling_down` for the exact
   // semantics.

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -35,8 +35,7 @@ pub struct SubnetTopology {
     pub canister_cycles_cost_schedule: i32,
     #[prost(message, repeated, tag = "8")]
     pub subnet_admins: ::prost::alloc::vec::Vec<super::super::super::types::v1::PrincipalId>,
-    /// Whether the subnet is "cooling down", i.e. quiescing: it inducts no ingress
-    /// messages.
+    /// Whether the subnet is "cooling down", i.e. quiescing.
     ///
     /// See `ic_replicated_state::SubnetTopology::cooling_down` for the exact
     /// semantics.

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -434,11 +434,11 @@ pub struct SubnetTopology {
     ///    expiring message statuses;
     ///  * (on all subnets) no messages are routed to a cooling down subnet --
     ///    including into the cooling down subnet's own loopback stream -- but
-    ///    retained in their respective output queues, so that the respective
-    ///    streams can be emptied;
-    ///  * it routes no messages from its canisters' output queues into any of
-    ///    its streams -- including its own loopback stream -- but retains them
-    ///    in those output queues, so that its streams can be emptied.
+    ///    retained in their respective output queues, so that streams to the
+    ///    cooling down subnet can be emptied;
+    ///  * it routes no messages from its canisters' output queues into streams
+    ///    -- including its own loopback stream -- but retains them in output
+    ///    queues, so streams from the cooling down subnet can be emptied.
     pub cooling_down: bool,
 }
 

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -435,7 +435,10 @@ pub struct SubnetTopology {
     ///  * (on all subnets) no messages are routed to a cooling down subnet --
     ///    including into the cooling down subnet's own loopback stream -- but
     ///    retained in their respective output queues, so that the respective
-    ///    streams can be emptied.
+    ///    streams can be emptied;
+    ///  * it routes no messages from its canisters' output queues into any of
+    ///    its streams -- including its own loopback stream -- but retains them
+    ///    in those output queues, so that its streams can be emptied.
     pub cooling_down: bool,
 }
 


### PR DESCRIPTION
Messages (requests and responses) in canister output queues are no longer routed into streams while the source subnet is cooling down. They are retained in their output queues until the subnet stops cooling down, rather than being rejected or dropped. This includes the loopback stream, i.e. a cooling down subnet does not route its canisters' messages to its loopback stream either.

The check is merged into the existing destination side check, so a queue is skipped (and counted in `mr_cooling_down_skipped_queues`) exactly once per round, whether it is the source subnet, the destination subnet, or both that are cooling down. As before, messages from the subnet's own output queues are exempt.