### PR TITLE
feat: Record canisters dropped by an online subnet split as deleted

### DIFF
--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -1335,7 +1335,7 @@ impl SystemMetadata {
             // retaining everything else on subnet A'.
             blockmaker_metrics_time_series,
             // Just updated by `ReplicatedState::online_split()`, adding delete operations
-            // for the snapshots of no longer hosted canisters.
+            // for the canisters dropped by the split.
             unflushed_checkpoint_ops,
             // Transient field; reset so that `generate_reject_responses_for_deleted_subnets()`
             // runs unconditionally on the first post-split round.

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -1191,8 +1191,9 @@ impl SystemMetadata {
     ///  * `heap_delta_estimate` and `expected_compiled_wasms` are expected to be
     ///    empty/zero.
     ///  * `unflushed_checkpoint_ops` contains both arbitrary pending operations;
-    ///    and delete operations for the snapshots of non-local canisters. It is
-    ///    therefore preserved untouched.
+    ///    and the delete operations recorded by `ReplicatedState::online_split()`
+    ///    for the canisters dropped by the split. It is therefore preserved
+    ///    untouched.
     pub fn online_split(
         self,
         subnet_id: SubnetId,

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1588,7 +1588,9 @@ impl ReplicatedState {
     /// Splitting the replicated state consists of:
     ///
     ///  * Retaining only the canisters that are to be hosted by `subnet_id`, as
-    ///    determined by the routing table (*hosted canisters*).
+    ///    determined by the routing table (*hosted canisters*); and recording the
+    ///    removal of the rest as `UnflushedCheckpointOp::DeleteCanister`, so that
+    ///    their directories are deleted from tip at the next flush.
     ///  * Retaining only the snapshots of *hosted canisters*.
     ///  * Pruning the ingress history, retaining only messages addressed to this
     ///    subnet and messages in terminal states (which will eventually time out).
@@ -1640,8 +1642,21 @@ impl ReplicatedState {
             );
         });
 
-        // Retain only canisters hosted by this subnet.
+        // Retain only canisters hosted by this subnet; and record the removal of the
+        // others, so that their directories are deleted from tip at the next flush,
+        // i.e. every round, and in order relative to the other checkpoint operations;
+        // rather than only when the next checkpoint is created.
+        let dropped_canister_ids: Vec<CanisterId> = canister_states
+            .all_keys()
+            .filter(|canister_id| lookup_subnet(canister_id) != Some(subnet_id))
+            .cloned()
+            .collect();
         canister_states.retain(|canister_id, _| lookup_subnet(canister_id) == Some(subnet_id));
+        for canister_id in dropped_canister_ids {
+            metadata
+                .unflushed_checkpoint_ops
+                .delete_canister(canister_id);
+        }
 
         // Adjust `CanisterQueues::(local|remote)_subnet_input_schedule` based on which
         // canisters are present in `canister_states`.

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1590,7 +1590,8 @@ impl ReplicatedState {
     ///  * Retaining only the canisters that are to be hosted by `subnet_id`, as
     ///    determined by the routing table (*hosted canisters*); and recording the
     ///    removal of the rest as `UnflushedCheckpointOp::DeleteCanister`, so that
-    ///    their directories are deleted from tip at the next flush.
+    ///    their directories are explicitly deleted from tip, in order relative to the
+    ///    other checkpoint operations.
     ///  * Retaining only the snapshots of *hosted canisters*.
     ///  * Pruning the ingress history, retaining only messages addressed to this
     ///    subnet and messages in terminal states (which will eventually time out).
@@ -1643,9 +1644,14 @@ impl ReplicatedState {
         });
 
         // Retain only canisters hosted by this subnet; and record the removal of the
-        // others, so that their directories are deleted from tip at the next flush,
-        // i.e. every round, and in order relative to the other checkpoint operations;
-        // rather than only when the next checkpoint is created.
+        // others, so that their directories are deleted from tip by the flush of these
+        // operations, in order relative to the other checkpoint operations.
+        //
+        // A splitting batch always requires a full state hash, so the split round is
+        // always a checkpoint round and `FilterTipCanisters` would remove the very same
+        // directories later in the same round. Recording the removals makes every
+        // canister directory mutation in tip an explicit, ordered operation, leaving
+        // `FilterTipCanisters` as a pure safety net.
         let dropped_canister_ids: Vec<CanisterId> = canister_states
             .all_keys()
             .filter(|canister_id| lookup_subnet(canister_id) != Some(subnet_id))

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1255,13 +1255,6 @@ fn split() {
     assert_eq!(expected, state_b);
 }
 
-/// Drops a canister from the state the same way `online_split()` does, i.e. without
-/// recording an `UnflushedCheckpointOp::DeleteCanister`.
-fn drop_canister(state: &mut ReplicatedState, canister_id: &CanisterId) {
-    state.take_canister_state(canister_id).unwrap();
-    state.metadata.subnet_schedule.remove(canister_id);
-}
-
 #[test]
 fn online_split() {
     // We will be splitting subnet A into A' and B.
@@ -1381,7 +1374,7 @@ fn online_split() {
     // Start off with the original state (plus new routing table).
     let mut expected = fixture.state.clone();
     // Only `CANISTER_1` should be left.
-    drop_canister(&mut expected, &CANISTER_2);
+    expected.remove_canister(&CANISTER_2);
     // The input schedules of `CANISTER_1` should have been repartitioned.
     let mut canister_state_arc = expected.take_canister_state(&CANISTER_1).unwrap();
     let canister_state = Arc::make_mut(&mut canister_state_arc);
@@ -1414,7 +1407,7 @@ fn online_split() {
     // New subnet ID.
     expected.metadata.own_subnet_id = SUBNET_B;
     // Only `CANISTER_2` should be hosted.
-    drop_canister(&mut expected, &CANISTER_1);
+    expected.remove_canister(&CANISTER_1);
     // The input schedules of `CANISTER_2` should have been repartitioned.
     let mut canister_state_arc = expected.take_canister_state(&CANISTER_2).unwrap();
     let canister_state = Arc::make_mut(&mut canister_state_arc);

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -106,9 +106,10 @@ pub(crate) enum TipRequest {
     },
     /// Filter canisters and snapshots in tip. Remove ones not present in the sets.
     ///
-    /// Canisters deleted during execution are removed from tip via
-    /// `UnflushedCheckpointOp::DeleteCanister`, so this only needs to catch canisters
-    /// dropped without a corresponding operation, i.e. during subnet splitting.
+    /// Canisters deleted during execution and canisters dropped by an online subnet
+    /// split are removed from tip via `UnflushedCheckpointOp::DeleteCanister`, so this
+    /// is only a safety net for canisters that disappeared from the state without a
+    /// corresponding operation.
     ///
     /// State: `tip_folder_state.has_filtered_canisters = true`
     FilterTipCanisters {

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8258,14 +8258,6 @@ fn restore_chunk_store_from_snapshot() {
     assert!(env.execute_ingress(canister_id, "read", vec![],).is_err(),);
 }
 
-/// Drops a canister from the state the same way `online_split()` does, i.e. without
-/// recording an `UnflushedCheckpointOp::DeleteCanister`: canisters dropped during a
-/// subnet split are removed from tip by `FilterTipCanisters` instead.
-fn drop_canister(state: &mut ReplicatedState, canister_id: &CanisterId) {
-    state.take_canister_state(canister_id).unwrap();
-    state.metadata.subnet_schedule.remove(canister_id);
-}
-
 #[test]
 fn can_split_with_inflight_restore_snapshot() {
     // We will be splitting subnet A into A' and B.
@@ -8348,11 +8340,11 @@ fn can_split_with_inflight_restore_snapshot() {
             if subnet_id == SUBNET_A {
                 other_subnet_id = SUBNET_B;
                 // `SUBNET_A` should only host `CANISTER_1` (and preserve its snapshot).
-                drop_canister(&mut expected, &CANISTER_2);
+                expected.remove_canister(&CANISTER_2);
             } else if subnet_id == SUBNET_B {
                 other_subnet_id = SUBNET_A;
                 // `SUBNET_B` should only host `CANISTER_2`.
-                drop_canister(&mut expected, &CANISTER_1);
+                expected.remove_canister(&CANISTER_1);
             } else {
                 unreachable!("Unexpected subnet ID: {:?}", subnet_id);
             }
@@ -8486,6 +8478,82 @@ fn can_rename_canister() {
     }
     can_rename_canister_impl(CertificationScope::Metadata);
     can_rename_canister_impl(CertificationScope::Full);
+}
+
+#[test]
+fn canister_dropped_by_split_is_removed_from_tip() {
+    fn canister_dropped_by_split_is_removed_from_tip_impl(certification_scope: CertificationScope) {
+        const SUBNET_A: SubnetId = SUBNET_1;
+        const SUBNET_B: SubnetId = SUBNET_2;
+        const RETAINED: CanisterId = CanisterId::from_u64(100);
+        const DROPPED: CanisterId = CanisterId::from_u64(200);
+
+        state_manager_test(|_metrics, state_manager| {
+            // Install both canisters and checkpoint the state, so that both have a
+            // directory in the tip.
+            let (_height, mut state) = state_manager.take_tip();
+            state.metadata.own_subnet_id = SUBNET_A;
+            insert_dummy_canister(&mut state, RETAINED);
+            insert_dummy_canister(&mut state, DROPPED);
+            state_manager.commit_and_certify(state, CertificationScope::Full, None);
+            state_manager.flush_tip_channel();
+
+            let (height, mut state) = state_manager.take_tip();
+            let tip = CheckpointLayout::<ReadOnly>::new_untracked(
+                state_manager.state_layout().raw_path().join("tip"),
+                height,
+            )
+            .unwrap();
+            assert_eq!(tip.canister_ids().unwrap(), vec![RETAINED, DROPPED]);
+
+            // Retain `RETAINED` on `SUBNET_A`, migrate `DROPPED` to `SUBNET_B`.
+            let routing_table = RoutingTable::try_from(btreemap! {
+                CanisterIdRange {start: CanisterId::from_u64(0), end: RETAINED} => SUBNET_A,
+                CanisterIdRange {start: DROPPED, end: DROPPED} => SUBNET_B,
+                CanisterIdRange {start: CanisterId::from_u64(201), end: CanisterId::from_u64(CANISTER_IDS_PER_SUBNET - 1)} => SUBNET_A,
+            })
+            .unwrap();
+            state.metadata.modify_network_topology(|network_topology| {
+                network_topology.set_routing_table(routing_table);
+            });
+
+            // Split the subnet, retaining `SUBNET_A`.
+            let state = state.online_split(SUBNET_A, SUBNET_B).unwrap();
+            assert_eq!(
+                state.canister_states().all_keys().collect::<Vec<_>>(),
+                vec![&RETAINED]
+            );
+            // The canister dropped by the split was recorded as deleted.
+            assert!(!state.system_metadata().unflushed_checkpoint_ops.is_empty());
+
+            // Trigger a flush either at the checkpoint or by committing exactly
+            // `NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY` rounds before the checkpoint.
+            if certification_scope == CertificationScope::Full {
+                state_manager.commit_and_certify(state, certification_scope.clone(), None);
+            } else {
+                state_manager.commit_and_certify(
+                    state,
+                    certification_scope.clone(),
+                    Some(BatchSummary {
+                        next_checkpoint_height: Height(
+                            2 + NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY,
+                        ),
+                        current_interval_length: Height(500),
+                    }),
+                );
+            }
+            state_manager.flush_tip_channel();
+
+            // The dropped canister's directory is gone from the tip, even without a
+            // checkpoint, i.e. without `FilterTipCanisters` having run.
+            assert_eq!(tip.canister_ids().unwrap(), vec![RETAINED]);
+            // And the checkpoint op has been flushed.
+            let (_height, state) = state_manager.take_tip();
+            assert!(state.system_metadata().unflushed_checkpoint_ops.is_empty());
+        });
+    }
+    canister_dropped_by_split_is_removed_from_tip_impl(CertificationScope::Metadata);
+    canister_dropped_by_split_is_removed_from_tip_impl(CertificationScope::Full);
 }
 
 #[test]

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -29,7 +29,7 @@ use ic_replicated_state::{
     canister_state::canister_snapshots::CanisterSnapshot,
     canister_state::{execution_state::WasmBinary, system_state::wasm_chunk_store::WasmChunkStore},
     metadata_state::{
-        ApiBoundaryNodeEntry,
+        ApiBoundaryNodeEntry, UnflushedCheckpointOp,
         testing::{NetworkTopologyTesting, SystemMetadataTesting},
     },
     page_map::{PageIndex, Shard, StorageLayout},
@@ -8524,7 +8524,14 @@ fn canister_dropped_by_split_is_removed_from_tip() {
                 vec![&RETAINED]
             );
             // The canister dropped by the split was recorded as deleted.
-            assert!(!state.system_metadata().unflushed_checkpoint_ops.is_empty());
+            assert_eq!(
+                state
+                    .system_metadata()
+                    .unflushed_checkpoint_ops
+                    .clone()
+                    .take(),
+                vec![UnflushedCheckpointOp::DeleteCanister(DROPPED)]
+            );
 
             // Trigger a flush either at the checkpoint or by committing exactly
             // `NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY` rounds before the checkpoint.

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -8480,6 +8480,15 @@ fn can_rename_canister() {
     can_rename_canister_impl(CertificationScope::Full);
 }
 
+/// Tests that a canister dropped by `ReplicatedState::online_split()` is removed
+/// from the tip by the flush of the recorded `UnflushedCheckpointOp::DeleteCanister`,
+/// i.e. without relying on `FilterTipCanisters`.
+///
+/// Note that in production a splitting batch always requires a full state hash (see
+/// `Batch::requires_full_state_hash()`), so the split round is always a checkpoint
+/// round and `FilterTipCanisters` would remove the directory in the same round
+/// anyway. The `CertificationScope::Metadata` case below therefore exercises the
+/// flush mechanism in isolation, not a state reachable in production.
 #[test]
 fn canister_dropped_by_split_is_removed_from_tip() {
     fn canister_dropped_by_split_is_removed_from_tip_impl(certification_scope: CertificationScope) {
@@ -8551,8 +8560,9 @@ fn canister_dropped_by_split_is_removed_from_tip() {
             }
             state_manager.flush_tip_channel();
 
-            // The dropped canister's directory is gone from the tip, even without a
-            // checkpoint, i.e. without `FilterTipCanisters` having run.
+            // The dropped canister's directory is gone from the tip. In the
+            // `Metadata` case this is solely due to the flushed delete operation, as
+            // `FilterTipCanisters` only runs when a checkpoint is created.
             assert_eq!(tip.canister_ids().unwrap(), vec![RETAINED]);
             // And the checkpoint op has been flushed.
             let (_height, state) = state_manager.take_tip();


### PR DESCRIPTION
`ReplicatedState::online_split()` retained only the canisters hosted by this subnet, dropping the rest without recording an
`UnflushedCheckpointOp::DeleteCanister`. Their directories were therefore removed from tip only when the next checkpoint was created, by `FilterTipCanisters`.

Record the removals, so that the directories are deleted from tip at the next flush, and in order relative to the other checkpoint operations. `FilterTipCanisters` is retained as a safety net for canisters that disappear from the state without a corresponding operation.

The `drop_canister` test helpers, which emulated dropping a canister without recording the operation, are replaced by `ReplicatedState::remove_canister()` again, which now models an online split exactly.