### PR TITLE
chore: Even better error messages for invalid keys

### DIFF
--- a/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
@@ -103,6 +103,12 @@ pub fn algo_id_and_public_key_bytes_from_der(
 /// DER-encoded key.
 pub const MAX_DER_NESTING_DEPTH: usize = 4;
 
+const SEQUENCE_TAG_NUMBER: u8 = 0x10;
+const SET_TAG_NUMBER: u8 = 0x11;
+
+const INCOMPLETE_ELEMENT: &str = "DER ends in the middle of an element";
+const LENGTH_TOO_LARGE: &str = "DER element length is too large";
+
 /// Parser for DER-encoded keys.
 struct KeyDerParser {
     key_der: Vec<u8>,
@@ -235,13 +241,12 @@ impl KeyDerParser {
         }
     }
 
-    /// Returns an error if `der` nests constructed ASN.1 elements more than
-    /// [`MAX_DER_NESTING_DEPTH`] levels deep. The scan only walks the
-    /// tag-length headers and leaves the actual decoding (and any other
-    /// structural error) to `simple_asn1`.
+    /// Returns an error if `der` nests ASN.1 elements more than
+    /// [`MAX_DER_NESTING_DEPTH`] levels deep, or if its tag-length headers
+    /// cannot be walked from start to end.
     fn check_der_nesting_depth(der: &[u8]) -> Result<(), KeyDerParsingError> {
-        // Exclusive end offsets of the constructed elements that are currently
-        // open; their number is the current nesting depth.
+        // Exclusive end offsets of the elements that are currently open; their
+        // number is the current nesting depth.
         let mut open_elements_end: Vec<usize> = Vec::new();
         let mut index = 0;
         while index < der.len() {
@@ -255,31 +260,47 @@ impl KeyDerParser {
 
             // Identifier octets: skip the high-tag-number form if present.
             let first_identifier_octet = der[index];
+            let universal_class = first_identifier_octet & 0xc0 == 0;
             let constructed = first_identifier_octet & 0x20 != 0;
+            let tag_number = first_identifier_octet & 0x1f;
+            let high_tag_number_form = tag_number == 0x1f;
             index += 1;
-            if first_identifier_octet & 0x1f == 0x1f {
+            if high_tag_number_form {
                 while index < der.len() && der[index] & 0x80 != 0 {
                     index += 1;
                 }
                 index += 1;
             }
 
+            // SEQUENCEs and SETs hold other elements whatever their
+            // constructed bit says; elements of the other classes hold other
+            // elements when it is set. The high-tag-number form can encode the
+            // SEQUENCE and SET tag numbers, so it is counted as well.
+            let container = if high_tag_number_form {
+                true
+            } else if universal_class {
+                tag_number == SEQUENCE_TAG_NUMBER || tag_number == SET_TAG_NUMBER
+            } else {
+                constructed
+            };
+
             // Length octets: short form, or long form giving the octet count.
+            // A first octet of 0x80 gives a length of zero.
             let Some(&first_length_octet) = der.get(index) else {
-                return Ok(());
+                return Err(Self::parsing_error(INCOMPLETE_ELEMENT));
             };
             index += 1;
             let content_length = if first_length_octet & 0x80 == 0 {
                 first_length_octet as usize
             } else {
                 let num_length_octets = (first_length_octet & 0x7f) as usize;
-                if num_length_octets == 0 || num_length_octets > core::mem::size_of::<usize>() {
-                    return Ok(());
+                if num_length_octets > core::mem::size_of::<usize>() {
+                    return Err(Self::parsing_error(LENGTH_TOO_LARGE));
                 }
                 let mut length = 0;
                 for _ in 0..num_length_octets {
                     let Some(&octet) = der.get(index) else {
-                        return Ok(());
+                        return Err(Self::parsing_error(INCOMPLETE_ELEMENT));
                     };
                     length = (length << 8) | octet as usize;
                     index += 1;
@@ -288,12 +309,12 @@ impl KeyDerParser {
             };
 
             let Some(content_end) = index.checked_add(content_length) else {
-                return Ok(());
+                return Err(Self::parsing_error(LENGTH_TOO_LARGE));
             };
             if content_end > der.len() {
-                return Ok(());
+                return Err(Self::parsing_error(INCOMPLETE_ELEMENT));
             }
-            if constructed {
+            if container {
                 if open_elements_end.len() + 1 > MAX_DER_NESTING_DEPTH {
                     return Err(Self::parsing_error(&format!(
                         "DER nesting depth exceeds the maximum of {MAX_DER_NESTING_DEPTH}"

--- a/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/lib.rs
@@ -266,7 +266,9 @@ impl KeyDerParser {
             let high_tag_number_form = tag_number == 0x1f;
             index += 1;
             if high_tag_number_form {
-                while index < der.len() && der[index] & 0x80 != 0 {
+                while let Some(octet) = der.get(index)
+                    && octet & 0x80 != 0
+                {
                     index += 1;
                 }
                 index += 1;

--- a/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/tests.rs
+++ b/rs/crypto/internal/crypto_lib/basic_sig/der_utils/src/tests.rs
@@ -146,3 +146,135 @@ fn should_report_the_types_of_unexpected_algorithm_identifier_parameters() {
          followed by an INTEGER"
     );
 }
+
+/// Returns a pseudo-random byte sequence of the given length.
+fn pseudo_random_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 33) as u8
+        })
+        .collect()
+}
+
+#[test]
+fn should_terminate_on_malformed_der() {
+    let mut inputs: Vec<Vec<u8>> = vec![
+        // Headers declaring more content than the input holds.
+        vec![0x30, 0x84, 0xff, 0xff, 0xff, 0xff],
+        vec![0x30, 0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        // Truncated headers.
+        vec![0x30],
+        vec![0x30, 0x81],
+        vec![0x1f, 0xff, 0xff],
+        // The indefinite length form, which is not valid DER.
+        vec![0x30, 0x80, 0x05, 0x00],
+        // Empty constructed elements, and constructed elements whose content
+        // reaches beyond the end of their parent.
+        [0x30, 0x00].repeat(100_000),
+        vec![0x30, 0x02, 0x30, 0x7f, 0x05, 0x00],
+        // Primitive elements without any content.
+        [0x05, 0x00].repeat(500_000),
+    ];
+    // Inputs that are not DER at all.
+    inputs.extend((0..64).map(|seed| pseudo_random_bytes(4096, seed)));
+
+    for input in inputs {
+        // The test terminating at all is what is being verified here.
+        let _ = KeyDerParser::check_der_nesting_depth(&input);
+        let _ = algo_id_and_public_key_bytes_from_der(&input);
+    }
+}
+
+/// Builds a DER `NULL` wrapped in `depth` definite-length elements with the
+/// given identifier octet.
+fn nested_with_tag(tag: u8, depth: usize) -> Vec<u8> {
+    let null = [0x05_u8, 0x00];
+    let mut headers: Vec<Vec<u8>> = Vec::with_capacity(depth);
+    let mut inner_length = null.len();
+    for _ in 0..depth {
+        let mut header = vec![tag];
+        header.extend_from_slice(&der_definite_length(inner_length));
+        inner_length += header.len();
+        headers.push(header);
+    }
+    let mut der = Vec::with_capacity(inner_length);
+    for header in headers.iter().rev() {
+        der.extend_from_slice(header);
+    }
+    der.extend_from_slice(&null);
+    der
+}
+
+/// SEQUENCEs and SETs are counted whatever their constructed bit says.
+#[test]
+fn should_count_the_depth_of_universal_containers_without_the_constructed_bit() {
+    for tag in [0x10_u8, 0x11] {
+        assert_eq!(
+            KeyDerParser::check_der_nesting_depth(&nested_with_tag(tag, MAX_DER_NESTING_DEPTH)),
+            Ok(())
+        );
+        assert!(
+            KeyDerParser::check_der_nesting_depth(&nested_with_tag(tag, MAX_DER_NESTING_DEPTH + 1))
+                .is_err(),
+            "nesting with tag {tag:#04x} was not rejected"
+        );
+        assert!(algo_id_and_public_key_bytes_from_der(&nested_with_tag(tag, 100)).is_err());
+    }
+}
+
+/// Elements using the high-tag-number form can carry the SEQUENCE and SET tag
+/// numbers, so their depth is counted as well.
+#[test]
+fn should_count_the_depth_of_elements_using_the_high_tag_number_form() {
+    // The SEQUENCE tag number encoded in the (non-minimal) long form.
+    let der = nested_with_tag_bytes(&[0x1f, 0x90, 0x10], MAX_DER_NESTING_DEPTH + 1);
+
+    assert!(KeyDerParser::check_der_nesting_depth(&der).is_err());
+}
+
+/// Keys whose headers cannot be walked from start to end are rejected.
+#[test]
+fn should_reject_der_that_cannot_be_scanned_in_full() {
+    let unscannable: [&[u8]; 4] = [
+        // An element whose content reaches beyond the end of the input.
+        &[0x30, 0x82, 0xff, 0xff],
+        // A length that needs more octets than a usize holds.
+        &[0x30, 0x89, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        // Headers that stop in the middle.
+        &[0x30],
+        &[0x30, 0x81],
+    ];
+
+    for prefix in unscannable {
+        let mut der = prefix.to_vec();
+        der.extend_from_slice(&nested_with_tag(0x30, 100));
+        assert!(
+            KeyDerParser::check_der_nesting_depth(&der).is_err(),
+            "unscannable prefix {prefix:02x?} was accepted"
+        );
+    }
+}
+
+/// Builds a DER `NULL` wrapped in `depth` definite-length elements with the
+/// given identifier octets.
+fn nested_with_tag_bytes(tag: &[u8], depth: usize) -> Vec<u8> {
+    let null = [0x05_u8, 0x00];
+    let mut headers: Vec<Vec<u8>> = Vec::with_capacity(depth);
+    let mut inner_length = null.len();
+    for _ in 0..depth {
+        let mut header = tag.to_vec();
+        header.extend_from_slice(&der_definite_length(inner_length));
+        inner_length += header.len();
+        headers.push(header);
+    }
+    let mut der = Vec::with_capacity(inner_length);
+    for header in headers.iter().rev() {
+        der.extend_from_slice(header);
+    }
+    der.extend_from_slice(&null);
+    der
+}


### PR DESCRIPTION
This is a follow-up to commit 42f67fe giving fine-grained error messages for some more cases of invalid pubkeys.