### PR TITLE
chore(CI): upgrade dependency-review-action to v5 and retry on snapshot warnings

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -46,6 +46,12 @@ jobs:
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
           $SHELL_WRAPPER python3 ci/src/dependencies/job/bazel_rust_gh_submission_job.py
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
+          # The base commit's dependency snapshot is submitted by a separate
+          # workflow run, so it can still be missing when this check compares
+          # the base against the PR head. Without a retry the comparison sees
+          # zero base dependencies, reports the entire tree as newly added and
+          # fails on pre-existing advisories.
+          retry-on-snapshot-warnings: true


### PR DESCRIPTION
The `dependency-review` job in `.github/workflows/security-checks.yml`
compares the dependency snapshot of a PR's base commit against the one of
its head commit. The head snapshot is submitted by the job itself, but the
base snapshot comes from a *different* workflow run, so it is occasionally
not there yet when the comparison runs. The action then sees zero base
dependencies, reports the entire crate tree (1346 packages) as newly added,
and fails on advisories that already exist on master.

That is what happened in [this run](https://github.com/dfinity/ic/actions/runs/32147072391/attempts/1):

```
The number of snapshots compared for the base SHA (0) and the head SHA (1)
do not match. You may see unexpected additions in the diff.
...
Cargo.Bazel.toml.lock » mio@0.8.10 – Mio's tokens for named pipes may be
delivered after deregistration (high severity)
##[error]Dependency review detected vulnerable packages.
```

`mio@0.8.10` was not introduced by that PR — it is unchanged on master, and
the PR did not touch `Cargo.Bazel.toml.lock` at all. Re-running the very same
job later [succeeded](https://github.com/dfinity/ic/actions/runs/32147072391/job/95754817859)
with zero additions and no vulnerabilities, without any change to the code
under test.

## Changes

* Set `retry-on-snapshot-warnings: true` so the action waits for the base
  snapshot to show up instead of failing on a comparison it already knows is
  incomplete. Note the accompanying `retry-on-snapshot-warnings-timeout`
  defaults to 120s, which is left as-is.
* Bump the action from `v4.9.0` to `v5.0.0`. That major release only moves the
  runtime from node20 to node24; no inputs were renamed or removed. It also
  silences the deprecation warning the old pin emitted, since node20 actions
  are already being forced onto node24 by the runner. `v5.0.0` requires
  Actions Runner >= v2.327.1, which the GitHub-hosted runners satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)