### PR TITLE
feat: Overcommit vCPUs to support more 4.2 nodes

### DIFF
--- a/ic-os/components/hostos/guestos/start-guestos.sh
+++ b/ic-os/components/hostos/guestos/start-guestos.sh
@@ -10,7 +10,7 @@ node_reward_type=$(get_config_value '.icos_settings.node_reward_type')
 case "${node_reward_type}" in
     type4.0) COUNT=32 ;;
     type4.1) COUNT=60 ;;
-    type4.2) COUNT=8 ;;
+    type4.2) COUNT=15 ;;
     type4.3) COUNT=4 ;;
     type4.4) COUNT=2 ;;
     *) COUNT=1 ;;

--- a/ic-os/components/setupos/install-hostos.sh
+++ b/ic-os/components/setupos/install-hostos.sh
@@ -122,7 +122,7 @@ function resize_partition() {
         case "${node_reward_type}" in
             type4.0) create_guestos_lvs 32 ;;
             type4.1) create_guestos_lvs 60 ;;
-            type4.2) create_guestos_lvs 8 ;;
+            type4.2) create_guestos_lvs 15 ;;
             type4.3) create_guestos_lvs 4 ;;
             type4.4) create_guestos_lvs 2 ;;
         esac

--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_vm_config.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_vm_config.rs
@@ -217,7 +217,7 @@ fn split_resources_for_type_4(
     let (memory, vcpus) = match &config.icos_settings.node_reward_type {
         Some(val) if val == "type4.0" => (memory / 32, vcpus / 32),
         Some(val) if val == "type4.1" => (memory / 60, 2 /* Overcommit vCPUs */),
-        Some(val) if val == "type4.2" => (memory / 8, vcpus / 8),
+        Some(val) if val == "type4.2" => (memory / 15, 8 /* Overcommit vCPUs */),
         Some(val) if val == "type4.3" => (memory / 4, vcpus / 4),
         Some(val) if val == "type4.4" => (memory / 2, vcpus / 2),
         _ => (memory, vcpus),


### PR DESCRIPTION
15 nodes evenly divides the memory to 32G, and overcommits the vCPUs to the same extent as 4.1 nodes.