### PR TITLE
feat(subnet-splitting): preemptively load the post-split DKG transcripts in the key manager

### DIFF
--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -252,7 +252,7 @@ impl DkgKeyManager {
                         warn!(
                             every_n_seconds => 5,
                             self.logger,
-                            "Couldn't get the next DKG summary for the new subnet after the split: {err:?}"
+                            "Couldn't compute the post-split DKG summary for the new subnet after the split: {err}"
                         );
                         return;
                     }
@@ -308,7 +308,7 @@ impl DkgKeyManager {
             scheduled,
         )
         .map_err(|err| {
-            format!("Couldn't determine the post-split subnet assignment after the split: {err:?}")
+            format!("Couldn't determine the post-split subnet assignment after the split: {err}")
         })?
         .new_subnet_id;
 

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -640,7 +640,7 @@ mod tests {
     use ic_registry_keys::make_catch_up_package_contents_key;
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_registry::SubnetRecordBuilder;
-    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id, test_replica_version};
     use ic_types::{
         NodeId, RegistryVersion, SubnetId,
         consensus::{
@@ -828,6 +828,7 @@ mod tests {
                     node_id: local_node_id,
                     // The local node always start in the source subnet.
                     subnet_id: source_subnet_id,
+                    replica_version: test_replica_version(),
                 })
                 .build();
 

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -297,7 +297,7 @@ impl DkgKeyManager {
     }
 
     fn get_post_split_summary(
-        &mut self,
+        &self,
         summary_block: &Block,
         scheduled: SplittingArgs,
     ) -> Result<DkgSummary, String> {

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -643,7 +643,6 @@ mod tests {
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::{
         NodeId, RegistryVersion, SubnetId,
-        backwards_compatibility::BackwardsCompatible,
         consensus::{
             BlockPayload, HashedBlock, Payload,
             dkg::{SplittingArgs, SubnetSplittingStatus},
@@ -908,12 +907,10 @@ mod tests {
                     .with_current_transcripts(current_transcripts);
 
                 splitting_summary.dkg.subnet_splitting_status =
-                    BackwardsCompatible::new_for_test_only(Some(SubnetSplittingStatus::Scheduled(
-                        SplittingArgs {
-                            source_subnet_id,
-                            destination_subnet_id,
-                        },
-                    )));
+                    SubnetSplittingStatus::Scheduled(SplittingArgs {
+                        source_subnet_id,
+                        destination_subnet_id,
+                    });
                 splitting_block.payload = Payload::new(
                     crypto_hash,
                     BlockPayload::Summary(splitting_summary.clone()),

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -854,7 +854,7 @@ mod tests {
                 )
                 .with_replica_config(ReplicaConfig {
                     node_id: local_node_id,
-                    // The local node always start in the source subnet.
+                    // The local node always starts in the source subnet.
                     subnet_id: source_subnet_id,
                     replica_version: test_replica_version(),
                 })

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -234,7 +234,7 @@ impl DkgKeyManager {
             let summary = if let Some(scheduled) =
                 subnet_splitting::is_split_scheduled(&summary_block)
             {
-                // If a subnet split is in progress, we should skip the `Scheduled` summary's
+                // If a subnet split is in progress, we can skip the `Scheduled` summary's
                 // transcripts (as the interval is skipped) and instead load the post-split one's.
                 match self.get_post_split_summary(&summary_block, scheduled) {
                     Ok(post_split_summary) => {

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -23,7 +23,6 @@ use ic_types::{
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use std::{
     collections::{HashMap, HashSet},
-    hash::Hash,
     sync::{
         Arc,
         mpsc::{Receiver, sync_channel},
@@ -524,28 +523,15 @@ impl DkgKeyManager {
 
         while let Some(summary_block) = next_summary_block {
             let summary = &summary_block.payload.as_ref().as_summary().dkg;
-            let next_summary_height = summary.get_next_start_height();
-            for transcript in summary
-                .current_transcripts()
-                .values()
-                .chain(summary.next_transcripts().values())
-            {
-                transcripts_to_retain.insert_by_cloning_if_not_present(transcript);
-            }
+            insert_transcripts_of(&mut transcripts_to_retain, summary);
 
-            next_summary_block = pool_reader.get_finalized_block(next_summary_height);
+            next_summary_block = pool_reader.get_finalized_block(summary.get_next_start_height());
         }
 
         // The removal below runs concurrently with the loading of the `summaries_to_load`'s
         // transcripts, so they must be part of the retain set.
         for summary in summaries_to_load {
-            for transcript in summary
-                .current_transcripts()
-                .values()
-                .chain(summary.next_transcripts().values())
-            {
-                transcripts_to_retain.insert_by_cloning_if_not_present(transcript);
-            }
+            insert_transcripts_of(&mut transcripts_to_retain, summary);
         }
 
         let crypto = self.crypto.clone();
@@ -646,36 +632,25 @@ fn dkg_id_log_msg(id: &NiDkgId) -> String {
     )
 }
 
-/// An extension trait for sets, allowing to insert a value the caller doesn't own without paying
-/// for a clone when the value is already in the set.
+/// Inserts the current and next transcripts of the given summary into the set, cloning only the
+/// transcripts that are not yet present.
 ///
 /// [`HashSet::insert`] takes the value by ownership, so inserting from a reference requires
-/// cloning up front — only to find out, after having paid for the clone, that an equal value was
-/// already present. This trait checks for presence first and clones only when the value is
-/// actually inserted.
-///
-/// This is useful when collecting the transcripts to retain in `delete_inactive_keys`: the next
-/// transcripts of a summary are always the current transcripts of the following summary, so the
-/// walk over the finalized summaries yields the (large) `NiDkgTranscript`s twice.
-///
-/// The price is that an actually inserted value is hashed twice: once by `contains` and once by
-/// `insert`.
-trait CloningInsertIfNotPresent<T> {
-    /// Inserts a clone of `value` into the set if no equal value is present, without cloning
-    /// otherwise. Returns `true` if the value was inserted.
-    fn insert_by_cloning_if_not_present(&mut self, value: &T) -> bool;
-}
-
-impl<T> CloningInsertIfNotPresent<T> for HashSet<T>
-where
-    T: Eq + Hash + Clone,
-{
-    fn insert_by_cloning_if_not_present(&mut self, value: &T) -> bool {
-        if self.contains(value) {
-            return false;
+/// cloning up front — only to find out, after having paid for the clone of a (large)
+/// [`NiDkgTranscript`], that an equal value was already present. Checking for presence first
+/// avoids that, and duplicates are the common case when collecting the transcripts to retain:
+/// the next transcripts of a summary are always the current transcripts of the following
+/// summary. The price is that an actually inserted transcript is hashed twice: once by
+/// `contains` and once by `insert`.
+fn insert_transcripts_of(transcripts: &mut HashSet<NiDkgTranscript>, summary: &DkgSummary) {
+    for transcript in summary
+        .current_transcripts()
+        .values()
+        .chain(summary.next_transcripts().values())
+    {
+        if !transcripts.contains(transcript) {
+            transcripts.insert(transcript.clone());
         }
-
-        self.insert(value.clone())
     }
 }
 
@@ -700,6 +675,7 @@ mod tests {
         crypto::crypto_hash,
     };
     use rstest::rstest;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_transcripts_get_loaded_and_retained() {
@@ -1055,31 +1031,42 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_by_cloning_if_not_present() {
+    fn test_insert_transcripts_of() {
+        let transcript = |start_height: u64| {
+            let committee = vec![node_test_id(0)];
+            let mut transcript = dummy_transcript_for_tests_with_params(
+                committee.clone(),
+                NiDkgTag::LowThreshold,
+                NiDkgTag::LowThreshold.threshold_for_subnet_of_size(committee.len()) as u32,
+                /*registry_version=*/ 1,
+            );
+            // Make the transcripts distinguishable from each other.
+            transcript.dkg_id.start_block_height = Height::from(start_height);
+            transcript
+        };
+        let summary = |current: &NiDkgTranscript, next: &NiDkgTranscript| {
+            DkgSummary::new(
+                /*configs=*/ vec![],
+                BTreeMap::from([(NiDkgTag::LowThreshold, current.clone())]),
+                BTreeMap::from([(NiDkgTag::LowThreshold, next.clone())]),
+                RegistryVersion::from(1),
+                /*interval_length=*/ Height::from(0),
+                /*next_interval_length=*/ Height::from(0),
+                /*height=*/ Height::from(0),
+                /*remote_dkg_attempts=*/ BTreeMap::new(),
+                SubnetSplittingStatus::NotScheduled,
+            )
+        };
+
+        let (a, b, c) = (transcript(0), transcript(1), transcript(2));
         let mut set = HashSet::new();
 
-        assert!(set.insert_by_cloning_if_not_present(&"a".to_string()));
-        assert!(set.insert_by_cloning_if_not_present(&"b".to_string()));
-        assert!(!set.insert_by_cloning_if_not_present(&"a".to_string()));
+        insert_transcripts_of(&mut set, &summary(&a, &b));
+        assert_eq!(set, HashSet::from([a.clone(), b.clone()]));
 
-        assert_eq!(set, HashSet::from(["a".to_string(), "b".to_string()]));
-    }
-
-    #[test]
-    fn test_insert_by_cloning_if_not_present_does_not_clone_present_values() {
-        #[derive(PartialEq, Eq, Hash)]
-        struct NoClone(u32);
-
-        impl Clone for NoClone {
-            fn clone(&self) -> Self {
-                panic!("An already present value should not be cloned");
-            }
-        }
-
-        let mut set = HashSet::from([NoClone(1)]);
-
-        // Must not clone (and hence not panic), since an equal value is already present.
-        assert!(!set.insert_by_cloning_if_not_present(&NoClone(1)));
-        assert_eq!(set.len(), 1);
+        // The next transcripts of a summary are the current transcripts of the following one,
+        // so the second summary only contributes one new transcript.
+        insert_transcripts_of(&mut set, &summary(&b, &c));
+        assert_eq!(set, HashSet::from([a, b, c]));
     }
 }

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -22,7 +22,6 @@ use ic_types::{
 };
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{
         Arc,
@@ -231,12 +230,14 @@ impl DkgKeyManager {
         // last seen height.
         let summary_block = cache.summary_block();
         if self.last_dkg_summary_height < Some(summary_block.height) {
-            let summary = if let Some(scheduled) =
-                subnet_splitting::is_split_scheduled(&summary_block)
-            {
-                // If a subnet split is in progress, we can skip the `Scheduled` summary's
-                // transcripts (as the interval is skipped) and instead load the post-split one's.
-                match self.get_post_split_summary(&summary_block, scheduled) {
+            let summary = &summary_block.payload.as_ref().as_summary().dkg;
+
+            // If a subnet split is in progress, we load the post-split summary's transcripts in
+            // addition to the regular summary's below: they are needed to sign the post-split
+            // CUP shares.
+            let post_split_summary = match subnet_splitting::is_split_scheduled(&summary_block) {
+                None => None,
+                Some(scheduled) => match self.get_post_split_summary(&summary_block, scheduled) {
                     Ok(post_split_summary) => {
                         info!(
                             self.logger,
@@ -244,21 +245,26 @@ impl DkgKeyManager {
                             post_split_summary.height
                         );
 
-                        Cow::Owned(post_split_summary)
+                        Some(post_split_summary)
                     }
                     Err(err) => {
-                        error!(
+                        warn!(
+                            every_n_seconds => 5,
                             self.logger,
                             "Couldn't get the next DKG summary for the new subnet after the split: {err:?}"
                         );
                         return;
                     }
-                }
-            } else {
-                Cow::Borrowed(&summary_block.payload.as_ref().as_summary().dkg)
+                },
             };
 
-            self.update_dkg_metrics(&summary);
+            let mut summaries_to_load = vec![summary];
+            if let Some(post_split_summary) = &post_split_summary {
+                summaries_to_load.push(post_split_summary);
+            }
+
+            self.update_dkg_metrics(summary);
+
             // Note that the order of these two calls is critical. We remove DKG keys that
             // are no longer relevant by telling the CSP which transcripts are still
             // relevant. However, over time, we may load new transcripts that are relevant.
@@ -273,12 +279,19 @@ impl DkgKeyManager {
             //
             // Note that the removal we trigger here still runs in parallel with the loads
             // below, so it is only harmless as long as the set of transcripts it retains is a
-            // superset of the ones we are about to load. This is why we hand `summary` to
-            // `delete_inactive_keys`: for a regular summary it is redundant, but the post-split
-            // summary is computed locally and thus invisible to the removal otherwise.
-            self.delete_inactive_keys(pool_reader, &summary);
-            self.load_transcripts_from_summary(&summary);
-            self.last_dkg_summary_height = Some(summary.height);
+            // superset of the ones we are about to load. This is why we hand `summaries_to_load`
+            // to `delete_inactive_keys`: for a regular summary it is redundant, but the
+            // post-split summary is computed locally and thus invisible to the removal
+            // otherwise.
+            self.delete_inactive_keys(pool_reader, &summaries_to_load);
+            for summary in &summaries_to_load {
+                self.load_transcripts_from_summary(summary);
+            }
+
+            // Even though we might have actually loaded a summary with higher height (the
+            // post-split summary), we still drive the state machine consistently with the if-guard
+            // above.
+            self.last_dkg_summary_height = Some(summary_block.height);
         }
     }
 
@@ -476,9 +489,13 @@ impl DkgKeyManager {
     /// Ask the CSP to drop DKG key material related to transcripts that are no
     /// longer relevant.
     ///
-    /// The transcripts of `summary_to_load`, i.e. the summary whose transcripts the caller is
-    /// about to load, are always retained. See the comment at the call site.
-    fn delete_inactive_keys(&mut self, pool_reader: &PoolReader<'_>, summary_to_load: &DkgSummary) {
+    /// The transcripts of `summaries_to_load`, i.e. the summaries whose transcripts the caller
+    /// is about to load, are always retained.
+    fn delete_inactive_keys(
+        &mut self,
+        pool_reader: &PoolReader<'_>,
+        summaries_to_load: &[&DkgSummary],
+    ) {
         if let Some(handle) = self.pending_key_removal.take() {
             // To make sure we delete all keys sequentially, we check if another key removal
             // is ongoing and if yes, we block until this thread is done. This
@@ -518,18 +535,15 @@ impl DkgKeyManager {
             next_summary_block = pool_reader.get_finalized_block(next_summary_height);
         }
 
-        // The removal below runs concurrently with the loading of `summary_to_load`'s
-        // transcripts, so they must be part of the retain set. For a regular summary this is a
-        // no-op, as it is the latest finalized summary and hence already covered by the walk
-        // above. The post-split summary however is computed locally from the registry and never
-        // enters the pool, so this is the only place where it can be picked up.
-        transcripts_to_retain.extend(
-            summary_to_load
+        // The removal below runs concurrently with the loading of the `summaries_to_load`'s
+        // transcripts, so they must be part of the retain set.
+        transcripts_to_retain.extend(summaries_to_load.iter().flat_map(|summary| {
+            summary
                 .current_transcripts()
                 .values()
-                .chain(summary_to_load.next_transcripts().values())
-                .cloned(),
-        );
+                .chain(summary.next_transcripts().values())
+                .cloned()
+        }));
 
         let crypto = self.crypto.clone();
         let logger = self.logger.clone();
@@ -778,13 +792,15 @@ mod tests {
     const SPLITTING_REGISTRY_VERSION: RegistryVersion = RegistryVersion::new(2);
 
     /// Verifies that when a subnet split is in progress, the key manager loads the transcripts from
-    /// the post-split DKG summary instead of the current summary's.
+    /// the post-split DKG summary in addition to the current summary's.
     #[rstest]
     // Run the test twice, once with the local node in the source subnet and once with it in the
     // destination subnet.
     #[case::source(true)]
     #[case::destination(false)]
-    fn test_subnet_splitting_loads_post_split_transcripts_instead(#[case] is_source_subnet: bool) {
+    fn test_subnet_splitting_loads_post_split_transcripts_in_addition(
+        #[case] is_source_subnet: bool,
+    ) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let source_subnet_id = subnet_test_id(1);
@@ -890,9 +906,9 @@ mod tests {
                 let mut splitting_summary = splitting_block.payload.as_ref().as_summary().clone();
                 // The current transcripts of this first summary are still the initial ones taken
                 // from the registry, which are also the ones the key manager loads from the genesis
-                // CUP. Give them a `NiDkgId` of their own, so that we can tell whether the key
-                // manager loaded this summary or the post-split one. The next transcripts are
-                // locally created, so their ids are distinct already.
+                // CUP. Give them a `NiDkgId` of their own, so that we can tell apart which of the
+                // summaries the key manager loaded. The next transcripts are locally created, so
+                // their ids are distinct already.
                 let current_transcripts = splitting_summary
                     .dkg
                     .current_transcripts()
@@ -969,41 +985,33 @@ mod tests {
                 );
                 key_manager.sync();
 
-                // The key manager should skip the transcripts from the splitting summary, but
-                // instead load the transcripts from the post split one, which is expected to be one
-                // interval later.
-                assert_eq!(
-                    key_manager.last_dkg_summary_height,
-                    Some(splitting_height + (dkg_interval_len + 1).into())
-                );
-                for (ids, expected_loaded) in [
-                    (genesis_ids, true),
-                    (splitting_ids, false),
-                    (post_split_ids.clone(), true),
-                ] {
+                // The key manager should set its last seen summary height to the splitting one
+                assert_eq!(key_manager.last_dkg_summary_height, Some(splitting_height));
+
+                // The key manager should load the transcripts from the splitting summary as
+                // usual, and additionally the transcripts from the post-split one.
+                for ids in [&genesis_ids, &splitting_ids, &post_split_ids] {
                     for id in ids {
-                        assert_eq!(
-                            csp.loaded_transcripts.read().unwrap().contains(&id),
-                            expected_loaded,
-                            "Transcript {} should {}have been loaded",
-                            dkg_id_log_msg(&id),
-                            if expected_loaded { "" } else { "not " }
+                        assert!(
+                            csp.loaded_transcripts.read().unwrap().contains(id),
+                            "Transcript {} should have been loaded",
+                            dkg_id_log_msg(id),
                         );
                     }
                 }
 
-                // The key removal runs in parallel with the loading, so the post-split
-                // transcripts must be retained as well, otherwise the keys we just loaded could
-                // be deleted right away.
+                // The key removal runs in parallel with the loading, so the transcripts of both
+                // loaded summaries must be retained as well, otherwise the keys we just loaded
+                // could be deleted right away.
                 let retained_transcripts = csp.retained_transcripts.read().unwrap();
                 let last_retained = retained_transcripts
                     .last()
                     .expect("The key manager should have asked for a key removal");
-                for id in post_split_ids {
+                for id in splitting_ids.iter().chain(post_split_ids.iter()) {
                     assert!(
-                        last_retained.contains(&id),
+                        last_retained.contains(id),
                         "Transcript {} should have been retained",
-                        dkg_id_log_msg(&id),
+                        dkg_id_log_msg(id),
                     );
                 }
             });

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -3,20 +3,26 @@
 //! there is something to do. On high-level, it's responsible of spawning
 //! threads triggering long-running CSP operation and book-keeping of
 //! thread-handles.
-use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader};
+use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader, subnet_splitting};
 use ic_interfaces::crypto::{ErrorReproducibility, LoadTranscriptResult, NiDkgAlgorithm};
+use ic_interfaces_registry::RegistryClient;
 use ic_logger::{ReplicaLogger, error, info, warn};
 use ic_metrics::{MetricsRegistry, buckets::decimal_buckets};
 use ic_types::{
     Height,
-    consensus::{HasHeight, dkg::DkgSummary},
+    consensus::{
+        Block, HasHeight,
+        dkg::{DkgSummary, SplittingArgs},
+    },
     crypto::threshold_sig::ni_dkg::{
         NiDkgId, NiDkgTag, NiDkgTargetSubnet, NiDkgTranscript,
         errors::load_transcript_error::DkgLoadTranscriptError,
     },
+    replica_config::ReplicaConfig,
 };
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{
         Arc,
@@ -24,6 +30,8 @@ use std::{
     },
     time::Instant,
 };
+
+use crate::payload_builder::get_post_split_dkg_summary;
 
 struct Metrics {
     pub dkg_ops_duration: HistogramVec,
@@ -94,6 +102,8 @@ pub struct DkgKeyManager {
     >,
     // This is a thread handle used to keep track of asynchronous key removals.
     pending_key_removal: Option<std::thread::JoinHandle<()>>,
+    registry: Arc<dyn RegistryClient>,
+    replica_config: ReplicaConfig,
 }
 
 impl DkgKeyManager {
@@ -103,6 +113,8 @@ impl DkgKeyManager {
         crypto: Arc<dyn ConsensusCrypto>,
         logger: ReplicaLogger,
         pool_reader: &PoolReader<'_>,
+        registry: Arc<dyn RegistryClient>,
+        replica_config: ReplicaConfig,
     ) -> Self {
         let mut manager = Self {
             crypto,
@@ -112,6 +124,8 @@ impl DkgKeyManager {
             last_cup_height: Default::default(),
             pending_transcript_loads: Default::default(),
             pending_key_removal: Default::default(),
+            registry,
+            replica_config,
         };
 
         // By calling on state change during initialization, we make sure, that the key store is
@@ -217,8 +231,34 @@ impl DkgKeyManager {
         // last seen height.
         let summary_block = cache.summary_block();
         if self.last_dkg_summary_height < Some(summary_block.height) {
-            let summary = summary_block.payload.as_ref().as_summary();
-            self.update_dkg_metrics(&summary.dkg);
+            let summary = if let Some(scheduled) =
+                subnet_splitting::is_split_scheduled(&summary_block)
+            {
+                // If a subnet split is in progress, we should skip the `Scheduled` summary's
+                // transcripts (as the interval is skipped) and instead load the post-split one's.
+                match self.get_post_split_summary(&summary_block, scheduled) {
+                    Ok(post_split_summary) => {
+                        info!(
+                            self.logger,
+                            "Loading post-split DKG transcripts from summary at height {}",
+                            post_split_summary.height
+                        );
+
+                        Cow::Owned(post_split_summary)
+                    }
+                    Err(err) => {
+                        error!(
+                            self.logger,
+                            "Couldn't get the next DKG summary for the new subnet after the split: {err:?}"
+                        );
+                        return;
+                    }
+                }
+            } else {
+                Cow::Borrowed(&summary_block.payload.as_ref().as_summary().dkg)
+            };
+
+            self.update_dkg_metrics(&summary);
             // Note that the order of these two calls is critical. We remove DKG keys that
             // are no longer relevant by telling the CSP which transcripts are still
             // relevant. However, over time, we may load new transcripts that are relevant.
@@ -230,10 +270,35 @@ impl DkgKeyManager {
             // parallel with the previous removal and theoretically we could finish loading
             // the next transcript before the previous removal (which would consider the
             // next transcript key irrelevant and remove it).
-            self.delete_inactive_keys(pool_reader);
-            self.load_transcripts_from_summary(&summary.dkg);
-            self.last_dkg_summary_height = Some(summary_block.height);
+            //
+            // Note that the removal we trigger here still runs in parallel with the loads
+            // below, so it is only harmless as long as the set of transcripts it retains is a
+            // superset of the ones we are about to load. This is why we hand `summary` to
+            // `delete_inactive_keys`: for a regular summary it is redundant, but the post-split
+            // summary is computed locally and thus invisible to the removal otherwise.
+            self.delete_inactive_keys(pool_reader, &summary);
+            self.load_transcripts_from_summary(&summary);
+            self.last_dkg_summary_height = Some(summary.height);
         }
+    }
+
+    fn get_post_split_summary(
+        &mut self,
+        summary_block: &Block,
+        scheduled: SplittingArgs,
+    ) -> Result<DkgSummary, String> {
+        let new_subnet_id = subnet_splitting::get_post_split_subnet_assignment(
+            self.replica_config.node_id,
+            summary_block,
+            self.registry.as_ref(),
+            scheduled,
+        )
+        .map_err(|err| {
+            format!("Couldn't determine the post-split subnet assignment after the split: {err:?}")
+        })?
+        .new_subnet_id;
+
+        get_post_split_dkg_summary(new_subnet_id, self.registry.as_ref(), summary_block)
     }
 
     /// Ensures that the pending transcripts are loaded BEFORE they are needed. For
@@ -409,8 +474,11 @@ impl DkgKeyManager {
     }
 
     /// Ask the CSP to drop DKG key material related to transcripts that are no
-    /// longer relevant
-    fn delete_inactive_keys(&mut self, pool_reader: &PoolReader<'_>) {
+    /// longer relevant.
+    ///
+    /// The transcripts of `summary_to_load`, i.e. the summary whose transcripts the caller is
+    /// about to load, are always retained. See the comment at the call site.
+    fn delete_inactive_keys(&mut self, pool_reader: &PoolReader<'_>, summary_to_load: &DkgSummary) {
         if let Some(handle) = self.pending_key_removal.take() {
             // To make sure we delete all keys sequentially, we check if another key removal
             // is ongoing and if yes, we block until this thread is done. This
@@ -449,6 +517,19 @@ impl DkgKeyManager {
 
             next_summary_block = pool_reader.get_finalized_block(next_summary_height);
         }
+
+        // The removal below runs concurrently with the loading of `summary_to_load`'s
+        // transcripts, so they must be part of the retain set. For a regular summary this is a
+        // no-op, as it is the latest finalized summary and hence already covered by the walk
+        // above. The post-split summary however is computed locally from the registry and never
+        // enters the pool, so this is the only place where it can be picked up.
+        transcripts_to_retain.extend(
+            summary_to_load
+                .current_transcripts()
+                .values()
+                .chain(summary_to_load.next_transcripts().values())
+                .cloned(),
+        );
 
         let crypto = self.crypto.clone();
         let logger = self.logger.clone();
@@ -553,15 +634,35 @@ mod tests {
     use super::*;
     use ic_consensus_mocks::{Dependencies, DependenciesBuilder};
     use ic_crypto_test_utils_crypto_returning_ok::CryptoReturningOk;
+    use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests_with_params;
     use ic_metrics::MetricsRegistry;
+    use ic_protobuf::registry::subnet::v1::{CatchUpPackageContents, InitialNiDkgTranscriptRecord};
+    use ic_registry_keys::make_catch_up_package_contents_key;
     use ic_test_utilities_logger::with_test_replica_logger;
+    use ic_test_utilities_registry::SubnetRecordBuilder;
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_types::{
+        NodeId, RegistryVersion, SubnetId,
+        backwards_compatibility::BackwardsCompatible,
+        consensus::{
+            BlockPayload, HashedBlock, Payload,
+            dkg::{SplittingArgs, SubnetSplittingStatus},
+        },
+        crypto::crypto_hash,
+    };
+    use rstest::rstest;
 
     #[test]
     fn test_transcripts_get_loaded_and_retained() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let dkg_interval_len = 3;
-                let Dependencies { mut pool, .. } = DependenciesBuilder::new(pool_config, 1)
+                let Dependencies {
+                    mut pool,
+                    registry,
+                    replica_config,
+                    ..
+                } = DependenciesBuilder::new(pool_config, 1)
                     .with_dkg_interval_length(dkg_interval_len)
                     .build();
                 let csp = Arc::new(CryptoReturningOk::default());
@@ -570,6 +671,8 @@ mod tests {
                     csp.clone(),
                     logger,
                     &PoolReader::new(&pool),
+                    registry,
+                    replica_config,
                 );
 
                 // Emulate the first invocation of the dkg key manager and make sure all
@@ -657,6 +760,254 @@ mod tests {
                 });
                 let retained = csp.retained_transcripts.read().unwrap()[2].clone();
                 assert_eq!(retained, summary_3_transcripts);
+            });
+        });
+    }
+
+    /// Returns the ids of all the current and next transcripts of the given summary.
+    fn transcript_ids(summary: &DkgSummary) -> HashSet<NiDkgId> {
+        summary
+            .current_transcripts()
+            .values()
+            .chain(summary.next_transcripts().values())
+            .map(|transcript| transcript.dkg_id.clone())
+            .collect()
+    }
+
+    /// The registry version at which the subnet split is scheduled, i.e. the version at which the
+    /// CUP contents that the two halves of the split start from are registered.
+    const SPLITTING_REGISTRY_VERSION: RegistryVersion = RegistryVersion::new(2);
+
+    /// Verifies that when a subnet split is in progress, the key manager loads the transcripts from
+    /// the post-split DKG summary instead of the current summary's.
+    #[rstest]
+    // Run the test twice, once with the local node in the source subnet and once with it in the
+    // destination subnet.
+    #[case::source(true)]
+    #[case::destination(false)]
+    fn test_subnet_splitting_loads_post_split_transcripts_instead(#[case] is_source_subnet: bool) {
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|logger| {
+                let source_subnet_id = subnet_test_id(1);
+                let destination_subnet_id = subnet_test_id(2);
+                let source_nodes = (0..4).map(node_test_id).collect::<Vec<_>>();
+                let destination_nodes = (4..8).map(node_test_id).collect::<Vec<_>>();
+                let dkg_interval_len = 3;
+
+                let (local_node_id, local_post_split_subnet_id) = if is_source_subnet {
+                    (source_nodes[0], source_subnet_id)
+                } else {
+                    (destination_nodes[0], destination_subnet_id)
+                };
+
+                let Dependencies {
+                    mut pool,
+                    registry,
+                    registry_data_provider,
+                    replica_config,
+                    ..
+                } = DependenciesBuilder::multiple_subnets(
+                    pool_config,
+                    vec![
+                        (
+                            1,
+                            source_subnet_id,
+                            SubnetRecordBuilder::from(&source_nodes)
+                                .with_dkg_interval_length(dkg_interval_len)
+                                .build(),
+                        ),
+                        (
+                            1,
+                            destination_subnet_id,
+                            SubnetRecordBuilder::from(&destination_nodes)
+                                .with_dkg_interval_length(dkg_interval_len)
+                                .build(),
+                        ),
+                    ],
+                )
+                .with_replica_config(ReplicaConfig {
+                    node_id: local_node_id,
+                    // The local node always start in the source subnet.
+                    subnet_id: source_subnet_id,
+                })
+                .build();
+
+                // A subnet split registers the CUP contents each half of the split starts from at
+                // the registry version at which the split is scheduled. Their transcripts are
+                // freshly created for the split, i.e. they are *not* the initial ones registered at
+                // genesis, which is what makes loading them observable below.
+                let post_split_height = Height::from(2 * (dkg_interval_len + 1));
+                let add_post_split_cup_contents = |subnet_id: SubnetId, committee: &[NodeId]| {
+                    let transcript_record = |tag: NiDkgTag| {
+                        let mut transcript = dummy_transcript_for_tests_with_params(
+                            committee.to_vec(),
+                            tag.clone(),
+                            tag.threshold_for_subnet_of_size(committee.len()) as u32,
+                            SPLITTING_REGISTRY_VERSION.get(),
+                        );
+                        // These are just dummy modifications to uniquely identify transcripts,
+                        // they do not reflect how they would actually look like.
+                        transcript.dkg_id.start_block_height = post_split_height;
+                        transcript.dkg_id.dealer_subnet = subnet_id;
+                        InitialNiDkgTranscriptRecord::from(transcript)
+                    };
+
+                    registry_data_provider
+                        .add(
+                            &make_catch_up_package_contents_key(subnet_id),
+                            SPLITTING_REGISTRY_VERSION,
+                            Some(CatchUpPackageContents {
+                                initial_ni_dkg_transcript_low_threshold: Some(transcript_record(
+                                    NiDkgTag::LowThreshold,
+                                )),
+                                initial_ni_dkg_transcript_high_threshold: Some(transcript_record(
+                                    NiDkgTag::HighThreshold,
+                                )),
+                                ..Default::default()
+                            }),
+                        )
+                        .expect("Failed to add the post-split CUP contents");
+                };
+                add_post_split_cup_contents(source_subnet_id, &source_nodes);
+                add_post_split_cup_contents(destination_subnet_id, &destination_nodes);
+                registry.update_to_latest_version();
+
+                // Advance dkg_interval_len rounds so the finalized tip is at height
+                // dkg_interval_len, stopping just before the next DKG interval boundary.
+                pool.advance_round_normal_operation_no_cup_n(dkg_interval_len);
+
+                // Build a DKG summary at the next interval boundary that signals a subnet split.
+                let mut splitting_proposal = pool.make_next_block();
+                let mut splitting_block = splitting_proposal.content.as_ref().clone();
+                let splitting_height = splitting_block.height;
+                // Safety-check: the summary block scheduling the split adopts the registry version
+                // at which the split was registered, which is the version at which the key manager
+                // looks up the post-split CUP contents.
+                assert_eq!(
+                    splitting_block.context.registry_version,
+                    SPLITTING_REGISTRY_VERSION
+                );
+                let mut splitting_summary = splitting_block.payload.as_ref().as_summary().clone();
+                // The current transcripts of this first summary are still the initial ones taken
+                // from the registry, which are also the ones the key manager loads from the genesis
+                // CUP. Give them a `NiDkgId` of their own, so that we can tell whether the key
+                // manager loaded this summary or the post-split one. The next transcripts are
+                // locally created, so their ids are distinct already.
+                let current_transcripts = splitting_summary
+                    .dkg
+                    .current_transcripts()
+                    .iter()
+                    .map(|(tag, transcript)| {
+                        let mut transcript = transcript.clone();
+                        transcript.dkg_id.start_block_height = splitting_height;
+                        (tag.clone(), transcript)
+                    })
+                    .collect();
+                splitting_summary.dkg = splitting_summary
+                    .dkg
+                    .with_current_transcripts(current_transcripts);
+
+                splitting_summary.dkg.subnet_splitting_status =
+                    BackwardsCompatible::new_for_test_only(Some(SubnetSplittingStatus::Scheduled(
+                        SplittingArgs {
+                            source_subnet_id,
+                            destination_subnet_id,
+                        },
+                    )));
+                splitting_block.payload = Payload::new(
+                    crypto_hash,
+                    BlockPayload::Summary(splitting_summary.clone()),
+                );
+                splitting_proposal.content = HashedBlock::new(crypto_hash, splitting_block.clone());
+                pool.advance_round_with_block(&splitting_proposal);
+
+                // The local node keeps its registry membership across the split, so the subnet it
+                // ends up on is the one it already runs.
+                let post_split_summary = get_post_split_dkg_summary(
+                    local_post_split_subnet_id,
+                    registry.as_ref(),
+                    &splitting_block,
+                )
+                .expect("Couldn't get the post-split summary");
+                // Safety-check: the post-split summary should have been produced by the registry,
+                // meaning `next_transcripts` should be empty
+                assert!(
+                    post_split_summary.next_transcripts().is_empty(),
+                    "The post-split summary should not contain next transcripts"
+                );
+
+                let cup_block = pool
+                    .get_cache()
+                    .catch_up_package()
+                    .content
+                    .block
+                    .into_inner();
+                let genesis_ids = transcript_ids(&cup_block.payload.as_ref().as_summary().dkg);
+                let splitting_ids = transcript_ids(&splitting_summary.dkg);
+                let post_split_ids = transcript_ids(&post_split_summary);
+                // Safety-check: the three sets of transcripts should be disjoint and non-empty,
+                // otherwise we can't tell which ones the key manager loaded.
+                assert!(
+                    !genesis_ids.is_empty()
+                        && !splitting_ids.is_empty()
+                        && !post_split_ids.is_empty(),
+                    "Each summary should reference transcripts of its own"
+                );
+                assert!(
+                    genesis_ids.is_disjoint(&splitting_ids)
+                        && genesis_ids.is_disjoint(&post_split_ids)
+                        && splitting_ids.is_disjoint(&post_split_ids),
+                    "The summaries should reference disjoint sets of transcripts"
+                );
+
+                let csp = Arc::new(CryptoReturningOk::default());
+                let mut key_manager = DkgKeyManager::new(
+                    MetricsRegistry::new(),
+                    csp.clone(),
+                    logger,
+                    &PoolReader::new(&pool),
+                    registry,
+                    replica_config,
+                );
+                key_manager.sync();
+
+                // The key manager should skip the transcripts from the splitting summary, but
+                // instead load the transcripts from the post split one, which is expected to be one
+                // interval later.
+                assert_eq!(
+                    key_manager.last_dkg_summary_height,
+                    Some(splitting_height + (dkg_interval_len + 1).into())
+                );
+                for (ids, expected_loaded) in [
+                    (genesis_ids, true),
+                    (splitting_ids, false),
+                    (post_split_ids.clone(), true),
+                ] {
+                    for id in ids {
+                        assert_eq!(
+                            csp.loaded_transcripts.read().unwrap().contains(&id),
+                            expected_loaded,
+                            "Transcript {} should {}have been loaded",
+                            dkg_id_log_msg(&id),
+                            if expected_loaded { "" } else { "not " }
+                        );
+                    }
+                }
+
+                // The key removal runs in parallel with the loading, so the post-split
+                // transcripts must be retained as well, otherwise the keys we just loaded could
+                // be deleted right away.
+                let retained_transcripts = csp.retained_transcripts.read().unwrap();
+                let last_retained = retained_transcripts
+                    .last()
+                    .expect("The key manager should have asked for a key removal");
+                for id in post_split_ids {
+                    assert!(
+                        last_retained.contains(&id),
+                        "Transcript {} should have been retained",
+                        dkg_id_log_msg(&id),
+                    );
+                }
             });
         });
     }

--- a/rs/consensus/dkg/src/dkg_key_manager.rs
+++ b/rs/consensus/dkg/src/dkg_key_manager.rs
@@ -23,6 +23,7 @@ use ic_types::{
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use std::{
     collections::{HashMap, HashSet},
+    hash::Hash,
     sync::{
         Arc,
         mpsc::{Receiver, sync_channel},
@@ -529,7 +530,7 @@ impl DkgKeyManager {
                 .values()
                 .chain(summary.next_transcripts().values())
             {
-                transcripts_to_retain.insert(transcript.clone());
+                transcripts_to_retain.insert_by_cloning_if_not_present(transcript);
             }
 
             next_summary_block = pool_reader.get_finalized_block(next_summary_height);
@@ -537,13 +538,15 @@ impl DkgKeyManager {
 
         // The removal below runs concurrently with the loading of the `summaries_to_load`'s
         // transcripts, so they must be part of the retain set.
-        transcripts_to_retain.extend(summaries_to_load.iter().flat_map(|summary| {
-            summary
+        for summary in summaries_to_load {
+            for transcript in summary
                 .current_transcripts()
                 .values()
                 .chain(summary.next_transcripts().values())
-                .cloned()
-        }));
+            {
+                transcripts_to_retain.insert_by_cloning_if_not_present(transcript);
+            }
+        }
 
         let crypto = self.crypto.clone();
         let logger = self.logger.clone();
@@ -641,6 +644,39 @@ fn dkg_id_log_msg(id: &NiDkgId) -> String {
         "NiDkgId{{ start_height: {}, threshold: {}{} }}",
         id.start_block_height, tag, remote
     )
+}
+
+/// An extension trait for sets, allowing to insert a value the caller doesn't own without paying
+/// for a clone when the value is already in the set.
+///
+/// [`HashSet::insert`] takes the value by ownership, so inserting from a reference requires
+/// cloning up front — only to find out, after having paid for the clone, that an equal value was
+/// already present. This trait checks for presence first and clones only when the value is
+/// actually inserted.
+///
+/// This is useful when collecting the transcripts to retain in `delete_inactive_keys`: the next
+/// transcripts of a summary are always the current transcripts of the following summary, so the
+/// walk over the finalized summaries yields the (large) `NiDkgTranscript`s twice.
+///
+/// The price is that an actually inserted value is hashed twice: once by `contains` and once by
+/// `insert`.
+trait CloningInsertIfNotPresent<T> {
+    /// Inserts a clone of `value` into the set if no equal value is present, without cloning
+    /// otherwise. Returns `true` if the value was inserted.
+    fn insert_by_cloning_if_not_present(&mut self, value: &T) -> bool;
+}
+
+impl<T> CloningInsertIfNotPresent<T> for HashSet<T>
+where
+    T: Eq + Hash + Clone,
+{
+    fn insert_by_cloning_if_not_present(&mut self, value: &T) -> bool {
+        if self.contains(value) {
+            return false;
+        }
+
+        self.insert(value.clone())
+    }
 }
 
 #[cfg(test)]
@@ -1016,5 +1052,34 @@ mod tests {
                 }
             });
         });
+    }
+
+    #[test]
+    fn test_insert_by_cloning_if_not_present() {
+        let mut set = HashSet::new();
+
+        assert!(set.insert_by_cloning_if_not_present(&"a".to_string()));
+        assert!(set.insert_by_cloning_if_not_present(&"b".to_string()));
+        assert!(!set.insert_by_cloning_if_not_present(&"a".to_string()));
+
+        assert_eq!(set, HashSet::from(["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn test_insert_by_cloning_if_not_present_does_not_clone_present_values() {
+        #[derive(PartialEq, Eq, Hash)]
+        struct NoClone(u32);
+
+        impl Clone for NoClone {
+            fn clone(&self) -> Self {
+                panic!("An already present value should not be cloned");
+            }
+        }
+
+        let mut set = HashSet::from([NoClone(1)]);
+
+        // Must not clone (and hence not panic), since an equal value is already present.
+        assert!(!set.insert_by_cloning_if_not_present(&NoClone(1)));
+        assert_eq!(set.len(), 1);
     }
 }

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -541,8 +541,13 @@ mod tests {
 
                 // Now we instantiate the DKG component for node Id = 1, who is a dealer.
                 let replica_1 = node_test_id(1);
-                let dkg_key_manager =
-                    new_dkg_key_manager(crypto.clone(), logger.clone(), &PoolReader::new(&pool));
+                let dkg_key_manager = new_dkg_key_manager(
+                    crypto.clone(),
+                    logger.clone(),
+                    &PoolReader::new(&pool),
+                    registry.clone(),
+                    replica_config.clone(),
+                );
                 let dkg = DkgImpl::new(
                     ReplicaConfig {
                         node_id: replica_1,
@@ -613,8 +618,13 @@ mod tests {
                 // Create another dealer and add his dealings into the unvalidated pool of
                 // replica 1.
                 let replica_2 = node_test_id(2);
-                let dkg_key_manager_2 =
-                    new_dkg_key_manager(crypto.clone(), logger.clone(), &PoolReader::new(&pool));
+                let dkg_key_manager_2 = new_dkg_key_manager(
+                    crypto.clone(),
+                    logger.clone(),
+                    &PoolReader::new(&pool),
+                    registry.clone(),
+                    replica_config.clone(),
+                );
                 let dkg_2 = DkgImpl::new(
                     ReplicaConfig {
                         node_id: replica_2,
@@ -703,8 +713,13 @@ mod tests {
                 let mut dkg_pool =
                     DkgPoolImpl::new(MetricsRegistry::new(), logger.clone(), Height::from(0));
                 // Let's check that replica 3, who's not a dealer, does not produce dealings.
-                let dkg_key_manager =
-                    new_dkg_key_manager(crypto.clone(), logger.clone(), &PoolReader::new(&pool));
+                let dkg_key_manager = new_dkg_key_manager(
+                    crypto.clone(),
+                    logger.clone(),
+                    &PoolReader::new(&pool),
+                    registry.clone(),
+                    replica_config.clone(),
+                );
                 let dkg = DkgImpl::new(
                     ReplicaConfig {
                         node_id: node_test_id(3),
@@ -721,8 +736,13 @@ mod tests {
                 assert!(dkg.on_state_change(&dkg_pool).is_empty());
 
                 // Now we instantiate the DKG component for node Id = 1, who is a dealer.
-                let dkg_key_manager =
-                    new_dkg_key_manager(crypto.clone(), logger.clone(), &PoolReader::new(&pool));
+                let dkg_key_manager = new_dkg_key_manager(
+                    crypto.clone(),
+                    logger.clone(),
+                    &PoolReader::new(&pool),
+                    registry.clone(),
+                    replica_config.clone(),
+                );
                 let dkg = DkgImpl::new(
                     ReplicaConfig {
                         node_id: node_test_id(1),
@@ -814,8 +834,13 @@ mod tests {
                 );
 
                 // Now we instantiate the DKG component for node Id = 1, who is a dealer.
-                let dkg_key_manager =
-                    new_dkg_key_manager(crypto.clone(), logger.clone(), &PoolReader::new(&pool));
+                let dkg_key_manager = new_dkg_key_manager(
+                    crypto.clone(),
+                    logger.clone(),
+                    &PoolReader::new(&pool),
+                    registry.clone(),
+                    replica_config.clone(),
+                );
                 let dkg = DkgImpl::new(
                     ReplicaConfig {
                         node_id: node_test_id(1),
@@ -1104,6 +1129,8 @@ mod tests {
                         crypto.clone(),
                         logger.clone(),
                         &PoolReader::new(&consensus_pool_1),
+                        registry_1.clone(),
+                        replica_config_1.clone(),
                     );
                     let dkg_1 = DkgImpl::new(
                         ReplicaConfig {
@@ -1123,6 +1150,8 @@ mod tests {
                         crypto.clone(),
                         logger.clone(),
                         &PoolReader::new(&consensus_pool_2),
+                        registry_2.clone(),
+                        replica_config_2.clone(),
                     );
                     let dkg_2 = DkgImpl::new(
                         ReplicaConfig {
@@ -1601,6 +1630,8 @@ mod tests {
                         crypto_1.clone(),
                         logger.clone(),
                         &PoolReader::new(&pool_1),
+                        dependencies_1.registry.clone(),
+                        dependencies_1.replica_config.clone(),
                     );
                     let dkg_1 = DkgImpl::new(
                         ReplicaConfig {
@@ -1627,7 +1658,13 @@ mod tests {
                         state_manager_2,
                         crypto_2.clone(),
                         pool_2.get_cache(),
-                        new_dkg_key_manager(crypto_2, logger.clone(), &PoolReader::new(&pool_2)),
+                        new_dkg_key_manager(
+                            crypto_2,
+                            logger.clone(),
+                            &PoolReader::new(&pool_2),
+                            dependencies_2.registry.clone(),
+                            dependencies_2.replica_config.clone(),
+                        ),
                         MetricsRegistry::new(),
                         logger.clone(),
                     );
@@ -2128,6 +2165,8 @@ mod tests {
                     deps.crypto.clone(),
                     logger.clone(),
                     &PoolReader::new(&deps.pool),
+                    deps.registry.clone(),
+                    deps.replica_config.clone(),
                 );
                 let receiver_dkg = DkgImpl::new(
                     ReplicaConfig {
@@ -2858,12 +2897,16 @@ mod tests {
         crypto: Arc<dyn ConsensusCrypto>,
         logger: ReplicaLogger,
         pool_reader: &PoolReader<'_>,
+        registry: Arc<dyn RegistryClient>,
+        replica_config: ReplicaConfig,
     ) -> Arc<Mutex<DkgKeyManager>> {
         Arc::new(Mutex::new(DkgKeyManager::new(
             MetricsRegistry::new(),
             crypto,
             logger,
             pool_reader,
+            registry,
+            replica_config,
         )))
     }
 

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -540,22 +540,19 @@ mod tests {
                     )));
 
                 // Now we instantiate the DKG component for node Id = 1, who is a dealer.
-                let replica_1 = node_test_id(1);
+                let replica_config_1 = ReplicaConfig {
+                    node_id: node_test_id(1),
+                    ..replica_config.clone()
+                };
                 let dkg_key_manager = new_dkg_key_manager(
                     crypto.clone(),
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    ReplicaConfig {
-                        node_id: replica_1,
-                        ..replica_config.clone()
-                    },
+                    replica_config_1.clone(),
                 );
                 let dkg = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: replica_1,
-                        ..replica_config.clone()
-                    },
+                    replica_config_1.clone(),
                     registry.clone(),
                     state_manager.clone(),
                     crypto.clone(),
@@ -585,9 +582,13 @@ mod tests {
                 }
                 assert_eq!(dealings.messages.len(), 3);
                 for tag in tags_iter(&vet_key_ids) {
-                    assert!(dealings.messages.iter().any(
-                        |m| m.signature.signer == replica_1 && m.content.dkg_id.dkg_tag == tag
-                    ));
+                    assert!(
+                        dealings
+                            .messages
+                            .iter()
+                            .any(|m| m.signature.signer == replica_config_1.node_id
+                                && m.content.dkg_id.dkg_tag == tag)
+                    );
                 }
 
                 // Now make sure, the dealing from the same dealer will not be included in a new
@@ -620,22 +621,19 @@ mod tests {
 
                 // Create another dealer and add his dealings into the unvalidated pool of
                 // replica 1.
-                let replica_2 = node_test_id(2);
+                let replica_config_2 = ReplicaConfig {
+                    node_id: node_test_id(2),
+                    ..replica_config
+                };
                 let dkg_key_manager_2 = new_dkg_key_manager(
                     crypto.clone(),
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    ReplicaConfig {
-                        node_id: replica_2,
-                        ..replica_config.clone()
-                    },
+                    replica_config_2.clone(),
                 );
                 let dkg_2 = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: replica_2,
-                        ..replica_config
-                    },
+                    replica_config_2.clone(),
                     registry,
                     state_manager,
                     crypto,
@@ -654,7 +652,7 @@ mod tests {
                         ChangeAction::AddToValidated(message) => {
                             dkg_pool.write().unwrap().insert(UnvalidatedArtifact {
                                 message: message.clone(),
-                                peer_id: replica_1,
+                                peer_id: replica_config_1.node_id,
                                 timestamp: UNIX_EPOCH,
                             })
                         }
@@ -689,9 +687,13 @@ mod tests {
                 }
                 assert_eq!(dealings.messages.len(), 3);
                 for tag in tags_iter(&vet_key_ids) {
-                    assert!(dealings.messages.iter().any(
-                        |m| m.signature.signer == replica_2 && m.content.dkg_id.dkg_tag == tag
-                    ));
+                    assert!(
+                        dealings
+                            .messages
+                            .iter()
+                            .any(|m| m.signature.signer == replica_config_2.node_id
+                                && m.content.dkg_id.dkg_tag == tag)
+                    );
                 }
             });
         });

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -450,7 +450,7 @@ mod tests {
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record};
     use ic_test_utilities_state::get_initial_state;
-    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id, test_replica_version};
     use ic_types::{
         RegistryVersion, ReplicaVersion,
         batch::ValidationContext,
@@ -546,7 +546,10 @@ mod tests {
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    replica_config.clone(),
+                    ReplicaConfig {
+                        node_id: replica_1,
+                        ..replica_config.clone()
+                    },
                 );
                 let dkg = DkgImpl::new(
                     ReplicaConfig {
@@ -623,7 +626,10 @@ mod tests {
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    replica_config.clone(),
+                    ReplicaConfig {
+                        node_id: replica_2,
+                        ..replica_config.clone()
+                    },
                 );
                 let dkg_2 = DkgImpl::new(
                     ReplicaConfig {
@@ -713,18 +719,19 @@ mod tests {
                 let mut dkg_pool =
                     DkgPoolImpl::new(MetricsRegistry::new(), logger.clone(), Height::from(0));
                 // Let's check that replica 3, who's not a dealer, does not produce dealings.
+                let replica_config_3 = ReplicaConfig {
+                    node_id: node_test_id(3),
+                    ..replica_config.clone()
+                };
                 let dkg_key_manager = new_dkg_key_manager(
                     crypto.clone(),
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    replica_config.clone(),
+                    replica_config_3.clone(),
                 );
                 let dkg = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: node_test_id(3),
-                        ..replica_config.clone()
-                    },
+                    replica_config_3,
                     registry.clone(),
                     state_manager.clone(),
                     crypto.clone(),
@@ -736,18 +743,19 @@ mod tests {
                 assert!(dkg.on_state_change(&dkg_pool).is_empty());
 
                 // Now we instantiate the DKG component for node Id = 1, who is a dealer.
+                let replica_config_1 = ReplicaConfig {
+                    node_id: node_test_id(1),
+                    ..replica_config
+                };
                 let dkg_key_manager = new_dkg_key_manager(
                     crypto.clone(),
                     logger.clone(),
                     &PoolReader::new(&pool),
                     registry.clone(),
-                    replica_config.clone(),
+                    replica_config_1.clone(),
                 );
                 let dkg = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: node_test_id(1),
-                        ..replica_config
-                    },
+                    replica_config_1,
                     registry,
                     state_manager,
                     crypto,
@@ -821,6 +829,12 @@ mod tests {
                     ..
                 } = DependenciesBuilder::new(pool_config, 2)
                     .with_dkg_interval_length(dkg_interval_length)
+                    .with_replica_config(ReplicaConfig {
+                        // Node Id = 1, who is a dealer
+                        node_id: node_test_id(1),
+                        subnet_id: subnet_test_id(0),
+                        replica_version: test_replica_version(),
+                    })
                     .without_state_manager_expectations()
                     .build();
 
@@ -833,7 +847,6 @@ mod tests {
                     Some(target_id),
                 );
 
-                // Now we instantiate the DKG component for node Id = 1, who is a dealer.
                 let dkg_key_manager = new_dkg_key_manager(
                     crypto.clone(),
                     logger.clone(),
@@ -842,10 +855,7 @@ mod tests {
                     replica_config.clone(),
                 );
                 let dkg = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: node_test_id(1),
-                        ..replica_config.clone()
-                    },
+                    replica_config,
                     registry.clone(),
                     state_manager.clone(),
                     crypto,
@@ -1091,23 +1101,33 @@ mod tests {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config_1| {
             ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config_2| {
                 let crypto = Arc::new(CryptoReturningOk::default());
-                let node_id_1 = node_test_id(1);
-                // This is not a dealer!
-                let node_id_2 = node_test_id(0);
                 let Dependencies {
                     pool: consensus_pool_1,
                     registry: registry_1,
                     state_manager: state_manager_1,
                     replica_config: replica_config_1,
                     ..
-                } = DependenciesBuilder::new(pool_config_1, 2).build();
+                } = DependenciesBuilder::new(pool_config_1, 2)
+                    .with_replica_config(ReplicaConfig {
+                        node_id: node_test_id(1),
+                        subnet_id: subnet_test_id(0),
+                        replica_version: test_replica_version(),
+                    })
+                    .build();
                 let Dependencies {
                     pool: consensus_pool_2,
                     registry: registry_2,
                     state_manager: state_manager_2,
                     replica_config: replica_config_2,
                     ..
-                } = DependenciesBuilder::new(pool_config_2, 2).build();
+                } = DependenciesBuilder::new(pool_config_2, 2)
+                    .with_replica_config(ReplicaConfig {
+                        // This is not a dealer!
+                        node_id: node_test_id(0),
+                        subnet_id: subnet_test_id(0),
+                        replica_version: test_replica_version(),
+                    })
+                    .build();
                 for state_manager in [&state_manager_1, &state_manager_2] {
                     state_manager
                         .get_mut()
@@ -1133,10 +1153,7 @@ mod tests {
                         replica_config_1.clone(),
                     );
                     let dkg_1 = DkgImpl::new(
-                        ReplicaConfig {
-                            node_id: node_id_1,
-                            ..replica_config_1.clone()
-                        },
+                        replica_config_1.clone(),
                         registry_1,
                         state_manager_1,
                         crypto.clone(),
@@ -1154,10 +1171,7 @@ mod tests {
                         replica_config_2.clone(),
                     );
                     let dkg_2 = DkgImpl::new(
-                        ReplicaConfig {
-                            node_id: node_id_2,
-                            ..replica_config_2.clone()
-                        },
+                        replica_config_2,
                         registry_2,
                         state_manager_2,
                         crypto.clone(),
@@ -1179,7 +1193,7 @@ mod tests {
                             dkg_key_manager: dkg_key_manager_2,
                             pool: consensus_pool_2,
                         },
-                        node_id_1,
+                        replica_config_1.node_id,
                     );
                 });
             });
@@ -1556,10 +1570,20 @@ mod tests {
                     // Set pool_1 and pool_2
                     let dependencies_1 = DependenciesBuilder::new(pool_config_1, 2)
                         .with_dkg_interval_length(dkg_interval_length)
+                        .with_replica_config(ReplicaConfig {
+                            node_id: node_test_id(1),
+                            subnet_id: subnet_test_id(0),
+                            replica_version: test_replica_version(),
+                        })
                         .without_state_manager_expectations()
                         .build();
                     let dependencies_2 = DependenciesBuilder::new(pool_config_2, 2)
                         .with_dkg_interval_length(dkg_interval_length)
+                        .with_replica_config(ReplicaConfig {
+                            node_id: node_test_id(2),
+                            subnet_id: subnet_test_id(0),
+                            replica_version: test_replica_version(),
+                        })
                         .without_state_manager_expectations()
                         .build();
 
@@ -1585,10 +1609,8 @@ mod tests {
                     let registry_2 = dependencies_2.registry.clone();
                     let state_manager_1 = dependencies_1.state_manager.clone();
                     let state_manager_2 = dependencies_2.state_manager.clone();
-                    let subnet_id_1 = dependencies_1.replica_config.subnet_id;
-                    let subnet_id_2 = dependencies_2.replica_config.subnet_id;
-                    let replica_version_1 = dependencies_1.replica_config.replica_version;
-                    let replica_version_2 = dependencies_2.replica_config.replica_version;
+                    let replica_config_1 = dependencies_1.replica_config;
+                    let replica_config_2 = dependencies_2.replica_config;
                     let mut pool_1 = dependencies_1.pool;
                     let mut pool_2 = dependencies_2.pool;
 
@@ -1626,35 +1648,27 @@ mod tests {
                     }
 
                     // Now we instantiate the DKG components. Node Id = 1 is a dealer.
-                    let dgk_key_manager_1 = new_dkg_key_manager(
+                    let dkg_key_manager_1 = new_dkg_key_manager(
                         crypto_1.clone(),
                         logger.clone(),
                         &PoolReader::new(&pool_1),
-                        dependencies_1.registry.clone(),
-                        dependencies_1.replica_config.clone(),
+                        registry_1.clone(),
+                        replica_config_1.clone(),
                     );
                     let dkg_1 = DkgImpl::new(
-                        ReplicaConfig {
-                            node_id: node_test_id(1),
-                            subnet_id: subnet_id_1,
-                            replica_version: replica_version_1,
-                        },
+                        replica_config_1,
                         registry_1,
                         state_manager_1,
                         crypto_1,
                         pool_1.get_cache(),
-                        dgk_key_manager_1.clone(),
+                        dkg_key_manager_1.clone(),
                         MetricsRegistry::new(),
                         logger.clone(),
                     );
 
                     let dkg_2 = DkgImpl::new(
-                        ReplicaConfig {
-                            node_id: node_test_id(2),
-                            subnet_id: subnet_id_2,
-                            replica_version: replica_version_2,
-                        },
-                        registry_2,
+                        replica_config_2.clone(),
+                        registry_2.clone(),
                         state_manager_2,
                         crypto_2.clone(),
                         pool_2.get_cache(),
@@ -1662,8 +1676,8 @@ mod tests {
                             crypto_2,
                             logger.clone(),
                             &PoolReader::new(&pool_2),
-                            dependencies_2.registry.clone(),
-                            dependencies_2.replica_config.clone(),
+                            registry_2,
+                            replica_config_2,
                         ),
                         MetricsRegistry::new(),
                         logger.clone(),
@@ -1676,7 +1690,7 @@ mod tests {
 
                     // The last summary contains two local configs, but the state contains an initial DKG context.
                     // dkg.on_state_change should create 4 dealings for all 4 resulting configs.
-                    sync_dkg_key_manager(&dgk_key_manager_1, &pool_1);
+                    sync_dkg_key_manager(&dkg_key_manager_1, &pool_1);
                     let change_set = dkg_1.on_state_change(&dkg_pool_1);
                     match &change_set.as_slice() {
                         &[
@@ -2147,6 +2161,12 @@ mod tests {
                 let target_id = NiDkgTargetId::new([9_u8; 32]);
 
                 let mut deps = DependenciesBuilder::new(pool_config, 2)
+                    .with_replica_config(ReplicaConfig {
+                        // Node 2 is a non-dealer receiver
+                        node_id: node_test_id(2),
+                        subnet_id: subnet_test_id(0),
+                        replica_version: test_replica_version(),
+                    })
                     .with_dkg_interval_length(dkg_interval_length)
                     .without_state_manager_expectations()
                     .build();
@@ -2169,10 +2189,7 @@ mod tests {
                     deps.replica_config.clone(),
                 );
                 let receiver_dkg = DkgImpl::new(
-                    ReplicaConfig {
-                        node_id: node_test_id(2),
-                        ..deps.replica_config.clone()
-                    },
+                    deps.replica_config.clone(),
                     deps.registry.clone(),
                     deps.state_manager.clone(),
                     deps.crypto.clone(),

--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -806,6 +806,11 @@ mod tests {
                         .build(),
                 )],
             )
+            .with_replica_config(ReplicaConfig {
+                node_id,
+                subnet_id,
+                replica_version: test_replica_version(),
+            })
             .build();
             state_manager
                 .get_mut()

--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -867,15 +867,11 @@ mod tests {
                 no_op_logger(),
                 &PoolReader::new(&pool),
                 registry.clone(),
-                replica_config,
+                replica_config.clone(),
             );
             let key_manager = Arc::new(Mutex::new(key_manager));
             let dkg_impl = DkgImpl::new(
-                ReplicaConfig {
-                    node_id,
-                    subnet_id,
-                    replica_version: test_replica_version(),
-                },
+                replica_config,
                 registry.clone(),
                 state_manager.clone(),
                 crypto.clone(),

--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -794,6 +794,7 @@ mod tests {
                 registry,
                 state_manager,
                 registry_data_provider,
+                replica_config,
                 ..
             } = DependenciesBuilder::single_subnet(
                 pool_config,
@@ -860,6 +861,8 @@ mod tests {
                 crypto.clone(),
                 no_op_logger(),
                 &PoolReader::new(&pool),
+                registry.clone(),
+                replica_config,
             );
             let key_manager = Arc::new(Mutex::new(key_manager));
             let dkg_impl = DkgImpl::new(

--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -671,8 +671,8 @@ mod tests {
         let metrics_registry = MetricsRegistry::new();
 
         let consensus_impl = ConsensusImpl::new(
-            replica_config,
-            registry,
+            replica_config.clone(),
+            registry.clone(),
             pool.get_cache(),
             crypto.clone(),
             Arc::new(FakeIngressSelector::new()),
@@ -688,6 +688,8 @@ mod tests {
                 crypto,
                 no_op_logger(),
                 &PoolReader::new(&pool),
+                registry,
+                replica_config,
             ))),
             Arc::new(FakeMessageRouting::new()),
             state_manager,

--- a/rs/consensus/tests/framework/runner.rs
+++ b/rs/consensus/tests/framework/runner.rs
@@ -140,6 +140,8 @@ impl<'a> ConsensusRunner<'a> {
             consensus_crypto.clone(),
             replica_logger.clone(),
             pool_reader,
+            deps.registry_client.clone(),
+            deps.replica_config.clone(),
         )));
         let malicious_flags = MaliciousFlags::default();
         let consensus = ic_consensus::consensus::ConsensusImpl::new(

--- a/rs/consensus/tests/payload.rs
+++ b/rs/consensus/tests/payload.rs
@@ -166,6 +166,8 @@ fn consensus_produces_expected_batches() {
             Arc::clone(&fake_crypto) as Arc<_>,
             no_op_logger(),
             &PoolReader::new(&*consensus_pool.read().unwrap()),
+            registry_client.clone(),
+            replica_config.clone(),
         )));
 
         let consensus = ic_consensus::consensus::ConsensusImpl::new(

--- a/rs/replay/src/validator.rs
+++ b/rs/replay/src/validator.rs
@@ -179,6 +179,8 @@ impl ReplayValidator {
             self.consensus_crypto.clone(),
             self.log.clone(),
             pool_reader,
+            self.registry.clone(),
+            self.replica_cfg.clone(),
         )
     }
 

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -547,7 +547,7 @@ fn start_consensus(
     let replica_config = ReplicaConfig {
         node_id,
         subnet_id,
-        replica_version: replica_version.clone(),
+        replica_version,
     };
     let dkg_key_manager = Arc::new(Mutex::new(ic_consensus_dkg::DkgKeyManager::new(
         metrics_registry.clone(),

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -554,6 +554,8 @@ fn start_consensus(
         Arc::clone(&consensus_crypto),
         log.clone(),
         &PoolReader::new(&*consensus_pool.read().unwrap()),
+        registry_client.clone(),
+        replica_config.clone(),
     )));
 
     let mut join_handles = vec![];


### PR DESCRIPTION
When a subnet split is scheduled, the DKG interval of the `Scheduled` summary is skipped. Its next transcripts will thus not be used and current transcripts were already loaded by the previous summary's next transcripts. 

This PR proposes to make the DKG key manager load the transcripts of the soon-to-be-created `PostSplit` summary instead of the `Scheduled` summary as soon as it observes it. This is needed to have the necessary key material needed to sign shares for the post-split CUP. It also drives the first interval following the split.

We also make sure to retain the transcripts in the concurrent key removal so the keys it just loaded don't get dropped again.
