### PR TITLE
chore: Cleanup Type 4.0 deployment path

### DIFF
--- a/ic-os/components/hostos/guestos/start-guestos.sh
+++ b/ic-os/components/hostos/guestos/start-guestos.sh
@@ -8,7 +8,6 @@ source /opt/ic/bin/config.sh
 node_reward_type=$(get_config_value '.icos_settings.node_reward_type')
 
 case "${node_reward_type}" in
-    type4.0) COUNT=32 ;;
     type4.1) COUNT=60 ;;
     type4.2) COUNT=15 ;;
     type4.3) COUNT=4 ;;

--- a/ic-os/components/setupos/install-hostos.sh
+++ b/ic-os/components/setupos/install-hostos.sh
@@ -120,7 +120,6 @@ function resize_partition() {
         }
 
         case "${node_reward_type}" in
-            type4.0) create_guestos_lvs 32 ;;
             type4.1) create_guestos_lvs 60 ;;
             type4.2) create_guestos_lvs 15 ;;
             type4.3) create_guestos_lvs 4 ;;

--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_vm_config.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_vm_config.rs
@@ -215,7 +215,6 @@ fn split_resources_for_type_4(
     /* topology */ Topology,
 ) {
     let (memory, vcpus) = match &config.icos_settings.node_reward_type {
-        Some(val) if val == "type4.0" => (memory / 32, vcpus / 32),
         Some(val) if val == "type4.1" => (memory / 60, 2 /* Overcommit vCPUs */),
         Some(val) if val == "type4.2" => (memory / 15, 8 /* Overcommit vCPUs */),
         Some(val) if val == "type4.3" => (memory / 4, vcpus / 4),
@@ -224,7 +223,7 @@ fn split_resources_for_type_4(
     };
 
     let topology = match &config.icos_settings.node_reward_type {
-        Some(val) if val == "type4.1" || val == "type4.0" => Topology {
+        Some(val) if val == "type4.1" => Topology {
             nr_of_sockets: 1,
             nr_of_cores: vcpus,
             nr_of_threads: 1,


### PR DESCRIPTION
4.0 is and was not used anywhere.

Type 4.0 originally was used to experiment with overcommitting vCPUs, and this later swapped with and replaced type 4.1.