### PR TITLE
feat(migration): always export the oldest-request-age metric

### DIFF
--- a/rs/migration_canister/src/canister_state.rs
+++ b/rs/migration_canister/src/canister_state.rs
@@ -133,10 +133,12 @@ pub mod requests {
     }
 
     /// Returns the age in nanos of the request that has been in flight the longest,
-    /// or `None` if there is no request in flight.
-    pub fn oldest_request_age_nanos() -> Option<u64> {
+    /// or 0 if there is no request in flight.
+    pub fn oldest_request_age_nanos() -> u64 {
         let now = now();
-        ACCEPTED_TIME.with_borrow(|a| a.values().map(|time| now.saturating_sub(time)).max())
+        ACCEPTED_TIME
+            .with_borrow(|a| a.values().map(|time| now.saturating_sub(time)).max())
+            .unwrap_or_default()
     }
 
     pub fn remove_request(request: &RequestState) {

--- a/rs/migration_canister/src/migration_canister.rs
+++ b/rs/migration_canister/src/migration_canister.rs
@@ -133,14 +133,12 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
         "Number of currently ongoing migration requests.",
     )?;
 
-    // This gauge is not set if there is no request in flight.
-    if let Some(age_nanos) = oldest_request_age_nanos() {
-        w.encode_gauge(
-            "migration_canister_oldest_request_in_flight_age_seconds",
-            age_nanos as f64 / 1_000_000_000_f64,
-            "Age in seconds of the migration request that has been in flight the longest.",
-        )?;
-    }
+    // This gauge is 0 if there is no request in flight.
+    w.encode_gauge(
+        "migration_canister_oldest_request_in_flight_age_seconds",
+        oldest_request_age_nanos() as f64 / 1_000_000_000_f64,
+        "Age in seconds of the migration request that has been in flight the longest.",
+    )?;
 
     w.encode_gauge(
         "migration_canister_num_successes_in_past_24_h",

--- a/rs/migration_canister/tests/tests.rs
+++ b/rs/migration_canister/tests/tests.rs
@@ -816,22 +816,15 @@ async fn metrics() {
         0.0
     );
 
-    assert_eq!(oldest_request_age(&metrics), None);
+    assert_eq!(oldest_request_age(&metrics), 0.0);
 }
 
 const OLDEST_REQUEST_AGE_METRIC: &str = "migration_canister_oldest_request_in_flight_age_seconds";
 
 /// Reads the age (in seconds) of the oldest request in flight.
-/// Returns `None` if the metric is not set, i.e., if no request is in flight.
-fn oldest_request_age(metrics: &Scrape) -> Option<f64> {
-    let is_metric_set = metrics
-        .samples
-        .iter()
-        .any(|sample| sample.metric == OLDEST_REQUEST_AGE_METRIC);
-    if !is_metric_set {
-        return None;
-    }
-    Some(get_gauge(metrics, OLDEST_REQUEST_AGE_METRIC))
+/// The metric is always set and equal to 0 if no request is in flight.
+fn oldest_request_age(metrics: &Scrape) -> f64 {
+    get_gauge(metrics, OLDEST_REQUEST_AGE_METRIC)
 }
 
 #[tokio::test]
@@ -865,8 +858,8 @@ async fn oldest_request_in_flight_metric() {
     ))
     .await;
 
-    // Without any request in flight, the metric is not set.
-    assert_eq!(oldest_request_age(&fetch_metrics(&pic).await), None);
+    // Without any request in flight, the metric is 0.
+    assert_eq!(oldest_request_age(&fetch_metrics(&pic).await), 0.0);
 
     migrate_canister(&pic, sender, &first).await.unwrap();
     pic.advance_time(Duration::from_secs(10)).await;
@@ -878,7 +871,7 @@ async fn oldest_request_in_flight_metric() {
         get_gauge(&metrics, "migration_canister_requests_in_flight"),
         1.0
     );
-    let age = oldest_request_age(&metrics).unwrap();
+    let age = oldest_request_age(&metrics);
     assert!((10.0..100.0).contains(&age), "unexpected age {age}");
 
     // A second, younger request does not affect the metric:
@@ -889,7 +882,7 @@ async fn oldest_request_in_flight_metric() {
         get_gauge(&metrics, "migration_canister_requests_in_flight"),
         2.0
     );
-    let age = oldest_request_age(&metrics).unwrap();
+    let age = oldest_request_age(&metrics);
     assert!((10.0..100.0).contains(&age), "unexpected age {age}");
 
     // Drive both migrations to completion. We advance time by a lot so that
@@ -911,7 +904,7 @@ async fn oldest_request_in_flight_metric() {
         get_gauge(&metrics, "migration_canister_requests_in_flight"),
         0.0
     );
-    assert_eq!(oldest_request_age(&metrics), None);
+    assert_eq!(oldest_request_age(&metrics), 0.0);
 }
 
 #[tokio::test]
@@ -931,6 +924,8 @@ async fn oldest_request_in_flight_metric_reset_on_failure() {
     };
 
     migrate_canister(&pic, sender, &args).await.unwrap();
+    pic.advance_time(Duration::from_secs(10)).await;
+    pic.tick().await;
 
     // The request has been accepted and thus its age is reported by the metric.
     let metrics = fetch_metrics(&pic).await;
@@ -938,7 +933,8 @@ async fn oldest_request_in_flight_metric_reset_on_failure() {
         get_gauge(&metrics, "migration_canister_requests_in_flight"),
         1.0
     );
-    assert!(oldest_request_age(&metrics).is_some());
+    let age = oldest_request_age(&metrics);
+    assert!(age >= 10.0, "unexpected age {age}");
 
     // Validation succeeded. Now we break migration by interfering.
     pic.start_canister(migrated_canister, Some(sender))
@@ -957,7 +953,7 @@ async fn oldest_request_in_flight_metric_reset_on_failure() {
         get_gauge(&metrics, "migration_canister_requests_in_flight"),
         0.0
     );
-    assert_eq!(oldest_request_age(&metrics), None);
+    assert_eq!(oldest_request_age(&metrics), 0.0);
 }
 
 async fn concurrent_migration(


### PR DESCRIPTION
`migration_canister_oldest_request_in_flight_age_seconds` used to be omitted from the metrics output if no request was in flight, which makes the metric hard to use in queries and alerts. Export it unconditionally instead, reporting 0 if there is no pending request.