### PR TITLE
fix: run the outcall cycles migration regardless of subnet activity

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1085,6 +1085,17 @@ impl SchedulerImpl {
     //
     // TODO(DSM-103): Consider only aborting actually scheduled canisters.
     fn finish_round(&self, state: &mut ReplicatedState, current_round_type: ExecutionRoundType) {
+        // Backfill the HTTP/ECDSA outcall cycles from the legacy scalar fields of
+        // `SubnetMetrics` into the corresponding entries of its by-use-case map.
+        // This must run regardless of subnet activity: the subnet-level use cases
+        // are only observed on outcalls, canister deletion and dropped messages,
+        // so tying the migration to an observation would leave the entries stale
+        // forever on a subnet that does none of these.
+        state
+            .metadata
+            .subnet_metrics
+            .migrate_outcalls_cycles_to_use_cases();
+
         let cost_schedule = state.get_own_cost_schedule();
         match current_round_type {
             ExecutionRoundType::CheckpointRound => {

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -37,7 +37,8 @@ use ic_types::messages::{
 };
 use ic_types::time::UNIX_EPOCH;
 use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Instructions, NominalCycles, NominalCyclesTesting,
+    CanisterCyclesCostSchedule, CompoundCycles, CyclesUseCase, Instructions, NominalCycles,
+    NominalCyclesTesting,
 };
 use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id, user_test_id};
 use more_asserts::assert_ge;
@@ -1298,6 +1299,47 @@ fn consumed_cycles_http_outcalls_are_added_to_consumed_cycles_total() {
             metric_vec(&[(&[("use_case", "HTTPOutcalls")], fee.nominal().get() as f64),]),
         );
     }
+}
+
+#[test]
+fn outcalls_cycles_are_migrated_into_use_cases_on_an_idle_subnet() {
+    let mut test = SchedulerTestBuilder::new().build();
+
+    // Simulate a subnet that consumed HTTP and ECDSA outcall cycles before
+    // use-case tracking existed: only the legacy scalar fields carry the history,
+    // the by-use-case map has no corresponding entries.
+    let subnet_metrics = &mut test.state_mut().metadata.subnet_metrics;
+    subnet_metrics.observe_consumed_cycles_http_outcalls(NominalCycles::new(100));
+    subnet_metrics.observe_consumed_cycles_ecdsa_outcalls(NominalCycles::new(200));
+    assert!(subnet_metrics.get_consumed_cycles_by_use_case().is_empty());
+
+    // A round in which the subnet observes no use case whatsoever: no outcall, no
+    // canister deletion, no dropped message.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    // The entries were nevertheless backfilled from the scalar fields.
+    let by_use_case = test
+        .state()
+        .metadata
+        .subnet_metrics
+        .get_consumed_cycles_by_use_case();
+    assert_eq!(
+        by_use_case[&CyclesUseCase::HTTPOutcalls],
+        NominalCycles::new(100)
+    );
+    assert_eq!(
+        by_use_case[&CyclesUseCase::ECDSAOutcalls],
+        NominalCycles::new(200)
+    );
+
+    // The monotonic counters map is left untouched, so no spurious counter jump.
+    assert!(
+        test.state()
+            .metadata
+            .subnet_metrics
+            .get_consumed_cycles_by_use_case_as_counters()
+            .is_empty()
+    );
 }
 
 #[test]

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -498,11 +498,6 @@ impl SubnetMetrics {
             .consumed_cycles_by_use_case_as_counters
             .entry(use_case)
             .or_insert_with(NominalCycles::zero) += cycles;
-
-        // Migrate the legacy scalar outcall fields into the use-case map. This
-        // runs on every observed use case, independently of whether the scalar
-        // fields themselves are observed.
-        self.migrate_outcalls_cycles_to_use_cases();
     }
 
     pub fn observe_consumed_cycles_by_deleted_canisters(&mut self, cycles: NominalCycles) {
@@ -536,10 +531,19 @@ impl SubnetMetrics {
     /// that predates use-case tracking while avoiding double counting the
     /// overlapping period.
     ///
-    /// This runs whenever a use case is observed (see
-    /// `observe_consumed_cycles_with_use_case`), i.e. independently of whether
-    /// the scalar fields themselves are observed, so the use-case entries also
-    /// catch up on subnets that stop performing outcalls.
+    /// This is called unconditionally once per round (from the scheduler's
+    /// `finish_round`), i.e. independently of any subnet activity. Hooking it to
+    /// an observation instead would leave the entries stale indefinitely on
+    /// subnets that observe no subnet-level use case at all: the subnet-level use
+    /// cases are only observed on HTTP outcalls, threshold signature outcalls,
+    /// canister deletion and cycles lost to dropped messages, so a subnet that
+    /// does none of these (e.g. one that has stopped performing outcalls) would
+    /// never catch up.
+    ///
+    /// Running once per round rather than per observation is equivalent, because
+    /// the call sites bump the scalar field and the matching use-case entry by
+    /// the same amount: `max(entry, scalar) + delta == max(entry + delta, scalar
+    /// + delta)`. It is also idempotent, so extra invocations are harmless.
     ///
     /// Only the `consumed_cycles_by_use_case` map is migrated; the monotonic
     /// `consumed_cycles_by_use_case_as_counters` map is intentionally left
@@ -549,7 +553,7 @@ impl SubnetMetrics {
     /// than zeroed, so that they remain the source of truth for readers such as
     /// `consumed_cycles_total` (which still reads them for now) and so that
     /// downgrading to an earlier replica version observes the correct totals.
-    fn migrate_outcalls_cycles_to_use_cases(&mut self) {
+    pub fn migrate_outcalls_cycles_to_use_cases(&mut self) {
         for (scalar, use_case) in [
             (
                 self.consumed_cycles_http_outcalls,

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2951,7 +2951,7 @@ fn consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases() {
 }
 
 #[test]
-fn observe_use_case_migrates_outcalls_scalar_fields_into_use_cases() {
+fn migrate_outcalls_scalar_fields_into_use_cases() {
     let mut subnet_metrics = SubnetMetrics {
         // Simulate a state persisted before use-case tracking existed: the scalar
         // fields hold the full history while the use-case entries only cover a
@@ -2969,10 +2969,12 @@ fn observe_use_case_migrates_outcalls_scalar_fields_into_use_cases() {
         ..Default::default()
     };
 
-    // Observing an *unrelated* use case triggers the migration, i.e. it runs
-    // independently of whether the HTTP/ECDSA scalar fields are observed.
+    // An unrelated use case is observed, as would happen during a round.
     subnet_metrics
         .observe_consumed_cycles_with_use_case(CyclesUseCase::Instructions, NominalCycles::new(5));
+
+    // The migration runs unconditionally at the end of the round.
+    subnet_metrics.migrate_outcalls_cycles_to_use_cases();
 
     let by_use_case = subnet_metrics.get_consumed_cycles_by_use_case();
 
@@ -3044,6 +3046,11 @@ fn observe_http_outcall_use_case_stays_in_lockstep_with_scalar() {
     subnet_metrics
         .observe_consumed_cycles_with_use_case(CyclesUseCase::HTTPOutcalls, NominalCycles::new(5));
 
+    // The migration runs unconditionally at the end of the round. Because both
+    // the scalar and the use-case entry grew by the same amount, reconciling
+    // after the increments yields the same result as reconciling before them.
+    subnet_metrics.migrate_outcalls_cycles_to_use_cases();
+
     // The use-case entry caught up to the (superset) scalar and grew by 5, with
     // no double counting.
     assert_eq!(
@@ -3061,6 +3068,47 @@ fn observe_http_outcall_use_case_stays_in_lockstep_with_scalar() {
         subnet_metrics.get_consumed_cycles_by_use_case_as_counters()[&CyclesUseCase::HTTPOutcalls],
         NominalCycles::new(65)
     );
+}
+
+#[test]
+fn migrate_outcalls_scalar_fields_without_any_observation() {
+    // A subnet that consumed ECDSA outcall cycles before use-case tracking
+    // existed and has been idle (in subnet-level terms) ever since: no outcall,
+    // no canister deletion, no dropped message. Nothing observes a use case, so
+    // the counters map is empty.
+    let mut subnet_metrics = SubnetMetrics {
+        consumed_cycles_ecdsa_outcalls: NominalCycles::new(200),
+        consumed_cycles_by_use_case: BTreeMap::from([(
+            CyclesUseCase::ECDSAOutcalls,
+            NominalCycles::new(150),
+        )]),
+        ..Default::default()
+    };
+
+    subnet_metrics.migrate_outcalls_cycles_to_use_cases();
+
+    // The stale entry was backfilled without any use case being observed.
+    assert_eq!(
+        subnet_metrics.get_consumed_cycles_by_use_case()[&CyclesUseCase::ECDSAOutcalls],
+        NominalCycles::new(200)
+    );
+    // A zero scalar does not insert a spurious entry.
+    assert!(
+        !subnet_metrics
+            .get_consumed_cycles_by_use_case()
+            .contains_key(&CyclesUseCase::HTTPOutcalls)
+    );
+    // The counters map is left untouched, i.e. still empty.
+    assert!(
+        subnet_metrics
+            .get_consumed_cycles_by_use_case_as_counters()
+            .is_empty()
+    );
+
+    // Idempotent: running it again changes nothing.
+    let before = subnet_metrics.get_consumed_cycles_by_use_case().clone();
+    subnet_metrics.migrate_outcalls_cycles_to_use_cases();
+    assert_eq!(subnet_metrics.get_consumed_cycles_by_use_case(), &before);
 }
 
 impl From<(u64, u64)> for BlockmakerStats {


### PR DESCRIPTION
The migration added in #10844, which brings the HTTPOutcalls / ECDSAOutcalls entries of SubnetMetrics::consumed_cycles_by_use_case up to the legacy scalar fields, was invoked from observe_consumed_cycles_with_use_case. That only fires when the subnet observes a subnet-level use case, and those are only observed on HTTP outcalls, threshold signature outcalls, canister deletion and cycles lost to dropped messages. A subnet that does none of these never runs the migration and its use-case entries stay stale indefinitely.

This is not hypothetical: on mainnet subnet
2fq7c-slacv-26cgz-vzbx2-2jrcs-5edph-i5s2j-tck77-c3rlz-iobzx-mqe, consumed_cycles_ecdsa_outcalls is 244_900_000_000_000 while the ECDSAOutcalls use-case entry is 228_370_000_000_000, a gap of 16_530_000_000_000 cycles. Its consumed_cycles_by_use_case_as_counters map is empty, which (since that map is incremented on the very same code path) shows that no subnet-level use case has been observed there since the counters were introduced in #9922, i.e. well before the migration was deployed.

The migration now runs from the scheduler's finish_round, which is documented as running unconditionally after each round and is also reached by the heap-delta early return and by checkpoint_round_with_no_execution. Running it once per round instead of per observation is equivalent, because the call sites bump the scalar field and the matching use-case entry by the same amount: max(entry, scalar) + delta == max(entry + delta, scalar + delta). It is also idempotent, so the extra invocations are harmless.