### PR TITLE
chore(dkg): remove summary's transcripts for remote subnets (2/4)

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -1056,10 +1056,7 @@ mod tests {
                 for dkg_id in summary.dkg.configs.keys() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(
-                    summary.dkg.transcripts_for_remote_subnets.as_ref(),
-                    Some(&vec![])
-                );
+                assert_eq!(summary.dkg.transcripts_for_remote_subnets.as_ref(), None);
                 // Verify that the remote_dkg_attempts are set to `Completed`.
                 assert_eq!(
                     summary.dkg.remote_dkg_attempts.get(&target_id),

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -268,7 +268,7 @@ pub struct DkgSummary {
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
     /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, true>,
+    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, false>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -302,7 +302,7 @@ impl DkgSummary {
                 .collect(),
             current_transcripts,
             next_transcripts,
-            transcripts_for_remote_subnets: BackwardsCompatible::new(vec![]),
+            transcripts_for_remote_subnets: BackwardsCompatible::empty(),
             registry_version,
             interval_length,
             next_interval_length,


### PR DESCRIPTION
Now that all subnets understand the sentinel field, stop hashing an empty vector of transcripts and start populating the sentinel field to declare that intent.

> V1 <-> V2 (https://github.com/dfinity/ic/pull/11221):
The goal of V2 is to actually stop hashing an empty vector, and instead just ignore it.
Upgrade V1 -> V2: V2 still understands `Some(vec![])` so will compute V1's summary's hash identically. For its own summaries, it starts to fill the sentinel (because the transcripts are `None`).
Rollback V2 -> V1: V1 understands the sentinel and thus ignores the transcripts while computing the hash.