### PR TITLE
chore(dkg): remove summary's transcripts for remote subnets (3/4)

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -1056,7 +1056,6 @@ mod tests {
                 for dkg_id in summary.dkg.configs.keys() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(summary.dkg.transcripts_for_remote_subnets.as_ref(), None);
                 // Verify that the remote_dkg_attempts are set to `Completed`.
                 assert_eq!(
                     summary.dkg.remote_dkg_attempts.get(&target_id),

--- a/rs/consensus/dkg/src/test_utils.rs
+++ b/rs/consensus/dkg/src/test_utils.rs
@@ -112,12 +112,7 @@ pub(super) fn extract_remote_dkgs_from_highest_block(
         .into_inner();
 
     match block.payload.as_ref() {
-        BlockPayload::Summary(summary) => summary
-            .dkg
-            .transcripts_for_remote_subnets
-            .as_ref()
-            .cloned()
-            .unwrap_or_default(),
+        BlockPayload::Summary(_) => vec![],
         BlockPayload::Data(data) => data.dkg.transcripts_for_remote_subnets.clone(),
     }
 }

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -376,7 +376,7 @@ fn deliver_batches(
 
 /// This function creates responses to the system calls that are redirected to
 /// consensus. There are two types of calls being handled here:
-/// - Initial NiDKG transcript creation, where a response may come from summary or data payloads.
+/// - Initial NiDKG transcript creation, where a response may come from data payloads.
 /// - Canister threshold signature creation, where a response may come from from data payloads.
 /// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
 fn generate_responses_to_subnet_calls(

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -392,10 +392,6 @@ fn generate_responses_to_subnet_calls(
                 "New DKG summary with config ids created: {:?}",
                 summary_payload.dkg.configs.keys().collect::<Vec<_>>()
             );
-            if let Some(transcripts) = summary_payload.dkg.transcripts_for_remote_subnets.as_ref() {
-                consensus_responses
-                    .append(&mut generate_responses_to_remote_dkgs(transcripts, log));
-            }
             CanisterHttpSpent::default()
         }
         BlockPayload::Data(data_payload) => {

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -40,15 +40,15 @@ message PostSplitArgs {
 
 // next id: 17
 message Summary {
-  reserved 5, 6, 8;
+  reserved 5, 6, 8, 10;
   reserved "transcripts_for_new_subnets";
+  reserved "transcripts_for_remote_subnets";
   uint64 registry_version = 1;
   uint64 interval_length = 2;
   uint64 next_interval_length = 3;
   uint64 height = 4;
   repeated NiDkgConfig configs = 7;
   repeated RemoteDkgAttemptCount remote_dkg_attempts = 9;
-  repeated CallbackIdedNiDkgTranscript transcripts_for_remote_subnets = 10;
   repeated NiDkgTranscript current_transcripts = 11;
   repeated NiDkgTranscript next_transcripts = 12;
   oneof subnet_splitting_status {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -396,8 +396,6 @@ pub struct Summary {
     pub configs: ::prost::alloc::vec::Vec<NiDkgConfig>,
     #[prost(message, repeated, tag = "9")]
     pub remote_dkg_attempts: ::prost::alloc::vec::Vec<RemoteDkgAttemptCount>,
-    #[prost(message, repeated, tag = "10")]
-    pub transcripts_for_remote_subnets: ::prost::alloc::vec::Vec<CallbackIdedNiDkgTranscript>,
     #[prost(message, repeated, tag = "11")]
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -4,7 +4,6 @@ use super::*;
 use crate::{
     ReplicaVersion,
     artifact::PbArtifact,
-    backwards_compatibility::BackwardsCompatible,
     crypto::threshold_sig::ni_dkg::{
         NiDkgDealing, NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTranscript,
         config::NiDkgConfig,
@@ -453,7 +452,7 @@ impl From<&DkgSummary> for pb::Summary {
             // otherwise decode the empty repeated field above into `Some(vec![])` and hash its
             // length prefix, where this version hashes nothing. It may only stop being set once no
             // replica version that reads it is deployed any more.
-            transcripts_for_remote_subnets_removed: Some(true),
+            transcripts_for_remote_subnets_removed: true,
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: Some(pb::summary::SubnetSplittingStatus::from(
                 summary.subnet_splitting_status,

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -267,8 +267,6 @@ pub struct DkgSummary {
     /// corresponding to this tag.
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
-    /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, false>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -302,7 +300,6 @@ impl DkgSummary {
                 .collect(),
             current_transcripts,
             next_transcripts,
-            transcripts_for_remote_subnets: BackwardsCompatible::empty(),
             registry_version,
             interval_length,
             next_interval_length,
@@ -451,21 +448,12 @@ impl From<&DkgSummary> for pb::Summary {
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),
-            transcripts_for_remote_subnets: summary
-                .transcripts_for_remote_subnets
-                .as_ref()
-                .map(|t| build_callback_ided_transcripts_vec(t.as_slice()))
-                // `None` -> empty vector
-                .unwrap_or_default(),
-            // Relay the marker instead of only ever setting it for our own summaries: `prost`
-            // drops unknown fields, so a replica version that decodes a summary coming from a
-            // version which no longer maintains the field and re-encodes it would otherwise strip
-            // the marker, turning `None` back into `Some(vec![])` downstream and thereby changing
-            // the hash of that summary.
-            transcripts_for_remote_subnets_removed: summary
-                .transcripts_for_remote_subnets
-                .as_ref()
-                .is_none(),
+            // The marker must keep being set even though this replica version no longer reads it:
+            // replica versions that still carry the field derive it from this marker, and would
+            // otherwise decode the empty repeated field above into `Some(vec![])` and hash its
+            // length prefix, where this version hashes nothing. It may only stop being set once no
+            // replica version that reads it is deployed any more.
+            transcripts_for_remote_subnets_removed: Some(true),
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: Some(pb::summary::SubnetSplittingStatus::from(
                 summary.subnet_splitting_status,
@@ -623,16 +611,6 @@ impl TryFrom<pb::Summary> for DkgSummary {
             interval_length: Height::from(summary.interval_length),
             next_interval_length: Height::from(summary.next_interval_length),
             height: Height::from(summary.height),
-            transcripts_for_remote_subnets: BackwardsCompatible::try_from_proto_with(
-                // A set marker means the summary was produced by a replica version that no longer
-                // maintains the field, in which case the repeated field must be ignored entirely,
-                // including for hashing. Without the marker the repeated field is authoritative,
-                // even when empty: an empty vector still contributes its length prefix to the hash
-                // preimage, exactly as it did before the field became `BackwardsCompatible`.
-                (!summary.transcripts_for_remote_subnets_removed)
-                    .then_some(summary.transcripts_for_remote_subnets),
-                |t| build_transcripts_vec_from_pb(t).map_err(ProxyDecodeError::Other),
-            )?,
             remote_dkg_attempts: build_remote_dkg_attempts_map(&summary.remote_dkg_attempts),
             subnet_splitting_status: try_from_option_field(
                 summary.subnet_splitting_status,


### PR DESCRIPTION
Now that we stopped hashing the empty vector of transcripts, we can safely remove the field from the summary, still filling the sentinel (if we did not, a rollback to the previous version would incorrectly hash an empty vector).

> V2 <-> V3 (https://github.com/dfinity/ic/pull/11223):
The goal of V3 is to remove the field entirely.
Upgrade V2 -> V3: V3 doesn't know about the transcripts anymore (the field is removed). V2 created a summary with `None` transcripts meaning their hash was not included, good.
Rollback V3 -> V2: V3 unconditionally sets the sentinel to `true`, meaning V2 will interpret the transcripts as `None` and not try to hash them.