### PR TITLE
chore(dkg): remove summary's transcripts for remote subnets (4/4)

### DIFF
--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -40,9 +40,10 @@ message PostSplitArgs {
 
 // next id: 17
 message Summary {
-  reserved 5, 6, 8, 10;
+  reserved 5, 6, 8, 10, 16;
   reserved "transcripts_for_new_subnets";
   reserved "transcripts_for_remote_subnets";
+  reserved "transcripts_for_remote_subnets_removed";
   uint64 registry_version = 1;
   uint64 interval_length = 2;
   uint64 next_interval_length = 3;
@@ -56,14 +57,6 @@ message Summary {
     SplittingArgs scheduled = 14;
     PostSplitArgs post_split = 15;
   }
-  // Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
-  //
-  // When set, field 10 must be ignored entirely, including when hashing the summary. This is what
-  // allows the field to be removed without changing the hash of a summary: replica versions that
-  // still maintain the field and versions that have dropped it derive the same hash from the same
-  // wire bytes, because both read this marker. `repeated` fields cannot express the difference
-  // between "absent" and "empty" on the wire, hence the separate marker.
-  bool transcripts_for_remote_subnets_removed = 16;
 }
 
 message CallbackIdedNiDkgTranscript {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -400,15 +400,6 @@ pub struct Summary {
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]
     pub next_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
-    /// Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
-    ///
-    /// When set, field 10 must be ignored entirely, including when hashing the summary. This is what
-    /// allows the field to be removed without changing the hash of a summary: replica versions that
-    /// still maintain the field and versions that have dropped it derive the same hash from the same
-    /// wire bytes, because both read this marker. `repeated` fields cannot express the difference
-    /// between "absent" and "empty" on the wire, hence the separate marker.
-    #[prost(bool, tag = "16")]
-    pub transcripts_for_remote_subnets_removed: bool,
     #[prost(oneof = "summary::SubnetSplittingStatus", tags = "13, 14, 15")]
     pub subnet_splitting_status: ::core::option::Option<summary::SubnetSplittingStatus>,
 }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -447,12 +447,6 @@ impl From<&DkgSummary> for pb::Summary {
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),
-            // The marker must keep being set even though this replica version no longer reads it:
-            // replica versions that still carry the field derive it from this marker, and would
-            // otherwise decode the empty repeated field above into `Some(vec![])` and hash its
-            // length prefix, where this version hashes nothing. It may only stop being set once no
-            // replica version that reads it is deployed any more.
-            transcripts_for_remote_subnets_removed: true,
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: Some(pb::summary::SubnetSplittingStatus::from(
                 summary.subnet_splitting_status,


### PR DESCRIPTION
The sentinel field is no longer read: remove it from the protobuf definition.

> V3 <-> V4 (https://github.com/dfinity/ic/pull/11224):
The goal of V4 is to remove the introduced sentinel field.
Upgrade V3 -> V4: V4 will ignore the sentinel field set by V3.
Rollback V4 -> V3: V3 will deserialize a summary with an unset sentinel, but it does not read it anyways.