### PR TITLE
refactor(batch delivery): highlight and group together differences between data and summary blocks delivery

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -995,7 +995,6 @@ mod tests {
                 for dkg_id in summary.dkg.configs.keys() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(summary.dkg.transcripts_for_remote_subnets.as_ref(), None);
                 // Verify that the remote_dkg_attempts are set to `Completed`.
                 assert_eq!(
                     summary.dkg.remote_dkg_attempts.get(&target_id),

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -995,10 +995,7 @@ mod tests {
                 for dkg_id in summary.dkg.configs.keys() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(
-                    summary.dkg.transcripts_for_remote_subnets.as_ref(),
-                    Some(&vec![])
-                );
+                assert_eq!(summary.dkg.transcripts_for_remote_subnets.as_ref(), None);
                 // Verify that the remote_dkg_attempts are set to `Completed`.
                 assert_eq!(
                     summary.dkg.remote_dkg_attempts.get(&target_id),

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -995,7 +995,10 @@ mod tests {
                 for dkg_id in summary.dkg.configs.keys() {
                     assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Local);
                 }
-                assert_eq!(summary.dkg.transcripts_for_remote_subnets.len(), 0);
+                assert_eq!(
+                    summary.dkg.transcripts_for_remote_subnets.as_ref(),
+                    Some(&vec![])
+                );
                 // Verify that the remote_dkg_attempts are set to `Completed`.
                 assert_eq!(
                     summary.dkg.remote_dkg_attempts.get(&target_id),

--- a/rs/consensus/dkg/src/test_utils.rs
+++ b/rs/consensus/dkg/src/test_utils.rs
@@ -112,7 +112,7 @@ pub(super) fn extract_remote_dkgs_from_highest_block(
         .into_inner();
 
     match block.payload.as_ref() {
-        BlockPayload::Summary(summary) => summary.dkg.transcripts_for_remote_subnets.clone(),
+        BlockPayload::Summary(_) => vec![],
         BlockPayload::Data(data) => data.dkg.transcripts_for_remote_subnets.clone(),
     }
 }

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -315,7 +315,7 @@ pub(crate) fn deliver_batches_with_result_processor(
 
 /// This function creates responses to the system calls that are redirected to
 /// consensus. There are two types of calls being handled here:
-/// - Initial NiDKG transcript creation, where a response may come from summary or data payloads.
+/// - Initial NiDKG transcript creation, where a response may come from data payloads.
 /// - Canister threshold signature creation, where a response may come from from data payloads.
 /// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
 fn generate_responses_to_subnet_calls(

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -314,11 +314,19 @@ pub(crate) fn deliver_batches_with_result_processor(
     Ok(last_delivered_batch_height)
 }
 
-/// This function creates responses to the system calls that are redirected to
-/// consensus. There are two types of calls being handled here:
-/// - Initial NiDKG transcript creation, where a response may come from data payloads.
-/// - Canister threshold signature creation, where a response may come from from data payloads.
-/// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
+/// Extracts from a data payload everything needed to deliver it as a batch, in the order returned:
+///
+/// - The [`BatchMessages`] of the batch payload.
+/// - The responses to the system calls that are redirected to consensus. There are three types of
+///   calls being handled here:
+///   - Initial NiDKG transcript creation.
+///   - Canister threshold signature creation.
+///   - CanisterHttpResponse handling, i.e. responses to canister http requests.
+///
+///   All of them are answered from the data payload; summary payloads carry no responses.
+/// - The [`BatchStats`] of the payload, including the canister http stats.
+/// - The cycles spent on the canister http requests answered by this payload and/or by previous
+///   payloads.
 fn get_messages_responses_stats_and_http_spent(
     height: Height,
     data_payload: &DataPayload,

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -235,7 +235,7 @@ pub(crate) fn deliver_batches_with_result_processor(
             }
             BlockPayload::Data(data_payload) => {
                 let (batch_messages, consensus_responses, batch_stats, canister_http_spent) =
-                    get_messages_responses_stats_and_http_spent(height, &data_payload, log);
+                    get_messages_responses_stats_and_http_spent(height, data_payload, log);
 
                 let batch_content = BatchContent::Data {
                     batch_messages,
@@ -733,14 +733,14 @@ mod tests {
             ],
         };
 
-        let block_payload = DataPayload {
+        let data_payload = DataPayload {
             batch: BatchPayload::default(),
             dkg: dkg_data,
             idkg: None,
         };
         let (_, responses, _, _) = get_messages_responses_stats_and_http_spent(
             Height::from(1),
-            &block_payload,
+            &data_payload,
             &no_op_logger(),
         );
 

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -331,10 +331,10 @@ fn generate_responses_to_subnet_calls(
                 "New DKG summary with config ids created: {:?}",
                 summary_payload.dkg.configs.keys().collect::<Vec<_>>()
             );
-            consensus_responses.append(&mut generate_responses_to_remote_dkgs(
-                &summary_payload.dkg.transcripts_for_remote_subnets,
-                log,
-            ));
+            if let Some(transcripts) = summary_payload.dkg.transcripts_for_remote_subnets.as_ref() {
+                consensus_responses
+                    .append(&mut generate_responses_to_remote_dkgs(transcripts, log));
+            }
             CanisterHttpSpent::default()
         }
         BlockPayload::Data(data_payload) => {

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -331,10 +331,6 @@ fn generate_responses_to_subnet_calls(
                 "New DKG summary with config ids created: {:?}",
                 summary_payload.dkg.configs.keys().collect::<Vec<_>>()
             );
-            if let Some(transcripts) = summary_payload.dkg.transcripts_for_remote_subnets.as_ref() {
-                consensus_responses
-                    .append(&mut generate_responses_to_remote_dkgs(transcripts, log));
-            }
             CanisterHttpSpent::default()
         }
         BlockPayload::Data(data_payload) => {

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -30,14 +30,16 @@ use ic_types::{
         ChainKeyData, ConsensusResponse,
     },
     consensus::{
-        Block, BlockPayload, HasVersion,
+        BlockPayload, DataPayload, HasVersion,
         dkg::RemoteTranscriptResult,
         idkg::{self},
     },
-    crypto::randomness_from_crypto_hashable,
-    crypto::threshold_sig::{
-        ThresholdSigPublicKey,
-        ni_dkg::{NiDkgId, NiDkgTag, NiDkgTranscript},
+    crypto::{
+        randomness_from_crypto_hashable,
+        threshold_sig::{
+            ThresholdSigPublicKey,
+            ni_dkg::{NiDkgId, NiDkgTag, NiDkgTranscript},
+        },
     },
     messages::{CallbackId, Payload, RejectContext},
 };
@@ -149,14 +151,8 @@ pub(crate) fn deliver_batches_with_result_processor(
         };
         let dkg_summary = &summary_block.payload.as_ref().as_summary().dkg;
 
-        if block.payload.is_summary() {
-            info!(
-                log,
-                "Delivering finalized batch at CUP height of {}", height
-            );
-        }
-        // When we are not delivering CUP block, we must check if the subnet is halted.
-        else {
+        if !block.payload.is_summary() {
+            // When delivering a data block, we must check if the subnet is halted.
             match status::get_status(
                 height,
                 &summary_block,
@@ -185,8 +181,6 @@ pub(crate) fn deliver_batches_with_result_processor(
             }
         }
 
-        let randomness = randomness_from_crypto_hashable(&tape);
-
         let mut chain_key_subnet_public_keys = BTreeMap::new();
         let (mut idkg_subnet_public_keys, idkg_pre_signatures) =
             get_idkg_subnet_public_keys_and_pre_signatures(
@@ -197,57 +191,63 @@ pub(crate) fn deliver_batches_with_result_processor(
                 block_stats.idkg_stats.as_mut(),
             );
         chain_key_subnet_public_keys.append(&mut idkg_subnet_public_keys);
-
         // Add vetKD keys to this map as well
         let (mut nidkg_subnet_public_keys, nidkg_ids) = get_vetkey_public_keys(dkg_summary, log);
         chain_key_subnet_public_keys.append(&mut nidkg_subnet_public_keys);
-
-        // If the subnet contains chain keys, log them on every summary block
-        if !chain_key_subnet_public_keys.is_empty() && block.payload.is_summary() {
-            info!(
-                log,
-                "Subnet {} contains chain keys: {:?}", subnet_id, chain_key_subnet_public_keys
-            );
-        }
-
-        let mut batch_stats = BatchStats::new(height);
-
         let chain_key_data = ChainKeyData {
             master_public_keys: chain_key_subnet_public_keys,
             idkg_pre_signatures,
             nidkg_ids,
         };
-        let (consensus_responses, canister_http_spent) =
-            generate_responses_to_subnet_calls(&block, &mut batch_stats, log);
-        // This flag can only be true, if we've called deliver_batches with a height
-        // limit.  In this case we also want to have a checkpoint for that last height.
-        let persist_batch = Some(height) == max_batch_height_to_deliver;
-        let requires_full_state_hash = block.payload.is_summary() || persist_batch;
-        let batch_content = match block.payload.as_ref() {
-            BlockPayload::Summary(_summary_payload) => BatchContent::Data {
-                batch_messages: BatchMessages::default(),
-                chain_key_data,
-                consensus_responses,
-                canister_http_spent,
-                requires_full_state_hash,
-            },
+
+        let (batch_content, batch_stats) = match block.payload.as_ref() {
+            BlockPayload::Summary(summary_payload) => {
+                info!(
+                    log,
+                    "Delivering finalized DKG summary at height {} with config ids: {:?}",
+                    height,
+                    summary_payload.dkg.configs.keys().collect::<Vec<_>>()
+                );
+
+                // If the subnet contains chain keys, log them on every summary block
+                if !chain_key_data.master_public_keys.is_empty() {
+                    info!(
+                        log,
+                        "Subnet {} contains chain keys: {:?}",
+                        subnet_id,
+                        chain_key_data.master_public_keys
+                    );
+                }
+
+                let batch_stats = BatchStats {
+                    batch_height: height.get(),
+                    ..Default::default()
+                };
+                let batch_content = BatchContent::Data {
+                    batch_messages: BatchMessages::default(),
+                    chain_key_data,
+                    consensus_responses: vec![],
+                    canister_http_spent: Default::default(),
+                    requires_full_state_hash: true,
+                };
+
+                (batch_content, batch_stats)
+            }
             BlockPayload::Data(data_payload) => {
-                batch_stats.add_from_payload(&data_payload.batch);
-                BatchContent::Data {
-                    batch_messages: data_payload
-                        .batch
-                        .clone()
-                        .into_messages()
-                        .map_err(|err| {
-                            error!(log, "batch payload deserialization failed: {:?}", err);
-                            err
-                        })
-                        .unwrap_or_default(),
+                let (batch_messages, consensus_responses, batch_stats, canister_http_spent) =
+                    get_messages_responses_stats_and_http_spent(height, &data_payload, log);
+
+                let batch_content = BatchContent::Data {
+                    batch_messages,
                     chain_key_data,
                     consensus_responses,
                     canister_http_spent,
-                    requires_full_state_hash,
-                }
+                    // This flag can only be true, if we've called deliver_batches with a height
+                    // limit.  In this case we also want to have a checkpoint for that last height.
+                    requires_full_state_hash: Some(height) == max_batch_height_to_deliver,
+                };
+
+                (batch_content, batch_stats)
             }
         };
 
@@ -282,6 +282,8 @@ pub(crate) fn deliver_batches_with_result_processor(
             failed_blockmakers: blockmaker_ranking[0..(block.rank.0 as usize)].to_vec(),
         };
 
+        let randomness = randomness_from_crypto_hashable(&tape);
+
         let next_checkpoint_height = dkg_summary.get_next_start_height();
         let current_interval_length = dkg_summary.interval_length;
         let batch = Batch {
@@ -292,7 +294,6 @@ pub(crate) fn deliver_batches_with_result_processor(
             }),
             content: batch_content,
             randomness,
-
             registry_version: block.context.registry_version,
             time: block.context.time,
             blockmaker_metrics,
@@ -318,44 +319,50 @@ pub(crate) fn deliver_batches_with_result_processor(
 /// - Initial NiDKG transcript creation, where a response may come from data payloads.
 /// - Canister threshold signature creation, where a response may come from from data payloads.
 /// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
-fn generate_responses_to_subnet_calls(
-    block: &Block,
-    stats: &mut BatchStats,
+fn get_messages_responses_stats_and_http_spent(
+    height: Height,
+    data_payload: &DataPayload,
     log: &ReplicaLogger,
-) -> (Vec<ConsensusResponse>, CanisterHttpSpent) {
-    let mut consensus_responses = Vec::new();
-    let canister_http_spent = match block.payload.as_ref() {
-        BlockPayload::Summary(summary_payload) => {
-            info!(
-                log,
-                "New DKG summary with config ids created: {:?}",
-                summary_payload.dkg.configs.keys().collect::<Vec<_>>()
-            );
-            CanisterHttpSpent::default()
-        }
-        BlockPayload::Data(data_payload) => {
-            consensus_responses.append(&mut generate_responses_to_remote_dkgs(
-                &data_payload.dkg.transcripts_for_remote_subnets,
-                log,
-            ));
+) -> (
+    BatchMessages,
+    Vec<ConsensusResponse>,
+    BatchStats,
+    CanisterHttpSpent,
+) {
+    let messages = data_payload
+        .batch
+        .clone()
+        .into_messages()
+        .map_err(|err| {
+            error!(log, "batch payload deserialization failed: {:?}", err);
+            err
+        })
+        .unwrap_or_default();
 
-            if let Some(payload) = &data_payload.idkg {
-                consensus_responses
-                    .append(&mut generate_responses_to_initial_dealings_calls(payload));
-            }
+    let mut responses = Vec::new();
+    responses.append(&mut generate_responses_to_remote_dkgs(
+        &data_payload.dkg.transcripts_for_remote_subnets,
+        log,
+    ));
 
-            let (mut http_responses, http_spent, http_stats) =
-                CanisterHttpPayloadBuilderImpl::into_messages(&data_payload.batch.canister_http);
-            consensus_responses.append(&mut http_responses);
-            stats.canister_http = http_stats;
+    if let Some(payload) = &data_payload.idkg {
+        responses.append(&mut generate_responses_to_initial_dealings_calls(payload));
+    }
 
-            let mut chain_key_responses =
-                ChainKeyPayloadBuilderImpl::into_messages(&data_payload.batch.chain_key);
-            consensus_responses.append(&mut chain_key_responses);
-            http_spent
-        }
+    let (mut http_responses, canister_http_spent, http_stats) =
+        CanisterHttpPayloadBuilderImpl::into_messages(&data_payload.batch.canister_http);
+    responses.append(&mut http_responses);
+
+    let mut chain_key_responses =
+        ChainKeyPayloadBuilderImpl::into_messages(&data_payload.batch.chain_key);
+    responses.append(&mut chain_key_responses);
+
+    let stats = BatchStats {
+        canister_http: http_stats,
+        ..BatchStats::from_payload(height, &data_payload.batch)
     };
-    (consensus_responses, canister_http_spent)
+
+    (messages, responses, stats, canister_http_spent)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -578,20 +585,16 @@ mod tests {
     use ic_management_canister_types_private::{SetupInitialDKGResponse, VetKdCurve, VetKdKeyId};
     use ic_test_utilities_types::ids::subnet_test_id;
     use ic_types::{
-        PrincipalId, RegistryVersion, SubnetId,
-        batch::{BatchPayload, ValidationContext},
+        PrincipalId, SubnetId,
+        batch::BatchPayload,
         consensus::{
-            DataPayload, Payload as ConsensusPayload, Rank,
+            DataPayload,
             dkg::{DkgDataPayload, RemoteTranscriptResult},
         },
-        crypto::{
-            CryptoHash, CryptoHashOf,
-            threshold_sig::ni_dkg::{
-                NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
-            },
+        crypto::threshold_sig::ni_dkg::{
+            NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
         },
         messages::{CallbackId, Payload},
-        time::UNIX_EPOCH,
     };
     use std::str::FromStr;
 
@@ -722,29 +725,16 @@ mod tests {
             ],
         };
 
-        let block_payload = BlockPayload::Data(DataPayload {
+        let block_payload = DataPayload {
             batch: BatchPayload::default(),
             dkg: dkg_data,
             idkg: None,
-        });
-
-        let payload = ConsensusPayload::new(ic_types::crypto::crypto_hash, block_payload);
-
-        let block = Block::new(
-            CryptoHashOf::from(CryptoHash(vec![0_u8; 32])),
-            payload,
+        };
+        let (_, responses, _, _) = get_messages_responses_stats_and_http_spent(
             Height::from(1),
-            Rank(0),
-            ValidationContext {
-                registry_version: RegistryVersion::from(1),
-                certified_height: Height::from(0),
-                time: UNIX_EPOCH,
-            },
+            &block_payload,
+            &no_op_logger(),
         );
-
-        let mut batch_stats = BatchStats::new(Height::from(1));
-        let (responses, _canister_http_spent) =
-            generate_responses_to_subnet_calls(&block, &mut batch_stats, &no_op_logger());
 
         assert_eq!(
             responses.len(),

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -145,21 +145,19 @@ pub(crate) struct BatchStats {
 }
 
 impl BatchStats {
-    pub(crate) fn new(batch_height: Height) -> Self {
+    pub(crate) fn from_payload(batch_height: Height, payload: &BatchPayload) -> Self {
         Self {
             batch_height: batch_height.get(),
-            ..Self::default()
+            ingress_messages_delivered: payload.ingress.message_count(),
+            ingress_message_bytes_delivered: payload.ingress.total_messages_size_estimate().get()
+                as usize,
+            xnet_bytes_delivered: payload.xnet.size_bytes(),
+            ingress_ids: payload.ingress.message_ids().cloned().collect(),
+            canister_http: CanisterHttpBatchStats {
+                payload_bytes: payload.canister_http.len(),
+                ..Default::default()
+            },
         }
-    }
-
-    pub(crate) fn add_from_payload(&mut self, payload: &BatchPayload) {
-        self.ingress_messages_delivered += payload.ingress.message_count();
-        self.ingress_message_bytes_delivered +=
-            payload.ingress.total_messages_size_estimate().get() as usize;
-        self.xnet_bytes_delivered += payload.xnet.size_bytes();
-        self.ingress_ids
-            .extend(payload.ingress.message_ids().cloned());
-        self.canister_http.payload_bytes = payload.canister_http.len();
     }
 }
 

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -38,7 +38,7 @@ message PostSplitArgs {
   SubnetId new_subnet_id = 1;
 }
 
-// next id: 16
+// next id: 17
 message Summary {
   reserved 5, 6, 8;
   reserved "transcripts_for_new_subnets";
@@ -56,6 +56,15 @@ message Summary {
     SplittingArgs scheduled = 14;
     PostSplitArgs post_split = 15;
   }
+  // Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
+  //
+  // When set, field 10 must be ignored entirely, including when hashing the summary. This is what
+  // allows the field to be removed without changing the hash of a summary: replica versions that
+  // still maintain the field and versions that have dropped it derive the same hash from the same
+  // wire bytes, because both read this marker. `repeated` fields cannot express the difference
+  // between "absent" and "empty" on the wire, hence the separate marker. See the documentation of
+  // `ic_types::backwards_compatibility::BackwardsCompatible` for the rollout this is part of.
+  optional bool transcripts_for_remote_subnets_removed = 16;
 }
 
 message CallbackIdedNiDkgTranscript {

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -40,9 +40,10 @@ message PostSplitArgs {
 
 // next id: 17
 message Summary {
-  reserved 5, 6, 8, 10;
+  reserved 5, 6, 8, 10, 16;
   reserved "transcripts_for_new_subnets";
   reserved "transcripts_for_remote_subnets";
+  reserved "transcripts_for_remote_subnets_removed";
   uint64 registry_version = 1;
   uint64 interval_length = 2;
   uint64 next_interval_length = 3;
@@ -56,14 +57,6 @@ message Summary {
     SplittingArgs scheduled = 14;
     PostSplitArgs post_split = 15;
   }
-  // Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
-  //
-  // When set, field 10 must be ignored entirely, including when hashing the summary. This is what
-  // allows the field to be removed without changing the hash of a summary: replica versions that
-  // still maintain the field and versions that have dropped it derive the same hash from the same
-  // wire bytes, because both read this marker. `repeated` fields cannot express the difference
-  // between "absent" and "empty" on the wire, hence the separate marker.
-  optional bool transcripts_for_remote_subnets_removed = 16;
 }
 
 message CallbackIdedNiDkgTranscript {

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -40,15 +40,15 @@ message PostSplitArgs {
 
 // next id: 17
 message Summary {
-  reserved 5, 6, 8;
+  reserved 5, 6, 8, 10;
   reserved "transcripts_for_new_subnets";
+  reserved "transcripts_for_remote_subnets";
   uint64 registry_version = 1;
   uint64 interval_length = 2;
   uint64 next_interval_length = 3;
   uint64 height = 4;
   repeated NiDkgConfig configs = 7;
   repeated RemoteDkgAttemptCount remote_dkg_attempts = 9;
-  repeated CallbackIdedNiDkgTranscript transcripts_for_remote_subnets = 10;
   repeated NiDkgTranscript current_transcripts = 11;
   repeated NiDkgTranscript next_transcripts = 12;
   oneof subnet_splitting_status {

--- a/rs/protobuf/def/types/v1/dkg.proto
+++ b/rs/protobuf/def/types/v1/dkg.proto
@@ -62,8 +62,7 @@ message Summary {
   // allows the field to be removed without changing the hash of a summary: replica versions that
   // still maintain the field and versions that have dropped it derive the same hash from the same
   // wire bytes, because both read this marker. `repeated` fields cannot express the difference
-  // between "absent" and "empty" on the wire, hence the separate marker. See the documentation of
-  // `ic_types::backwards_compatibility::BackwardsCompatible` for the rollout this is part of.
+  // between "absent" and "empty" on the wire, hence the separate marker.
   optional bool transcripts_for_remote_subnets_removed = 16;
 }
 

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -408,8 +408,7 @@ pub struct Summary {
     /// allows the field to be removed without changing the hash of a summary: replica versions that
     /// still maintain the field and versions that have dropped it derive the same hash from the same
     /// wire bytes, because both read this marker. `repeated` fields cannot express the difference
-    /// between "absent" and "empty" on the wire, hence the separate marker. See the documentation of
-    /// `ic_types::backwards_compatibility::BackwardsCompatible` for the rollout this is part of.
+    /// between "absent" and "empty" on the wire, hence the separate marker.
     #[prost(bool, optional, tag = "16")]
     pub transcripts_for_remote_subnets_removed: ::core::option::Option<bool>,
     #[prost(oneof = "summary::SubnetSplittingStatus", tags = "13, 14, 15")]

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -396,8 +396,6 @@ pub struct Summary {
     pub configs: ::prost::alloc::vec::Vec<NiDkgConfig>,
     #[prost(message, repeated, tag = "9")]
     pub remote_dkg_attempts: ::prost::alloc::vec::Vec<RemoteDkgAttemptCount>,
-    #[prost(message, repeated, tag = "10")]
-    pub transcripts_for_remote_subnets: ::prost::alloc::vec::Vec<CallbackIdedNiDkgTranscript>,
     #[prost(message, repeated, tag = "11")]
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -400,15 +400,6 @@ pub struct Summary {
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]
     pub next_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
-    /// Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
-    ///
-    /// When set, field 10 must be ignored entirely, including when hashing the summary. This is what
-    /// allows the field to be removed without changing the hash of a summary: replica versions that
-    /// still maintain the field and versions that have dropped it derive the same hash from the same
-    /// wire bytes, because both read this marker. `repeated` fields cannot express the difference
-    /// between "absent" and "empty" on the wire, hence the separate marker.
-    #[prost(bool, optional, tag = "16")]
-    pub transcripts_for_remote_subnets_removed: ::core::option::Option<bool>,
     #[prost(oneof = "summary::SubnetSplittingStatus", tags = "13, 14, 15")]
     pub subnet_splitting_status: ::core::option::Option<summary::SubnetSplittingStatus>,
 }

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -381,7 +381,7 @@ pub struct PostSplitArgs {
     #[prost(message, optional, tag = "1")]
     pub new_subnet_id: ::core::option::Option<SubnetId>,
 }
-/// next id: 16
+/// next id: 17
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Summary {
     #[prost(uint64, tag = "1")]
@@ -402,6 +402,16 @@ pub struct Summary {
     pub current_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
     #[prost(message, repeated, tag = "12")]
     pub next_transcripts: ::prost::alloc::vec::Vec<NiDkgTranscript>,
+    /// Set by replica versions that no longer maintain `transcripts_for_remote_subnets` (field 10).
+    ///
+    /// When set, field 10 must be ignored entirely, including when hashing the summary. This is what
+    /// allows the field to be removed without changing the hash of a summary: replica versions that
+    /// still maintain the field and versions that have dropped it derive the same hash from the same
+    /// wire bytes, because both read this marker. `repeated` fields cannot express the difference
+    /// between "absent" and "empty" on the wire, hence the separate marker. See the documentation of
+    /// `ic_types::backwards_compatibility::BackwardsCompatible` for the rollout this is part of.
+    #[prost(bool, optional, tag = "16")]
+    pub transcripts_for_remote_subnets_removed: ::core::option::Option<bool>,
     #[prost(oneof = "summary::SubnetSplittingStatus", tags = "13, 14, 15")]
     pub subnet_splitting_status: ::core::option::Option<summary::SubnetSplittingStatus>,
 }

--- a/rs/types/types/src/backwards_compatibility.rs
+++ b/rs/types/types/src/backwards_compatibility.rs
@@ -32,6 +32,23 @@ use std::hash::{Hash, Hasher};
 /// 2. When the change is deployed to all replicas, we can switch the type to
 ///    `BackwardsCompatible<T, true>` and the field can begin to be populated.
 /// 3. When the change is deployed to all replicas, we can replace the type with `T`.
+///
+/// Lifecycle of removing an existing field in a backwards compatible way, i.e. the above in
+/// reverse:
+/// 1. Replace the field's type `T` with `BackwardsCompatible<T, true>`, keeping it populated. This
+///    step is hash neutral, because `Some(v)` hashes like `v`.
+/// 2. When the change is deployed to all replicas, switch the type to
+///    `BackwardsCompatible<T, false>`, so that the field is no longer populated.
+/// 3. When the change is deployed to all replicas, remove the field.
+///
+/// Step 2 is only hash neutral if every replica version derives the same `Option` from the same
+/// protobuf. That holds when the protobuf can tell an absent field from a present one, which is
+/// where the `None` of a newly added field comes from in the first place. A `repeated` field cannot:
+/// empty and absent are the same bytes on the wire, and an empty collection is not hash invisible
+/// the way `None` is, since `<[T]>::hash` writes a length prefix even for an empty slice. Removing a
+/// collection field therefore needs an explicit presence marker on the wire, introduced in step 1
+/// and only set from step 2 onwards, so that both versions read the presence from the bytes rather
+/// than deciding it by version.
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct BackwardsCompatible<T, const SETTABLE: bool>(Option<T>);
 
@@ -90,8 +107,17 @@ impl<T, const SETTABLE: bool> BackwardsCompatible<T, SETTABLE> {
     pub fn try_from_proto<Proto: TryInto<T, Error = ProxyDecodeError>>(
         proto: Option<Proto>,
     ) -> Result<Self, ProxyDecodeError> {
+        Self::try_from_proto_with(proto, |p| p.try_into())
+    }
+
+    /// Like [`try_from_proto`](Self::try_from_proto), for protobuf values whose conversion is not
+    /// expressed as a `TryFrom` impl.
+    pub fn try_from_proto_with<Proto>(
+        proto: Option<Proto>,
+        convert: impl FnOnce(Proto) -> Result<T, ProxyDecodeError>,
+    ) -> Result<Self, ProxyDecodeError> {
         match proto {
-            Some(value) => Ok(Self(Some(value.try_into()?))),
+            Some(value) => Ok(Self(Some(convert(value)?))),
             None => Ok(Self(None)),
         }
     }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -268,7 +268,7 @@ pub struct DkgSummary {
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
     /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: Vec<RemoteTranscriptResult>,
+    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, true>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -301,7 +301,7 @@ impl DkgSummary {
                 .collect(),
             current_transcripts,
             next_transcripts,
-            transcripts_for_remote_subnets: vec![],
+            transcripts_for_remote_subnets: BackwardsCompatible::new(vec![]),
             registry_version,
             interval_length,
             next_interval_length,
@@ -453,9 +453,22 @@ impl From<&DkgSummary> for pb::Summary {
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),
-            transcripts_for_remote_subnets: build_callback_ided_transcripts_vec(
-                summary.transcripts_for_remote_subnets.as_slice(),
-            ),
+            transcripts_for_remote_subnets: summary
+                .transcripts_for_remote_subnets
+                .as_ref()
+                .map(|t| build_callback_ided_transcripts_vec(t.as_slice()))
+                // `None` -> empty vector
+                .unwrap_or_default(),
+            // Relay the marker instead of only ever setting it for our own summaries: `prost`
+            // drops unknown fields, so a replica version that decodes a summary coming from a
+            // version which no longer maintains the field and re-encodes it would otherwise strip
+            // the marker, turning `None` back into `Some(vec![])` downstream and thereby changing
+            // the hash of that summary.
+            transcripts_for_remote_subnets_removed: summary
+                .transcripts_for_remote_subnets
+                .as_ref()
+                .is_none()
+                .then_some(true),
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: summary
                 .subnet_splitting_status
@@ -614,10 +627,18 @@ impl TryFrom<pb::Summary> for DkgSummary {
             interval_length: Height::from(summary.interval_length),
             next_interval_length: Height::from(summary.next_interval_length),
             height: Height::from(summary.height),
-            transcripts_for_remote_subnets: build_transcripts_vec_from_pb(
-                summary.transcripts_for_remote_subnets,
-            )
-            .map_err(ProxyDecodeError::Other)?,
+            transcripts_for_remote_subnets: BackwardsCompatible::try_from_proto_with(
+                // A set marker means the summary was produced by a replica version that no longer
+                // maintains the field, in which case the repeated field must be ignored entirely,
+                // including for hashing. Without the marker the repeated field is authoritative,
+                // even when empty: an empty vector still contributes its length prefix to the hash
+                // preimage, exactly as it did before the field became `BackwardsCompatible`.
+                (!summary
+                    .transcripts_for_remote_subnets_removed
+                    .unwrap_or_default())
+                .then_some(summary.transcripts_for_remote_subnets),
+                |t| build_transcripts_vec_from_pb(t).map_err(ProxyDecodeError::Other),
+            )?,
             remote_dkg_attempts: build_remote_dkg_attempts_map(&summary.remote_dkg_attempts),
             subnet_splitting_status: BackwardsCompatible::try_from_proto(
                 summary.subnet_splitting_status,

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -267,8 +267,6 @@ pub struct DkgSummary {
     /// corresponding to this tag.
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
-    /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, false>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -301,7 +299,6 @@ impl DkgSummary {
                 .collect(),
             current_transcripts,
             next_transcripts,
-            transcripts_for_remote_subnets: BackwardsCompatible::empty(),
             registry_version,
             interval_length,
             next_interval_length,
@@ -453,22 +450,12 @@ impl From<&DkgSummary> for pb::Summary {
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),
-            transcripts_for_remote_subnets: summary
-                .transcripts_for_remote_subnets
-                .as_ref()
-                .map(|t| build_callback_ided_transcripts_vec(t.as_slice()))
-                // `None` -> empty vector
-                .unwrap_or_default(),
-            // Relay the marker instead of only ever setting it for our own summaries: `prost`
-            // drops unknown fields, so a replica version that decodes a summary coming from a
-            // version which no longer maintains the field and re-encodes it would otherwise strip
-            // the marker, turning `None` back into `Some(vec![])` downstream and thereby changing
-            // the hash of that summary.
-            transcripts_for_remote_subnets_removed: summary
-                .transcripts_for_remote_subnets
-                .as_ref()
-                .is_none()
-                .then_some(true),
+            // The marker must keep being set even though this replica version no longer reads it:
+            // replica versions that still carry the field derive it from this marker, and would
+            // otherwise decode the empty repeated field above into `Some(vec![])` and hash its
+            // length prefix, where this version hashes nothing. It may only stop being set once no
+            // replica version that reads it is deployed any more.
+            transcripts_for_remote_subnets_removed: Some(true),
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: summary
                 .subnet_splitting_status
@@ -627,18 +614,6 @@ impl TryFrom<pb::Summary> for DkgSummary {
             interval_length: Height::from(summary.interval_length),
             next_interval_length: Height::from(summary.next_interval_length),
             height: Height::from(summary.height),
-            transcripts_for_remote_subnets: BackwardsCompatible::try_from_proto_with(
-                // A set marker means the summary was produced by a replica version that no longer
-                // maintains the field, in which case the repeated field must be ignored entirely,
-                // including for hashing. Without the marker the repeated field is authoritative,
-                // even when empty: an empty vector still contributes its length prefix to the hash
-                // preimage, exactly as it did before the field became `BackwardsCompatible`.
-                (!summary
-                    .transcripts_for_remote_subnets_removed
-                    .unwrap_or_default())
-                .then_some(summary.transcripts_for_remote_subnets),
-                |t| build_transcripts_vec_from_pb(t).map_err(ProxyDecodeError::Other),
-            )?,
             remote_dkg_attempts: build_remote_dkg_attempts_map(&summary.remote_dkg_attempts),
             subnet_splitting_status: BackwardsCompatible::try_from_proto(
                 summary.subnet_splitting_status,

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -450,12 +450,6 @@ impl From<&DkgSummary> for pb::Summary {
             interval_length: summary.interval_length.get(),
             next_interval_length: summary.next_interval_length.get(),
             height: summary.height.get(),
-            // The marker must keep being set even though this replica version no longer reads it:
-            // replica versions that still carry the field derive it from this marker, and would
-            // otherwise decode the empty repeated field above into `Some(vec![])` and hash its
-            // length prefix, where this version hashes nothing. It may only stop being set once no
-            // replica version that reads it is deployed any more.
-            transcripts_for_remote_subnets_removed: Some(true),
             remote_dkg_attempts: build_remote_dkg_attempts_vec(&summary.remote_dkg_attempts),
             subnet_splitting_status: summary
                 .subnet_splitting_status

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -268,7 +268,7 @@ pub struct DkgSummary {
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
     /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, true>,
+    pub transcripts_for_remote_subnets: BackwardsCompatible<Vec<RemoteTranscriptResult>, false>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -301,7 +301,7 @@ impl DkgSummary {
                 .collect(),
             current_transcripts,
             next_transcripts,
-            transcripts_for_remote_subnets: BackwardsCompatible::new(vec![]),
+            transcripts_for_remote_subnets: BackwardsCompatible::empty(),
             registry_version,
             interval_length,
             next_interval_length,


### PR DESCRIPTION
This PR cleans up a bit batch delivery by decoupling some different parts of the component and make the code read more easily. In particular, instead of matching on the payload type at multiple different places, move all parts that actually differ between the two payload types as part of the same `match`.  It then also becomes clearer to see the differences between a "summary" `Batch` and a "data" `Batch`.