### PR TITLE
perf(embedders): avoid a redundant copy in save_log_message

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1892,21 +1892,27 @@ impl SystemApiImpl {
 
     /// Appends the specified bytes on the heap as a string to the canister's logs.
     pub fn save_log_message(&mut self, src: usize, size: usize, heap: &[u8]) {
-        self.sandbox_safe_system_state.append_canister_log(
-            self.api_type.time(),
-            valid_subslice(
-                "save_log_message",
-                InternalAddress::new(src),
-                InternalAddress::new(size),
-                heap,
-            )
-            .unwrap_or(
-                // Do not trap here!
-                // If the specified memory range is invalid, ignore it and log the error message.
-                b"(debug_print message out of memory bounds)",
-            )
-            .to_vec(),
-        );
+        // The log record is truncated to the log's byte capacity anyway
+        // (see `CanisterLog::add_record`), so only copy the bytes that are kept.
+        let max_size = self
+            .sandbox_safe_system_state
+            .canister_log()
+            .byte_capacity();
+        // The bounds check covers the whole `[src, src + size)` range so that an
+        // out-of-bounds range is reported as such instead of being truncated.
+        let content = match valid_subslice(
+            "save_log_message",
+            InternalAddress::new(src),
+            InternalAddress::new(size),
+            heap,
+        ) {
+            Ok(bytes) => bytes[..size.min(max_size)].to_vec(),
+            // Do not trap here!
+            // If the specified memory range is invalid, ignore it and log the error message.
+            Err(_) => b"(debug_print message out of memory bounds)".to_vec(),
+        };
+        self.sandbox_safe_system_state
+            .append_canister_log(self.api_type.time(), content);
     }
 
     /// Takes collected canister log records.


### PR DESCRIPTION
`save_log_message` copied the whole `[src, src + size)` heap range into an owned `Vec` before appending it to the canister log. The log then truncates each record to its byte capacity, so all bytes beyond that capacity were copied only to be dropped right away.

Copy just the bytes that are actually retained. The bounds check still covers the full range, so an out-of-bounds range is reported as such rather than being truncated, and the resulting log record is unchanged.