### PR TITLE
chore: merge idx into infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,11 +78,11 @@ go.sum                    @dfinity/infra
 /.github/workflows/                                                      @dfinity/infra
 /.github/workflows/container-scan-nightly.yml                            @dfinity/infra @dfinity/node
 /.github/workflows/ledger-suite-release.yml                              @dfinity/defi @dfinity/infra
-/.github/workflows/publish-crates.yml                                    @dfinity/infra
+/.github/workflows/publish-crates.yml                                    @dfinity/infra @dfinity/security
 /.github/workflows/repro-check.yml                                       @dfinity/dre @dfinity/infra
 /.github/workflows/rosetta-release.yml                                   @dfinity/defi @dfinity/infra
 /.github/CODEOWNERS                                                      @dfinity/ic-owners-owners
-.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/infra
+.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/infra @dfinity/security
 /ci/                                                                     @dfinity/infra
 /ci/src/dependencies/                                                    @dfinity/node
 /ci/src/dependencies/integration/github/github_api.py                    @dfinity/infra @dfinity/node

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,22 +3,22 @@
 * @dfinity/ic-owners-owners
 
 # [Misc]
-/.devcontainer/           @dfinity/idx
+/.devcontainer/           @dfinity/infra
 /buf.yaml                 @dfinity/core-protocol
 /cpp/                     @dfinity/node
-/licenses/                @dfinity/idx
-/bin/                     @dfinity/idx
+/licenses/                @dfinity/infra
+/bin/                     @dfinity/infra
 /bin/fuzzing/             @dfinity/core-protocol
 
 # [Bazel]
-.bazelrc                           @dfinity/idx
-.bazelversion                      @dfinity/idx
-/bazel/                            @dfinity/idx
-/bazel/fuzz_testing.bzl            @dfinity/idx @dfinity/core-protocol
-/BUILD.bazel                       @dfinity/idx
-/third_party/                      @dfinity/idx
-/MODULE.bazel                      @dfinity/idx
-/PULL_REQUEST_BAZEL_TARGETS        @dfinity/idx
+.bazelrc                           @dfinity/infra
+.bazelversion                      @dfinity/infra
+/bazel/                            @dfinity/infra
+/bazel/fuzz_testing.bzl            @dfinity/infra @dfinity/core-protocol
+/BUILD.bazel                       @dfinity/infra
+/third_party/                      @dfinity/infra
+/MODULE.bazel                      @dfinity/infra
+/PULL_REQUEST_BAZEL_TARGETS        @dfinity/infra
 
 # [Rust Lang]
 rust-toolchain.toml       @dfinity/core-protocol
@@ -27,16 +27,16 @@ deny.toml                 @dfinity/core-protocol
 clippy.toml               @dfinity/core-protocol
 
 # [Golang]
-go.mod                    @dfinity/idx
-go.sum                    @dfinity/idx
+go.mod                    @dfinity/infra
+go.sum                    @dfinity/infra
 
 # [DevEnv]
-.vscode/                  @dfinity/idx
+.vscode/                  @dfinity/infra
 
-.claude/                  @dfinity/idx
+.claude/                  @dfinity/infra
 
 # [Publishing-Artifacts]
-/publish/ @dfinity/idx
+/publish/ @dfinity/infra
 
 # [Packages]
 /packages/canlog/                               @dfinity/defi
@@ -74,24 +74,24 @@ go.sum                    @dfinity/idx
 /rs/monitoring/                                  @dfinity/dre
 
 # [GitHub-Ci]
-/.github/                                                                @dfinity/idx
-/.github/workflows/                                                      @dfinity/idx
-/.github/workflows/container-scan-nightly.yml                            @dfinity/idx @dfinity/node
-/.github/workflows/ledger-suite-release.yml                              @dfinity/defi @dfinity/idx
-/.github/workflows/publish-crates.yml                                    @dfinity/idx @dfinity/security
-/.github/workflows/repro-check.yml                                       @dfinity/dre @dfinity/idx
-/.github/workflows/rosetta-release.yml                                   @dfinity/defi @dfinity/idx
+/.github/                                                                @dfinity/infra
+/.github/workflows/                                                      @dfinity/infra
+/.github/workflows/container-scan-nightly.yml                            @dfinity/infra @dfinity/node
+/.github/workflows/ledger-suite-release.yml                              @dfinity/defi @dfinity/infra
+/.github/workflows/publish-crates.yml                                    @dfinity/infra @dfinity/security
+/.github/workflows/repro-check.yml                                       @dfinity/dre @dfinity/infra
+/.github/workflows/rosetta-release.yml                                   @dfinity/defi @dfinity/infra
 /.github/CODEOWNERS                                                      @dfinity/ic-owners-owners
-.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/idx @dfinity/security
-/ci/                                                                     @dfinity/idx
+.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/infra @dfinity/security
+/ci/                                                                     @dfinity/infra
 /ci/src/dependencies/                                                    @dfinity/node
-/ci/src/dependencies/integration/github/github_api.py                    @dfinity/idx @dfinity/node
-/ci/src/dependencies/integration/github/github_dependency_submission.py  @dfinity/idx
-/ci/src/dependencies/job/bazel_rust_gh_submission_job.py                 @dfinity/idx
-/ci/src/dependencies/parser/                                             @dfinity/idx
+/ci/src/dependencies/integration/github/github_api.py                    @dfinity/infra @dfinity/node
+/ci/src/dependencies/integration/github/github_dependency_submission.py  @dfinity/infra
+/ci/src/dependencies/job/bazel_rust_gh_submission_job.py                 @dfinity/infra
+/ci/src/dependencies/parser/                                             @dfinity/infra
 /ci/scripts/repro-check                                                  @dfinity/dre
-/.pre-commit-config.yaml                                                 @dfinity/idx
-/pre-commit/                                                             @dfinity/idx
+/.pre-commit-config.yaml                                                 @dfinity/infra
+/pre-commit/                                                             @dfinity/infra
 
 # [Rust]
 /rs/                                                    @dfinity/core-protocol
@@ -143,7 +143,7 @@ go.sum                    @dfinity/idx
 /rs/p2p/                                                @dfinity/core-protocol
 /rs/phantom_newtype/                                    @dfinity/core-protocol
 /rs/pocket_ic_server/                                   @dfinity/core-protocol
-/rs/prep/                                               @dfinity/idx
+/rs/prep/                                               @dfinity/infra
 /rs/protobuf/                                           @dfinity/core-protocol
 /rs/protobuf/def/registry/                              @dfinity/governance-team
 /rs/protobuf/src/gen/registry/                          @dfinity/governance-team
@@ -188,15 +188,15 @@ go.sum                    @dfinity/idx
 /rs/state_tool/                                         @dfinity/core-protocol
 /rs/sys/                                                @dfinity/core-protocol
 /rs/test_utilities/                                     @dfinity/core-protocol
-/rs/tests/                                              @dfinity/idx
-/rs/tests/idx/                                          @dfinity/idx
-/rs/tests/testnets/                                     @dfinity/idx
+/rs/tests/                                              @dfinity/infra
+/rs/tests/idx/                                          @dfinity/infra
+/rs/tests/testnets/                                     @dfinity/infra
 /rs/tests/testnets/cloud_engine.rs                      @dfinity/dre
 /rs/tests/testnets/mainnet_nns/                         @dfinity/core-protocol
 /rs/tests/testnets/mainnet_nns.rs                       @dfinity/core-protocol
 /rs/tests/testnets/nns_recovery.rs                      @dfinity/core-protocol
-/rs/tests/testnets/baremetal_app_subnet.rs              @dfinity/idx @dfinity/node
-/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/core-protocol @dfinity/idx
+/rs/tests/testnets/baremetal_app_subnet.rs              @dfinity/infra @dfinity/node
+/rs/tests/driver/src/driver/simulate_network.rs         @dfinity/core-protocol @dfinity/infra
 /rs/tests/boundary_nodes/                               @dfinity/node
 /rs/tests/ckbtc/                                        @dfinity/defi
 /rs/tests/consensus/                                    @dfinity/core-protocol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,11 +78,11 @@ go.sum                    @dfinity/infra
 /.github/workflows/                                                      @dfinity/infra
 /.github/workflows/container-scan-nightly.yml                            @dfinity/infra @dfinity/node
 /.github/workflows/ledger-suite-release.yml                              @dfinity/defi @dfinity/infra
-/.github/workflows/publish-crates.yml                                    @dfinity/infra @dfinity/security
+/.github/workflows/publish-crates.yml                                    @dfinity/infra
 /.github/workflows/repro-check.yml                                       @dfinity/dre @dfinity/infra
 /.github/workflows/rosetta-release.yml                                   @dfinity/defi @dfinity/infra
 /.github/CODEOWNERS                                                      @dfinity/ic-owners-owners
-.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/infra @dfinity/security
+.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST                         @dfinity/infra
 /ci/                                                                     @dfinity/infra
 /ci/src/dependencies/                                                    @dfinity/node
 /ci/src/dependencies/integration/github/github_api.py                    @dfinity/infra @dfinity/node


### PR DESCRIPTION
IDX, Platform Ops and the Dashboard team have been merged into @dfinity/infra. So this moves the ownership of idx to infra.
