### PR TITLE
feat: Raise a critical error if canisters are filtered from tip

### DIFF
--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -1002,6 +1002,10 @@ impl SystemMetadata {
     ///
     /// In phase 2 (see [`Self::after_split()`]) the ingress history is pruned and
     /// the split marker is reset.
+    ///
+    /// `unflushed_checkpoint_ops` (holding the delete operations recorded by
+    /// `ReplicatedState::split()` for the canisters dropped by the split) is preserved
+    /// on both subnets, so that the dropped canisters' directories are deleted from tip.
     pub fn split(
         mut self,
         subnet_id: SubnetId,
@@ -1033,6 +1037,10 @@ impl SystemMetadata {
 
         // Preserve ingress history.
         res.ingress_history = self.ingress_history;
+
+        // Preserve the delete operations recorded by `ReplicatedState::split()` for the
+        // canisters dropped by the split, so that their directories are deleted from tip.
+        res.unflushed_checkpoint_ops = self.unflushed_checkpoint_ops;
 
         // Ensure monotonic time for migrated canisters: apply `new_subnet_batch_time`
         // if specified and not smaller than `self.batch_time`; else, default to

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1460,7 +1460,7 @@ impl ReplicatedState {
         // enforce an explicit decision whenever new fields are added.
         let Self {
             mut canister_states,
-            metadata,
+            mut metadata,
             mut subnet_queues,
             mut refunds,
             consensus_queue,
@@ -1470,15 +1470,28 @@ impl ReplicatedState {
         // Consensus queue is always empty at the end of the round.
         assert!(consensus_queue.is_empty());
 
-        // Retain only canisters hosted by `own_subnet_id`.
+        // Retain only canisters hosted by `subnet_id`; and record the removal of the
+        // others, so that their directories are deleted from tip by the flush of these
+        // operations, making `TipRequest::FilterTipCanisters` a pure safety net.
         //
         // TODO: Validate that canisters are split across no more than 2 subnets.
-        canister_states.retain(|canister_id, _| {
+        let is_local_canister = |canister_id: &CanisterId| {
             routing_table
                 .lookup_entry(*canister_id)
                 .map(|(_range, subnet_id)| subnet_id)
                 == Some(subnet_id)
-        });
+        };
+        let dropped_canister_ids: Vec<CanisterId> = canister_states
+            .all_keys()
+            .filter(|canister_id| !is_local_canister(canister_id))
+            .cloned()
+            .collect();
+        canister_states.retain(|canister_id, _| is_local_canister(canister_id));
+        for canister_id in dropped_canister_ids {
+            metadata
+                .unflushed_checkpoint_ops
+                .delete_canister(canister_id);
+        }
 
         // All subnet messages (ingress and canister) only remain on subnet A' because:
         //

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -19,6 +19,7 @@ use ic_replicated_state::{
         execution_state::{CustomSection, CustomSectionType, WasmMetadata},
     },
     metadata_state::{
+        UnflushedCheckpointOp,
         subnet_call_context_manager::{
             BitcoinGetSuccessorsContext, BitcoinSendTransactionInternalContext, InstallCodeCallId,
             StopCanisterCall, SubnetCallContext,
@@ -1181,8 +1182,15 @@ fn split() {
 
     // Start off with the original state.
     let mut expected = fixture.state.clone();
-    // Only `CANISTER_1` should be left.
+    // Only `CANISTER_1` should be left; with the removal of `CANISTER_2` recorded as a
+    // checkpoint operation, so that its directory is deleted from tip. (Its scheduling
+    // priority is only pruned in phase 2, by `after_split()` below, so this cannot use
+    // `remove_canister()`, which would drop it here.)
     expected.take_canister_state(&CANISTER_2);
+    expected
+        .metadata
+        .unflushed_checkpoint_ops
+        .push(UnflushedCheckpointOp::DeleteCanister(CANISTER_2));
     // And the split marker should be set.
     expected.metadata.split_from = Some(SUBNET_A);
     // Otherwise, the state should be the same.
@@ -1222,6 +1230,12 @@ fn split() {
     // Only `CANISTER_2` should be left, with no scheduling priority.
     expected.put_canister_state(fixture.state.canister_state(&CANISTER_2).unwrap().clone());
     expected.metadata.subnet_schedule.remove(&CANISTER_2);
+    // The removal of `CANISTER_1` should have been recorded as a checkpoint operation,
+    // so that its directory is deleted from tip.
+    expected
+        .metadata
+        .unflushed_checkpoint_ops
+        .push(UnflushedCheckpointOp::DeleteCanister(CANISTER_1));
     // The full ingress history should be preserved.
     expected.metadata.ingress_history = fixture.state.metadata.ingress_history.clone();
     // And the split marker should be set.

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -493,13 +493,16 @@ impl TipHandler {
     }
 
     /// Deletes canisters from tip if they are not in `ids`.
+    ///
+    /// Returns the IDs of the deleted canisters.
     pub fn filter_tip_canisters(
         &mut self,
         height: Height,
         ids: &BTreeSet<CanisterId>,
-    ) -> Result<(), LayoutError> {
+    ) -> Result<Vec<CanisterId>, LayoutError> {
         let tip = self.tip(height)?;
         let canisters_on_disk = tip.canister_ids()?;
+        let mut deleted_canister_ids = Vec::new();
         for id in canisters_on_disk {
             if !ids.contains(&id) {
                 let canister_path = tip.canister(&id)?.raw_path();
@@ -508,9 +511,10 @@ impl TipHandler {
                     message: "Cannot remove canister.".to_string(),
                     io_err: err,
                 })?;
+                deleted_canister_ids.push(id);
             }
         }
-        Ok(())
+        Ok(deleted_canister_ids)
     }
 
     /// Deletes snapshots from tip if they are not in `ids`.

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -122,6 +122,13 @@ pub(crate) const CRITICAL_ERROR_CHECKPOINT_SOFT_INVARIANT_BROKEN: &str =
 const CRITICAL_ERROR_REPLICATED_STATE_ALTERED_AFTER_CHECKPOINT: &str =
     "state_manager_replicated_state_altered_after_checkpoint";
 
+/// Critical error tracking canister directories unexpectedly removed from tip by
+/// `TipRequest::FilterTipCanisters`, which is only meant to be a safety net: every
+/// canister directory removal should be covered by an explicit
+/// `UnflushedCheckpointOp::DeleteCanister`.
+pub(crate) const CRITICAL_ERROR_TIP_CANISTERS_FILTERED: &str =
+    "state_manager_tip_canisters_filtered";
+
 /// How long to keep archived and diverged states.
 const ARCHIVED_DIVERGED_CHECKPOINT_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60); // 30 days
 
@@ -236,6 +243,7 @@ pub struct CheckpointMetrics {
     load_canister_step_duration: HistogramVec,
     load_checkpoint_soft_invariant_broken: IntCounter,
     replicated_state_altered_after_checkpoint: IntCounter,
+    tip_canisters_filtered: IntCounter,
     tip_handler_request_duration: HistogramVec,
     num_page_maps_by_load_status: IntGaugeVec,
     num_loaded_wasm_files_by_source: IntGaugeVec,
@@ -273,6 +281,9 @@ impl CheckpointMetrics {
         let replicated_state_altered_after_checkpoint = metrics_registry
             .error_counter(CRITICAL_ERROR_REPLICATED_STATE_ALTERED_AFTER_CHECKPOINT);
 
+        let tip_canisters_filtered =
+            metrics_registry.error_counter(CRITICAL_ERROR_TIP_CANISTERS_FILTERED);
+
         let tip_handler_request_duration = metrics_registry.histogram_vec(
             "state_manager_tip_handler_request_duration_seconds",
             "Duration to execute requests to Tip handling thread in seconds.",
@@ -298,6 +309,7 @@ impl CheckpointMetrics {
             load_canister_step_duration,
             load_checkpoint_soft_invariant_broken,
             replicated_state_altered_after_checkpoint,
+            tip_canisters_filtered,
             tip_handler_request_duration,
             num_page_maps_by_load_status,
             num_loaded_wasm_files_by_source,

--- a/rs/state_manager/src/split.rs
+++ b/rs/state_manager/src/split.rs
@@ -201,6 +201,10 @@ fn write_checkpoint(
 
     let new_height = old_height.increment();
 
+    // Tip was reset to the pre-split checkpoint above, so it still holds the directories
+    // of the canisters dropped by the split. They are removed by the flush of the
+    // `DeleteCanister` operations recorded by `ReplicatedState::split()`, which is the
+    // first thing `make_unvalidated_checkpoint()` does, before creating the checkpoint.
     let (_state, cp_layout) = make_unvalidated_checkpoint(
         state,
         new_height,

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CRITICAL_ERROR_CHUNK_ID_USAGE_NEARING_LIMITS, CheckpointError, NUMBER_OF_CHECKPOINT_THREADS,
-    PageMapType, SharedState, StateManagerMetrics,
+    CRITICAL_ERROR_CHUNK_ID_USAGE_NEARING_LIMITS, CRITICAL_ERROR_TIP_CANISTERS_FILTERED,
+    CheckpointError, NUMBER_OF_CHECKPOINT_THREADS, PageMapType, SharedState, StateManagerMetrics,
     checkpoint::validate_and_finalize_checkpoint_and_remove_unverified_marker,
     compute_bundled_manifest,
     manifest::{BaseManifestInfo, RehashManifest},
@@ -106,10 +106,15 @@ pub(crate) enum TipRequest {
     },
     /// Filter canisters and snapshots in tip. Remove ones not present in the sets.
     ///
-    /// Canisters deleted during execution and canisters dropped by an online subnet
-    /// split are removed from tip via `UnflushedCheckpointOp::DeleteCanister`, so this
-    /// is only a safety net for canisters that disappeared from the state without a
-    /// corresponding operation.
+    /// Canisters deleted during execution and canisters dropped by a subnet split are
+    /// removed from tip via `UnflushedCheckpointOp::DeleteCanister`, so this is only a
+    /// safety net for canisters that disappeared from the state without a corresponding
+    /// operation. Actually removing a canister directory here therefore raises the
+    /// `CRITICAL_ERROR_TIP_CANISTERS_FILTERED` critical error.
+    ///
+    /// Snapshot deletions, on the other hand, are not recorded as checkpoint
+    /// operations, so filtering is the regular mechanism for removing the directories
+    /// of deleted snapshots from tip.
     ///
     /// State: `tip_folder_state.has_filtered_canisters = true`
     FilterTipCanisters {
@@ -302,7 +307,7 @@ pub(crate) fn spawn_tip_thread(
                             let _timer = request_timer(&metrics, "filter_tip_canisters");
                             debug_assert!(!tip_state.tip_folder_state.has_filtered_canisters);
                             tip_state.tip_folder_state.has_filtered_canisters = true;
-                            tip_handler
+                            let filtered_canister_ids = tip_handler
                                 .filter_tip_canisters(height, &canister_ids)
                                 .unwrap_or_else(|err| {
                                     fatal!(
@@ -312,6 +317,19 @@ pub(crate) fn spawn_tip_thread(
                                         err
                                     )
                                 });
+                            if !filtered_canister_ids.is_empty() {
+                                // Every canister directory removal should be covered by an
+                                // explicit `UnflushedCheckpointOp::DeleteCanister`, making this
+                                // a mere safety net.
+                                error!(
+                                    log,
+                                    "{}: Removed canister directories without a corresponding checkpoint operation at height @{}: {:?}",
+                                    CRITICAL_ERROR_TIP_CANISTERS_FILTERED,
+                                    height,
+                                    filtered_canister_ids,
+                                );
+                                metrics.checkpoint_metrics.tip_canisters_filtered.inc();
+                            }
                             tip_handler
                                 .filter_tip_snapshots(height, &snapshot_ids)
                                 .unwrap_or_else(|err| {

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -57,7 +57,7 @@ use ic_test_utilities_io::{make_mutable, make_readonly, write_all_at};
 use ic_test_utilities_logger::with_test_replica_logger;
 use ic_test_utilities_metrics::{
     HistogramStats, Labels, fetch_gauge, fetch_histogram_stats, fetch_histogram_vec_stats,
-    fetch_int_counter_vec, fetch_int_gauge,
+    fetch_int_counter_vec, fetch_int_gauge, metric_vec, nonzero_values,
 };
 use ic_test_utilities_state::{arb_stream, arb_stream_slice, canister_ids};
 use ic_test_utilities_tmpdir::tmpdir;
@@ -7036,7 +7036,7 @@ fn can_delete_canister() {
         let (_height, mut state) = state_manager.take_tip();
 
         // Delete the canister
-        let _deleted_canister = state.take_canister_state(&canister_test_id(100));
+        let _deleted_canister = state.remove_canister(&canister_test_id(100));
 
         // Commit two rounds, once without checkpointing and once with
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
@@ -8624,6 +8624,49 @@ fn deleted_canister_is_removed_from_tip() {
     }
     deleted_canister_is_removed_from_tip_impl(CertificationScope::Metadata);
     deleted_canister_is_removed_from_tip_impl(CertificationScope::Full);
+}
+
+/// Tests that `FilterTipCanisters` raises a critical error if it actually removes a
+/// canister directory from tip: every such removal is expected to be covered by an
+/// explicit `UnflushedCheckpointOp::DeleteCanister`, so filtering is only a safety net.
+#[test]
+fn filtering_canister_from_tip_raises_critical_error() {
+    state_manager_test(|metrics, state_manager| {
+        let canister_id = canister_test_id(100);
+
+        // Install a canister and checkpoint the state, so that the canister has a
+        // directory in the tip.
+        let (_height, mut state) = state_manager.take_tip();
+        insert_dummy_canister(&mut state, canister_id);
+        state_manager.commit_and_certify(state, CertificationScope::Full, None);
+        state_manager.flush_tip_channel();
+
+        let (height, mut state) = state_manager.take_tip();
+        let tip = CheckpointLayout::<ReadOnly>::new_untracked(
+            state_manager.state_layout().raw_path().join("tip"),
+            height,
+        )
+        .unwrap();
+        assert_eq!(tip.canister_ids().unwrap(), vec![canister_id]);
+        assert_error_counters(metrics);
+
+        // Drop the canister from the state without recording a `DeleteCanister`
+        // operation, so that its directory is only removed by `FilterTipCanisters`.
+        let mut canister_states = state.take_canister_states();
+        canister_states.remove(&canister_id);
+        state.put_canister_states(canister_states);
+        assert!(state.system_metadata().unflushed_checkpoint_ops.is_empty());
+
+        state_manager.commit_and_certify(state, CertificationScope::Full, None);
+        state_manager.flush_tip_channel();
+
+        // The canister directory is gone from the tip, but a critical error was raised.
+        assert!(tip.canister_ids().unwrap().is_empty());
+        assert_eq!(
+            metric_vec(&[(&[("error", "state_manager_tip_canisters_filtered")], 1)]),
+            nonzero_values(fetch_int_counter_vec(metrics, "critical_errors"))
+        );
+    });
 }
 
 #[test_strategy::proptest(ProptestConfig { cases: 20, ..ProptestConfig::default() })]


### PR DESCRIPTION
Canisters deleted during execution and canisters dropped by an online subnet split are removed from tip via `UnflushedCheckpointOp::DeleteCanister`. This change extends that to the offline subnet split (`ReplicatedState::split()`, used by `ic-state-tool split` and the subnet splitting recovery tool): it resets tip to the pre-split checkpoint and then checkpoints the split state, so the dropped canisters' directories were removed from tip only by `TipRequest::FilterTipCanisters`. The deletions are recorded on both sides of the split — each run drops the canisters not hosted by its target subnet — with `SystemMetadata::split()` preserving the operations on subnet B, whose metadata is otherwise built from scratch. The operations are transient: they are flushed (and taken) before the checkpoint is written and are never persisted, so neither the checkpoint contents nor the state hash are affected.

Every canister directory removal from tip is thus an explicit, ordered operation and `FilterTipCanisters` is only a safety net for canisters that disappeared from the state without a corresponding operation. `TipHandler::filter_tip_canisters()` therefore returns the IDs of the canisters it removed; if the list is non-empty, the tip thread logs an error and bumps the new
`state_manager_tip_canisters_filtered` critical error.

Snapshot deletions are not recorded as checkpoint operations, so filtering remains the regular mechanism for removing deleted snapshots' directories from tip and does not raise a critical error.

Tests: the new `filtering_canister_from_tip_raises_critical_error` covers the critical error. `can_delete_canister` deleted a canister using `take_canister_state()`, which is meant for temporarily taking a canister out of the state and hence records no operation; it now uses `remove_canister()`, as production code does. The `split` expectations in `replicated_state.rs` account for the newly recorded delete operations.