### PR TITLE
feat(system-tests): give local-backend testnets a non-ULA IPv6 prefix

### DIFF
--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -48,9 +48,6 @@ system_test_nns(
 
 system_test_nns(
     name = "node_registration_with_max_rewardable_nodes_test",
-    # TODO: support this test on the local backend (drop `backend = "farm"`).
-    # The reason it fails is the same as is documented for //rs/tests/node:ipv4_integration_test.
-    backend = "farm",
     cpus = MIN_LOCAL_CPUS + 2 * DEFAULT_VCPUS_PER_VM,  # 1 fast single-node System + 1 unassigned = 2 IC Node VMs * 6 vCPUs.
     deps = [
         # Keep sorted.
@@ -63,9 +60,6 @@ system_test_nns(
 
 system_test_nns(
     name = "node_registration_with_node_allowance_test",
-    # TODO: support this test on the local backend (drop `backend = "farm"`).
-    # The reason it fails is the same as is documented for //rs/tests/node:ipv4_integration_test.
-    backend = "farm",
     cpus = MIN_LOCAL_CPUS + 2 * DEFAULT_VCPUS_PER_VM,  # 1 fast single-node System + 1 unassigned = 2 IC Node VMs * 6 vCPUs.
     deps = [
         # Keep sorted.

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -241,7 +241,7 @@ pub fn init_ic(
     // the nodes reachable from the driver. Port 8080 is always added by
     // `ic-prep`.
     //
-    // Only the driver is whitelisted, not the group's whole ULA range `fd00::/8`
+    // Only the driver is whitelisted, not the group's whole range `2001:db8::/32`
     // that every VM — the nodes included — is addressed out of. Whitelisting
     // that range would open these ports, 8080 among them, between all nodes, so
     // node↔node traffic would no longer be governed by the registry's

--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -241,7 +241,7 @@ pub fn init_ic(
     // the nodes reachable from the driver. Port 8080 is always added by
     // `ic-prep`.
     //
-    // Only the driver is whitelisted, not the group's whole range `2001:db8::/32`
+    // Only the driver is whitelisted, not the group's whole range (`GROUP_PREFIX`)
     // that every VM — the nodes included — is addressed out of. Whitelisting
     // that range would open these ports, 8080 among them, between all nodes, so
     // node↔node traffic would no longer be governed by the registry's

--- a/rs/tests/driver/src/driver/ic.rs
+++ b/rs/tests/driver/src/driver/ic.rs
@@ -271,7 +271,7 @@ impl InternetComputer {
     }
 
     /// Whitelist every VM in the test group on the nodes' firewall, by adding
-    /// the local backend's ULA range ([`LocalBackend::GROUP_ULA_PREFIX`]) to the
+    /// the local backend's whole range ([`LocalBackend::GROUP_PREFIX`]) to the
     /// whitelist.
     ///
     /// A shorthand for the common case of
@@ -279,7 +279,7 @@ impl InternetComputer {
     /// and what the local backend did unconditionally before the whitelist was
     /// narrowed to the driver's own addresses.
     pub fn with_group_wide_firewall_whitelist(self) -> Self {
-        self.with_extra_firewall_whitelist(vec![LocalBackend::GROUP_ULA_PREFIX.to_string()], vec![])
+        self.with_extra_firewall_whitelist(vec![LocalBackend::GROUP_PREFIX.to_string()], vec![])
     }
 
     /// Add a single unassigned node with the given IPv4 configuration

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -40,7 +40,7 @@ use std::time::{Duration, Instant};
 
 /// The domain under which the group's `dnsmasq` synthesises a DNS name for every
 /// address in the group's `/64`, by writing the address with `:` replaced by `-`
-/// (e.g. `2001-db8-1-2--3.ipv6.nip.io`).
+/// (e.g. `2a00-fb01-400-2c--3.ipv6.nip.io`).
 ///
 /// This mirrors the public `nip.io` wildcard DNS service, which is what system
 /// tests use when they need to reach a VM by a *name* rather than by an address
@@ -406,28 +406,41 @@ impl LocalBackend {
         sanitize_name(&format!("ictest-{group_name}-{vm_name}"))
     }
 
-    /// Returns the per-group IPv6 prefix (a deterministic /64 in the
-    /// documentation range [`GROUP_PREFIX`](Self::GROUP_PREFIX)).
-    ///
-    /// The prefix is deliberately *not* a ULA: the orchestrator reads a ULA or
-    /// link-local address as a sign that it is running in a cloud and goes off
-    /// to query the cloud metadata server for its public address before it can
-    /// register itself (`assemble_add_node_message` in
-    /// `rs/orchestrator/src/registration.rs`). There is no metadata server here,
-    /// so a node could never self-register. Farm hands out globally routable
-    /// addresses and so never takes that branch; this keeps the local backend
-    /// on the same side of it.
-    ///
-    /// `2001:db8::/32` leaves 16 bits for the group before the `/48` the
-    /// subnet-ids below need, so the group digest is shorter than the bridge's
-    /// and TAP's (see [`bridge_name`](Self::bridge_name)). A collision between
-    /// two groups is unobservable regardless: each test owns a private network
-    /// namespace (see
-    /// [`ensure_administrable_netns`](Self::ensure_administrable_netns)).
+    /// Returns the `/64` the group's *nodes* are addressed out of, i.e. subnet-id
+    /// 0 of [`group_subnet_prefix`](Self::group_subnet_prefix).
     fn group_ipv6_prefix(group_name: &str) -> String {
+        Self::group_subnet_prefix(group_name, 0)
+    }
+
+    /// Returns `2a00:fb01:400:<group><subnet>::`, the group's `/64` for
+    /// `subnet_id` (0 for the nodes, 1..=3 for the driver's own addresses).
+    ///
+    /// The range is deliberately an ordinary global unicast prefix rather than a
+    /// reserved one. It must not be a ULA or link-local address, because the
+    /// orchestrator reads those as a sign that it is running in a cloud and
+    /// blocks on cloud metadata discovery before it can register itself
+    /// (`assemble_add_node_message` in `rs/orchestrator/src/registration.rs`),
+    /// which never completes here. But reserved ranges are no good either: they
+    /// are exactly the ones software special-cases. `2001:db8::/32` (RFC 3849)
+    /// looks appealing for a fake network and breaks `bitcoind`, whose
+    /// `CNetAddr::IsValid()` rejects documentation addresses outright, so every
+    /// RPC from the driver is refused with "Client network is not allowed RPC
+    /// access" even under `-rpcallowip='::/0'`. A boring routable-looking prefix
+    /// has no such classifier to trip over. Nothing leaves the group's network
+    /// namespace, so real-world routability is irrelevant — only how software
+    /// *classifies* the bits.
+    ///
+    /// [`GROUP_PREFIX`](Self::GROUP_PREFIX) is a `/56`, which leaves one byte
+    /// before the `/64` boundary: 6 bits of group digest and 2 bits of
+    /// subnet-id. The digest is therefore much shorter than the bridge's and
+    /// TAP's (see [`bridge_name`](Self::bridge_name)), but a collision between
+    /// two groups is unobservable: each test owns a private network namespace
+    /// (see [`ensure_administrable_netns`](Self::ensure_administrable_netns)).
+    fn group_subnet_prefix(group_name: &str, subnet_id: u8) -> String {
         use ic_crypto_sha2::Sha256;
+        debug_assert!(subnet_id < 4, "subnet-id must fit in 2 bits");
         let hash = Sha256::hash(group_name.as_bytes());
-        format!("2001:db8:{:02x}{:02x}::", hash[0], hash[1])
+        format!("2a00:fb01:400:{:02x}::", (hash[0] & 0xfc) | subnet_id)
     }
 
     /// Returns the per-group IPv6 gateway address (`<prefix>1`). Assigned to the
@@ -459,9 +472,7 @@ impl LocalBackend {
     /// SLAAC; [`create_group`](Self::create_group) overrides the node `/64`'s
     /// connected-route source to it.
     pub fn group_mgmt_ipv6(group_name: &str) -> String {
-        use ic_crypto_sha2::Sha256;
-        let hash = Sha256::hash(group_name.as_bytes());
-        format!("2001:db8:{:02x}{:02x}:1::1", hash[0], hash[1])
+        format!("{}1", Self::group_subnet_prefix(group_name, 1))
     }
 
     /// Returns the per-group IPv6 address the driver streams the nodes' journald
@@ -477,9 +488,7 @@ impl LocalBackend {
     /// Like the management address it is assigned to `lo` in
     /// [`create_group`](Self::create_group).
     pub fn group_logs_ipv6(group_name: &str) -> String {
-        use ic_crypto_sha2::Sha256;
-        let hash = Sha256::hash(group_name.as_bytes());
-        format!("2001:db8:{:02x}{:02x}:2::1", hash[0], hash[1])
+        format!("{}1", Self::group_subnet_prefix(group_name, 2))
     }
 
     /// Returns the per-group IPv6 address the file server
@@ -497,9 +506,7 @@ impl LocalBackend {
     /// own traffic. Like it, this is assigned to `lo` in
     /// [`create_group`](Self::create_group).
     pub fn group_files_ipv6(group_name: &str) -> String {
-        use ic_crypto_sha2::Sha256;
-        let hash = Sha256::hash(group_name.as_bytes());
-        format!("2001:db8:{:02x}{:02x}:3::1", hash[0], hash[1])
+        format!("{}1", Self::group_subnet_prefix(group_name, 3))
     }
 
     /// The IPv6 range every address the local backend hands out lives in: the
@@ -508,12 +515,12 @@ impl LocalBackend {
     /// firewall; see
     /// [`InternetComputer::with_group_wide_firewall_whitelist`](crate::driver::ic::InternetComputer::with_group_wide_firewall_whitelist).
     ///
-    /// `2001:db8::/32` is the range RFC 3849 reserves for documentation, so
-    /// nothing can legitimately route it. That is what the backend needs: the
-    /// addresses never leave its network namespace, yet they must not look
-    /// local to the node software — see
-    /// [`group_ipv6_prefix`](Self::group_ipv6_prefix).
-    pub const GROUP_PREFIX: &'static str = "2001:db8::/32";
+    /// `2a00:fb01:400::/56` is DFINITY's Zurich DC prefix. The addresses never
+    /// leave the group's network namespace, so nothing is actually routed there;
+    /// it is used because an ordinary global unicast prefix is the one thing no
+    /// classifier special-cases — see
+    /// [`group_subnet_prefix`](Self::group_subnet_prefix).
+    pub const GROUP_PREFIX: &'static str = "2a00:fb01:400::/56";
 
     /// The three addresses the test driver reaches the group's VMs from: the
     /// management source ([`group_mgmt_ipv6`](Self::group_mgmt_ipv6)), the

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -40,7 +40,7 @@ use std::time::{Duration, Instant};
 
 /// The domain under which the group's `dnsmasq` synthesises a DNS name for every
 /// address in the group's `/64`, by writing the address with `:` replaced by `-`
-/// (e.g. `fd00-1-2--3.ipv6.nip.io`).
+/// (e.g. `2001-db8-1-2--3.ipv6.nip.io`).
 ///
 /// This mirrors the public `nip.io` wildcard DNS service, which is what system
 /// tests use when they need to reach a VM by a *name* rather than by an address
@@ -407,14 +407,27 @@ impl LocalBackend {
     }
 
     /// Returns the per-group IPv6 prefix (a deterministic /64 in the
-    /// ULA range `fd00::/8`).
+    /// documentation range [`GROUP_PREFIX`](Self::GROUP_PREFIX)).
+    ///
+    /// The prefix is deliberately *not* a ULA: the orchestrator reads a ULA or
+    /// link-local address as a sign that it is running in a cloud and goes off
+    /// to query the cloud metadata server for its public address before it can
+    /// register itself (`assemble_add_node_message` in
+    /// `rs/orchestrator/src/registration.rs`). There is no metadata server here,
+    /// so a node could never self-register. Farm hands out globally routable
+    /// addresses and so never takes that branch; this keeps the local backend
+    /// on the same side of it.
+    ///
+    /// `2001:db8::/32` leaves 16 bits for the group before the `/48` the
+    /// subnet-ids below need, so the group digest is shorter than the bridge's
+    /// and TAP's (see [`bridge_name`](Self::bridge_name)). A collision between
+    /// two groups is unobservable regardless: each test owns a private network
+    /// namespace (see
+    /// [`ensure_administrable_netns`](Self::ensure_administrable_netns)).
     fn group_ipv6_prefix(group_name: &str) -> String {
         use ic_crypto_sha2::Sha256;
         let hash = Sha256::hash(group_name.as_bytes());
-        format!(
-            "fd00:{:02x}{:02x}:{:02x}{:02x}::",
-            hash[0], hash[1], hash[2], hash[3]
-        )
+        format!("2001:db8:{:02x}{:02x}::", hash[0], hash[1])
     }
 
     /// Returns the per-group IPv6 gateway address (`<prefix>1`). Assigned to the
@@ -448,10 +461,7 @@ impl LocalBackend {
     pub fn group_mgmt_ipv6(group_name: &str) -> String {
         use ic_crypto_sha2::Sha256;
         let hash = Sha256::hash(group_name.as_bytes());
-        format!(
-            "fd00:{:02x}{:02x}:{:02x}{:02x}:1::1",
-            hash[0], hash[1], hash[2], hash[3]
-        )
+        format!("2001:db8:{:02x}{:02x}:1::1", hash[0], hash[1])
     }
 
     /// Returns the per-group IPv6 address the driver streams the nodes' journald
@@ -469,10 +479,7 @@ impl LocalBackend {
     pub fn group_logs_ipv6(group_name: &str) -> String {
         use ic_crypto_sha2::Sha256;
         let hash = Sha256::hash(group_name.as_bytes());
-        format!(
-            "fd00:{:02x}{:02x}:{:02x}{:02x}:2::1",
-            hash[0], hash[1], hash[2], hash[3]
-        )
+        format!("2001:db8:{:02x}{:02x}:2::1", hash[0], hash[1])
     }
 
     /// Returns the per-group IPv6 address the file server
@@ -492,18 +499,21 @@ impl LocalBackend {
     pub fn group_files_ipv6(group_name: &str) -> String {
         use ic_crypto_sha2::Sha256;
         let hash = Sha256::hash(group_name.as_bytes());
-        format!(
-            "fd00:{:02x}{:02x}:{:02x}{:02x}:3::1",
-            hash[0], hash[1], hash[2], hash[3]
-        )
+        format!("2001:db8:{:02x}{:02x}:3::1", hash[0], hash[1])
     }
 
-    /// The IPv6 ULA range every address the local backend hands out lives in:
-    /// the nodes' `/64`, the driver's own addresses and any other VM in the
-    /// group. Offered to tests that have to whitelist the *whole* group on the
-    /// nodes' firewall; see
+    /// The IPv6 range every address the local backend hands out lives in: the
+    /// nodes' `/64`, the driver's own addresses and any other VM in the group.
+    /// Offered to tests that have to whitelist the *whole* group on the nodes'
+    /// firewall; see
     /// [`InternetComputer::with_group_wide_firewall_whitelist`](crate::driver::ic::InternetComputer::with_group_wide_firewall_whitelist).
-    pub const GROUP_ULA_PREFIX: &'static str = "fd00::/8";
+    ///
+    /// `2001:db8::/32` is the range RFC 3849 reserves for documentation, so
+    /// nothing can legitimately route it. That is what the backend needs: the
+    /// addresses never leave its network namespace, yet they must not look
+    /// local to the node software — see
+    /// [`group_ipv6_prefix`](Self::group_ipv6_prefix).
+    pub const GROUP_PREFIX: &'static str = "2001:db8::/32";
 
     /// The three addresses the test driver reaches the group's VMs from: the
     /// management source ([`group_mgmt_ipv6`](Self::group_mgmt_ipv6)), the

--- a/rs/tests/networking/canister_http_socks_test.rs
+++ b/rs/tests/networking/canister_http_socks_test.rs
@@ -152,7 +152,7 @@ fn setup_and_run_subnet_test(
 
     // The outcall has to target a *host name*, not an address literal: the
     // adapter's socks connector always encodes the SOCKS5 target as a domain
-    // name, and for an IPv6 URL that string keeps its brackets (`[fd00::1]`),
+    // name, and for an IPv6 URL that string keeps its brackets (`[2001:db8::1]`),
     // which the dante server on the API boundary node cannot resolve.
     //
     // So name the webserver after its own address, the way the public `nip.io`

--- a/rs/tests/networking/canister_http_socks_test.rs
+++ b/rs/tests/networking/canister_http_socks_test.rs
@@ -152,7 +152,7 @@ fn setup_and_run_subnet_test(
 
     // The outcall has to target a *host name*, not an address literal: the
     // adapter's socks connector always encodes the SOCKS5 target as a domain
-    // name, and for an IPv6 URL that string keeps its brackets (`[2001:db8::1]`),
+    // name, and for an IPv6 URL that string keeps its brackets (`[fd00::1]`),
     // which the dante server on the API boundary node cannot resolve.
     //
     // So name the webserver after its own address, the way the public `nip.io`

--- a/rs/tests/networking/firewall/firewall_priority_test.rs
+++ b/rs/tests/networking/firewall/firewall_priority_test.rs
@@ -142,14 +142,23 @@ pub fn override_firewall_rules_with_priority(env: TestEnv) {
     // On the Local backend the driver reaches the nodes from a per-group
     // management address that lives *outside* the node `/64` (so the GuestOS
     // firewall's built-in accept for the node's own prefix does not shadow the
-    // rules under test). That source is in the backend's own range
-    // (`LocalBackend::GROUP_PREFIX`), which the Farm `default_rules` prefixes do
-    // not cover, so add it explicitly here; otherwise the deny rule would never
-    // match the driver and the port would stay reachable. Node-to-node traffic
-    // on 8080 is unaffected: it is allowed at higher priority by the
-    // orchestrator's automatic node whitelisting.
+    // rules under test). Add the backend's own range
+    // (`LocalBackend::GROUP_PREFIX`) so the deny rule matches the driver at all;
+    // otherwise the port would stay reachable. Node-to-node traffic on 8080 is
+    // unaffected: it is allowed at higher priority by the orchestrator's
+    // automatic node whitelisting.
+    //
+    // `GROUP_PREFIX` is a real DC prefix that the `default_rules` above already
+    // list, so today this adds nothing and is kept only so the test still works
+    // if the backend moves to a prefix they do not cover. Appending blindly
+    // would be a bug: these render into an anonymous nftables set
+    // (`ip6 saddr { ... }`), and `nft` rejects a set with a repeated element,
+    // taking the whole ruleset down with it.
     if SystemTestBackend::read_attribute(&env) == SystemTestBackend::Local {
-        deny_prefixes.push(LocalBackend::GROUP_PREFIX.to_string());
+        let group_prefix = LocalBackend::GROUP_PREFIX.to_string();
+        if !deny_prefixes.contains(&group_prefix) {
+            deny_prefixes.push(group_prefix);
+        }
     }
     let mut node_rules = vec![FirewallRule {
         ipv4_prefixes: vec![],

--- a/rs/tests/networking/firewall/firewall_priority_test.rs
+++ b/rs/tests/networking/firewall/firewall_priority_test.rs
@@ -37,6 +37,7 @@ use ic_system_test_driver::{
     driver::{
         group::SystemTestGroup,
         ic::{InternetComputer, Subnet},
+        local_backend::LocalBackend,
         test_env::{TestEnv, TestEnvAttribute},
         test_env_api::{
             HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot,
@@ -141,13 +142,14 @@ pub fn override_firewall_rules_with_priority(env: TestEnv) {
     // On the Local backend the driver reaches the nodes from a per-group
     // management address that lives *outside* the node `/64` (so the GuestOS
     // firewall's built-in accept for the node's own prefix does not shadow the
-    // rules under test). That source is in the ULA range `fd00::/8`, which the
-    // Farm `default_rules` prefixes do not cover, so add it explicitly here;
-    // otherwise the deny rule would never match the driver and the port would
-    // stay reachable. Node-to-node traffic on 8080 is unaffected: it is allowed
-    // at higher priority by the orchestrator's automatic node whitelisting.
+    // rules under test). That source is in the backend's own range
+    // (`LocalBackend::GROUP_PREFIX`), which the Farm `default_rules` prefixes do
+    // not cover, so add it explicitly here; otherwise the deny rule would never
+    // match the driver and the port would stay reachable. Node-to-node traffic
+    // on 8080 is unaffected: it is allowed at higher priority by the
+    // orchestrator's automatic node whitelisting.
     if SystemTestBackend::read_attribute(&env) == SystemTestBackend::Local {
-        deny_prefixes.push("fd00::/8".to_string());
+        deny_prefixes.push(LocalBackend::GROUP_PREFIX.to_string());
     }
     let mut node_rules = vec![FirewallRule {
         ipv4_prefixes: vec![],

--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -6,26 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "ipv4_integration_test",
-    # TODO: support this test on the local backend (drop `backend = "farm"`).
-    # It fails on the local backend during in-test node *self*-re-registration:
-    # the test wipes the unassigned node's keys + restarts its services and expects
-    # it to register itself again (registry version 3 -> 4), which never happens.
-    # Root cause: the local backend assigns nodes ULA `fd00::/8` IPv6 addresses, and
-    # the orchestrator's `assemble_add_node_message`
-    # (rs/orchestrator/src/registration.rs) treats a ULA / link-local address as a
-    # signal that it's running in a cloud: `if addr.is_unicast_link_local() ||
-    # addr.is_unique_local() { addr = CloudType::discover()?...obtain_public_ip()? }`.
-    # `CloudType::discover` (rs/ic_os/config/tool/src/guestos/cloud.rs) probes the
-    # cloud metadata server at http://169.254.169.254, which doesn't exist locally,
-    # so it errors out after exhausting its retries. `assemble_add_node_message`
-    # then fails on every iteration, the orchestrator never calls the registry
-    # `add_node` endpoint, and the registry never advances to version 4 -- so the
-    # 3rd `block_for_newer_registry_version()` in the test times out.
-    # Initial node setup is unaffected because those nodes are written to the
-    # registry by ic-prep/bootstrap on the driver side, bypassing the orchestrator's
-    # cloud-discovery self-registration path. On Farm the nodes get globally
-    # routable IPv6 addresses, so the cloud-discovery branch is skipped entirely.
-    backend = "farm",
     cpus = MIN_LOCAL_CPUS + 3 * DEFAULT_VCPUS_PER_VM,  # 3 IC Node VMs (1 System + 1 Application + 1 unassigned) * 6 vCPUs.
     proc_macro_deps = [
         "@crate_index//:indoc",


### PR DESCRIPTION
## What

Support the `ipv4_integration_test`, `node_registration_with_node_allowance_test` and `node_registration_with_max_rewardable_nodes_test` on the local backend.

## Why

`ipv4_integration_test` wipes an unassigned node's keys and restarts its services so the node registers *itself* again through the orchestrator. That never completed on the local backend, which is why the test was pinned to Farm along with `node_registration_with_node_allowance_test` and `node_registration_with_max_rewardable_nodes_test`.

### Why it could not run locally

The local backend addressed its groups out of the ULA range `fd00::/8`, and `assemble_add_node_message` (`rs/orchestrator/src/registration.rs`) reads a ULA or link-local address as a sign that it is running in a cloud: it goes off to `CloudType::discover()` to learn its public address before it can build the `add_node` payload. There is no metadata server at 169.254.169.254 in the local backend, so that call spun through its 120 retries and failed, the payload was never assembled, `add_node` was never called and the registry never advanced. Initial node setup was unaffected because those records are written by ic-prep on the driver side, bypassing self-registration entirely.

## How

Address the groups out of a regular IPv6 global unicast address. We choose `2a00:fb01:400::/56` — DFINITY's zh1 DC. `is_unique_local()` is then false and the cloud branch is skipped, exactly as it is on Farm, whose nodes are globally routable. This removes a divergence rather than working around one.

The layout keeps its shape — nodes on subnet-id 0, the driver's management, journald and file-server addresses on 1, 2 and 3, so the driver still reaches the nodes from outside their `/64` and the firewall's accept-own-prefix rule cannot shadow registry deny rules. A `/56` leaves one byte before the `/64` boundary, so it is 6 bits of group digest and 2 bits of subnet-id. Collisions stay unobservable: each test owns a private network namespace, and bridge and TAP names keep their own 40-bit digests. The four `format!`s become one packing helper, since the bit layout has to agree in all four places.

`GROUP_ULA_PREFIX` becomes `GROUP_PREFIX`, and `firewall_priority_test` — which had the range written out a second time — now takes it from there.

### Why not a reserved range

The first attempt used `2001:db8::/32` (RFC 3849), on the reasoning that a range reserved for documentation is safe *because* nothing routes it. That is backwards, and it broke `btc_get_balance_test` — the only failure in 960 tests on RBE. Bitcoin Core marks the documentation range invalid outright: `CNetAddr::IsValid()` returns false for `IsRFC3849()`, and `CSubNet::Match()` refuses any address that is not valid, so `-rpcallowip='::/0'` can never match the driver. 272k rejections of "Client network is not allowed RPC access", and `get_balance` timed out.

Two more conflicts with the same range turned up while looking into it, so it was simply the wrong choice: the registry canister's `IPV6_STRICT_CHECKS` names `2001:db8::/32` invalid (dormant only because the caller passes `strict=false`), and `canister_http_correctness_test` asserts that an outcall to `https://[2001:db8::1]` fails.

Reserved ranges are exactly the ones software special-cases. What the backend needs is a prefix no classifier has reason to look twice at. Nothing is routed to zh1 from here either — the addresses never leave the group's network namespace — the difference is that an ordinary global unicast prefix is classified as ordinary. The backend already relies on being able to squat inside that namespace: it puts the Cloudflare and Google resolver addresses on the group bridge so nodes get a resolver without any node side configuration.