### PR TITLE
feat(cketh): drive the sweeper transaction pipeline from its own timer task

### DIFF
--- a/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
@@ -95,7 +95,7 @@ fn deposit_derivation_path(schema: DepositAddressSchema, account: &Account) -> V
     ]
 }
 
-fn sweeper_derivation_path() -> Vec<ByteBuf> {
+pub(crate) fn sweeper_derivation_path() -> Vec<ByteBuf> {
     vec![ByteBuf::from(vec![SWEEPER_SCHEMA_TAG])]
 }
 

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -20,6 +20,7 @@ pub mod memo;
 pub mod numeric;
 pub mod state;
 pub mod storage;
+pub mod sweep;
 pub mod timed_sized_map;
 pub mod tx;
 pub mod withdraw;

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -41,6 +41,8 @@ pub const BALANCE_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);
 pub const PROCESS_REIMBURSEMENT: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL: Duration = Duration::from_secs(3 * 60);
+pub const PROCESS_SWEEPER_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);
+pub const PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL: Duration = Duration::from_secs(3 * 60);
 pub const MINT_RETRY_DELAY: Duration = Duration::from_secs(3 * 60);
 pub const EVM_RPC_ID_PRODUCTION: Principal =
     Principal::from_slice(&[0, 0, 0, 0, 2, 48, 0, 204, 1, 1]);

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -47,7 +47,8 @@ use ic_cketh_minter::withdraw::{
 };
 use ic_cketh_minter::{
     BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, PROCESS_REIMBURSEMENT,
-    REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL, SCRAPING_ETH_LOGS_INTERVAL, state, storage,
+    PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL,
+    SCRAPING_ETH_LOGS_INTERVAL, state, storage,
 };
 use ic_cketh_minter::{endpoints, erc20};
 use ic_ethereum_types::Address;
@@ -100,9 +101,7 @@ fn setup_timers() {
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
         process_retrieve_eth_requests().await;
     });
-    // Drains the sweeper send-pipeline on the same cadence as withdrawals; early-returns cheaply while
-    // no sweep is enqueued (nothing enqueues one in production yet — see `crate::sweep`).
-    ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
+    ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
         process_sweeper_transactions().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_REIMBURSEMENT, async || {

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -38,6 +38,7 @@ use ic_cketh_minter::state::transactions::{
 use ic_cketh_minter::state::{
     STATE, State, lazy_call_ecdsa_public_key, mutate_state, read_state, transactions,
 };
+use ic_cketh_minter::sweep::process_sweeper_transactions;
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::lazy_refresh_gas_fee_estimate;
 use ic_cketh_minter::withdraw::{
@@ -98,6 +99,11 @@ fn setup_timers() {
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
         process_retrieve_eth_requests().await;
+    });
+    // Drains the sweeper send-pipeline on the same cadence as withdrawals; early-returns cheaply while
+    // no sweep is enqueued (nothing enqueues one in production yet — see `crate::sweep`).
+    ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
+        process_sweeper_transactions().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_REIMBURSEMENT, async || {
         process_reimbursement().await;

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -249,6 +249,7 @@ impl State {
         Some(ecdsa_public_key_to_address(&pubkey))
     }
 
+    /// The minter's dedicated sweeper address, `None` until the ECDSA public key is cached.
     pub fn sweeper_address(&self) -> Option<Address> {
         let (master_public_key, chain_code) = self.public_key_and_chain_code()?;
         Some(sweeper_address(&master_public_key, &chain_code))
@@ -951,4 +952,5 @@ pub enum TaskType {
     MintCkErc20,
     RefreshLatestBlockHeight,
     BalanceScan,
+    SweeperSend,
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -212,6 +212,12 @@ impl SweepId {
     }
 }
 
+impl fmt::Display for SweepId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -212,12 +212,6 @@ impl SweepId {
     }
 }
 
-impl fmt::Display for SweepId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2906,11 +2906,12 @@ mod sweep_lane {
     use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
-    use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
+    use crate::numeric::{TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
         CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
         SweepRequest, TransactionPipeline,
     };
+    use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
         SignableTransaction, SignedAuthorization, SweepTransaction,
@@ -2919,7 +2920,6 @@ mod sweep_lane {
     use ethnum::u256;
     use ic_ethereum_types::Address;
 
-    const SWEEP_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
     const EIP1559_TX_ID: u8 = 2;
     const SET_CODE_TX_ID: u8 = 4;
 
@@ -2975,7 +2975,7 @@ mod sweep_lane {
             .create_transaction(
                 pipeline.next_transaction_nonce(),
                 gas_fee_estimate(),
-                SWEEP_GAS_LIMIT,
+                SWEEP_TRANSACTION_GAS_LIMIT,
                 EthereumNetwork::Sepolia,
             )
             .expect("BUG: the fixture allowance covers the fixture fee");
@@ -3177,7 +3177,7 @@ mod sweep_lane {
             .create_transaction(
                 pipeline.next_transaction_nonce(),
                 gas_fee_estimate(),
-                SWEEP_GAS_LIMIT,
+                SWEEP_TRANSACTION_GAS_LIMIT,
                 EthereumNetwork::Sepolia,
             )
             .expect("BUG: the fixture allowance covers the fixture fee")
@@ -3194,7 +3194,8 @@ mod sweep_lane {
         };
 
         assert_eq!(
-            tx.max_fee_per_gas.transaction_cost(SWEEP_GAS_LIMIT),
+            tx.max_fee_per_gas
+                .transaction_cost(SWEEP_TRANSACTION_GAS_LIMIT),
             Some(request.max_transaction_fee)
         );
         assert_eq!(
@@ -3214,7 +3215,7 @@ mod sweep_lane {
         let created = request.create_transaction(
             TransactionNonce::ZERO,
             spiked_fee,
-            SWEEP_GAS_LIMIT,
+            SWEEP_TRANSACTION_GAS_LIMIT,
             EthereumNetwork::Sepolia,
         );
 
@@ -3240,14 +3241,14 @@ mod sweep_lane {
             gas_fee_estimate().max_priority_fee_per_gas
                 > request
                     .max_transaction_fee
-                    .into_wei_per_gas(SWEEP_GAS_LIMIT)
+                    .into_wei_per_gas(SWEEP_TRANSACTION_GAS_LIMIT)
                     .unwrap()
         );
 
         let created = request.create_transaction(
             TransactionNonce::ZERO,
             gas_fee_estimate(),
-            SWEEP_GAS_LIMIT,
+            SWEEP_TRANSACTION_GAS_LIMIT,
             EthereumNetwork::Sepolia,
         );
 

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -1,0 +1,257 @@
+//! Sending transactions **from the minter's dedicated sweeper address** on the sweeper's own nonce
+//! sequence, so a stuck sweep can never head-of-line-block a withdrawal on the main address'
+//! pipeline.
+//!
+//! This is the preparatory send-pipeline: it drives the sweeper [`TransactionPipeline`] through the same
+//! create → sign → send → resubmit → finalize state machine as user withdrawals
+//! ([`crate::withdraw`]), reusing that module's sender-agnostic RPC helpers
+//! (`latest_transaction_count`, `finalized_transaction_count`, `send_signed_transactions`,
+//! `fetch_finalized_receipts`), but signing with the sweeper derivation path (`[3]`) and reading
+//! the sweeper address' own transaction count.
+//!
+//! Deliberately out of scope here (follow-ups): EIP-7702 (`0x04`) first-time delegation, building
+//! the delegate sweep call data from the balance-sweep queue, and gating the pipeline on prepaid sweep
+//! gas. Nothing enqueues a [`SweepRequest`] in production yet, so this task early-returns on an
+//! empty pipeline.
+
+use crate::{
+    deposit_address::sweeper_derivation_path,
+    guard::TimerGuard,
+    logs::{DEBUG, INFO},
+    numeric::{GasAmount, TransactionCount},
+    state::{
+        State, TaskType,
+        audit::{EventType, process_event},
+        mutate_state, read_state,
+        transactions::{CreateSweepTransactionError, PipelineRequest},
+    },
+    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate},
+    withdraw::{
+        fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
+        send_signed_transactions,
+    },
+};
+use futures::future::join_all;
+use ic_canister_log::log;
+use ic_ethereum_types::Address;
+use ic_management_canister_types_private::DerivationPath;
+
+/// Gas limit of a sweep transaction. A fixed, conservative bound for the preparatory type-`0x02`
+/// pipeline; a per-request estimate arrives with the real delegate sweep call.
+pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+
+const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
+const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
+const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
+
+pub async fn process_sweeper_transactions() {
+    let _guard = match TimerGuard::new(TaskType::SweeperSend) {
+        Ok(guard) => guard,
+        Err(e) => {
+            log!(
+                DEBUG,
+                "Failed retrieving timer guard to process sweeper transactions: {e:?}",
+            );
+            return;
+        }
+    };
+
+    if read_state(|s| !s.sweeper_transactions.has_pending_requests()) {
+        return;
+    }
+
+    let Some(sender) = read_state(State::sweeper_address) else {
+        log!(
+            DEBUG,
+            "[process_sweeper_transactions]: SKIPPING: the sweeper address is unknown (ECDSA public key not cached yet)"
+        );
+        return;
+    };
+
+    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate().await {
+        Some(gas_fee_estimate) => gas_fee_estimate,
+        None => {
+            log!(
+                INFO,
+                "[process_sweeper_transactions]: failed retrieving gas fee estimate",
+            );
+            return;
+        }
+    };
+
+    let latest_transaction_count = latest_transaction_count(sender).await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
+    create_transactions_batch(&gas_fee_estimate);
+    sign_transactions_batch().await;
+    send_transactions_batch(latest_transaction_count).await;
+    finalize_transactions_batch(sender).await;
+
+    if read_state(|s| s.sweeper_transactions.has_pending_requests()) {
+        ic_cdk_timers::set_timer(
+            crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
+            async { process_sweeper_transactions().await },
+        );
+    }
+}
+
+async fn resubmit_transactions_batch(
+    latest_transaction_count: Option<TransactionCount>,
+    gas_fee_estimate: &GasFeeEstimate,
+) {
+    if read_state(|s| s.sweeper_transactions.is_sent_tx_empty()) {
+        return;
+    }
+    let Some(latest_transaction_count) = latest_transaction_count else {
+        return;
+    };
+    let transactions_to_resubmit = read_state(|s| {
+        s.sweeper_transactions
+            .create_resubmit_transactions(latest_transaction_count, gas_fee_estimate.clone())
+    });
+    for result in transactions_to_resubmit {
+        match result {
+            Ok((sweep_id, transaction)) => {
+                log!(
+                    INFO,
+                    "[process_sweeper_transactions]: resubmitting sweep transaction {transaction:?}"
+                );
+                mutate_state(|s| {
+                    process_event(
+                        s,
+                        EventType::ReplacedSweeperTransaction {
+                            sweep_id,
+                            transaction,
+                        },
+                    )
+                });
+            }
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[process_sweeper_transactions]: failed to resubmit sweep transaction: {e:?}"
+                );
+            }
+        }
+    }
+}
+
+fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
+    for request in read_state(|s| {
+        s.sweeper_transactions
+            .requests_batch(SWEEP_REQUESTS_BATCH_SIZE)
+    }) {
+        let ethereum_network = read_state(State::ethereum_network);
+        let nonce = read_state(|s| s.sweeper_transactions.next_transaction_nonce());
+        let sweep_id = request.id;
+        match request.create_transaction(
+            nonce,
+            gas_fee_estimate.clone(),
+            SWEEP_TRANSACTION_GAS_LIMIT,
+            ethereum_network,
+        ) {
+            Ok(transaction) => {
+                mutate_state(|s| {
+                    process_event(
+                        s,
+                        EventType::CreatedSweeperTransaction {
+                            sweep_id,
+                            transaction,
+                        },
+                    );
+                });
+            }
+            Err(CreateSweepTransactionError::InsufficientTransactionFee {
+                allowed_max_transaction_fee,
+                actual_max_transaction_fee,
+                ..
+            }) => {
+                log!(
+                    INFO,
+                    "[process_sweeper_transactions]: Sweep {sweep_id} has prepaid gas {allowed_max_transaction_fee:?}, below the current transaction fee {actual_max_transaction_fee:?}. Sweep moved back to end of queue."
+                );
+                mutate_state(|s| s.sweeper_transactions.reschedule_request(sweep_id));
+            }
+        }
+    }
+}
+
+async fn sign_transactions_batch() {
+    let transactions_batch: Vec<_> = read_state(|s| {
+        s.sweeper_transactions
+            .transactions_to_sign_batch(SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE)
+    });
+    let results = join_all(
+        transactions_batch
+            .into_iter()
+            .map(|(sweep_id, tx)| async move {
+                (
+                    sweep_id,
+                    crate::tx::sign(tx, DerivationPath::new(sweeper_derivation_path())).await,
+                )
+            }),
+    )
+    .await;
+    for (sweep_id, result) in results {
+        match result {
+            Ok(transaction) => mutate_state(|s| {
+                process_event(
+                    s,
+                    EventType::SignedSweeperTransaction {
+                        sweep_id,
+                        transaction,
+                    },
+                )
+            }),
+            Err(e) => log!(
+                INFO,
+                "[process_sweeper_transactions]: error signing sweep {sweep_id}: {e:?}"
+            ),
+        }
+    }
+}
+
+async fn send_transactions_batch(latest_transaction_count: Option<TransactionCount>) {
+    let Some(latest_transaction_count) = latest_transaction_count else {
+        return;
+    };
+    let transactions_to_send: Vec<_> = read_state(|s| {
+        s.sweeper_transactions.transactions_to_send_batch(
+            latest_transaction_count,
+            SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE,
+        )
+    });
+    send_signed_transactions(&transactions_to_send).await;
+}
+
+async fn finalize_transactions_batch(sender: Address) {
+    if read_state(|s| s.sweeper_transactions.is_sent_tx_empty()) {
+        return;
+    }
+    match finalized_transaction_count(sender).await {
+        Ok(finalized_tx_count) => {
+            let txs_to_finalize = read_state(|s| {
+                s.sweeper_transactions
+                    .sent_transactions_to_finalize(&finalized_tx_count)
+            });
+            if let Some(receipts) = fetch_finalized_receipts(txs_to_finalize).await {
+                for (sweep_id, transaction_receipt) in receipts {
+                    mutate_state(|s| {
+                        process_event(
+                            s,
+                            EventType::FinalizedSweeperTransaction {
+                                sweep_id,
+                                transaction_receipt: transaction_receipt.into(),
+                            },
+                        );
+                    });
+                }
+            }
+        }
+        Err(e) => {
+            log!(
+                INFO,
+                "[process_sweeper_transactions]: failed to get finalized transaction count: {e:?}"
+            );
+        }
+    }
+}

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -31,8 +31,8 @@ use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 
-/// Gas limit of a sweep transaction. A fixed, conservative bound for the preparatory type-`0x02`
-/// pipeline; a per-request estimate arrives with the real delegate sweep call.
+/// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
+/// with the real delegate sweep call.
 pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
@@ -83,7 +83,7 @@ pub async fn process_sweeper_transactions() {
     resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
     create_transactions_batch(&gas_fee_estimate);
     sign_transactions_batch().await;
-    send_transactions_batch(latest_transaction_count).await;
+    send_transactions_batch(sender, latest_transaction_count).await;
     finalize_transactions_batch(sender).await;
 
     if read_state(|s| s.sweeper_transactions.has_pending_requests()) {
@@ -213,7 +213,10 @@ async fn sign_transactions_batch() {
     }
 }
 
-async fn send_transactions_batch(latest_transaction_count: Option<TransactionCount>) {
+async fn send_transactions_batch(
+    sender: Address,
+    latest_transaction_count: Option<TransactionCount>,
+) {
     let Some(latest_transaction_count) = latest_transaction_count else {
         return;
     };
@@ -223,7 +226,7 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
             SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE,
         )
     });
-    send_signed_transactions(&transactions_to_send).await;
+    send_signed_transactions(sender, &transactions_to_send).await;
 }
 
 async fn finalize_transactions_batch(sender: Address) {

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -170,7 +170,7 @@ fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
             }) => {
                 log!(
                     INFO,
-                    "[process_sweeper_transactions]: Sweep {sweep_id} has prepaid gas {allowed_max_transaction_fee:?}, below the current transaction fee {actual_max_transaction_fee:?}. Sweep moved back to end of queue."
+                    "[process_sweeper_transactions]: Sweep {sweep_id:?} has prepaid gas {allowed_max_transaction_fee:?}, below the current transaction fee {actual_max_transaction_fee:?}. Sweep moved back to end of queue."
                 );
                 mutate_state(|s| s.sweeper_transactions.reschedule_request(sweep_id));
             }
@@ -207,7 +207,7 @@ async fn sign_transactions_batch() {
             }),
             Err(e) => log!(
                 INFO,
-                "[process_sweeper_transactions]: error signing sweep {sweep_id}: {e:?}"
+                "[process_sweeper_transactions]: error signing sweep {sweep_id:?}: {e:?}"
             ),
         }
     }

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -71,10 +71,15 @@ pub async fn process_sweeper_transactions() {
     let gas_fee_estimate = match lazy_refresh_gas_fee_estimate().await {
         Some(gas_fee_estimate) => gas_fee_estimate,
         None => {
+            // The withdrawal task refreshes the same estimate under a shared guard and runs first
+            // on an equal cadence, so losing that race is expected rather than exceptional. Retry
+            // instead of waiting a whole interval: by then the refresh it was holding has cached an
+            // estimate this task can reuse.
             log!(
                 INFO,
-                "[process_sweeper_transactions]: failed retrieving gas fee estimate",
+                "[process_sweeper_transactions]: failed retrieving gas fee estimate, retrying",
             );
+            schedule_retry();
             return;
         }
     };

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -2,17 +2,12 @@
 //! sequence, so a stuck sweep can never head-of-line-block a withdrawal on the main address'
 //! pipeline.
 //!
-//! This is the preparatory send-pipeline: it drives the sweeper [`TransactionPipeline`] through the same
+//! It drives the sweeper [`TransactionPipeline`] through the same
 //! create → sign → send → resubmit → finalize state machine as user withdrawals
 //! ([`crate::withdraw`]), reusing that module's sender-agnostic RPC helpers
 //! (`latest_transaction_count`, `finalized_transaction_count`, `send_signed_transactions`,
 //! `fetch_finalized_receipts`), but signing with the sweeper derivation path (`[3]`) and reading
 //! the sweeper address' own transaction count.
-//!
-//! Deliberately out of scope here (follow-ups): EIP-7702 (`0x04`) first-time delegation, building
-//! the delegate sweep call data from the balance-sweep queue, and gating the pipeline on prepaid sweep
-//! gas. Nothing enqueues a [`SweepRequest`] in production yet, so this task early-returns on an
-//! empty pipeline.
 
 use crate::{
     deposit_address::sweeper_derivation_path,

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -87,11 +87,14 @@ pub async fn process_sweeper_transactions() {
     finalize_transactions_batch(sender).await;
 
     if read_state(|s| s.sweeper_transactions.has_pending_requests()) {
-        ic_cdk_timers::set_timer(
-            crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
-            async { process_sweeper_transactions().await },
-        );
+        schedule_retry();
     }
+}
+
+fn schedule_retry() {
+    ic_cdk_timers::set_timer(crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL, async {
+        process_sweeper_transactions().await
+    });
 }
 
 async fn resubmit_transactions_batch(

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -183,7 +183,7 @@ pub async fn process_retrieve_eth_requests() {
     resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
     create_transactions_batch(gas_fee_estimate);
     sign_transactions_batch().await;
-    send_transactions_batch(latest_transaction_count).await;
+    send_transactions_batch(sender, latest_transaction_count).await;
     finalize_transactions_batch(sender).await;
 
     if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
@@ -207,7 +207,10 @@ pub(crate) async fn latest_transaction_count(sender: Address) -> Option<Transact
     {
         Ok(transaction_count) => Some(transaction_count),
         Err(e) => {
-            log!(INFO, "Failed to get the latest transaction count: {e:?}");
+            log!(
+                INFO,
+                "Failed to get the latest transaction count of {sender}: {e:?}"
+            );
             None
         }
     }
@@ -353,7 +356,10 @@ async fn sign_transactions_batch() {
         log!(INFO, "Errors encountered during signing: {errors:?}");
     }
 }
-async fn send_transactions_batch(latest_transaction_count: Option<TransactionCount>) {
+async fn send_transactions_batch(
+    sender: Address,
+    latest_transaction_count: Option<TransactionCount>,
+) {
     let latest_transaction_count = match latest_transaction_count {
         Some(latest_transaction_count) => latest_transaction_count,
         None => {
@@ -364,13 +370,14 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
         s.withdrawal_transactions
             .transactions_to_send_batch(latest_transaction_count, TRANSACTIONS_TO_SEND_BATCH_SIZE)
     });
-    send_signed_transactions(&transactions_to_send).await;
+    send_signed_transactions(sender, &transactions_to_send).await;
 }
 
 /// Broadcast already-signed transactions via the EVM RPC canister. Sender- and
 /// transaction-type-agnostic, so both the main-address withdrawal pipeline (type `0x02`) and the
 /// sweeper-address pipeline (type `0x02` or `0x04`) reuse it.
 pub(crate) async fn send_signed_transactions<T: SignableTransaction + std::fmt::Debug>(
+    sender: Address,
     transactions_to_send: &[Signed<T>],
 ) {
     let rpc_client = read_state(rpc_client);
@@ -385,7 +392,10 @@ pub(crate) async fn send_signed_transactions<T: SignableTransaction + std::fmt::
     .await;
 
     for (signed_tx, result) in zip(transactions_to_send, results) {
-        log!(DEBUG, "Sent transaction {signed_tx:?}: {result:?}");
+        log!(
+            DEBUG,
+            "Sent transaction from {sender} {signed_tx:?}: {result:?}"
+        );
         match result {
             Ok(SendRawTransactionStatus::Ok(_)) | Ok(SendRawTransactionStatus::NonceTooLow) => {
                 // In case of resubmission we may hit the case of SendRawTransactionStatus::NonceTooLow
@@ -395,12 +405,12 @@ pub(crate) async fn send_signed_transactions<T: SignableTransaction + std::fmt::
             Ok(SendRawTransactionStatus::InsufficientFunds)
             | Ok(SendRawTransactionStatus::NonceTooHigh) => log!(
                 INFO,
-                "Failed to send transaction {signed_tx:?}: {result:?}. Will retry later.",
+                "Failed to send transaction from {sender} {signed_tx:?}: {result:?}. Will retry later.",
             ),
             Err(e) => {
                 log!(
                     INFO,
-                    "Failed to send transaction {signed_tx:?}: {e:?}. Will retry later."
+                    "Failed to send transaction from {sender} {signed_tx:?}: {e:?}. Will retry later."
                 )
             }
         };

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -443,9 +443,7 @@ async fn finalize_transactions_batch(sender: Address) {
 /// the batch should be retried later (a receipt fetch failed, or the same hash came back with two
 /// different receipts). On success the map is keyed by pipeline id, and its keys are asserted to be
 /// exactly the ids expected to finalize. Sender/id-agnostic, so both pipelines reuse it.
-pub(crate) async fn fetch_finalized_receipts<
-    Id: Copy + Ord + std::fmt::Debug + std::fmt::Display,
->(
+pub(crate) async fn fetch_finalized_receipts<Id: Copy + Ord + std::fmt::Debug>(
     txs_to_finalize: BTreeMap<Hash, Id>,
 ) -> Option<BTreeMap<Id, EvmTransactionReceipt>> {
     let expected_finalized_ids: BTreeSet<Id> = txs_to_finalize.values().copied().collect();
@@ -465,14 +463,14 @@ pub(crate) async fn fetch_finalized_receipts<
             Ok(Some(receipt)) => {
                 log!(
                     DEBUG,
-                    "Received transaction receipt {receipt:?} for transaction {hash} and id {id}"
+                    "Received transaction receipt {receipt:?} for transaction {hash} and id {id:?}"
                 );
                 match receipts.get(&id) {
                     // by construction we never query twice the same transaction hash, which is a field in TransactionReceipt.
                     Some(existing_receipt) => {
                         log!(
                             INFO,
-                            "ERROR: received different receipts for transaction {hash} with id {id}: {existing_receipt:?} and {receipt:?}. Will retry later"
+                            "ERROR: received different receipts for transaction {hash} with id {id:?}: {existing_receipt:?} and {receipt:?}. Will retry later"
                         );
                         return None;
                     }
@@ -484,13 +482,13 @@ pub(crate) async fn fetch_finalized_receipts<
             Ok(None) => {
                 log!(
                     DEBUG,
-                    "Transaction {hash} for id {id} was not mined, it's probably a resubmitted transaction",
+                    "Transaction {hash} for id {id:?} was not mined, it's probably a resubmitted transaction",
                 )
             }
             Err(e) => {
                 log!(
                     INFO,
-                    "Failed to get transaction receipt for {hash} and id {id}: {e:?}. Will retry later",
+                    "Failed to get transaction receipt for {hash} and id {id:?}: {e:?}. Will retry later",
                 );
                 return None;
             }

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -18,7 +18,7 @@ use crate::{
             ReimbursementRequest, WithdrawalRequest,
         },
     },
-    tx::{GasFeeEstimate, SignedEip1559TransactionRequest, lazy_refresh_gas_fee_estimate},
+    tx::{GasFeeEstimate, SignableTransaction, Signed, lazy_refresh_gas_fee_estimate},
 };
 use candid::Nat;
 use evm_rpc_types::{
@@ -367,10 +367,11 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
     send_signed_transactions(&transactions_to_send).await;
 }
 
-/// Broadcast already-signed transactions via the EVM RPC canister. Sender-agnostic, so both the
-/// main-address withdrawal pipeline and the sweeper-address pipeline reuse it.
-pub(crate) async fn send_signed_transactions(
-    transactions_to_send: &[SignedEip1559TransactionRequest],
+/// Broadcast already-signed transactions via the EVM RPC canister. Sender- and
+/// transaction-type-agnostic, so both the main-address withdrawal pipeline (type `0x02`) and the
+/// sweeper-address pipeline (type `0x02` or `0x04`) reuse it.
+pub(crate) async fn send_signed_transactions<T: SignableTransaction + std::fmt::Debug>(
+    transactions_to_send: &[Signed<T>],
 ) {
     let rpc_client = read_state(rpc_client);
     let results = join_all(transactions_to_send.iter().map(async |tx| {

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -195,7 +195,7 @@ pub async fn process_retrieve_eth_requests() {
 }
 
 /// The latest (unconfirmed) transaction count of `sender` on chain, used to gate resubmission and
-/// sending. Reused by both the main-address pipeline and the sweeper-address pipeline (`sender` differs).
+/// sending.
 pub(crate) async fn latest_transaction_count(sender: Address) -> Option<TransactionCount> {
     match read_state(rpc_client)
         .get_transaction_count((sender.into_bytes(), BlockTag::Latest))

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -1,3 +1,4 @@
+use crate::eth_rpc::Hash;
 use crate::{
     MAIN_DERIVATION_PATH,
     eth_logs::LedgerSubaccount,
@@ -7,7 +8,7 @@ use crate::{
     },
     guard::TimerGuard,
     logs::{DEBUG, INFO},
-    numeric::{GasAmount, LedgerBurnIndex, LedgerMintIndex, TransactionCount},
+    numeric::{GasAmount, LedgerMintIndex, TransactionCount},
     state::{
         State, TaskType,
         audit::{EventType, process_event},
@@ -17,7 +18,7 @@ use crate::{
             ReimbursementRequest, WithdrawalRequest,
         },
     },
-    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate},
+    tx::{GasFeeEstimate, SignedEip1559TransactionRequest, lazy_refresh_gas_fee_estimate},
 };
 use candid::Nat;
 use evm_rpc_types::{
@@ -25,6 +26,7 @@ use evm_rpc_types::{
 };
 use futures::future::join_all;
 use ic_canister_log::log;
+use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 use icrc_ledger_client_cdk::{CdkRuntime, ICRC1Client};
 use icrc_ledger_types::icrc1::{
@@ -176,12 +178,13 @@ pub async fn process_retrieve_eth_requests() {
         }
     };
 
-    let latest_transaction_count = latest_transaction_count().await;
+    let sender = minter_address().await;
+    let latest_transaction_count = latest_transaction_count(sender).await;
     resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
     create_transactions_batch(gas_fee_estimate);
     sign_transactions_batch().await;
     send_transactions_batch(latest_transaction_count).await;
-    finalize_transactions_batch().await;
+    finalize_transactions_batch(sender).await;
 
     if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
         ic_cdk_timers::set_timer(
@@ -191,9 +194,11 @@ pub async fn process_retrieve_eth_requests() {
     }
 }
 
-async fn latest_transaction_count() -> Option<TransactionCount> {
+/// The latest (unconfirmed) transaction count of `sender` on chain, used to gate resubmission and
+/// sending. Reused by both the main-address pipeline and the sweeper-address pipeline (`sender` differs).
+pub(crate) async fn latest_transaction_count(sender: Address) -> Option<TransactionCount> {
     match read_state(rpc_client)
-        .get_transaction_count((minter_address().await.into_bytes(), BlockTag::Latest))
+        .get_transaction_count((sender.into_bytes(), BlockTag::Latest))
         .with_cycles(MIN_ATTACHED_CYCLES)
         .try_send()
         .await
@@ -359,7 +364,14 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
         s.withdrawal_transactions
             .transactions_to_send_batch(latest_transaction_count, TRANSACTIONS_TO_SEND_BATCH_SIZE)
     });
+    send_signed_transactions(&transactions_to_send).await;
+}
 
+/// Broadcast already-signed transactions via the EVM RPC canister. Sender-agnostic, so both the
+/// main-address withdrawal pipeline and the sweeper-address pipeline reuse it.
+pub(crate) async fn send_signed_transactions(
+    transactions_to_send: &[SignedEip1559TransactionRequest],
+) {
     let rpc_client = read_state(rpc_client);
     let results = join_all(transactions_to_send.iter().map(async |tx| {
         rpc_client
@@ -394,81 +406,29 @@ async fn send_transactions_batch(latest_transaction_count: Option<TransactionCou
     }
 }
 
-async fn finalize_transactions_batch() {
+async fn finalize_transactions_batch(sender: Address) {
     if read_state(|s| s.withdrawal_transactions.is_sent_tx_empty()) {
         return;
     }
 
-    match finalized_transaction_count().await {
+    match finalized_transaction_count(sender).await {
         Ok(finalized_tx_count) => {
             let txs_to_finalize = read_state(|s| {
                 s.withdrawal_transactions
                     .sent_transactions_to_finalize(&finalized_tx_count)
             });
-            let expected_finalized_withdrawal_ids: BTreeSet<_> =
-                txs_to_finalize.values().cloned().collect();
-            let rpc_client = read_state(rpc_client);
-            let results = join_all(txs_to_finalize.keys().map(async |hash| {
-                rpc_client
-                    .get_transaction_receipt(*hash)
-                    .with_cycles(MIN_ATTACHED_CYCLES)
-                    .try_send()
-                    .await
-                    .reduce_with_strategy(NoReduction)
-            }))
-            .await;
-            let mut receipts: BTreeMap<LedgerBurnIndex, EvmTransactionReceipt> = BTreeMap::new();
-            for ((hash, withdrawal_id), result) in zip(txs_to_finalize, results) {
-                match result {
-                    Ok(Some(receipt)) => {
-                        log!(
-                            DEBUG,
-                            "Received transaction receipt {receipt:?} for transaction {hash} and withdrawal ID {withdrawal_id}"
+            if let Some(receipts) = fetch_finalized_receipts(txs_to_finalize).await {
+                for (withdrawal_id, transaction_receipt) in receipts {
+                    mutate_state(|s| {
+                        process_event(
+                            s,
+                            EventType::FinalizedTransaction {
+                                withdrawal_id,
+                                transaction_receipt: transaction_receipt.into(),
+                            },
                         );
-                        match receipts.get(&withdrawal_id) {
-                            // by construction we never query twice the same transaction hash, which is a field in TransactionReceipt.
-                            Some(existing_receipt) => {
-                                log!(
-                                    INFO,
-                                    "ERROR: received different receipts for transaction {hash} with withdrawal ID {withdrawal_id}: {existing_receipt:?} and {receipt:?}. Will retry later"
-                                );
-                                return;
-                            }
-                            None => {
-                                receipts.insert(withdrawal_id, receipt);
-                            }
-                        }
-                    }
-                    Ok(None) => {
-                        log!(
-                            DEBUG,
-                            "Transaction {hash} for withdrawal ID {withdrawal_id} was not mined, it's probably a resubmitted transaction",
-                        )
-                    }
-                    Err(e) => {
-                        log!(
-                            INFO,
-                            "Failed to get transaction receipt for {hash} and withdrawal ID {withdrawal_id}: {e:?}. Will retry later",
-                        );
-                        return;
-                    }
+                    });
                 }
-            }
-            let actual_finalized_withdrawal_ids: BTreeSet<_> = receipts.keys().cloned().collect();
-            assert_eq!(
-                expected_finalized_withdrawal_ids, actual_finalized_withdrawal_ids,
-                "ERROR: unexpected transaction receipts for some withdrawal IDs"
-            );
-            for (withdrawal_id, transaction_receipt) in receipts {
-                mutate_state(|s| {
-                    process_event(
-                        s,
-                        EventType::FinalizedTransaction {
-                            withdrawal_id,
-                            transaction_receipt: transaction_receipt.into(),
-                        },
-                    );
-                });
             }
         }
 
@@ -478,10 +438,76 @@ async fn finalize_transactions_batch() {
     }
 }
 
-async fn finalized_transaction_count() -> Result<TransactionCount, MultiCallError<TransactionCount>>
-{
+/// Fetch the finalized receipts for the given (transaction hash → pipeline id) map. Returns `None` when
+/// the batch should be retried later (a receipt fetch failed, or the same hash came back with two
+/// different receipts). On success the map is keyed by pipeline id, and its keys are asserted to be
+/// exactly the ids expected to finalize. Sender/id-agnostic, so both pipelines reuse it.
+pub(crate) async fn fetch_finalized_receipts<
+    Id: Copy + Ord + std::fmt::Debug + std::fmt::Display,
+>(
+    txs_to_finalize: BTreeMap<Hash, Id>,
+) -> Option<BTreeMap<Id, EvmTransactionReceipt>> {
+    let expected_finalized_ids: BTreeSet<Id> = txs_to_finalize.values().copied().collect();
+    let rpc_client = read_state(rpc_client);
+    let results = join_all(txs_to_finalize.keys().map(async |hash| {
+        rpc_client
+            .get_transaction_receipt(*hash)
+            .with_cycles(MIN_ATTACHED_CYCLES)
+            .try_send()
+            .await
+            .reduce_with_strategy(NoReduction)
+    }))
+    .await;
+    let mut receipts: BTreeMap<Id, EvmTransactionReceipt> = BTreeMap::new();
+    for ((hash, id), result) in zip(txs_to_finalize, results) {
+        match result {
+            Ok(Some(receipt)) => {
+                log!(
+                    DEBUG,
+                    "Received transaction receipt {receipt:?} for transaction {hash} and id {id}"
+                );
+                match receipts.get(&id) {
+                    // by construction we never query twice the same transaction hash, which is a field in TransactionReceipt.
+                    Some(existing_receipt) => {
+                        log!(
+                            INFO,
+                            "ERROR: received different receipts for transaction {hash} with id {id}: {existing_receipt:?} and {receipt:?}. Will retry later"
+                        );
+                        return None;
+                    }
+                    None => {
+                        receipts.insert(id, receipt);
+                    }
+                }
+            }
+            Ok(None) => {
+                log!(
+                    DEBUG,
+                    "Transaction {hash} for id {id} was not mined, it's probably a resubmitted transaction",
+                )
+            }
+            Err(e) => {
+                log!(
+                    INFO,
+                    "Failed to get transaction receipt for {hash} and id {id}: {e:?}. Will retry later",
+                );
+                return None;
+            }
+        }
+    }
+    let actual_finalized_ids: BTreeSet<Id> = receipts.keys().copied().collect();
+    assert_eq!(
+        expected_finalized_ids, actual_finalized_ids,
+        "ERROR: unexpected transaction receipts for some ids"
+    );
+    Some(receipts)
+}
+
+pub(crate) async fn finalized_transaction_count(
+    sender: Address,
+) -> Result<TransactionCount, MultiCallError<TransactionCount>> {
     read_state(rpc_client)
-        .get_transaction_count((minter_address().await.into_bytes(), BlockTag::Finalized))
+        .get_transaction_count((sender.into_bytes(), BlockTag::Finalized))
         .with_cycles(MIN_ATTACHED_CYCLES)
         .try_send()
         .await


### PR DESCRIPTION
## Why

- The sweeper address has its own transaction pipeline, but nothing moves requests through it.
- This is the task that does, on the sweeper's own nonce sequence.

## What

- `sweep::process_sweeper_transactions` runs the sweeper pipeline through the same create → sign → send → resubmit → finalize cycle as withdrawals.
- It signs with the sweeper derivation path `[3]` and reads the sweeper address' own transaction count.
- It takes its own `TaskType::SweeperSend` timer guard, so a slow sweep round neither blocks the withdrawal task nor is blocked by it — the point of a separate nonce sequence.
- A sweep whose prepaid gas cannot cover the current fee is logged and moved back to the end of the queue, as the withdrawal task does, rather than priced at something that could not be mined.
- The transaction type stays the request's business: a sweep that must still install delegations is sent as EIP-7702, any other as EIP-1559.

## Prerequisite commit

- Four RPC helpers in `withdraw` were implicitly about the main address, calling `minter_address()` themselves or keying receipts by `LedgerBurnIndex`.
- Reading a transaction count, broadcasting signed transactions and fetching finalized receipts are specific to neither a sender nor what a request is keyed by, so the sender becomes an argument and the receipt fetch becomes generic over the pipeline id.
- Behaviour is unchanged: the receipt loop moves into `fetch_finalized_receipts`, which returns `None` where the loop used to return early.

## Scope

- Nothing enqueues a `SweepRequest` yet, so the task early-returns on an empty pipeline and is inert in production.
- Still to come: the sweep-queue→`SweepRequest` source, and gating on prepaid sweep gas.

## Note for reviewers

- The sweep driver and the withdrawal driver are now near-identical five-stage loops over different request types, down to a private trio of batch-size constants that are `5` in both files.
- Deduplicating them is the obvious follow-up now that the pipeline is generic, but it would bury this change, so it is left for its own PR.


[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
