### PR TITLE
fix(cketh): require two agreeing providers for the balance scan

### DIFF
--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -3,7 +3,9 @@ pub mod batcher;
 #[cfg(test)]
 mod tests;
 
-use crate::eth_rpc_client::{AnyOf, MIN_ATTACHED_CYCLES, ToReducedWithStrategy, rpc_client};
+use crate::eth_rpc_client::{
+    MIN_ATTACHED_CYCLES, NoReduction, ToReducedWithStrategy, balance_scan_rpc_client,
+};
 use crate::guard::TimerGuard;
 use crate::logs::{DEBUG, INFO};
 use crate::numeric::{BlockNumber, Erc20Value};
@@ -38,9 +40,7 @@ const MAX_CALLS_PER_BATCH: usize = 1_000;
 
 pub async fn balance_scan() {
     let now = Timestamp::from_nanos(ic_cdk::api::time());
-    // TODO DEFI-2923: use a lower threshold rpc client, e.g. 2-out-of-3 since we use latest block height
-    // and only to notify the sweeper (no minting)
-    let client = read_state(rpc_client);
+    let client = read_state(balance_scan_rpc_client);
     scan(now, client).await;
 }
 
@@ -115,7 +115,9 @@ enum ScanOutcome {
 /// into one [`ScanOutcome`].
 ///
 /// Pairs whose chunk failed yield no outcome at all, so a failed chunk is retried next tick rather
-/// than silently advanced until its next scheduled slot.
+/// than silently advanced until its next scheduled slot. A batch the providers disagree on is such
+/// a failure: [`NoReduction`] never falls back to a single provider's answer, so one provider
+/// claiming an empty balance cannot hide a funded address.
 async fn scan_balances<R: Runtime>(
     due: &[ScanTarget],
     latest_block: BlockNumber,
@@ -141,7 +143,7 @@ async fn scan_balances<R: Runtime>(
             .with_cycles(MIN_ATTACHED_CYCLES)
             .try_send()
             .await
-            .reduce_with_strategy(AnyOf)
+            .reduce_with_strategy(NoReduction)
         {
             Ok(hex) => match batcher::decode_balance_batch(hex.as_ref(), calls.len()) {
                 Ok(balances) => {

--- a/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
@@ -2,12 +2,16 @@ use super::*;
 use crate::deposit_address::DepositAddress;
 use crate::state::automatic_deposits::{DepositRequest, ScanProgress};
 use crate::test_fixtures;
-use evm_rpc_types::{ConsensusStrategy, Hex, MultiRpcResult, RpcServices};
+use evm_rpc_types::{
+    ConsensusStrategy, EthMainnetService, Hex, MultiRpcResult, RpcService, RpcServices,
+};
 use ic_canister_runtime::{IcError, StubRuntime};
 use icrc_ledger_types::icrc1::account::Account;
 use std::str::FromStr;
 
 const TOKEN_A: Address = Address::new([0x22; 20]);
+const BLOCK_PI: RpcService = RpcService::EthMainnet(EthMainnetService::BlockPi);
+const PUBLIC_NODE: RpcService = RpcService::EthMainnet(EthMainnetService::PublicNode);
 
 fn account(owner: u64) -> Account {
     Account {
@@ -279,6 +283,34 @@ async fn should_yield_no_outcome_for_a_pair_whose_chunk_failed() {
     assert!(outcomes.is_empty(), "a failed chunk must yield no outcome");
 }
 
+#[tokio::test]
+async fn should_yield_no_outcome_when_providers_disagree_on_a_balance() {
+    let now = ts();
+    let latest = BlockNumber::new(1_000);
+    let (token, min) = MIN_DEPOSITS[0];
+    let holder = (account(1), DepositAddress::new(Address::new([0xa1; 20])));
+    seed_state(Some(latest), token, &[holder], now);
+
+    // One provider reports the funded balance, another a well-formed zero: without two providers
+    // agreeing there is no answer to act on, so the chunk fails and is retried rather than the
+    // funded address being written off as empty.
+    let targets = due_targets(now, latest);
+    let outcomes = scan_balances(
+        &targets,
+        latest,
+        stub_client(vec![Ok(MultiRpcResult::Inconsistent(vec![
+            (BLOCK_PI, Ok(encoded_balances(&[Erc20Value::ZERO]))),
+            (PUBLIC_NODE, Ok(encoded_balances(&[min]))),
+        ]))]),
+    )
+    .await;
+
+    assert!(
+        outcomes.is_empty(),
+        "a batch without provider agreement must yield no outcome"
+    );
+}
+
 fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<ScanTarget> {
     read_state(|s| {
         s.automatic_deposits
@@ -321,16 +353,24 @@ fn stub_client(
     EvmRpcClient::builder(runtime, candid::Principal::anonymous())
         .with_rpc_sources(RpcServices::EthMainnet(None))
         .with_consensus_strategy(ConsensusStrategy::Threshold {
-            total: Some(4),
-            min: 3,
+            total: Some(3),
+            min: 2,
         })
         .with_retry_strategy(DoubleCycles::with_max_num_retries(10))
         .build()
 }
 
 fn ok_balances(balances: &[Erc20Value]) -> Result<MultiRpcResult<Hex>, IcError> {
-    let blob: Vec<u8> = balances.iter().flat_map(|b| b.to_be_bytes()).collect();
-    Ok(MultiRpcResult::Consistent(Ok(Hex::from(blob))))
+    Ok(MultiRpcResult::Consistent(Ok(encoded_balances(balances))))
+}
+
+fn encoded_balances(balances: &[Erc20Value]) -> Hex {
+    Hex::from(
+        balances
+            .iter()
+            .flat_map(|b| b.to_be_bytes())
+            .collect::<Vec<u8>>(),
+    )
 }
 
 fn live_entry(now: Timestamp, account: &Account, token: Address) -> ScanProgress {

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -91,9 +91,13 @@ fn rpc_client_with_threshold(
         .build()
 }
 
-/// The `total` Sepolia services to query. Mainnet leaves the choice to the EVM RPC canister's own
-/// defaults, but on Sepolia the services are named, and `ConsensusStrategy::Threshold` demands
-/// exactly as many named services as it queries — so a client querying fewer takes a prefix.
+/// The `total` Sepolia services to query, from the set this minter is willing to use.
+///
+/// Mainnet leaves the choice to the EVM RPC canister, which ranks its supported providers by how
+/// recently each last answered. Sepolia names them instead because that canister's supported set
+/// also holds `rpc.sepolia.org`, which this minter dropped, and naming is the only way to exclude
+/// it. Naming then fixes the count too — `ConsensusStrategy::Threshold` rejects a `total` that
+/// differs from the number of named services — so a client querying fewer takes a prefix.
 fn sepolia_services(total: u8) -> Vec<EthSepoliaService> {
     const SERVICES: &[EthSepoliaService] = &[
         EthSepoliaService::BlockPi,

--- a/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_rpc_client/mod.rs
@@ -28,40 +28,85 @@ pub const ETH_GET_LOGS_INITIAL_RESPONSE_SIZE_ESTIMATE: u64 = 100;
 
 pub const MIN_ATTACHED_CYCLES: u128 = 500_000_000_000;
 
+/// How many providers a client queries, and how many of them must return the same result for the
+/// EVM RPC canister to report a consistent one.
+pub struct Threshold {
+    pub total: u8,
+    pub min: u8,
+}
+
+impl Threshold {
+    /// The threshold [`balance_scan_rpc_client`] queries with.
+    pub const BALANCE_SCAN: Self = Self { total: 3, min: 2 };
+}
+
+/// Client for the queries whose result the minter acts on irreversibly: minting, and signing and
+/// sending transactions.
 pub fn rpc_client(state: &State) -> EvmRpcClient<IcRuntime, CandidResponseConverter, DoubleCycles> {
-    const TOTAL_NUMBER_OF_PROVIDERS: u8 = 4;
-    const MAX_NUM_RETRIES: u32 = 10;
-
-    let chain = state.ethereum_network();
-    let evm_rpc_id = state.evm_rpc_id();
-
-    let providers = match chain {
-        EthereumNetwork::Mainnet => EvmRpcServices::EthMainnet(None),
-        EthereumNetwork::Sepolia => EvmRpcServices::EthSepolia(Some(vec![
-            EthSepoliaService::BlockPi,
-            EthSepoliaService::PublicNode,
-            EthSepoliaService::Alchemy,
-            EthSepoliaService::Ankr,
-        ])),
-    };
-
-    let min_threshold = match chain {
+    let min = match state.ethereum_network() {
         EthereumNetwork::Mainnet => 3_u8,
         EthereumNetwork::Sepolia => 2_u8,
     };
+    rpc_client_with_threshold(state, Threshold { total: 4, min })
+}
+
+/// Client for the ckERC20 automatic-deposit balance scan.
+///
+/// A lower threshold than [`rpc_client`] is acceptable because the scan reads balances at the
+/// latest (non-finalized) block only to notify the sweeper: nothing is minted off this path. Two
+/// providers must still agree, which — combined with [`NoReduction`] at the call site — is what
+/// stops a single faulty or malicious provider from hiding a funded deposit address behind a
+/// well-formed all-zeros answer.
+pub fn balance_scan_rpc_client(
+    state: &State,
+) -> EvmRpcClient<IcRuntime, CandidResponseConverter, DoubleCycles> {
+    rpc_client_with_threshold(state, Threshold::BALANCE_SCAN)
+}
+
+fn rpc_client_with_threshold(
+    state: &State,
+    threshold: Threshold,
+) -> EvmRpcClient<IcRuntime, CandidResponseConverter, DoubleCycles> {
+    const MAX_NUM_RETRIES: u32 = 10;
+
     assert!(
-        min_threshold <= TOTAL_NUMBER_OF_PROVIDERS,
+        threshold.min <= threshold.total,
         "BUG: min_threshold too high"
     );
 
-    EvmRpcClient::builder(IcRuntime::new(), evm_rpc_id)
+    let providers = match state.ethereum_network() {
+        EthereumNetwork::Mainnet => EvmRpcServices::EthMainnet(None),
+        EthereumNetwork::Sepolia => {
+            EvmRpcServices::EthSepolia(Some(sepolia_services(threshold.total)))
+        }
+    };
+
+    EvmRpcClient::builder(IcRuntime::new(), state.evm_rpc_id())
         .with_rpc_sources(providers)
         .with_consensus_strategy(ConsensusStrategy::Threshold {
-            total: Some(TOTAL_NUMBER_OF_PROVIDERS),
-            min: min_threshold,
+            total: Some(threshold.total),
+            min: threshold.min,
         })
         .with_retry_strategy(DoubleCycles::with_max_num_retries(MAX_NUM_RETRIES))
         .build()
+}
+
+/// The `total` Sepolia services to query. Mainnet leaves the choice to the EVM RPC canister's own
+/// defaults, but on Sepolia the services are named, and `ConsensusStrategy::Threshold` demands
+/// exactly as many named services as it queries — so a client querying fewer takes a prefix.
+fn sepolia_services(total: u8) -> Vec<EthSepoliaService> {
+    const SERVICES: &[EthSepoliaService] = &[
+        EthSepoliaService::BlockPi,
+        EthSepoliaService::PublicNode,
+        EthSepoliaService::Alchemy,
+        EthSepoliaService::Ankr,
+    ];
+    assert!(
+        usize::from(total) <= SERVICES.len(),
+        "BUG: {total} Sepolia services requested, only {} available",
+        SERVICES.len()
+    );
+    SERVICES[..usize::from(total)].to_vec()
 }
 
 /// Aggregates responses of different providers to the same query.

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -1,4 +1,5 @@
 use crate::events::MinterEventAssert;
+use crate::evm_rpc_provider::JsonRpcProvider;
 use crate::flow::{
     DepositCkEthParams, DepositParams, DepositTransactionData, LedgerTransactionAssert,
     ProcessWithdrawal, encode_principal,
@@ -26,6 +27,7 @@ use ic_cketh_minter::endpoints::events::{EventPayload, EventSource};
 use ic_cketh_minter::endpoints::{
     CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode, MinterInfo,
 };
+use ic_cketh_minter::eth_rpc_client::Threshold;
 use ic_cketh_minter::numeric::{BlockNumber, Erc20Value};
 use ic_cketh_minter::{
     BALANCE_SCAN_INTERVAL, REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL, SCRAPING_ETH_LOGS_INTERVAL,
@@ -46,6 +48,7 @@ use std::iter::{once, zip};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use strum::IntoEnumIterator;
 
 pub const DEFAULT_ERC20_WITHDRAWAL_DESTINATION_ADDRESS: &str =
     "0x221E931fbFcb9bd54DdD26cE6f5e29E98AdD01C0";
@@ -169,8 +172,14 @@ impl CkErc20Setup {
     /// schedule is advanced before returning.
     pub fn run_balance_scan(&self, balances: &[u128]) {
         self.env.advance_time(BALANCE_SCAN_INTERVAL);
+        // The balance scan queries fewer providers than the minter's other calls, so only the first
+        // `Threshold::BALANCE_SCAN.total` of them answer — stubbing all of them would leave a stub
+        // unconsumed.
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(balances))
+            .respond_for_providers_with(
+                JsonRpcProvider::iter().take(usize::from(Threshold::BALANCE_SCAN.total)),
+                balance_scan_response(balances),
+            )
             .build()
             .expect_rpc_calls(self);
         for _ in 0..MAX_TICKS {


### PR DESCRIPTION
Resolves [DEFI-2964](https://dfinity.atlassian.net/browse/DEFI-2964), raised in review of #10873.

The ckERC20 automatic-deposit balance scan read the latest block through a 3-of-4 RPC client and reduced each batch with `AnyOf`. Whenever the other providers disagreed or returned a decode failure, a single bad or malicious provider answering a well-formed all-zeros `balanceOf` could decide the scan on its own — the scan would see nothing and a funded deposit address would never be flagged.

The scan now uses its own 2-of-3 client reduced with `NoReduction`, so two providers must agree before the minter acts on a batch, and a batch they disagree on is treated as a failed chunk and retried on the next tick. A lower threshold than the minting path is acceptable here because the scan reads a non-finalized block height only to notify the sweeper; nothing is minted off this path. The finalized-deposit log-scraping client is unchanged.

This resolves the `TODO DEFI-2923` that already anticipated the change at the call site.

Notable in the diff: the balance-scan threshold is exposed as `Threshold::BALANCE_SCAN` so the integration-test fixture derives how many providers to stub from production rather than restating the number — the mock asserts every stub is consumed, so a drift there fails the ckERC20 suite.

[DEFI-2964]: https://dfinity.atlassian.net/browse/DEFI-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ