### PR TITLE
fix(registry-helper): get_replica_version_record supports blank replica_version_id.

### DIFF
--- a/rs/registry/helpers/src/subnet.rs
+++ b/rs/registry/helpers/src/subnet.rs
@@ -515,17 +515,10 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
         subnet_id: SubnetId,
         version: RegistryVersion,
     ) -> RegistryClientResult<ReplicaVersionRecord> {
-        let bytes = self.get_value(&make_subnet_record_key(subnet_id), version);
-        Ok(match deserialize_registry_value::<SubnetRecord>(bytes)? {
-            Some(record) => {
-                let bytes = self.get_value(
-                    &make_replica_version_key(record.replica_version_id),
-                    version,
-                );
-                deserialize_registry_value::<ReplicaVersionRecord>(bytes)?
-            }
-            None => None,
-        })
+        let Some(replica_version) = self.get_replica_version(subnet_id, version)? else {
+            return Ok(None);
+        };
+        self.get_replica_version_record_from_version_id(&replica_version, version)
     }
 
     fn get_replica_version_record_from_version_id(
@@ -850,6 +843,61 @@ mod tests {
             .get_replica_version_record(subnet_id, version)
             .unwrap();
         assert_eq!(result, Some(replica_version_record))
+    }
+
+    #[test]
+    fn can_get_replica_version_record_for_cloud_engine_with_blank_replica_version_id() {
+        // Step 1: Prepare the world: a CloudEngine subnet with a blank
+        // replica_version_id, resolved via StandardEngineReplicaVersionRecord
+        // to "new".
+        let engine_subnet_id = subnet_id(1);
+        let new_replica_version_record = ReplicaVersionRecord {
+            release_package_sha256_hex: "abc123".to_string(),
+            ..Default::default()
+        };
+
+        let data_provider = ProtoRegistryDataProvider::new();
+        data_provider
+            .add(
+                &make_subnet_record_key(engine_subnet_id),
+                RegistryVersion::from(2),
+                Some(SubnetRecord {
+                    replica_version_id: "".to_string(),
+                    subnet_type: SubnetType::CloudEngine as i32,
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+        data_provider
+            .add(
+                &make_standard_engine_replica_version_record_key(),
+                RegistryVersion::from(2),
+                Some(StandardEngineReplicaVersionRecord {
+                    new_replica_version_id: "new".to_string(),
+                    old_replica_version_id: "old".to_string(),
+                    deployment_progress: 1.0,
+                }),
+            )
+            .unwrap();
+        data_provider
+            .add(
+                &make_replica_version_key("new"),
+                RegistryVersion::from(2),
+                Some(new_replica_version_record.clone()),
+            )
+            .unwrap();
+
+        let registry = FakeRegistryClient::new(Arc::new(data_provider));
+        registry.update_to_latest_version();
+
+        // Step 2: Run the code under test.
+        let result = registry
+            .get_replica_version_record(engine_subnet_id, RegistryVersion::from(2))
+            .unwrap();
+
+        // Step 3: Verify result(s). Blank resolves to "new" (deployment_progress
+        // is 1.0), so this must be new_replica_version_record, not None.
+        assert_eq!(result, Some(new_replica_version_record));
     }
 
     #[test]


### PR DESCRIPTION
Blank replica_version_id only allowed when the subject of the request is an engine, not general subnet.

This is per StandardEngineReplicaVersionRecord.

This should have been done earlier, when we modified get_replica_version in #10840. Björn commented in a later PR that [we forgot to do this][fulfills].

[fulfills]: https://github.com/dfinity/ic/pull/10888#issuecomment-5094374132