### PR TITLE
fix: enable mld listener queries, disable multicast snooping

### DIFF
--- a/ic-os/components/networking/nftables/hostos/nftables.template
+++ b/ic-os/components/networking/nftables/hostos/nftables.template
@@ -69,6 +69,7 @@ table ip6 filter {
     nd-router-advert,
     nd-neighbor-solicit,
     nd-neighbor-advert,
+    mld-listener-query,
   }
 
   set rate_limit {

--- a/rs/ic_os/config/tool/templates/ic.json5.template
+++ b/rs/ic_os/config/tool/templates/ic.json5.template
@@ -247,6 +247,7 @@ table ip6 filter {\n\
     nd-router-advert,\n\
     nd-neighbor-solicit,\n\
     nd-neighbor-advert,\n\
+    mld-listener-query,\n\
   }\n\
 \n\
   set rate_limit {\n\
@@ -396,6 +397,7 @@ table ip6 filter {\n\
     nd-router-advert,\n\
     nd-neighbor-solicit,\n\
     nd-neighbor-advert,\n\
+    mld-listener-query,\n\
   }\n\
 \n\
   set rate_limit {\n\
@@ -569,7 +571,7 @@ table ip6 filter {\n\
     #   - The rule allows a maximum of <<MAX_SIMULTANEOUS_CONNECTIONS_PER_IP_ADDRESS>> persistent connections to any ip6 address.\n\
     #   - The rule drops all new connections that goes over the configured limit.\n\
     ct state new add @connection_limit { ip6 saddr ct count over <<MAX_SIMULTANEOUS_CONNECTIONS_PER_IP_ADDRESS>> } counter name connection_limit_v6_counter drop\n\
-    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept\n\
+    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, mld-listener-query } accept\n\
     ct state { invalid } drop\n\
     ct state { established, related } accept\n\
     ip6 saddr { {{ ipv6_prefix }} } ct state { new } tcp dport { 7070, 9091, 9100, 9324, 19531, 19100, 19522 } accept\n\

--- a/rs/ic_os/networking/network/src/systemd.rs
+++ b/rs/ic_os/networking/network/src/systemd.rs
@@ -45,7 +45,8 @@ Kind=bridge
 
 [Bridge]
 ForwardDelaySec=0
-STP=false";
+STP=false
+MulticastSnooping=no";
 
 fn generate_bridge6_network_content(
     ipv6_address: &str,

--- a/rs/orchestrator/testdata/nftables_assigned_cloud_engine.conf.golden
+++ b/rs/orchestrator/testdata/nftables_assigned_cloud_engine.conf.golden
@@ -67,6 +67,7 @@ table ip6 filter {
     nd-router-advert,
     nd-neighbor-solicit,
     nd-neighbor-advert,
+    mld-listener-query,
   }
 
   set rate_limit {

--- a/rs/orchestrator/testdata/nftables_assigned_replica.conf.golden
+++ b/rs/orchestrator/testdata/nftables_assigned_replica.conf.golden
@@ -66,6 +66,7 @@ table ip6 filter {
     nd-router-advert,
     nd-neighbor-solicit,
     nd-neighbor-advert,
+    mld-listener-query,
   }
 
   set rate_limit {

--- a/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
@@ -86,7 +86,7 @@ table ip6 filter {
     #   - The rule allows a maximum of 400 persistent connections to any ip6 address.
     #   - The rule drops all new connections that goes over the configured limit.
     ct state new add @connection_limit { ip6 saddr ct count over 400 } counter name connection_limit_v6_counter drop
-    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, mld-listener-query } accept
     ct state { invalid } drop
     ct state { established, related } accept
     ip6 saddr { ::/64 } ct state { new } tcp dport { 7070, 9091, 9100, 9324, 19531, 19100, 19522 } accept

--- a/rs/orchestrator/testdata/nftables_boundary_node_system_subnet.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node_system_subnet.conf.golden
@@ -86,7 +86,7 @@ table ip6 filter {
     #   - The rule allows a maximum of 400 persistent connections to any ip6 address.
     #   - The rule drops all new connections that goes over the configured limit.
     ct state new add @connection_limit { ip6 saddr ct count over 400 } counter name connection_limit_v6_counter drop
-    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert } accept
+    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, echo-request, echo-reply, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, mld-listener-query } accept
     ct state { invalid } drop
     ct state { established, related } accept
     ip6 saddr { ::/64 } ct state { new } tcp dport { 7070, 9091, 9100, 9324, 19531, 19100, 19522 } accept

--- a/rs/orchestrator/testdata/nftables_unassigned_cloud_engine.conf.golden
+++ b/rs/orchestrator/testdata/nftables_unassigned_cloud_engine.conf.golden
@@ -65,6 +65,7 @@ table ip6 filter {
     nd-router-advert,
     nd-neighbor-solicit,
     nd-neighbor-advert,
+    mld-listener-query,
   }
 
   set rate_limit {

--- a/rs/orchestrator/testdata/nftables_unassigned_replica.conf.golden
+++ b/rs/orchestrator/testdata/nftables_unassigned_replica.conf.golden
@@ -65,6 +65,7 @@ table ip6 filter {
     nd-router-advert,
     nd-neighbor-solicit,
     nd-neighbor-advert,
+    mld-listener-query,
   }
 
   set rate_limit {


### PR DESCRIPTION
A few SEV-enabled machines fail to upgrade, however after a reboot the upgrade all of a sudden succeeds. The guest does not respond to MLD queries (firewall blocks them) and as a consequence, the bridge in the HostOS does not flood the group and neighbor discovery messages to the guest. This prevents the upgrade VM to connect to the active VM. This only happens if there is an active MLD querier around (switch/router). We see this issue only on very few machines.