### PR TITLE
fix(tests): Disable mainnet NNS variant of standard_engine_replica_version_test

### DIFF
--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -168,19 +168,29 @@ system_test_nns(
     backend = "farm",
     # 1 API BN + 1 System + 2 * 4 Cloud Engine = 10 IC Node VMs * 6 vCPUs.
     cpus = MIN_LOCAL_CPUS + 10 * DEFAULT_VCPUS_PER_VM,
-    # TODO: Re-enable this once a governance canister containing the relaxed
-    # `UpdateStandardEngineReplicaVersion` validation from PR 10939 has been
-    # released to mainnet (i.e. once `governance` in
-    # mainnet-canister-revisions.json points at such a version).
+    # TODO: Re-enable this once BOTH of these pins in
+    # mainnet-canister-revisions.json have caught up:
     #
-    # Why: this test elects a second GuestOS/Replica version, and such versions
-    # are named `<commit>-test` (see `guestos_update` below). The mainnet
-    # governance canister still requires the replica version IDs in an
-    # `UpdateStandardEngineReplicaVersion` proposal to be 40-character
-    # hexadecimal strings, so it rejects the proposal that this test submits.
+    #   1. `governance` needs to include PR 10939, which relaxed the
+    #      `UpdateStandardEngineReplicaVersion` validation. The currently pinned
+    #      governance (8aa4680e37) still requires replica version IDs to be
+    #      40-character hexadecimal strings, so it rejects the proposal this test
+    #      submits: this test elects a second GuestOS/Replica version, and those
+    #      are named `<commit>-test` (see `guestos_update` below).
     #
-    # The `_head_nns` variant, which runs against the governance canister built
-    # from this branch, keeps running daily, so the test is still covered.
+    #   2. `engine-controller` needs `create_engine` to return the new subnet ID.
+    #      The currently pinned engine-controller (c8649149f7) returns
+    #      `Result<(), String>`, which this test cannot decode since it expects
+    #      `Result<NewSubnet, String>`.
+    #
+    # Note that `engine-controller` is NOT bumped by the mainnet-revisions bot
+    # (it is absent from NNS_CANISTER_NAME_TO_ID in
+    # rs/nervous_system/tools/sync-with-released-nervous-system-wasms), so a
+    # governance-only bump will not be enough to unblock this test.
+    #
+    # The `_head_nns` variant, which runs against the NNS canisters built from
+    # this branch, keeps its `long_test` tag and so keeps running on every push
+    # to master. The test therefore remains covered.
     enable_mainnet_nns_variant = False,
     # This is needed so that the test can elect a second Guestos/Replica version.
     guestos_update = "test",

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -168,6 +168,20 @@ system_test_nns(
     backend = "farm",
     # 1 API BN + 1 System + 2 * 4 Cloud Engine = 10 IC Node VMs * 6 vCPUs.
     cpus = MIN_LOCAL_CPUS + 10 * DEFAULT_VCPUS_PER_VM,
+    # TODO: Re-enable this once a governance canister containing the relaxed
+    # `UpdateStandardEngineReplicaVersion` validation from PR 10939 has been
+    # released to mainnet (i.e. once `governance` in
+    # mainnet-canister-revisions.json points at such a version).
+    #
+    # Why: this test elects a second GuestOS/Replica version, and such versions
+    # are named `<commit>-test` (see `guestos_update` below). The mainnet
+    # governance canister still requires the replica version IDs in an
+    # `UpdateStandardEngineReplicaVersion` proposal to be 40-character
+    # hexadecimal strings, so it rejects the proposal that this test submits.
+    #
+    # The `_head_nns` variant, which runs against the governance canister built
+    # from this branch, keeps running daily, so the test is still covered.
+    enable_mainnet_nns_variant = False,
     # This is needed so that the test can elect a second Guestos/Replica version.
     guestos_update = "test",
     tags = [


### PR DESCRIPTION
## Problem

`//rs/tests/consensus/orchestrator:standard_engine_replica_version_test` (added by #10939) is failing on master with:

```
Unexpected response: Error(GovernanceError { error_type: 16, error_message:
  "Proposal invalid because of new_replica_version_id is not a 40-character hexadecimal string
   (it was \"c818497b5cd2bbc60af597f7aadc036640ed0463-test\")" })
```

## Root cause

`system_test_nns` declares two targets: the plain-named one runs against the NNS canisters **from mainnet** (pinned in `mainnet-canister-revisions.json`), and `<name>_head_nns` runs against the ones built from the branch.

The mainnet governance canister is pinned at rev `8aa4680e37`, which still contains the strict check:

```console
$ git show 8aa4680e37:rs/nns/governance/src/proposals/update_standard_engine_replica_version.rs
  if !is_potential_full_git_commit_id(new_replica_version_id) {
      "new_replica_version_id is not a 40-character hexadecimal string (it was {:?})"
```

This test sets `guestos_update = "test"` and elects a second GuestOS/Replica version, which is named `<commit>-test`, so the mainnet governance canister rejects the `UpdateStandardEngineReplicaVersion` proposal that the test submits at step 3.

#10939 itself relaxed that validation to just `ReplicaVersion::try_from`, and added `test_test_suffix_replica_version_id_is_valid` asserting a `-test` suffix is accepted — but that change has not reached mainnet yet.

This merged red because `long_test`-tagged targets are skipped on PRs (`skip_long_tests` defaults to `true` in `ci-main.yml`) and only run on protected branches.

## Fix

Set `enable_mainnet_nns_variant = False`. Same pattern as `canister_migration_test` in `rs/tests/execution/BUILD.bazel`.

The `_head_nns` variant is unaffected: because `"long_test" in tags`, `system_test_nns` adds no extra tags to it, so it keeps running on every push to master against the HEAD NNS canisters — the test remains covered.

Verified with `bazel query`:

```console
$ bazel query 'attr(tags, "manual", //rs/tests/consensus/orchestrator:*)' | grep standard_engine
//rs/tests/consensus/orchestrator:standard_engine_replica_version_test          # now manual
//rs/tests/consensus/orchestrator:standard_engine_replica_version_test_colocate
//rs/tests/consensus/orchestrator:standard_engine_replica_version_test_head_nns_colocate
//rs/tests/consensus/orchestrator:standard_engine_replica_version_test_head_nns_local
//rs/tests/consensus/orchestrator:standard_engine_replica_version_test_local
```

`standard_engine_replica_version_test_head_nns` is absent from that list, i.e. it still runs.

## Re-enabling this later needs TWO pins to catch up, not one

The TODO in the BUILD file spells this out, because it is a trap otherwise:

1. **`governance`** must include #10939 (the validation relaxation described above).
2. **`engine-controller`** must have `create_engine` return the new subnet ID. The pinned rev `c8649149f7` returns `Result<(), String>`:

   ```console
   $ git show c8649149f7:rs/engine_controller/canister/canister.rs | grep -A1 'async fn create_engine'
   async fn create_engine(args: CreateEngineArgs) -> Result<(), String> {
   ```

   whereas the test decodes `Result<NewSubnet, String>` (`standard_engine_replica_version_test.rs:178`). So the mainnet variant would still fail, at step 4, with a Candid decode error rather than a governance rejection.

And `engine-controller` is **not** bumped by the mainnet-revisions bot — it is absent from `NNS_CANISTER_NAME_TO_ID` in `rs/nervous_system/tools/sync-with-released-nervous-system-wasms/src/main.rs:23-36` — so a governance-only bump will not unblock this test.

The mainnet *registry* canister, for what it's worth, is **not** a blocker: at rev `8aa4680e37` the blank-`replica_version_id` gate is a flag that already defaults to enabled (`rs/registry/canister/src/flags.rs`), and `do_update_standard_engine_replica_version` / `engine_upgrade_priority` are both present.

## Note for reviewers

#10939 relaxed a user-visible governance validation without an entry in `rs/nns/governance/unreleased_changelog.md` (that file is the bare template at HEAD). Worth adding separately — it is the signal that blocker 1 above has cleared.

Labelled `CI_ALL_BAZEL_TARGETS` so this PR actually runs the `long_test` targets, including the `_head_nns` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)