### PR TITLE
feat(cketh): install a deposit address' delegation with its first sweep

### DIFF
--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -343,7 +343,6 @@ rust_binary(
         "@crate_index//:ethers-core",
         "@crate_index//:ethnum",
         "@crate_index//:flate2",
-        "@crate_index//:hex",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:num-traits",
         "@crate_index//:rlp",

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -343,6 +343,7 @@ rust_binary(
         "@crate_index//:ethers-core",
         "@crate_index//:ethnum",
         "@crate_index//:flate2",
+        "@crate_index//:hex",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:num-traits",
         "@crate_index//:rlp",

--- a/rs/ethereum/cketh/minter/canbench/results.yml
+++ b/rs/ethereum/cketh/minter/canbench/results.yml
@@ -2,7 +2,7 @@ benches:
   bench_post_upgrade:
     total:
       calls: 1
-      instructions: 1155000934
+      instructions: 1187292943
       heap_increase: 290
       stable_memory_increase: 0
     scopes: {}

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -560,6 +560,26 @@ type UnsignedTransaction = record {
     access_list : vec record { address : text; storage_keys : vec blob };
 };
 
+// An EIP-7702 authorization tuple: a deposit address' signed consent to delegate
+// its code to `delegate`, signed by the address itself.
+type SignedAuthorization = record {
+    chain_id : nat;
+    delegate : text;
+    nonce : nat;
+    y_parity : bool;
+    // 32-byte signature components.
+    r : blob;
+    s : blob;
+};
+
+// A sweep transaction the minter has created but not yet signed: a transaction,
+// plus the delegations it installs on the way. With none it is sent as a plain
+// EIP-1559 (0x02) transaction, and otherwise as an EIP-7702 (0x04) one.
+type UnsignedSweeperTransaction = record {
+    transaction : UnsignedTransaction;
+    authorization_list : vec SignedAuthorization;
+};
+
 type Event = record {
     timestamp : nat64;
     payload : variant {
@@ -631,10 +651,13 @@ type Event = record {
             data : blob;
             max_transaction_fee : nat;
             created_at : nat64;
+            // Delegations the sweep installs on the way, empty if every address
+            // it touches is already delegated.
+            authorizations : vec SignedAuthorization;
         };
         CreatedSweeperTransaction : record {
             sweep_id : nat;
-            transaction : UnsignedTransaction;
+            transaction : UnsignedSweeperTransaction;
         };
         SignedSweeperTransaction : record {
             sweep_id : nat;
@@ -642,7 +665,7 @@ type Event = record {
         };
         ReplacedSweeperTransaction : record {
             sweep_id : nat;
-            transaction : UnsignedTransaction;
+            transaction : UnsignedSweeperTransaction;
         };
         FinalizedSweeperTransaction : record {
             sweep_id : nat;

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -433,6 +433,29 @@ pub mod events {
         pub access_list: Vec<AccessListItem>,
     }
 
+    /// An [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) authorization tuple: a deposit
+    /// address' signed consent to delegate its code to `delegate`, signed by the address itself.
+    #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+    pub struct SignedAuthorization {
+        pub chain_id: Nat,
+        pub delegate: String,
+        pub nonce: Nat,
+        pub y_parity: bool,
+        /// 32-byte signature component.
+        pub r: ByteBuf,
+        /// 32-byte signature component.
+        pub s: ByteBuf,
+    }
+
+    /// A sweep transaction the minter has created but not yet signed: a transaction, plus the
+    /// delegations it installs on the way. With none it is sent as a plain EIP-1559 (`0x02`)
+    /// transaction, and otherwise as an EIP-7702 (`0x04`) one.
+    #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+    pub struct UnsignedSweeperTransaction {
+        pub transaction: UnsignedTransaction,
+        pub authorization_list: Vec<SignedAuthorization>,
+    }
+
     #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
     pub enum TransactionStatus {
         Success,
@@ -529,10 +552,13 @@ pub mod events {
             data: ByteBuf,
             max_transaction_fee: Nat,
             created_at: u64,
+            /// Delegations the sweep installs on the way, empty if every address it touches is
+            /// already delegated.
+            authorizations: Vec<SignedAuthorization>,
         },
         CreatedSweeperTransaction {
             sweep_id: Nat,
-            transaction: UnsignedTransaction,
+            transaction: UnsignedSweeperTransaction,
         },
         SignedSweeperTransaction {
             sweep_id: Nat,
@@ -540,7 +566,7 @@ pub mod events {
         },
         ReplacedSweeperTransaction {
             sweep_id: Nat,
-            transaction: UnsignedTransaction,
+            transaction: UnsignedSweeperTransaction,
         },
         FinalizedSweeperTransaction {
             sweep_id: Nat,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -676,11 +676,13 @@ async fn get_canister_status() -> ic_cdk_management_canister::CanisterStatusResu
 fn get_events(arg: GetEventsArg) -> GetEventsResult {
     use ic_cketh_minter::endpoints::events::{
         AccessListItem, ReimbursementIndex as CandidReimbursementIndex,
+        SignedAuthorization as CandidSignedAuthorization,
         TransactionReceipt as CandidTransactionReceipt,
-        TransactionStatus as CandidTransactionStatus, UnsignedTransaction,
+        TransactionStatus as CandidTransactionStatus, UnsignedSweeperTransaction,
+        UnsignedTransaction,
     };
     use ic_cketh_minter::eth_rpc_client::responses::TransactionReceipt;
-    use ic_cketh_minter::tx::Eip1559TransactionRequest;
+    use ic_cketh_minter::tx::{SignableTransaction, SignedAuthorization, SweepTransaction};
     use serde_bytes::ByteBuf;
 
     const MAX_EVENTS_PER_RESPONSE: u64 = 100;
@@ -714,18 +716,18 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
         }
     }
 
-    fn map_unsigned_transaction(tx: Eip1559TransactionRequest) -> UnsignedTransaction {
+    fn map_unsigned_transaction<T: SignableTransaction>(tx: &T) -> UnsignedTransaction {
         UnsignedTransaction {
-            chain_id: tx.chain_id.into(),
-            nonce: tx.nonce.into(),
-            max_priority_fee_per_gas: tx.max_priority_fee_per_gas.into(),
-            max_fee_per_gas: tx.max_fee_per_gas.into(),
-            gas_limit: tx.gas_limit.into(),
-            destination: tx.destination.to_string(),
-            value: tx.amount.into(),
-            data: ByteBuf::from(tx.data),
+            chain_id: tx.chain_id().into(),
+            nonce: tx.nonce().into(),
+            max_priority_fee_per_gas: tx.max_priority_fee_per_gas().into(),
+            max_fee_per_gas: tx.max_fee_per_gas().into(),
+            gas_limit: tx.gas_limit().into(),
+            destination: tx.destination().to_string(),
+            value: (*tx.amount()).into(),
+            data: ByteBuf::from(tx.data().to_vec()),
             access_list: tx
-                .access_list
+                .access_list()
                 .0
                 .iter()
                 .map(|item| AccessListItem {
@@ -738,6 +740,29 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                 })
                 .collect(),
         }
+    }
+
+    fn map_unsigned_sweeper_transaction(tx: &SweepTransaction) -> UnsignedSweeperTransaction {
+        UnsignedSweeperTransaction {
+            transaction: map_unsigned_transaction(tx),
+            authorization_list: map_authorizations(tx.authorizations()),
+        }
+    }
+
+    fn map_authorizations(
+        authorizations: &[SignedAuthorization],
+    ) -> Vec<CandidSignedAuthorization> {
+        authorizations
+            .iter()
+            .map(|authorization| CandidSignedAuthorization {
+                chain_id: authorization.chain_id.into(),
+                delegate: authorization.delegate.to_string(),
+                nonce: authorization.nonce.into(),
+                y_parity: authorization.y_parity,
+                r: ByteBuf::from(authorization.r.to_be_bytes()),
+                s: ByteBuf::from(authorization.s.to_be_bytes()),
+            })
+            .collect()
     }
 
     fn map_transaction_receipt(receipt: TransactionReceipt) -> CandidTransactionReceipt {
@@ -886,7 +911,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     transaction,
                 } => EP::CreatedTransaction {
                     withdrawal_id: withdrawal_id.get().into(),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_transaction(&transaction),
                 },
                 EventType::SignedTransaction {
                     withdrawal_id,
@@ -900,7 +925,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     transaction,
                 } => EP::ReplacedTransaction {
                     withdrawal_id: withdrawal_id.get().into(),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_transaction(&transaction),
                 },
                 EventType::FinalizedTransaction {
                     withdrawal_id,
@@ -916,6 +941,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     data,
                     max_transaction_fee,
                     created_at,
+                    authorizations,
                 }) => EP::AcceptedSweepRequest {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
@@ -923,13 +949,14 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     data: ByteBuf::from(data),
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,
+                    authorizations: map_authorizations(&authorizations),
                 },
                 EventType::CreatedSweeperTransaction {
                     sweep_id,
                     transaction,
                 } => EP::CreatedSweeperTransaction {
                     sweep_id: sweep_id.0.into(),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_sweeper_transaction(&transaction),
                 },
                 EventType::SignedSweeperTransaction {
                     sweep_id,
@@ -943,7 +970,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     transaction,
                 } => EP::ReplacedSweeperTransaction {
                     sweep_id: sweep_id.0.into(),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_sweeper_transaction(&transaction),
                 },
                 EventType::FinalizedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -1,5 +1,8 @@
 use crate::checked_amount::CheckedAmountOf;
-use crate::endpoints::events::{Event as CandidEvent, EventPayload, UnsignedTransaction};
+use crate::endpoints::events::{
+    Event as CandidEvent, EventPayload, SignedAuthorization as CandidSignedAuthorization,
+    UnsignedSweeperTransaction, UnsignedTransaction,
+};
 use crate::erc20::CkErc20Token;
 use crate::eth_logs::{LedgerSubaccount, ReceivedErc20Event, ReceivedEthEvent};
 use crate::eth_rpc_client::responses::TransactionReceipt;
@@ -12,8 +15,9 @@ use crate::state::transactions::{
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
-    AccessList, AccessListItem, Eip1559TransactionRequest, SignedEip1559TransactionRequest,
-    StorageKey,
+    AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
+    SignedEip1559TransactionRequest, SignedSweepTransaction, StorageKey, SweepTransaction,
+    TransactionSignature,
 };
 use candid::Principal;
 use ic_agent::identity::AnonymousIdentity;
@@ -180,7 +184,9 @@ impl GetEventsFile {
             }
         }
 
-        fn map_signed_transaction(raw_transaction: &str) -> SignedEip1559TransactionRequest {
+        fn decode_signed_transaction(
+            raw_transaction: &str,
+        ) -> (Eip1559TransactionRequest, TransactionSignature) {
             use crate::tx::TransactionSignature;
             use ethers_core::types::transaction::eip2718::TypedTransaction;
             use ethnum::u256;
@@ -252,7 +258,38 @@ impl GetEventsFile {
                 s: map_ethers_u256(decoded_sig.s),
             };
 
-            SignedEip1559TransactionRequest::from((request, signature))
+            (request, signature)
+        }
+        fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
+            let (transaction, signature) = decode_signed_transaction(raw_transaction);
+            SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
+        }
+
+        fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTransaction {
+            SweepTransaction::new(
+                map_unsigned_transaction(tx.transaction),
+                map_authorizations(tx.authorization_list),
+            )
+        }
+
+        fn map_authorizations(
+            authorizations: Vec<CandidSignedAuthorization>,
+        ) -> Vec<SignedAuthorization> {
+            fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
+                ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
+            }
+
+            authorizations
+                .into_iter()
+                .map(|authorization| SignedAuthorization {
+                    chain_id: authorization.chain_id.0.to_u64().unwrap(),
+                    delegate: authorization.delegate.parse().unwrap(),
+                    nonce: authorization.nonce.try_into().unwrap(),
+                    y_parity: authorization.y_parity,
+                    r: map_signature_component(&authorization.r),
+                    s: map_signature_component(&authorization.s),
+                })
+                .collect()
         }
 
         Event {
@@ -358,7 +395,9 @@ impl GetEventsFile {
                     raw_transaction,
                 } => ET::SignedTransaction {
                     withdrawal_id: map_nat(withdrawal_id),
-                    transaction: map_signed_transaction(&raw_transaction),
+                    transaction: SignedEip1559TransactionRequest::from(decode_signed_transaction(
+                        &raw_transaction,
+                    )),
                 },
                 EventPayload::ReplacedTransaction {
                     withdrawal_id,
@@ -381,6 +420,7 @@ impl GetEventsFile {
                     data,
                     max_transaction_fee,
                     created_at,
+                    authorizations,
                 } => ET::AcceptedSweepRequest(SweepRequest {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
@@ -388,27 +428,28 @@ impl GetEventsFile {
                     data: data.into_vec(),
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,
+                    authorizations: map_authorizations(authorizations),
                 }),
                 EventPayload::CreatedSweeperTransaction {
                     sweep_id,
                     transaction,
                 } => ET::CreatedSweeperTransaction {
                     sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_sweeper_transaction(transaction),
                 },
                 EventPayload::SignedSweeperTransaction {
                     sweep_id,
                     raw_transaction,
                 } => ET::SignedSweeperTransaction {
                     sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                    transaction: map_signed_transaction(&raw_transaction),
+                    transaction: map_signed_sweep_transaction(&raw_transaction),
                 },
                 EventPayload::ReplacedSweeperTransaction {
                     sweep_id,
                     transaction,
                 } => ET::ReplacedSweeperTransaction {
                     sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                    transaction: map_unsigned_transaction(transaction),
+                    transaction: map_unsigned_sweeper_transaction(transaction),
                 },
                 EventPayload::FinalizedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -16,8 +16,8 @@ use crate::state::transactions::{
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
     AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
-    SignedEip1559TransactionRequest, SignedSweepTransaction, StorageKey, SweepTransaction,
-    TransactionSignature,
+    SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
+    StorageKey, SweepTransaction, TransactionSignature,
 };
 use candid::Principal;
 use ic_agent::identity::AnonymousIdentity;
@@ -261,6 +261,18 @@ impl GetEventsFile {
             (request, signature)
         }
         fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
+            const EIP_7702_TRANSACTION_TYPE: u8 = 4;
+
+            let raw_bytes = hex::decode(raw_transaction.trim_start_matches("0x"))
+                .expect("BUG: sent sweep transaction is not hex-encoded");
+            if raw_bytes.first() == Some(&EIP_7702_TRANSACTION_TYPE) {
+                let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
+                    .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
+                return SignedSweepTransaction::from((
+                    SweepTransaction::Eip7702(signed.transaction().clone()),
+                    signed.signature().clone(),
+                ));
+            }
             let (transaction, signature) = decode_signed_transaction(raw_transaction);
             SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
         }

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -15,7 +15,7 @@ use crate::state::transactions::{
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
-    AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
+    AccessList, AccessListItem, DelegatingSweep, Eip1559TransactionRequest, SignedAuthorization,
     SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
     StorageKey, SweepTransaction, TransactionSignature,
 };
@@ -269,7 +269,10 @@ impl GetEventsFile {
                 let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
                     .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
                 return SignedSweepTransaction::from((
-                    SweepTransaction::Eip7702(signed.transaction().clone()),
+                    SweepTransaction::Eip7702(
+                        DelegatingSweep::new(signed.transaction().clone())
+                            .expect("BUG: sent EIP-7702 sweep installs no delegation"),
+                    ),
                     signed.signature().clone(),
                 ));
             }

--- a/rs/ethereum/cketh/minter/src/state/event.rs
+++ b/rs/ethereum/cketh/minter/src/state/event.rs
@@ -9,7 +9,10 @@ use crate::state::transactions::{
     ReimbursementRequest, SweepId, SweepRequest,
 };
 use crate::timed_sized_map::Timestamp;
-use crate::tx::{Eip1559TransactionRequest, SignedEip1559TransactionRequest};
+use crate::tx::{
+    Eip1559TransactionRequest, SignedEip1559TransactionRequest, SignedSweepTransaction,
+    SweepTransaction,
+};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use minicbor::{Decode, Encode};
@@ -195,7 +198,7 @@ pub enum EventType {
         #[n(0)]
         sweep_id: SweepId,
         #[n(1)]
-        transaction: Eip1559TransactionRequest,
+        transaction: SweepTransaction,
     },
     /// The minter signed a sweep transaction.
     #[n(30)]
@@ -203,7 +206,7 @@ pub enum EventType {
         #[n(0)]
         sweep_id: SweepId,
         #[n(1)]
-        transaction: SignedEip1559TransactionRequest,
+        transaction: SignedSweepTransaction,
     },
     /// The minter replaced a sweep transaction after a fee bump.
     #[n(31)]
@@ -211,7 +214,7 @@ pub enum EventType {
         #[n(0)]
         sweep_id: SweepId,
         #[n(1)]
-        transaction: Eip1559TransactionRequest,
+        transaction: SweepTransaction,
     },
     /// The minter observed a sweep transaction being included in a finalized Ethereum block.
     #[n(32)]

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -18,7 +18,8 @@ use crate::numeric::{
 };
 use crate::tx::{
     Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
-    Resubmittable, SignableTransaction, Signed, SignedEip1559TransactionRequest, TransactionPrice,
+    Resubmittable, SignableTransaction, Signed, SignedAuthorization,
+    SignedEip1559TransactionRequest, TransactionPrice,
 };
 use candid::Principal;
 use ic_canister_log::log;
@@ -215,8 +216,7 @@ impl SweepId {
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.
 ///
-/// For now this is a plain EIP-1559 transaction (type `0x02`); the EIP-7702 (`0x04`) first-time
-/// delegation and the sweep-queue-driven construction of the delegate call data are follow-ups.
+/// The sweep-queue-driven construction of the delegate call data is a follow-up.
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub struct SweepRequest {
     /// This sweep's identity (the pipeline's alternate map key).
@@ -241,6 +241,11 @@ pub struct SweepRequest {
     /// The IC time at which the sweep was decided.
     #[n(5)]
     pub created_at: u64,
+    /// Delegations to install on the way, one signed by each deposit address the sweep touches
+    /// that is not yet delegated to the sweeper contract. Empty once they all are, and a sweep
+    /// with none is a plain EIP-1559 transaction.
+    #[n(6)]
+    pub authorizations: Vec<SignedAuthorization>,
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Decode, Encode)]

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -17,9 +17,8 @@ use crate::numeric::{
     TransactionNonce, Wei,
 };
 use crate::tx::{
-    Eip1559TransactionRequest, FinalizedEip1559Transaction, GasFeeEstimate, SignableTransaction,
-    SignedEip1559TransactionRequest, SignedTransactionRequest, TransactionPrice,
-    TransactionRequest,
+    Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
+    Resubmittable, SignableTransaction, Signed, SignedEip1559TransactionRequest, TransactionPrice,
 };
 use candid::Principal;
 use ic_canister_log::log;
@@ -440,9 +439,9 @@ pub struct TransactionPipeline<R: PipelineRequest> {
     pending_requests: VecDeque<R>,
     // Processed requests (transaction created, sent, or finalized).
     processed_requests: BTreeMap<R::Id, R>,
-    created_tx: MultiKeyMap<TransactionNonce, R::Id, TransactionRequest>,
-    sent_tx: MultiKeyMap<TransactionNonce, R::Id, Vec<SignedTransactionRequest>>,
-    finalized_tx: MultiKeyMap<TransactionNonce, R::Id, FinalizedEip1559Transaction>,
+    created_tx: MultiKeyMap<TransactionNonce, R::Id, CreatedTransaction<R>>,
+    sent_tx: MultiKeyMap<TransactionNonce, R::Id, Vec<SentTransaction<R>>>,
+    finalized_tx: MultiKeyMap<TransactionNonce, R::Id, Finalized<R::Transaction>>,
     next_nonce: TransactionNonce,
 }
 
@@ -487,18 +486,28 @@ pub enum ResubmitTransactionError<Id> {
 /// How far a transaction has got through the pipeline. Carries the transaction itself, since
 /// every caller that asks the stage also wants the transaction at it.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum TransactionStage<'a> {
-    Created(&'a Eip1559TransactionRequest),
+pub enum TransactionStage<'a, T: SignableTransaction> {
+    Created(&'a T),
     /// The most recently sent transaction, i.e. the one with the highest fee.
-    Sent(&'a SignedTransactionRequest),
-    Finalized(&'a FinalizedEip1559Transaction),
+    Sent(&'a Resubmittable<Signed<T>>),
+    Finalized(&'a Finalized<T>),
 }
 
 /// One outcome of [`TransactionPipeline::create_resubmit_transactions`]: the fee-bumped transaction to
 /// re-sign (paired with its pipeline id), or why it could not be bumped.
-type ResubmitResult<Id> = Result<(Id, Eip1559TransactionRequest), ResubmitTransactionError<Id>>;
+type ResubmitResult<Id, Tx> = Result<(Id, Tx), ResubmitTransactionError<Id>>;
 
-impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
+/// A transaction created for a request, with the strategy for bumping its fee.
+type CreatedTransaction<R> = Resubmittable<<R as PipelineRequest>::Transaction>;
+
+/// A transaction signed and sent for a request, with the strategy for bumping its fee.
+type SentTransaction<R> = Resubmittable<Signed<<R as PipelineRequest>::Transaction>>;
+
+impl<R> TransactionPipeline<R>
+where
+    R: PipelineRequest + Clone + Eq + fmt::Debug,
+    R::Transaction: Clone + Eq + fmt::Debug,
+{
     pub fn new(next_nonce: TransactionNonce) -> Self {
         Self {
             pending_requests: VecDeque::new(),
@@ -553,11 +562,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         self.record_request(request);
     }
 
-    pub fn record_created_transaction(
-        &mut self,
-        id: R::Id,
-        transaction: Eip1559TransactionRequest,
-    ) {
+    pub fn record_created_transaction(&mut self, id: R::Id, transaction: R::Transaction) {
         let position = self
             .pending_requests
             .iter()
@@ -567,7 +572,11 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         request.assert_created_transaction(&transaction);
         let resubmission = request.resubmission_strategy();
         let nonce = self.next_nonce;
-        assert_eq!(transaction.nonce, nonce, "BUG: transaction nonce mismatch");
+        assert_eq!(
+            transaction.nonce(),
+            nonce,
+            "BUG: transaction nonce mismatch"
+        );
         self.next_nonce = self
             .next_nonce
             .checked_increment()
@@ -576,7 +585,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
             .pending_requests
             .remove(position)
             .expect("BUG: position was just found in the queue");
-        let transaction_request = TransactionRequest {
+        let transaction_request = Resubmittable {
             transaction,
             resubmission,
         };
@@ -588,10 +597,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         assert_eq!(self.processed_requests.insert(id, request), None);
     }
 
-    pub fn record_signed_transaction(
-        &mut self,
-        signed_transaction: SignedEip1559TransactionRequest,
-    ) {
+    pub fn record_signed_transaction(&mut self, signed_transaction: Signed<R::Transaction>) {
         let created_tx = self
             .created_tx
             .get(&signed_transaction.nonce())
@@ -626,7 +632,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         &self,
         latest_transaction_count: TransactionCount,
         current_gas_fee: GasFeeEstimate,
-    ) -> Vec<ResubmitResult<R::Id>> {
+    ) -> Vec<ResubmitResult<R::Id, R::Transaction>> {
         // If transaction count at block height H is c > 0, then transactions with nonces
         // 0, 1, ..., c - 1 were mined. If transaction count is 0, then no transactions were mined.
         // The nonce of the first pending transaction is then exactly c.
@@ -666,8 +672,8 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         transactions_to_resubmit
     }
 
-    pub fn record_resubmit_transaction(&mut self, new_tx: Eip1559TransactionRequest) {
-        let nonce = new_tx.nonce;
+    pub fn record_resubmit_transaction(&mut self, new_tx: R::Transaction) {
+        let nonce = new_tx.nonce();
         let (id, last_sent_tx) = Self::expect_last_sent_tx_entry(&self.sent_tx, &nonce);
         assert!(
             equal_ignoring_fee_and_amount(last_sent_tx.as_ref().transaction(), &new_tx),
@@ -710,7 +716,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         &mut self,
         id: R::Id,
         receipt: &TransactionReceipt,
-    ) -> FinalizedEip1559Transaction {
+    ) -> Finalized<R::Transaction> {
         let sent_tx = self
             .sent_tx
             .get_alt(&id)
@@ -766,16 +772,13 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
 
     pub fn transactions_to_sign_iter(
         &self,
-    ) -> impl Iterator<Item = (&TransactionNonce, &R::Id, &Eip1559TransactionRequest)> {
+    ) -> impl Iterator<Item = (&TransactionNonce, &R::Id, &R::Transaction)> {
         self.created_tx
             .iter()
             .map(|(nonce, id, tx)| (nonce, id, tx.as_ref()))
     }
 
-    pub fn transactions_to_sign_batch(
-        &self,
-        batch_size: usize,
-    ) -> Vec<(R::Id, Eip1559TransactionRequest)> {
+    pub fn transactions_to_sign_batch(&self, batch_size: usize) -> Vec<(R::Id, R::Transaction)> {
         self.transactions_to_sign_iter()
             .take(batch_size)
             .map(|(_nonce, id, tx)| (*id, tx.clone()))
@@ -786,7 +789,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
         &self,
         latest_transaction_count: TransactionCount,
         batch_size: usize,
-    ) -> Vec<SignedEip1559TransactionRequest> {
+    ) -> Vec<Signed<R::Transaction>> {
         let first_pending_tx_nonce: TransactionNonce = latest_transaction_count.change_units();
         self.sent_tx
             .iter()
@@ -803,19 +806,13 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
 
     pub fn sent_transactions_iter(
         &self,
-    ) -> impl Iterator<
-        Item = (
-            &TransactionNonce,
-            &R::Id,
-            Vec<&SignedEip1559TransactionRequest>,
-        ),
-    > {
+    ) -> impl Iterator<Item = (&TransactionNonce, &R::Id, Vec<&Signed<R::Transaction>>)> {
         self.sent_tx
             .iter()
             .map(|(nonce, index, txs)| (nonce, index, txs.iter().map(|tx| tx.as_ref()).collect()))
     }
 
-    pub fn get_finalized_transaction(&self, id: &R::Id) -> Option<&FinalizedEip1559Transaction> {
+    pub fn get_finalized_transaction(&self, id: &R::Id) -> Option<&Finalized<R::Transaction>> {
         self.finalized_tx.get_alt(id)
     }
 
@@ -824,7 +821,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
     }
 
     /// How far the transaction for `id` has got, or `None` if the pipeline holds none.
-    pub fn transaction_stage(&self, id: &R::Id) -> Option<TransactionStage<'_>> {
+    pub fn transaction_stage(&self, id: &R::Id) -> Option<TransactionStage<'_, R::Transaction>> {
         if let Some(tx) = self.created_tx.get_alt(id) {
             return Some(TransactionStage::Created(tx.as_ref()));
         }
@@ -843,7 +840,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
 
     pub fn finalized_transactions_iter(
         &self,
-    ) -> impl Iterator<Item = (&TransactionNonce, &R::Id, &FinalizedEip1559Transaction)> {
+    ) -> impl Iterator<Item = (&TransactionNonce, &R::Id, &Finalized<R::Transaction>)> {
         self.finalized_tx.iter()
     }
 
@@ -856,9 +853,9 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
     }
 
     fn expect_last_sent_tx_entry<'a>(
-        sent_tx: &'a MultiKeyMap<TransactionNonce, R::Id, Vec<SignedTransactionRequest>>,
+        sent_tx: &'a MultiKeyMap<TransactionNonce, R::Id, Vec<SentTransaction<R>>>,
         nonce: &TransactionNonce,
-    ) -> (&'a R::Id, &'a SignedTransactionRequest) {
+    ) -> (&'a R::Id, &'a SentTransaction<R>) {
         let (id, sent_txs) = sent_tx
             .get_entry(nonce)
             .expect("BUG: sent transaction not found");
@@ -867,7 +864,7 @@ impl<R: PipelineRequest + Clone + Eq + fmt::Debug> TransactionPipeline<R> {
     }
 
     fn cleanup_failed_resubmitted_transactions(
-        created_tx: &mut MultiKeyMap<TransactionNonce, R::Id, TransactionRequest>,
+        created_tx: &mut MultiKeyMap<TransactionNonce, R::Id, CreatedTransaction<R>>,
         nonce: &TransactionNonce,
     ) {
         use crate::logs::INFO;
@@ -1062,7 +1059,7 @@ impl WithdrawalTransactions {
         &self,
         latest_transaction_count: TransactionCount,
         current_gas_fee: GasFeeEstimate,
-    ) -> Vec<ResubmitResult<LedgerBurnIndex>> {
+    ) -> Vec<ResubmitResult<LedgerBurnIndex, Eip1559TransactionRequest>> {
         self.pipeline
             .create_resubmit_transactions(latest_transaction_count, current_gas_fee)
     }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -17,8 +17,9 @@ use crate::numeric::{
     TransactionNonce, Wei,
 };
 use crate::tx::{
-    Eip1559TransactionRequest, FinalizedEip1559Transaction, GasFeeEstimate,
-    SignedEip1559TransactionRequest, SignedTransactionRequest, TransactionRequest,
+    Eip1559TransactionRequest, FinalizedEip1559Transaction, GasFeeEstimate, SignableTransaction,
+    SignedEip1559TransactionRequest, SignedTransactionRequest, TransactionPrice,
+    TransactionRequest,
 };
 use candid::Principal;
 use ic_canister_log::log;
@@ -1428,14 +1429,15 @@ impl TransactionCallData {
 /// * `max_fee_per_gas`
 /// * `max_priority_fee_per_gas`
 /// * `amount` (because the cost of the transaction is paid by the beneficiary and so influencing the fee does influence the transaction amount)
-fn equal_ignoring_fee_and_amount(
-    lhs: &Eip1559TransactionRequest,
-    rhs: &Eip1559TransactionRequest,
-) -> bool {
-    let mut rhs_with_lhs_fee_and_amount = rhs.clone();
-    rhs_with_lhs_fee_and_amount.max_fee_per_gas = lhs.max_fee_per_gas;
-    rhs_with_lhs_fee_and_amount.max_priority_fee_per_gas = lhs.max_priority_fee_per_gas;
-    rhs_with_lhs_fee_and_amount.amount = lhs.amount;
+fn equal_ignoring_fee_and_amount<T: SignableTransaction + Eq>(lhs: &T, rhs: &T) -> bool {
+    let rhs_with_lhs_fee_and_amount = rhs.with_price_and_amount(
+        TransactionPrice {
+            gas_limit: rhs.gas_limit(),
+            max_fee_per_gas: lhs.max_fee_per_gas(),
+            max_priority_fee_per_gas: lhs.max_priority_fee_per_gas(),
+        },
+        *lhs.amount(),
+    );
 
     lhs == &rhs_with_lhs_fee_and_amount
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -7,11 +7,13 @@ use super::{
 };
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{GasAmount, LedgerBurnIndex, TransactionNonce, Wei};
-use crate::tx::{Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy};
+use crate::tx::{
+    Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy, SignableTransaction,
+};
 use std::fmt;
 
 /// A request that can flow through a `TransactionPipeline`: it carries an identity used as the
-/// pipeline's alternate map key, and knows the EIP-1559 transaction it turns into.
+/// pipeline's alternate map key, and knows the transaction it turns into.
 ///
 /// Implemented by [`WithdrawalRequest`] — the minter's **main address** pipeline
 /// (`Id = LedgerBurnIndex`) — and by [`SweepRequest`] — the dedicated **sweeper address** pipeline
@@ -20,6 +22,9 @@ pub trait PipelineRequest {
     /// The pipeline's alternate map key: a ckETH `LedgerBurnIndex` for withdrawals, a `SweepId`
     /// for sweeps.
     type Id: Copy + Ord + fmt::Debug;
+
+    /// The transaction this request turns into.
+    type Transaction: SignableTransaction;
 
     /// Why [`Self::create_transaction`] could not build a transaction. A request that always funds
     /// its own fee can set this to [`std::convert::Infallible`], making the failure unrepresentable
@@ -34,9 +39,9 @@ pub trait PipelineRequest {
 
     /// Assert that a freshly created transaction is consistent with the request: it goes to the
     /// right address, and moves the right amount.
-    fn assert_created_transaction(&self, transaction: &Eip1559TransactionRequest);
+    fn assert_created_transaction(&self, transaction: &Self::Transaction);
 
-    /// Creates the EIP-1559 transaction that fulfils this request.
+    /// Creates the transaction that fulfils this request.
     ///
     /// # Errors
     /// * [`Self::Error`] if the request cannot cover the transaction fee.
@@ -46,11 +51,12 @@ pub trait PipelineRequest {
         gas_fee_estimate: GasFeeEstimate,
         gas_limit: GasAmount,
         ethereum_network: EthereumNetwork,
-    ) -> Result<Eip1559TransactionRequest, Self::Error>;
+    ) -> Result<Self::Transaction, Self::Error>;
 }
 
 impl PipelineRequest for WithdrawalRequest {
     type Id = LedgerBurnIndex;
+    type Transaction = Eip1559TransactionRequest;
     type Error = CreateTransactionError;
 
     fn id(&self) -> LedgerBurnIndex {
@@ -187,6 +193,7 @@ impl PipelineRequest for WithdrawalRequest {
 
 impl PipelineRequest for SweepRequest {
     type Id = SweepId;
+    type Transaction = Eip1559TransactionRequest;
     type Error = CreateSweepTransactionError;
 
     fn id(&self) -> SweepId {

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -9,6 +9,7 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{GasAmount, LedgerBurnIndex, TransactionNonce, Wei};
 use crate::tx::{
     Eip1559TransactionRequest, GasFeeEstimate, ResubmissionStrategy, SignableTransaction,
+    SweepTransaction,
 };
 use std::fmt;
 
@@ -193,7 +194,7 @@ impl PipelineRequest for WithdrawalRequest {
 
 impl PipelineRequest for SweepRequest {
     type Id = SweepId;
-    type Transaction = Eip1559TransactionRequest;
+    type Transaction = SweepTransaction;
     type Error = CreateSweepTransactionError;
 
     fn id(&self) -> SweepId {
@@ -206,28 +207,38 @@ impl PipelineRequest for SweepRequest {
         }
     }
 
-    fn assert_created_transaction(&self, transaction: &Eip1559TransactionRequest) {
+    fn assert_created_transaction(&self, transaction: &SweepTransaction) {
         assert_eq!(
-            self.destination, transaction.destination,
+            &self.destination,
+            transaction.destination(),
             "BUG: request and transaction destination mismatch"
         );
         assert_eq!(
-            transaction.amount, self.amount,
+            transaction.amount(),
+            &self.amount,
             "BUG: sweep transaction amount should equal the request amount"
         );
         assert_eq!(
-            transaction.data, self.data,
+            transaction.data(),
+            self.data,
             "BUG: sweep transaction should carry the request's call data"
+        );
+        assert_eq!(
+            transaction.authorizations(),
+            self.authorizations.as_slice(),
+            "BUG: sweep transaction should install exactly the request's delegations"
         );
     }
 
+    /// A sweep that must still install delegations becomes an EIP-7702 transaction, and a sweep of
+    /// addresses already delegated a plain EIP-1559 one.
     fn create_transaction(
         &self,
         nonce: TransactionNonce,
         gas_fee_estimate: GasFeeEstimate,
         gas_limit: GasAmount,
         ethereum_network: EthereumNetwork,
-    ) -> Result<Eip1559TransactionRequest, CreateSweepTransactionError> {
+    ) -> Result<SweepTransaction, CreateSweepTransactionError> {
         assert!(
             gas_limit > GasAmount::ZERO,
             "BUG: gas limit should be non-zero"
@@ -249,16 +260,19 @@ impl PipelineRequest for SweepRequest {
                     .unwrap_or(Wei::MAX),
             });
         }
-        Ok(Eip1559TransactionRequest {
-            chain_id: ethereum_network.chain_id(),
-            nonce,
-            max_priority_fee_per_gas: gas_fee_estimate.max_priority_fee_per_gas,
-            max_fee_per_gas,
-            gas_limit,
-            destination: self.destination,
-            amount: self.amount,
-            data: self.data.clone(),
-            access_list: Default::default(),
-        })
+        Ok(SweepTransaction::new(
+            Eip1559TransactionRequest {
+                chain_id: ethereum_network.chain_id(),
+                nonce,
+                max_priority_fee_per_gas: gas_fee_estimate.max_priority_fee_per_gas,
+                max_fee_per_gas,
+                gas_limit,
+                destination: self.destination,
+                amount: self.amount,
+                data: self.data.clone(),
+                access_list: Default::default(),
+            },
+            self.authorizations.clone(),
+        ))
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -11,8 +11,8 @@ use crate::state::transactions::{
     WithdrawalRequest, WithdrawalTransactions,
 };
 use crate::tx::{
-    AccessList, Eip1559TransactionRequest, GasFeeEstimate, SignedEip1559TransactionRequest,
-    TransactionSignature,
+    AccessList, Eip1559TransactionRequest, GasFeeEstimate, SignableTransaction, Signed,
+    SignedEip1559TransactionRequest, TransactionSignature,
 };
 use crate::withdraw::estimate_gas_limit;
 use ic_ethereum_types::Address;
@@ -2908,14 +2908,20 @@ mod sweep_lane {
     use crate::lifecycle::EthereumNetwork;
     use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        CreateSweepTransactionError, Eip1559TransactionRequest, PipelineRequest,
-        ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline,
+        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
+        SweepRequest, TransactionPipeline,
     };
-    use crate::tx::GasFeeEstimate;
+    use crate::tx::{
+        Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate, SignableTransaction,
+        SignedAuthorization, SweepTransaction,
+    };
     use assert_matches::assert_matches;
+    use ethnum::u256;
     use ic_ethereum_types::Address;
 
     const SWEEP_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+    const EIP1559_TX_ID: u8 = 2;
+    const SET_CODE_TX_ID: u8 = 4;
 
     fn sweep_request(id: u64) -> SweepRequest {
         SweepRequest {
@@ -2925,6 +2931,26 @@ mod sweep_lane {
             data: vec![0xaa, 0xbb, 0xcc],
             max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
             created_at: 1_620_328_630_000_000_000,
+            authorizations: vec![],
+        }
+    }
+
+    /// A sweep of two deposit addresses that are not yet delegated to the sweeper contract.
+    fn delegating_sweep_request(id: u64) -> SweepRequest {
+        SweepRequest {
+            authorizations: vec![authorization(1), authorization(2)],
+            ..sweep_request(id)
+        }
+    }
+
+    fn authorization(seed: u8) -> SignedAuthorization {
+        SignedAuthorization {
+            chain_id: EthereumNetwork::Sepolia.chain_id(),
+            delegate: Address::new([0xde; 20]),
+            nonce: TransactionNonce::ZERO,
+            y_parity: false,
+            r: u256::from(seed),
+            s: u256::from(seed),
         }
     }
 
@@ -2932,10 +2958,18 @@ mod sweep_lane {
         TransactionPipeline::new(TransactionNonce::ZERO)
     }
 
+    fn higher_gas_fee_estimate() -> GasFeeEstimate {
+        let estimate = gas_fee_estimate();
+        GasFeeEstimate {
+            base_fee_per_gas: estimate.base_fee_per_gas.checked_mul(2_u8).unwrap(),
+            max_priority_fee_per_gas: estimate.max_priority_fee_per_gas.checked_mul(2_u8).unwrap(),
+        }
+    }
+
     fn create_and_record_sweep_tx(
         pipeline: &mut TransactionPipeline<SweepRequest>,
         request: SweepRequest,
-    ) -> Eip1559TransactionRequest {
+    ) -> SweepTransaction {
         let id = request.id;
         let tx = request
             .create_transaction(
@@ -2957,14 +2991,62 @@ mod sweep_lane {
 
         let tx = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
 
-        assert_eq!(tx.nonce, TransactionNonce::ZERO);
+        assert_eq!(tx.nonce(), TransactionNonce::ZERO);
         assert_eq!(
             pipeline.next_transaction_nonce(),
             TransactionNonce::from(1_u64)
         );
-        assert_eq!(tx.destination, sweep_request(0).destination);
-        assert_eq!(tx.amount, Wei::ZERO);
-        assert_eq!(tx.data, sweep_request(0).data);
+        assert_eq!(tx.destination(), &sweep_request(0).destination);
+        assert_eq!(tx.amount(), &Wei::ZERO);
+        assert_eq!(tx.data(), sweep_request(0).data);
+    }
+
+    #[test]
+    fn should_sweep_delegated_addresses_with_an_eip1559_transaction() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(sweep_request(0));
+
+        let tx = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+
+        assert_eq!(tx.transaction_type(), EIP1559_TX_ID);
+        assert_eq!(tx.authorizations(), &[]);
+    }
+
+    #[test]
+    fn should_install_delegations_with_an_eip7702_transaction() {
+        let mut pipeline = sweeper_pipeline();
+        let request = delegating_sweep_request(0);
+        pipeline.record_request(request.clone());
+
+        let tx = create_and_record_sweep_tx(&mut pipeline, request.clone());
+
+        assert_eq!(tx.transaction_type(), SET_CODE_TX_ID);
+        assert_eq!(tx.authorizations(), request.authorizations.as_slice());
+        assert_eq!(tx.destination(), &request.destination);
+        assert_eq!(tx.amount(), &request.amount);
+        assert_eq!(tx.data(), request.data);
+        assert_eq!(tx.nonce(), TransactionNonce::ZERO);
+    }
+
+    #[test]
+    fn should_keep_the_delegations_when_bumping_the_fee() {
+        let mut pipeline = sweeper_pipeline();
+        let request = delegating_sweep_request(0);
+        pipeline.record_request(request.clone());
+        let created = create_and_record_sweep_tx(&mut pipeline, request.clone());
+        pipeline.record_signed_transaction(sign_transaction(created.clone()));
+
+        let resubmitted = pipeline
+            .create_resubmit_transactions(TransactionCount::ZERO, higher_gas_fee_estimate());
+
+        let [Ok((id, bumped))] = resubmitted.as_slice() else {
+            panic!("BUG: expected exactly one transaction to resubmit, got {resubmitted:?}");
+        };
+        assert_eq!(id, &SweepId(0));
+        assert_eq!(bumped.transaction_type(), SET_CODE_TX_ID);
+        assert_eq!(bumped.authorizations(), request.authorizations.as_slice());
+        assert!(bumped.max_priority_fee_per_gas() > created.max_priority_fee_per_gas());
+        assert_eq!(bumped.max_fee_per_gas(), created.max_fee_per_gas());
     }
 
     #[test]
@@ -2983,6 +3065,24 @@ mod sweep_lane {
     }
 
     #[test]
+    fn should_finalize_a_sweep_that_installed_delegations() {
+        let mut pipeline = sweeper_pipeline();
+        pipeline.record_request(delegating_sweep_request(0));
+        let created = create_and_record_sweep_tx(&mut pipeline, delegating_sweep_request(0));
+        let signed = sign_transaction(created);
+        pipeline.record_signed_transaction(signed.clone());
+
+        let receipt = transaction_receipt(&signed, TransactionStatus::Success);
+        let finalized = pipeline.record_finalized_transaction(SweepId(0), &receipt);
+
+        assert_eq!(finalized.transaction_hash(), &signed.hash());
+        assert_eq!(
+            finalized.transaction().authorizations(),
+            delegating_sweep_request(0).authorizations.as_slice()
+        );
+    }
+
+    #[test]
     fn should_advance_the_nonce_across_two_sweeps() {
         let mut pipeline = sweeper_pipeline();
         pipeline.record_request(sweep_request(0));
@@ -2991,8 +3091,8 @@ mod sweep_lane {
         let first = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
         let second = create_and_record_sweep_tx(&mut pipeline, sweep_request(1));
 
-        assert_eq!(first.nonce, TransactionNonce::ZERO);
-        assert_eq!(second.nonce, TransactionNonce::from(1_u64));
+        assert_eq!(first.nonce(), TransactionNonce::ZERO);
+        assert_eq!(second.nonce(), TransactionNonce::from(1_u64));
         assert_eq!(
             pipeline.next_transaction_nonce(),
             TransactionNonce::from(2_u64)
@@ -3004,43 +3104,67 @@ mod sweep_lane {
     fn should_trap_when_the_created_transaction_carries_other_call_data() {
         let mut pipeline = sweeper_pipeline();
         pipeline.record_request(sweep_request(0));
-        let tx = sweep_request(0)
+        let SweepTransaction::Eip1559(tx) = created_sweep_transaction(&pipeline, sweep_request(0))
+        else {
+            panic!("BUG: a sweep with no delegations to install is an EIP-1559 transaction");
+        };
+
+        pipeline.record_created_transaction(
+            SweepId(0),
+            SweepTransaction::new(
+                Eip1559TransactionRequest {
+                    data: vec![0xff],
+                    ..tx
+                },
+                vec![],
+            ),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "sweep transaction should install exactly the request's delegations")]
+    fn should_trap_when_the_created_transaction_installs_other_delegations() {
+        let mut pipeline = sweeper_pipeline();
+        let request = delegating_sweep_request(0);
+        pipeline.record_request(request.clone());
+        let SweepTransaction::Eip7702(tx) = created_sweep_transaction(&pipeline, request) else {
+            panic!("BUG: a sweep with delegations to install is an EIP-7702 transaction");
+        };
+
+        pipeline.record_created_transaction(
+            SweepId(0),
+            SweepTransaction::Eip7702(Eip7702TransactionRequest {
+                authorization_list: vec![authorization(3)],
+                ..tx
+            }),
+        );
+    }
+
+    /// The transaction `request` creates on `pipeline`'s next nonce, without recording it.
+    fn created_sweep_transaction(
+        pipeline: &TransactionPipeline<SweepRequest>,
+        request: SweepRequest,
+    ) -> SweepTransaction {
+        request
             .create_transaction(
                 pipeline.next_transaction_nonce(),
                 gas_fee_estimate(),
                 SWEEP_GAS_LIMIT,
                 EthereumNetwork::Sepolia,
             )
-            .expect("BUG: the fixture allowance covers the fixture fee");
-
-        pipeline.record_created_transaction(
-            SweepId(0),
-            Eip1559TransactionRequest {
-                data: vec![0xff],
-                ..tx
-            },
-        );
+            .expect("BUG: the fixture allowance covers the fixture fee")
     }
 
     #[test]
     fn should_allocate_the_whole_fee_allowance_to_a_sweep_transaction() {
         let request = sweep_request(0);
-        let tx = request
-            .create_transaction(
-                TransactionNonce::ZERO,
-                gas_fee_estimate(),
-                SWEEP_GAS_LIMIT,
-                EthereumNetwork::Sepolia,
-            )
-            .expect("BUG: the fixture allowance covers the fixture fee");
+        let pipeline = sweeper_pipeline();
 
-        assert_eq!(
-            tx.max_fee_per_gas,
-            request
-                .max_transaction_fee
-                .into_wei_per_gas(SWEEP_GAS_LIMIT)
-                .unwrap()
-        );
+        let SweepTransaction::Eip1559(tx) = created_sweep_transaction(&pipeline, request.clone())
+        else {
+            panic!("BUG: a sweep with no delegations to install is an EIP-1559 transaction");
+        };
+
         assert_eq!(
             tx.max_fee_per_gas.transaction_cost(SWEEP_GAS_LIMIT),
             Some(request.max_transaction_fee)
@@ -3059,7 +3183,7 @@ mod sweep_lane {
             ..gas_fee_estimate()
         };
 
-        let error = request.create_transaction(
+        let created = request.create_transaction(
             TransactionNonce::ZERO,
             spiked_fee,
             SWEEP_GAS_LIMIT,
@@ -3067,7 +3191,7 @@ mod sweep_lane {
         );
 
         assert_matches!(
-            error,
+            created,
             Err(CreateSweepTransactionError::InsufficientTransactionFee {
                 id,
                 allowed_max_transaction_fee,
@@ -3092,7 +3216,7 @@ mod sweep_lane {
                     .unwrap()
         );
 
-        let error = request.create_transaction(
+        let created = request.create_transaction(
             TransactionNonce::ZERO,
             gas_fee_estimate(),
             SWEEP_GAS_LIMIT,
@@ -3100,7 +3224,7 @@ mod sweep_lane {
         );
 
         assert_matches!(
-            error,
+            created,
             Err(CreateSweepTransactionError::InsufficientTransactionFee { .. })
         );
     }
@@ -3350,8 +3474,8 @@ fn resubmit_transaction_with_bumped_price(
     signed_tx
 }
 
-fn transaction_receipt(
-    signed_tx: &SignedEip1559TransactionRequest,
+fn transaction_receipt<T: SignableTransaction>(
+    signed_tx: &Signed<T>,
     status: TransactionStatus,
 ) -> TransactionReceipt {
     use std::str::FromStr;
@@ -3361,15 +3485,15 @@ fn transaction_receipt(
         )
         .unwrap(),
         block_number: BlockNumber::new(4190269),
-        effective_gas_price: signed_tx.transaction().max_fee_per_gas,
-        gas_used: signed_tx.transaction().gas_limit,
+        effective_gas_price: signed_tx.transaction().max_fee_per_gas(),
+        gas_used: signed_tx.transaction().gas_limit(),
         status,
         transaction_hash: signed_tx.hash(),
     }
 }
 
-fn sign_transaction(transaction: Eip1559TransactionRequest) -> SignedEip1559TransactionRequest {
-    SignedEip1559TransactionRequest::from((transaction, dummy_signature()))
+fn sign_transaction<T: SignableTransaction>(transaction: T) -> Signed<T> {
+    Signed::from((transaction, dummy_signature()))
 }
 
 fn dummy_signature() -> TransactionSignature {

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -3004,29 +3004,29 @@ mod sweep_lane {
     #[test]
     fn should_sweep_with_the_transaction_type_the_delegations_to_install_call_for() {
         struct Case {
-            addresses_to_delegate: &'static str,
+            scenario: &'static str,
             authorizations: Vec<SignedAuthorization>,
             expected_transaction_type: u8,
         }
 
         for case in [
             Case {
-                addresses_to_delegate: "none",
+                scenario: "every swept address already delegated",
                 authorizations: vec![],
                 expected_transaction_type: EIP1559_TX_ID,
             },
             Case {
-                addresses_to_delegate: "one",
+                scenario: "one swept address still to delegate",
                 authorizations: vec![authorization(1)],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
             Case {
-                addresses_to_delegate: "two",
-                authorizations: delegating_sweep_request(0).authorizations,
+                scenario: "two swept addresses still to delegate",
+                authorizations: vec![authorization(1), authorization(2)],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
         ] {
-            let context = format!("{} address(es) to delegate", case.addresses_to_delegate);
+            let context = case.scenario;
             let request = SweepRequest {
                 authorizations: case.authorizations,
                 ..sweep_request(0)

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -3002,30 +3002,55 @@ mod sweep_lane {
     }
 
     #[test]
-    fn should_sweep_delegated_addresses_with_an_eip1559_transaction() {
-        let mut pipeline = sweeper_pipeline();
-        pipeline.record_request(sweep_request(0));
+    fn should_sweep_with_the_transaction_type_the_delegations_to_install_call_for() {
+        struct Case {
+            addresses_to_delegate: &'static str,
+            authorizations: Vec<SignedAuthorization>,
+            expected_transaction_type: u8,
+        }
 
-        let tx = create_and_record_sweep_tx(&mut pipeline, sweep_request(0));
+        for case in [
+            Case {
+                addresses_to_delegate: "none",
+                authorizations: vec![],
+                expected_transaction_type: EIP1559_TX_ID,
+            },
+            Case {
+                addresses_to_delegate: "one",
+                authorizations: vec![authorization(1)],
+                expected_transaction_type: SET_CODE_TX_ID,
+            },
+            Case {
+                addresses_to_delegate: "two",
+                authorizations: delegating_sweep_request(0).authorizations,
+                expected_transaction_type: SET_CODE_TX_ID,
+            },
+        ] {
+            let context = format!("{} address(es) to delegate", case.addresses_to_delegate);
+            let request = SweepRequest {
+                authorizations: case.authorizations,
+                ..sweep_request(0)
+            };
+            let mut pipeline = sweeper_pipeline();
+            pipeline.record_request(request.clone());
 
-        assert_eq!(tx.transaction_type(), EIP1559_TX_ID);
-        assert_eq!(tx.authorizations(), &[]);
-    }
+            let tx = create_and_record_sweep_tx(&mut pipeline, request.clone());
 
-    #[test]
-    fn should_install_delegations_with_an_eip7702_transaction() {
-        let mut pipeline = sweeper_pipeline();
-        let request = delegating_sweep_request(0);
-        pipeline.record_request(request.clone());
-
-        let tx = create_and_record_sweep_tx(&mut pipeline, request.clone());
-
-        assert_eq!(tx.transaction_type(), SET_CODE_TX_ID);
-        assert_eq!(tx.authorizations(), request.authorizations.as_slice());
-        assert_eq!(tx.destination(), &request.destination);
-        assert_eq!(tx.amount(), &request.amount);
-        assert_eq!(tx.data(), request.data);
-        assert_eq!(tx.nonce(), TransactionNonce::ZERO);
+            assert_eq!(
+                tx.transaction_type(),
+                case.expected_transaction_type,
+                "{context}"
+            );
+            assert_eq!(
+                tx.authorizations(),
+                request.authorizations.as_slice(),
+                "{context}"
+            );
+            assert_eq!(tx.destination(), &request.destination, "{context}");
+            assert_eq!(tx.amount(), &request.amount, "{context}");
+            assert_eq!(tx.data(), request.data, "{context}");
+            assert_eq!(tx.nonce(), TransactionNonce::ZERO, "{context}");
+        }
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2912,8 +2912,8 @@ mod sweep_lane {
         SweepRequest, TransactionPipeline,
     };
     use crate::tx::{
-        Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate, SignableTransaction,
-        SignedAuthorization, SweepTransaction,
+        DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
+        SignableTransaction, SignedAuthorization, SweepTransaction,
     };
     use assert_matches::assert_matches;
     use ethnum::u256;
@@ -3158,10 +3158,13 @@ mod sweep_lane {
 
         pipeline.record_created_transaction(
             SweepId(0),
-            SweepTransaction::Eip7702(Eip7702TransactionRequest {
-                authorization_list: vec![authorization(3)],
-                ..tx
-            }),
+            SweepTransaction::Eip7702(
+                DelegatingSweep::new(Eip7702TransactionRequest {
+                    authorization_list: vec![authorization(3)],
+                    ..tx.transaction().clone()
+                })
+                .unwrap(),
+            ),
         );
     }
 

--- a/rs/ethereum/cketh/minter/src/tx/eip_1559.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_1559.rs
@@ -1,12 +1,5 @@
-use super::{
-    AccessList, GasFeeEstimate, ResubmissionStrategy, ResubmitTransactionError, Resubmittable,
-    SignableTransaction, Signed, TransactionPrice,
-};
-use crate::{
-    eth_rpc::Hash,
-    eth_rpc_client::responses::{TransactionReceipt, TransactionStatus},
-    numeric::{BlockNumber, GasAmount, TransactionNonce, Wei, WeiPerGas},
-};
+use super::{AccessList, Finalized, Resubmittable, SignableTransaction, Signed, TransactionPrice};
+use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
 use ic_ethereum_types::Address;
 use minicbor::{Decode, Encode};
 use rlp::RlpStream;
@@ -17,6 +10,10 @@ const EIP1559_TX_ID: u8 = 2;
 /// Use [`sign`](super::sign) to create a newly signed transaction or
 /// `SignedEip1559TransactionRequest::from()` if the signature is already known.
 pub type SignedEip1559TransactionRequest = Signed<Eip1559TransactionRequest>;
+
+/// Immutable finalized EIP-1559 transaction.
+/// Use [`Signed::try_finalize`] to create a finalized transaction.
+pub type FinalizedEip1559Transaction = Finalized<Eip1559TransactionRequest>;
 
 pub type TransactionRequest = Resubmittable<Eip1559TransactionRequest>;
 pub type SignedTransactionRequest = Resubmittable<SignedEip1559TransactionRequest>;
@@ -50,135 +47,11 @@ impl AsRef<Eip1559TransactionRequest> for Eip1559TransactionRequest {
     }
 }
 
-impl SignedTransactionRequest {
-    pub fn resubmit(
-        &self,
-        new_gas_fee: GasFeeEstimate,
-    ) -> Result<Option<Eip1559TransactionRequest>, ResubmitTransactionError> {
-        let transaction_request = self.transaction.transaction();
-        let last_tx_price = transaction_request.transaction_price();
-        let new_tx_price = last_tx_price
-            .clone()
-            .resubmit_transaction_price(new_gas_fee);
-        if new_tx_price == last_tx_price {
-            return Ok(None);
-        }
-
-        if new_tx_price.max_transaction_fee() > self.resubmission.allowed_max_transaction_fee() {
-            return Err(ResubmitTransactionError::InsufficientTransactionFee {
-                allowed_max_transaction_fee: self.resubmission.allowed_max_transaction_fee(),
-                actual_max_transaction_fee: new_tx_price.max_transaction_fee(),
-            });
-        }
-        let new_amount = match self.resubmission {
-            ResubmissionStrategy::ReduceEthAmount { withdrawal_amount } => {
-                withdrawal_amount.checked_sub(new_tx_price.max_transaction_fee())
-                    .expect("BUG: withdrawal_amount covers new transaction fee because it was checked before")
-            }
-            ResubmissionStrategy::GuaranteeEthAmount { .. } => transaction_request.amount,
-        };
-        Ok(Some(Eip1559TransactionRequest {
-            max_priority_fee_per_gas: new_tx_price.max_priority_fee_per_gas,
-            max_fee_per_gas: new_tx_price.max_fee_per_gas,
-            gas_limit: new_tx_price.gas_limit,
-            amount: new_amount,
-            ..transaction_request.clone()
-        }))
-    }
-}
-
 impl rlp::Encodable for Eip1559TransactionRequest {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.begin_unbounded_list();
         self.rlp_inner(s);
         s.finalize_unbounded_list();
-    }
-}
-
-/// Immutable finalized transaction.
-/// Use `SignedEip1559TransactionRequest::try_finalize()` to create a finalized transaction.
-#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
-pub struct FinalizedEip1559Transaction {
-    #[n(0)]
-    transaction: SignedEip1559TransactionRequest,
-    #[n(1)]
-    receipt: TransactionReceipt,
-}
-
-impl AsRef<Eip1559TransactionRequest> for FinalizedEip1559Transaction {
-    fn as_ref(&self) -> &Eip1559TransactionRequest {
-        self.transaction.as_ref()
-    }
-}
-
-impl FinalizedEip1559Transaction {
-    pub fn destination(&self) -> &Address {
-        &self.transaction.transaction().destination
-    }
-
-    pub fn block_number(&self) -> &BlockNumber {
-        &self.receipt.block_number
-    }
-
-    pub fn transaction_amount(&self) -> &Wei {
-        &self.transaction.transaction().amount
-    }
-
-    pub fn transaction_hash(&self) -> &Hash {
-        &self.receipt.transaction_hash
-    }
-
-    pub fn transaction_data(&self) -> &[u8] {
-        &self.transaction.transaction().data
-    }
-
-    pub fn transaction(&self) -> &Eip1559TransactionRequest {
-        self.transaction.transaction()
-    }
-
-    pub fn transaction_price(&self) -> TransactionPrice {
-        self.transaction.transaction().transaction_price()
-    }
-
-    pub fn effective_transaction_fee(&self) -> Wei {
-        self.receipt.effective_transaction_fee()
-    }
-
-    pub fn transaction_status(&self) -> &TransactionStatus {
-        &self.receipt.status
-    }
-}
-
-impl SignedEip1559TransactionRequest {
-    pub fn try_finalize(
-        self,
-        receipt: TransactionReceipt,
-    ) -> Result<FinalizedEip1559Transaction, String> {
-        if self.hash() != receipt.transaction_hash {
-            return Err(format!(
-                "transaction hash mismatch: expected {}, got {}",
-                self.hash(),
-                receipt.transaction_hash
-            ));
-        }
-        if self.transaction().max_fee_per_gas < receipt.effective_gas_price {
-            return Err(format!(
-                "transaction max_fee_per_gas {} is smaller than effective_gas_price {}",
-                self.transaction().max_fee_per_gas,
-                receipt.effective_gas_price
-            ));
-        }
-        if self.transaction().gas_limit < receipt.gas_used {
-            return Err(format!(
-                "transaction gas limit {} is smaller than gas used {}",
-                self.transaction().gas_limit,
-                receipt.gas_used
-            ));
-        }
-        Ok(FinalizedEip1559Transaction {
-            transaction: self,
-            receipt,
-        })
     }
 }
 
@@ -213,5 +86,27 @@ impl SignableTransaction for Eip1559TransactionRequest {
 
     fn max_priority_fee_per_gas(&self) -> WeiPerGas {
         self.max_priority_fee_per_gas
+    }
+
+    fn destination(&self) -> &Address {
+        &self.destination
+    }
+
+    fn amount(&self) -> &Wei {
+        &self.amount
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {
+        Self {
+            max_priority_fee_per_gas: price.max_priority_fee_per_gas,
+            max_fee_per_gas: price.max_fee_per_gas,
+            gas_limit: price.gas_limit,
+            amount,
+            ..self.clone()
+        }
     }
 }

--- a/rs/ethereum/cketh/minter/src/tx/eip_1559.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_1559.rs
@@ -72,6 +72,10 @@ impl SignableTransaction for Eip1559TransactionRequest {
         rlp.append(&self.access_list);
     }
 
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
     fn nonce(&self) -> TransactionNonce {
         self.nonce
     }
@@ -98,6 +102,10 @@ impl SignableTransaction for Eip1559TransactionRequest {
 
     fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    fn access_list(&self) -> &AccessList {
+        &self.access_list
     }
 
     fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -220,6 +220,17 @@ impl SignableTransaction for Eip7702TransactionRequest {
     }
 }
 
+// TODO(DEFI-2970): drop this decoder in favour of one from `alloy`, whose `TxEip7702` already
+// implements it. It is hand-written because the only EIP-7702-aware library is not a dependency
+// yet: `ethers-core`, which the replay tests use to decode EIP-1559 transactions, was archived
+// before EIP-7702 and stops at transaction type `0x02`.
+//
+// It also sits in productive code although only tests call it, because no test-only home is
+// reachable from all of its callers: `ic-cketh-test-utils` cannot serve this crate's own unit
+// tests, since those compile this crate a second time under `cfg(test)` and would receive
+// `Eip7702TransactionRequest` values of the other compilation, while the `dump_stable_memory`
+// binary links this library and so cannot see `#[cfg(test)]` items either. Moving to `alloy`
+// removes the decoder from here altogether, which settles both.
 impl SignedEip7702TransactionRequest {
     /// Decodes the payload a signed EIP-7702 transaction is broadcast as, i.e.
     /// `0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to,

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -1,5 +1,6 @@
 use super::{
-    AccessList, SignableTransaction, Signed, compute_recovery_id, encode_u256, split_in_two,
+    AccessList, SignableTransaction, Signed, TransactionPrice, compute_recovery_id, encode_u256,
+    split_in_two,
 };
 use crate::{
     eth_rpc::Hash,
@@ -18,8 +19,6 @@ const EIP7702_AUTHORIZATION_MAGIC: u8 = 5;
 /// Immutable signed EIP-7702 transaction.
 /// Use [`sign`](super::sign) to create a newly signed transaction or
 /// `SignedEip7702TransactionRequest::from()` if the signature is already known.
-// TODO(DEFI-2926): mirror the `Resubmittable`/fee-bump machinery used for EIP-1559 transactions
-// once EIP-7702 transactions are wired into the resubmission path.
 pub type SignedEip7702TransactionRequest = Signed<Eip7702TransactionRequest>;
 
 /// <https://eips.ethereum.org/EIPS/eip-7702>
@@ -187,5 +186,27 @@ impl SignableTransaction for Eip7702TransactionRequest {
 
     fn max_priority_fee_per_gas(&self) -> WeiPerGas {
         self.max_priority_fee_per_gas
+    }
+
+    fn destination(&self) -> &Address {
+        &self.destination
+    }
+
+    fn amount(&self) -> &Wei {
+        &self.amount
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {
+        Self {
+            max_priority_fee_per_gas: price.max_priority_fee_per_gas,
+            max_fee_per_gas: price.max_fee_per_gas,
+            gas_limit: price.gas_limit,
+            amount,
+            ..self.clone()
+        }
     }
 }

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -249,6 +249,24 @@ impl SignedEip7702TransactionRequest {
             ));
         }
         let rlp = Rlp::new(payload);
+        let authorization_list: Vec<SignedAuthorization> = decode_list(&rlp, 9)?
+            .iter()
+            .map(|item| {
+                Ok(SignedAuthorization {
+                    chain_id: decode_val(item, 0)?,
+                    delegate: decode_address(item, 1)?,
+                    nonce: decode_amount(item, 2)?,
+                    y_parity: decode_val(item, 3)?,
+                    r: decode_u256(item, 4)?,
+                    s: decode_u256(item, 5)?,
+                })
+            })
+            .collect::<Result<_, String>>()?;
+        if authorization_list.is_empty() {
+            return Err(format!(
+                "an EIP-7702 transaction (type {SET_CODE_TX_ID}) must have a non-empty authorization list"
+            ));
+        }
         let transaction = Eip7702TransactionRequest {
             chain_id: decode_val(&rlp, 0)?,
             nonce: decode_amount(&rlp, 1)?,
@@ -272,19 +290,7 @@ impl SignedEip7702TransactionRequest {
                     })
                     .collect::<Result<_, String>>()?,
             ),
-            authorization_list: decode_list(&rlp, 9)?
-                .iter()
-                .map(|item| {
-                    Ok(SignedAuthorization {
-                        chain_id: decode_val(item, 0)?,
-                        delegate: decode_address(item, 1)?,
-                        nonce: decode_amount(item, 2)?,
-                        y_parity: decode_val(item, 3)?,
-                        r: decode_u256(item, 4)?,
-                        s: decode_u256(item, 5)?,
-                    })
-                })
-                .collect::<Result<_, String>>()?,
+            authorization_list,
         };
         let signature = TransactionSignature {
             signature_y_parity: decode_val(&rlp, 10)?,

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -172,6 +172,10 @@ impl SignableTransaction for Eip7702TransactionRequest {
         rlp.append_list(&self.authorization_list);
     }
 
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
     fn nonce(&self) -> TransactionNonce {
         self.nonce
     }
@@ -198,6 +202,10 @@ impl SignableTransaction for Eip7702TransactionRequest {
 
     fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    fn access_list(&self) -> &AccessList {
+        &self.access_list
     }
 
     fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -1,8 +1,9 @@
 use super::{
-    AccessList, SignableTransaction, Signed, TransactionPrice, compute_recovery_id, encode_u256,
-    split_in_two,
+    AccessList, AccessListItem, SignableTransaction, Signed, StorageKey, TransactionPrice,
+    TransactionSignature, compute_recovery_id, encode_u256, split_in_two,
 };
 use crate::{
+    checked_amount::CheckedAmountOf,
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
     state::read_state,
@@ -11,7 +12,7 @@ use ethnum::u256;
 use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 use minicbor::{Decode, Encode};
-use rlp::RlpStream;
+use rlp::{Rlp, RlpStream};
 
 const SET_CODE_TX_ID: u8 = 4;
 const EIP7702_AUTHORIZATION_MAGIC: u8 = 5;
@@ -217,4 +218,121 @@ impl SignableTransaction for Eip7702TransactionRequest {
             ..self.clone()
         }
     }
+}
+
+impl SignedEip7702TransactionRequest {
+    /// Decodes the payload a signed EIP-7702 transaction is broadcast as, i.e.
+    /// `0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to,
+    /// value, data, access_list, authorization_list, y_parity, r, s])`. The inverse of
+    /// [`Signed::raw_transaction_bytes`].
+    ///
+    /// # Errors
+    /// * a description of why `raw_transaction` is not such a payload.
+    pub fn decode(raw_transaction: &[u8]) -> Result<Self, String> {
+        let (transaction_type, payload) = raw_transaction
+            .split_first()
+            .ok_or_else(|| "empty transaction".to_string())?;
+        if *transaction_type != SET_CODE_TX_ID {
+            return Err(format!(
+                "expected an EIP-7702 transaction (type {SET_CODE_TX_ID}), got type {transaction_type}"
+            ));
+        }
+        let rlp = Rlp::new(payload);
+        let transaction = Eip7702TransactionRequest {
+            chain_id: decode_val(&rlp, 0)?,
+            nonce: decode_amount(&rlp, 1)?,
+            max_priority_fee_per_gas: decode_amount(&rlp, 2)?,
+            max_fee_per_gas: decode_amount(&rlp, 3)?,
+            gas_limit: decode_amount(&rlp, 4)?,
+            destination: decode_address(&rlp, 5)?,
+            amount: decode_amount(&rlp, 6)?,
+            data: decode_bytes(&rlp, 7)?.to_vec(),
+            access_list: AccessList(
+                decode_list(&rlp, 8)?
+                    .iter()
+                    .map(|item| {
+                        Ok(AccessListItem {
+                            address: decode_address(item, 0)?,
+                            storage_keys: decode_list(item, 1)?
+                                .iter()
+                                .map(|key| Ok(StorageKey(decode_be_bytes_of(key)?)))
+                                .collect::<Result<_, String>>()?,
+                        })
+                    })
+                    .collect::<Result<_, String>>()?,
+            ),
+            authorization_list: decode_list(&rlp, 9)?
+                .iter()
+                .map(|item| {
+                    Ok(SignedAuthorization {
+                        chain_id: decode_val(item, 0)?,
+                        delegate: decode_address(item, 1)?,
+                        nonce: decode_amount(item, 2)?,
+                        y_parity: decode_val(item, 3)?,
+                        r: decode_u256(item, 4)?,
+                        s: decode_u256(item, 5)?,
+                    })
+                })
+                .collect::<Result<_, String>>()?,
+        };
+        let signature = TransactionSignature {
+            signature_y_parity: decode_val(&rlp, 10)?,
+            r: decode_u256(&rlp, 11)?,
+            s: decode_u256(&rlp, 12)?,
+        };
+        Ok(Self::from((transaction, signature)))
+    }
+}
+
+fn decode_bytes<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<&'a [u8], String> {
+    decode_be_bytes_slice(&item_at(rlp, index)?)
+}
+
+fn item_at<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<Rlp<'a>, String> {
+    rlp.at(index)
+        .map_err(|e| format!("missing RLP item at index {index}: {e}"))
+}
+
+fn decode_be_bytes_slice<'a>(rlp: &Rlp<'a>) -> Result<&'a [u8], String> {
+    rlp.data()
+        .map_err(|e| format!("expected a byte string: {e}"))
+}
+
+fn decode_be_bytes_of(rlp: &Rlp) -> Result<[u8; 32], String> {
+    let data = decode_be_bytes_slice(rlp)?;
+    if data.len() > 32 {
+        return Err(format!("expected at most 32 bytes, got {}", data.len()));
+    }
+    let mut bytes = [0_u8; 32];
+    bytes[32 - data.len()..].copy_from_slice(data);
+    Ok(bytes)
+}
+
+fn decode_amount<Unit>(rlp: &Rlp, index: usize) -> Result<CheckedAmountOf<Unit>, String> {
+    Ok(CheckedAmountOf::from_be_bytes(decode_be_bytes_of(
+        &item_at(rlp, index)?,
+    )?))
+}
+
+fn decode_u256(rlp: &Rlp, index: usize) -> Result<u256, String> {
+    Ok(u256::from_be_bytes(decode_be_bytes_of(&item_at(
+        rlp, index,
+    )?)?))
+}
+
+fn decode_val<T: rlp::Decodable>(rlp: &Rlp, index: usize) -> Result<T, String> {
+    item_at(rlp, index)?
+        .as_val()
+        .map_err(|e| format!("malformed RLP item at index {index}: {e}"))
+}
+
+fn decode_address(rlp: &Rlp, index: usize) -> Result<Address, String> {
+    let data = decode_bytes(rlp, index)?;
+    Ok(Address::new(data.try_into().map_err(|_| {
+        format!("expected a 20-byte address, got {} bytes", data.len())
+    })?))
+}
+
+fn decode_list<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<Vec<Rlp<'a>>, String> {
+    Ok(item_at(rlp, index)?.iter().collect())
 }

--- a/rs/ethereum/cketh/minter/src/tx/finalized.rs
+++ b/rs/ethereum/cketh/minter/src/tx/finalized.rs
@@ -1,0 +1,92 @@
+use super::{SignableTransaction, Signed, TransactionPrice};
+use crate::{
+    eth_rpc::Hash,
+    eth_rpc_client::responses::{TransactionReceipt, TransactionStatus},
+    numeric::{BlockNumber, Wei},
+};
+use ic_ethereum_types::Address;
+use minicbor::{Decode, Encode};
+
+/// Immutable finalized transaction.
+/// Use [`Signed::try_finalize`] to create a finalized transaction.
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
+pub struct Finalized<T: SignableTransaction> {
+    #[n(0)]
+    transaction: Signed<T>,
+    #[n(1)]
+    receipt: TransactionReceipt,
+}
+
+impl<T: SignableTransaction> Finalized<T> {
+    pub fn block_number(&self) -> &BlockNumber {
+        &self.receipt.block_number
+    }
+
+    pub fn transaction_hash(&self) -> &Hash {
+        &self.receipt.transaction_hash
+    }
+
+    pub fn effective_transaction_fee(&self) -> Wei {
+        self.receipt.effective_transaction_fee()
+    }
+
+    pub fn transaction_status(&self) -> &TransactionStatus {
+        &self.receipt.status
+    }
+
+    pub fn destination(&self) -> &Address {
+        self.transaction.transaction().destination()
+    }
+
+    pub fn transaction_amount(&self) -> &Wei {
+        self.transaction.transaction().amount()
+    }
+
+    pub fn transaction_data(&self) -> &[u8] {
+        self.transaction.transaction().data()
+    }
+
+    pub fn transaction(&self) -> &T {
+        self.transaction.transaction()
+    }
+
+    pub fn transaction_price(&self) -> TransactionPrice {
+        self.transaction.transaction().transaction_price()
+    }
+}
+
+impl<T: SignableTransaction> AsRef<T> for Finalized<T> {
+    fn as_ref(&self) -> &T {
+        self.transaction.as_ref()
+    }
+}
+
+impl<T: SignableTransaction> Signed<T> {
+    pub fn try_finalize(self, receipt: TransactionReceipt) -> Result<Finalized<T>, String> {
+        if self.hash() != receipt.transaction_hash {
+            return Err(format!(
+                "transaction hash mismatch: expected {}, got {}",
+                self.hash(),
+                receipt.transaction_hash
+            ));
+        }
+        if self.transaction().max_fee_per_gas() < receipt.effective_gas_price {
+            return Err(format!(
+                "transaction max_fee_per_gas {} is smaller than effective_gas_price {}",
+                self.transaction().max_fee_per_gas(),
+                receipt.effective_gas_price
+            ));
+        }
+        if self.transaction().gas_limit() < receipt.gas_used {
+            return Err(format!(
+                "transaction gas limit {} is smaller than gas used {}",
+                self.transaction().gas_limit(),
+                receipt.gas_used
+            ));
+        }
+        Ok(Finalized {
+            transaction: self,
+            receipt,
+        })
+    }
+}

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -3,6 +3,7 @@ mod tests;
 
 mod eip_1559;
 mod eip_7702;
+mod finalized;
 mod signed;
 
 pub use eip_1559::{
@@ -12,6 +13,7 @@ pub use eip_1559::{
 pub use eip_7702::{
     Authorization, Eip7702TransactionRequest, SignedAuthorization, SignedEip7702TransactionRequest,
 };
+pub use finalized::Finalized;
 pub use signed::{SignableTransaction, Signed, TransactionSignature, sign};
 
 use crate::{
@@ -94,6 +96,45 @@ impl<T> Resubmittable<T> {
             transaction: other,
             resubmission: self.resubmission.clone(),
         }
+    }
+}
+
+impl<T: SignableTransaction> Resubmittable<Signed<T>> {
+    /// The same transaction at the price needed to resubmit it under `new_gas_fee`, or `None` if
+    /// its current price is still enough.
+    ///
+    /// # Errors
+    /// * [`ResubmitTransactionError::InsufficientTransactionFee`] if the new price exceeds the
+    ///   transaction fee the resubmission strategy allows.
+    pub fn resubmit(
+        &self,
+        new_gas_fee: GasFeeEstimate,
+    ) -> Result<Option<T>, ResubmitTransactionError> {
+        let transaction = self.transaction.transaction();
+        let last_tx_price = transaction.transaction_price();
+        let new_tx_price = last_tx_price
+            .clone()
+            .resubmit_transaction_price(new_gas_fee);
+        if new_tx_price == last_tx_price {
+            return Ok(None);
+        }
+
+        if new_tx_price.max_transaction_fee() > self.resubmission.allowed_max_transaction_fee() {
+            return Err(ResubmitTransactionError::InsufficientTransactionFee {
+                allowed_max_transaction_fee: self.resubmission.allowed_max_transaction_fee(),
+                actual_max_transaction_fee: new_tx_price.max_transaction_fee(),
+            });
+        }
+        let new_amount = match self.resubmission {
+            ResubmissionStrategy::ReduceEthAmount { withdrawal_amount } => {
+                withdrawal_amount.checked_sub(new_tx_price.max_transaction_fee())
+                    .expect("BUG: withdrawal_amount covers new transaction fee because it was checked before")
+            }
+            ResubmissionStrategy::GuaranteeEthAmount { .. } => *transaction.amount(),
+        };
+        Ok(Some(
+            transaction.with_price_and_amount(new_tx_price, new_amount),
+        ))
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -5,6 +5,7 @@ mod eip_1559;
 mod eip_7702;
 mod finalized;
 mod signed;
+mod sweep;
 
 pub use eip_1559::{
     Eip1559TransactionRequest, FinalizedEip1559Transaction, SignedEip1559TransactionRequest,
@@ -15,6 +16,7 @@ pub use eip_7702::{
 };
 pub use finalized::Finalized;
 pub use signed::{SignableTransaction, Signed, TransactionSignature, sign};
+pub use sweep::{SignedSweepTransaction, SweepTransaction};
 
 use crate::{
     eth_rpc::Hash,

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -16,7 +16,7 @@ pub use eip_7702::{
 };
 pub use finalized::Finalized;
 pub use signed::{SignableTransaction, Signed, TransactionSignature, sign};
-pub use sweep::{SignedSweepTransaction, SweepTransaction};
+pub use sweep::{DelegatingSweep, SignedSweepTransaction, SweepTransaction};
 
 use crate::{
     eth_rpc::Hash,

--- a/rs/ethereum/cketh/minter/src/tx/signed.rs
+++ b/rs/ethereum/cketh/minter/src/tx/signed.rs
@@ -1,10 +1,11 @@
 use super::{TransactionPrice, compute_recovery_id, encode_u256, split_in_two};
 use crate::{
     eth_rpc::Hash,
-    numeric::{GasAmount, TransactionNonce, WeiPerGas},
+    numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
     state::read_state,
 };
 use ethnum::u256;
+use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 use minicbor::{Decode, Encode};
 use rlp::RlpStream;
@@ -43,6 +44,21 @@ pub trait SignableTransaction: rlp::Encodable {
     fn max_fee_per_gas(&self) -> WeiPerGas;
 
     fn max_priority_fee_per_gas(&self) -> WeiPerGas;
+
+    /// Address the transaction is sent to.
+    fn destination(&self) -> &Address;
+
+    /// ETH value moved by the transaction.
+    fn amount(&self) -> &Wei;
+
+    /// The transaction's call data.
+    fn data(&self) -> &[u8];
+
+    /// The same transaction at a different price and amount, e.g. to bump the fee of a
+    /// transaction that is not being mined.
+    fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self
+    where
+        Self: Sized;
 
     /// The signing digest `keccak256(transaction_type || rlp([..payload fields..]))`,
     /// i.e. the hash signed over to authorize the transaction, where `||` denotes string

--- a/rs/ethereum/cketh/minter/src/tx/signed.rs
+++ b/rs/ethereum/cketh/minter/src/tx/signed.rs
@@ -200,6 +200,10 @@ impl<T: SignableTransaction> Signed<T> {
         &self.inner.transaction
     }
 
+    pub fn signature(&self) -> &TransactionSignature {
+        &self.inner.signature
+    }
+
     pub fn nonce(&self) -> TransactionNonce {
         self.inner.transaction.nonce()
     }

--- a/rs/ethereum/cketh/minter/src/tx/signed.rs
+++ b/rs/ethereum/cketh/minter/src/tx/signed.rs
@@ -1,4 +1,4 @@
-use super::{TransactionPrice, compute_recovery_id, encode_u256, split_in_two};
+use super::{AccessList, TransactionPrice, compute_recovery_id, encode_u256, split_in_two};
 use crate::{
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
@@ -37,6 +37,8 @@ pub trait SignableTransaction: rlp::Encodable {
     /// RLP-encode the transaction payload, i.e. without the type prefix nor the signature.
     fn rlp_inner(&self, rlp: &mut RlpStream);
 
+    fn chain_id(&self) -> u64;
+
     fn nonce(&self) -> TransactionNonce;
 
     fn gas_limit(&self) -> GasAmount;
@@ -53,6 +55,9 @@ pub trait SignableTransaction: rlp::Encodable {
 
     /// The transaction's call data.
     fn data(&self) -> &[u8];
+
+    /// Addresses and storage keys the transaction pre-declares access to.
+    fn access_list(&self) -> &AccessList;
 
     /// The same transaction at a different price and amount, e.g. to bump the fee of a
     /// transaction that is not being mined.

--- a/rs/ethereum/cketh/minter/src/tx/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/tx/sweep.rs
@@ -14,12 +14,14 @@ pub type SignedSweepTransaction = Signed<SweepTransaction>;
 
 /// A transaction sent from the minter's dedicated sweeper address: a plain EIP-1559 transaction
 /// (`0x02`), or an EIP-7702 one (`0x04`) whose authorization list additionally installs the
-/// delegation to the sweeper contract of every deposit address it sweeps.
+/// delegation to the sweeper contract of those deposit addresses it sweeps that are not delegated
+/// yet. The ones already delegated are swept without an authorization tuple, so the list can be
+/// shorter than the set of addresses swept.
 ///
-/// A deposit address is delegated once and stays delegated, so only the first sweep touching it
-/// needs type `0x04`. The [`SweepTransaction::Eip7702`] variant therefore always carries a
-/// non-empty authorization list: [`SweepTransaction::new`] is what decides the variant, and it
-/// decides on exactly that.
+/// A deposit address is delegated once and stays delegated, so a sweep needs type `0x04` only as
+/// long as it still touches an address no earlier sweep delegated. The
+/// [`SweepTransaction::Eip7702`] variant therefore always carries a non-empty authorization list:
+/// [`SweepTransaction::new`] is what decides the variant, and it decides on exactly that.
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub enum SweepTransaction {
     #[n(0)]

--- a/rs/ethereum/cketh/minter/src/tx/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/tx/sweep.rs
@@ -77,6 +77,16 @@ impl SweepTransaction {
         if authorizations.is_empty() {
             return Self::Eip1559(transaction);
         }
+        // EIP-7702 skips an authorization whose chain id is neither zero nor the chain the
+        // transaction runs on, without failing the transaction: the sweep would pay for the
+        // delegation, not install it, and then call an address with no code.
+        assert!(
+            authorizations
+                .iter()
+                .all(|a| a.chain_id == 0 || a.chain_id == transaction.chain_id),
+            "BUG: authorization for another chain than {}",
+            transaction.chain_id
+        );
         let delegating = Eip7702TransactionRequest {
             chain_id: transaction.chain_id,
             nonce: transaction.nonce,

--- a/rs/ethereum/cketh/minter/src/tx/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/tx/sweep.rs
@@ -1,0 +1,133 @@
+use super::{
+    AccessList, Eip1559TransactionRequest, Eip7702TransactionRequest, SignableTransaction, Signed,
+    SignedAuthorization, TransactionPrice,
+};
+use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
+use ic_ethereum_types::Address;
+use minicbor::{Decode, Encode};
+use rlp::RlpStream;
+
+/// Immutable signed sweep transaction.
+/// Use [`sign`](super::sign) to create a newly signed transaction or
+/// `SignedSweepTransaction::from()` if the signature is already known.
+pub type SignedSweepTransaction = Signed<SweepTransaction>;
+
+/// A transaction sent from the minter's dedicated sweeper address: a plain EIP-1559 transaction
+/// (`0x02`), or an EIP-7702 one (`0x04`) whose authorization list additionally installs the
+/// delegation to the sweeper contract of every deposit address it sweeps.
+///
+/// A deposit address is delegated once and stays delegated, so only the first sweep touching it
+/// needs type `0x04`. The [`SweepTransaction::Eip7702`] variant therefore always carries a
+/// non-empty authorization list: [`SweepTransaction::new`] is what decides the variant, and it
+/// decides on exactly that.
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
+pub enum SweepTransaction {
+    #[n(0)]
+    Eip1559(#[n(0)] Eip1559TransactionRequest),
+    #[n(1)]
+    Eip7702(#[n(0)] Eip7702TransactionRequest),
+}
+
+impl SweepTransaction {
+    /// The sweep `transaction`, installing the delegations `authorizations` attests to: type
+    /// `0x04` if there are any to install, and type `0x02` if there are none.
+    pub fn new(
+        transaction: Eip1559TransactionRequest,
+        authorizations: Vec<SignedAuthorization>,
+    ) -> Self {
+        if authorizations.is_empty() {
+            return Self::Eip1559(transaction);
+        }
+        Self::Eip7702(Eip7702TransactionRequest {
+            chain_id: transaction.chain_id,
+            nonce: transaction.nonce,
+            max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
+            max_fee_per_gas: transaction.max_fee_per_gas,
+            gas_limit: transaction.gas_limit,
+            destination: transaction.destination,
+            amount: transaction.amount,
+            data: transaction.data,
+            access_list: transaction.access_list,
+            authorization_list: authorizations,
+        })
+    }
+
+    /// The delegations this transaction installs, empty for a plain EIP-1559 sweep.
+    pub fn authorizations(&self) -> &[SignedAuthorization] {
+        match self {
+            Self::Eip1559(_) => &[],
+            Self::Eip7702(transaction) => &transaction.authorization_list,
+        }
+    }
+
+    /// The transaction in whichever shape it takes, for everything both shapes have in common.
+    fn as_signable(&self) -> &dyn SignableTransaction {
+        match self {
+            Self::Eip1559(transaction) => transaction,
+            Self::Eip7702(transaction) => transaction,
+        }
+    }
+}
+
+impl rlp::Encodable for SweepTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.as_signable().rlp_append(s)
+    }
+}
+
+impl SignableTransaction for SweepTransaction {
+    fn transaction_type(&self) -> u8 {
+        self.as_signable().transaction_type()
+    }
+
+    fn rlp_inner(&self, rlp: &mut RlpStream) {
+        self.as_signable().rlp_inner(rlp)
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.as_signable().chain_id()
+    }
+
+    fn nonce(&self) -> TransactionNonce {
+        self.as_signable().nonce()
+    }
+
+    fn gas_limit(&self) -> GasAmount {
+        self.as_signable().gas_limit()
+    }
+
+    fn max_fee_per_gas(&self) -> WeiPerGas {
+        self.as_signable().max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> WeiPerGas {
+        self.as_signable().max_priority_fee_per_gas()
+    }
+
+    fn destination(&self) -> &Address {
+        self.as_signable().destination()
+    }
+
+    fn amount(&self) -> &Wei {
+        self.as_signable().amount()
+    }
+
+    fn data(&self) -> &[u8] {
+        self.as_signable().data()
+    }
+
+    fn access_list(&self) -> &AccessList {
+        self.as_signable().access_list()
+    }
+
+    fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {
+        match self {
+            Self::Eip1559(transaction) => {
+                Self::Eip1559(transaction.with_price_and_amount(price, amount))
+            }
+            Self::Eip7702(transaction) => {
+                Self::Eip7702(transaction.with_price_and_amount(price, amount))
+            }
+        }
+    }
+}

--- a/rs/ethereum/cketh/minter/src/tx/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/tx/sweep.rs
@@ -27,7 +27,44 @@ pub enum SweepTransaction {
     #[n(0)]
     Eip1559(#[n(0)] Eip1559TransactionRequest),
     #[n(1)]
-    Eip7702(#[n(0)] Eip7702TransactionRequest),
+    Eip7702(#[n(0)] DelegatingSweep),
+}
+
+/// An EIP-7702 sweep, i.e. one whose authorization list installs at least one delegation. A
+/// type-`0x04` transaction with an empty list is invalid, and encoding one traps, so the
+/// transaction is private and reachable only through [`DelegatingSweep::new`] — including when it
+/// comes back from the event log, where a trap would be an unupgradeable canister rather than a
+/// failed operation.
+#[derive(Clone, Eq, PartialEq, Debug, Encode)]
+#[cbor(transparent)]
+pub struct DelegatingSweep(#[n(0)] Eip7702TransactionRequest);
+
+impl DelegatingSweep {
+    /// The sweep `transaction`, or [`None`] if it installs no delegation.
+    pub fn new(transaction: Eip7702TransactionRequest) -> Option<Self> {
+        if transaction.authorization_list.is_empty() {
+            return None;
+        }
+        Some(Self(transaction))
+    }
+
+    pub fn transaction(&self) -> &Eip7702TransactionRequest {
+        &self.0
+    }
+
+    /// The same sweep at a different price: a fee bump leaves the authorization list alone, so what
+    /// it installs is unchanged.
+    fn with_price_and_amount(&self, price: TransactionPrice, amount: Wei) -> Self {
+        Self(self.0.with_price_and_amount(price, amount))
+    }
+}
+
+impl<'b, C> minicbor::Decode<'b, C> for DelegatingSweep {
+    fn decode(d: &mut minicbor::Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        Self::new(d.decode_with(ctx)?).ok_or_else(|| {
+            minicbor::decode::Error::message("EIP-7702 sweep with an empty authorization list")
+        })
+    }
 }
 
 impl SweepTransaction {
@@ -40,7 +77,7 @@ impl SweepTransaction {
         if authorizations.is_empty() {
             return Self::Eip1559(transaction);
         }
-        Self::Eip7702(Eip7702TransactionRequest {
+        let delegating = Eip7702TransactionRequest {
             chain_id: transaction.chain_id,
             nonce: transaction.nonce,
             max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
@@ -51,14 +88,17 @@ impl SweepTransaction {
             data: transaction.data,
             access_list: transaction.access_list,
             authorization_list: authorizations,
-        })
+        };
+        Self::Eip7702(
+            DelegatingSweep::new(delegating).expect("BUG: the authorization list is not empty"),
+        )
     }
 
     /// The delegations this transaction installs, empty for a plain EIP-1559 sweep.
     pub fn authorizations(&self) -> &[SignedAuthorization] {
         match self {
             Self::Eip1559(_) => &[],
-            Self::Eip7702(transaction) => &transaction.authorization_list,
+            Self::Eip7702(sweep) => &sweep.transaction().authorization_list,
         }
     }
 
@@ -66,7 +106,7 @@ impl SweepTransaction {
     fn as_signable(&self) -> &dyn SignableTransaction {
         match self {
             Self::Eip1559(transaction) => transaction,
-            Self::Eip7702(transaction) => transaction,
+            Self::Eip7702(sweep) => sweep.transaction(),
         }
     }
 }
@@ -127,9 +167,7 @@ impl SignableTransaction for SweepTransaction {
             Self::Eip1559(transaction) => {
                 Self::Eip1559(transaction.with_price_and_amount(price, amount))
             }
-            Self::Eip7702(transaction) => {
-                Self::Eip7702(transaction.with_price_and_amount(price, amount))
-            }
+            Self::Eip7702(sweep) => Self::Eip7702(sweep.with_price_and_amount(price, amount)),
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -695,6 +695,30 @@ mod sweep {
         );
     }
 
+    #[test]
+    #[should_panic(expected = "BUG: authorization for another chain")]
+    fn should_trap_on_an_authorization_for_another_chain() {
+        let other_chain = SignedAuthorization {
+            chain_id: sweep_transaction().chain_id + 1,
+            ..authorization()
+        };
+
+        let _ = SweepTransaction::new(sweep_transaction(), vec![other_chain]);
+    }
+
+    #[test]
+    fn should_accept_an_authorization_valid_on_every_chain() {
+        let any_chain = SignedAuthorization {
+            chain_id: 0,
+            ..authorization()
+        };
+
+        let sweep = SweepTransaction::new(sweep_transaction(), vec![any_chain.clone()]);
+
+        assert_eq!(sweep.transaction_type(), SET_CODE_TX_ID);
+        assert_eq!(sweep.authorizations(), &[any_chain]);
+    }
+
     fn sweep_transaction() -> Eip1559TransactionRequest {
         Eip1559TransactionRequest {
             chain_id: 11155111,

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -489,6 +489,135 @@ mod eip7702 {
     }
 }
 
+mod sweep {
+    use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
+    use crate::tx::{
+        AccessList, Eip1559TransactionRequest, SignableTransaction, SignedAuthorization,
+        SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
+        SweepTransaction, TransactionSignature,
+    };
+    use ethnum::u256;
+    use ic_ethereum_types::Address;
+    use std::str::FromStr;
+
+    const EIP1559_TX_ID: u8 = 2;
+    const SET_CODE_TX_ID: u8 = 4;
+
+    #[test]
+    fn should_sign_a_plain_sweep_as_its_eip1559_transaction() {
+        let transaction = sweep_transaction();
+        let sweep = SweepTransaction::new(transaction.clone(), vec![]);
+
+        assert_eq!(sweep.transaction_type(), EIP1559_TX_ID);
+        assert_eq!(sweep.authorizations(), &[]);
+        assert_eq!(sweep.hash(), transaction.hash());
+        assert_eq!(
+            SignedSweepTransaction::from((sweep, signature())).raw_transaction_hex_string(),
+            SignedEip1559TransactionRequest::from((transaction, signature()))
+                .raw_transaction_hex_string()
+        );
+    }
+
+    #[test]
+    fn should_sign_a_delegating_sweep_as_its_eip7702_transaction() {
+        let sweep = SweepTransaction::new(sweep_transaction(), vec![authorization()]);
+        let SweepTransaction::Eip7702(transaction) = sweep.clone() else {
+            panic!("BUG: a sweep with an authorization must be a type-0x04 transaction");
+        };
+
+        assert_eq!(sweep.transaction_type(), SET_CODE_TX_ID);
+        assert_eq!(sweep.authorizations(), &[authorization()]);
+        assert_eq!(sweep.hash(), transaction.hash());
+        assert_eq!(
+            SignedSweepTransaction::from((sweep, signature())).raw_transaction_hex_string(),
+            SignedEip7702TransactionRequest::from((transaction, signature()))
+                .raw_transaction_hex_string()
+        );
+    }
+
+    #[test]
+    fn should_cbor_encoding_of_sweep_transaction_be_stable() {
+        let expected: [(SweepTransaction, Vec<u8>); 2] = [
+            (
+                SweepTransaction::new(sweep_transaction(), vec![]),
+                vec![
+                    130, 0, 129, 137, 26, 0, 170, 54, 167, 6, 26, 89, 104, 47, 0, 26, 89, 134, 83,
+                    205, 26, 0, 1, 134, 160, 84, 180, 75, 94, 117, 106, 137, 71, 117, 252, 50, 237,
+                    223, 51, 20, 187, 27, 25, 68, 220, 52, 0, 66, 18, 52, 128,
+                ],
+            ),
+            (
+                SweepTransaction::new(sweep_transaction(), vec![authorization()]),
+                vec![
+                    130, 1, 129, 138, 26, 0, 170, 54, 167, 6, 26, 89, 104, 47, 0, 26, 89, 134, 83,
+                    205, 26, 0, 1, 134, 160, 84, 180, 75, 94, 117, 106, 137, 71, 117, 252, 50, 237,
+                    223, 51, 20, 187, 27, 25, 68, 220, 52, 0, 66, 18, 52, 128, 129, 134, 26, 0,
+                    170, 54, 167, 84, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                    0, 244, 194, 88, 32, 66, 85, 108, 79, 42, 63, 78, 78, 99, 156, 202, 82, 77, 29,
+                    167, 14, 96, 136, 20, 23, 212, 100, 62, 83, 130, 237, 17, 10, 82, 113, 158,
+                    175, 194, 88, 32, 23, 47, 89, 26, 42, 118, 61, 11, 214, 177, 61, 4, 45, 140,
+                    94, 182, 110, 135, 241, 41, 201, 220, 119, 173, 166, 107, 96, 65, 1, 45, 178,
+                    179,
+                ],
+            ),
+        ];
+        for (sweep, expected_encoding) in expected {
+            let mut encoded: Vec<u8> = Vec::new();
+            minicbor::encode(&sweep, &mut encoded).unwrap();
+
+            assert_eq!(encoded, expected_encoding);
+
+            let decoded: SweepTransaction = minicbor::decode(&encoded).unwrap();
+            assert_eq!(decoded, sweep);
+        }
+    }
+
+    fn sweep_transaction() -> Eip1559TransactionRequest {
+        Eip1559TransactionRequest {
+            chain_id: 11155111,
+            nonce: TransactionNonce::from(6_u8),
+            max_priority_fee_per_gas: WeiPerGas::new(0x59682f00),
+            max_fee_per_gas: WeiPerGas::new(0x598653cd),
+            gas_limit: GasAmount::new(100_000),
+            destination: Address::from_str("0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34").unwrap(),
+            amount: Wei::ZERO,
+            data: hex::decode("1234").unwrap(),
+            access_list: AccessList::new(),
+        }
+    }
+
+    fn authorization() -> SignedAuthorization {
+        SignedAuthorization {
+            chain_id: 11155111,
+            delegate: Address::from_str("0x0202020202020202020202020202020202020202").unwrap(),
+            nonce: TransactionNonce::ZERO,
+            y_parity: false,
+            r: u256::from_str_hex(
+                "0x42556c4f2a3f4e4e639cca524d1da70e60881417d4643e5382ed110a52719eaf",
+            )
+            .unwrap(),
+            s: u256::from_str_hex(
+                "0x172f591a2a763d0bd6b13d042d8c5eb66e87f129c9dc77ada66b6041012db2b3",
+            )
+            .unwrap(),
+        }
+    }
+
+    fn signature() -> TransactionSignature {
+        TransactionSignature {
+            signature_y_parity: true,
+            r: u256::from_str_hex(
+                "0x7d097b81dc8bf5ad313f8d6656146d4723d0e6bb3fb35f1a709e6a3d4426c0f3",
+            )
+            .unwrap(),
+            s: u256::from_str_hex(
+                "0x4f8a618d959e7d96e19156f0f5f2ed321b34e2004a0c8fdb7f02bc7d08b74441",
+            )
+            .unwrap(),
+        }
+    }
+}
+
 fn arb_transaction_price() -> impl Strategy<Value = TransactionPrice> {
     use crate::numeric::WeiPerGas;
     use crate::test_fixtures::arb::arb_checked_amount_of;

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -427,6 +427,33 @@ mod eip7702 {
     }
 
     #[test]
+    fn should_refuse_to_decode_a_transaction_without_authorizations() {
+        use rlp::{Rlp, RlpStream};
+
+        const AUTHORIZATION_LIST_INDEX: usize = 9;
+        const FIELD_COUNT: usize = 13;
+
+        let raw_transaction = sample_signed_transaction().raw_transaction_bytes();
+        let (transaction_type, payload) = raw_transaction.split_first().unwrap();
+        let fields = Rlp::new(payload);
+        let mut stream = RlpStream::new_list(FIELD_COUNT);
+        for index in 0..FIELD_COUNT {
+            if index == AUTHORIZATION_LIST_INDEX {
+                stream.begin_list(0);
+            } else {
+                stream.append_raw(fields.at(index).unwrap().as_raw(), 1);
+            }
+        }
+        let mut without_authorizations = vec![*transaction_type];
+        without_authorizations.extend(stream.out());
+
+        assert_matches!(
+            SignedEip7702TransactionRequest::decode(&without_authorizations),
+            Err(e) if e.contains("non-empty authorization list")
+        );
+    }
+
+    #[test]
     fn should_refuse_to_decode_an_empty_transaction() {
         assert_matches!(
             SignedEip7702TransactionRequest::decode(&[]),

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -571,10 +571,12 @@ mod eip7702 {
 mod sweep {
     use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
     use crate::tx::{
-        AccessList, Eip1559TransactionRequest, SignableTransaction, SignedAuthorization,
-        SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
-        SweepTransaction, TransactionSignature,
+        AccessList, DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest,
+        SignableTransaction, SignedAuthorization, SignedEip1559TransactionRequest,
+        SignedEip7702TransactionRequest, SignedSweepTransaction, SweepTransaction,
+        TransactionSignature,
     };
+    use assert_matches::assert_matches;
     use ethnum::u256;
     use ic_ethereum_types::Address;
     use std::str::FromStr;
@@ -606,6 +608,7 @@ mod sweep {
 
         assert_eq!(sweep.transaction_type(), SET_CODE_TX_ID);
         assert_eq!(sweep.authorizations(), &[authorization()]);
+        let transaction = transaction.transaction().clone();
         assert_eq!(sweep.hash(), transaction.hash());
         assert_eq!(
             SignedSweepTransaction::from((sweep, signature())).raw_transaction_hex_string(),
@@ -649,6 +652,47 @@ mod sweep {
             let decoded: SweepTransaction = minicbor::decode(&encoded).unwrap();
             assert_eq!(decoded, sweep);
         }
+    }
+
+    #[test]
+    fn should_refuse_a_delegating_sweep_that_installs_nothing() {
+        let SweepTransaction::Eip7702(sweep) =
+            SweepTransaction::new(sweep_transaction(), vec![authorization()])
+        else {
+            panic!("BUG: a sweep with an authorization must be a type-0x04 transaction");
+        };
+
+        assert_eq!(
+            DelegatingSweep::new(Eip7702TransactionRequest {
+                authorization_list: vec![],
+                ..sweep.transaction().clone()
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn should_refuse_to_decode_a_delegating_sweep_that_installs_nothing() {
+        let SweepTransaction::Eip7702(sweep) =
+            SweepTransaction::new(sweep_transaction(), vec![authorization()])
+        else {
+            panic!("BUG: a sweep with an authorization must be a type-0x04 transaction");
+        };
+        let empty = Eip7702TransactionRequest {
+            authorization_list: vec![],
+            ..sweep.transaction().clone()
+        };
+        let encoded = minicbor::to_vec(&empty).unwrap();
+
+        assert_matches!(
+            minicbor::decode::<DelegatingSweep>(&encoded),
+            Err(e) if e.to_string().contains("empty authorization list")
+        );
+        assert_eq!(
+            minicbor::decode::<DelegatingSweep>(&minicbor::to_vec(sweep.transaction()).unwrap())
+                .unwrap(),
+            sweep
+        );
     }
 
     fn sweep_transaction() -> Eip1559TransactionRequest {

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -222,9 +222,10 @@ fn should_cbor_encoding_be_stable() {
 mod eip7702 {
     use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
     use crate::tx::{
-        AccessList, Authorization, Eip7702TransactionRequest, SignedAuthorization,
-        SignedEip7702TransactionRequest, TransactionSignature,
+        AccessList, AccessListItem, Authorization, Eip7702TransactionRequest, SignedAuthorization,
+        SignedEip7702TransactionRequest, StorageKey, TransactionSignature,
     };
+    use assert_matches::assert_matches;
     use ethnum::u256;
     use ic_ethereum_types::Address;
     use std::str::FromStr;
@@ -399,6 +400,54 @@ mod eip7702 {
         assert_eq!(recovered.as_bytes(), authority.as_ref());
     }
 
+    #[test]
+    fn should_decode_the_raw_bytes_it_encoded() {
+        for signed_tx in [
+            sample_signed_transaction(),
+            sample_signed_transaction_with_access_list(),
+        ] {
+            let decoded =
+                SignedEip7702TransactionRequest::decode(&signed_tx.raw_transaction_bytes())
+                    .unwrap();
+
+            assert_eq!(decoded, signed_tx);
+            assert_eq!(decoded.hash(), signed_tx.hash());
+        }
+    }
+
+    #[test]
+    fn should_refuse_to_decode_a_transaction_of_another_type() {
+        let mut raw_transaction = sample_signed_transaction().raw_transaction_bytes();
+        raw_transaction[0] = 2;
+
+        assert_matches!(
+            SignedEip7702TransactionRequest::decode(&raw_transaction),
+            Err(e) if e.contains("got type 2")
+        );
+    }
+
+    #[test]
+    fn should_refuse_to_decode_an_empty_transaction() {
+        assert_matches!(
+            SignedEip7702TransactionRequest::decode(&[]),
+            Err(e) if e.contains("empty transaction")
+        );
+    }
+
+    /// The sample transaction carries an empty access list, so decoding it exercises neither the
+    /// nested storage keys nor the address inside an access-list item.
+    fn sample_signed_transaction_with_access_list() -> SignedEip7702TransactionRequest {
+        let signed_tx = sample_signed_transaction();
+        let transaction = Eip7702TransactionRequest {
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::from_str("0x0303030303030303030303030303030303030303").unwrap(),
+                storage_keys: vec![StorageKey([0x11; 32]), StorageKey([0x22; 32])],
+            }]),
+            ..signed_tx.transaction().clone()
+        };
+        SignedEip7702TransactionRequest::from((transaction, sample_transaction_signature()))
+    }
+
     fn sample_signed_transaction() -> SignedEip7702TransactionRequest {
         let authorization = SignedAuthorization {
             chain_id: 6,
@@ -426,7 +475,11 @@ mod eip7702 {
             access_list: AccessList::new(),
             authorization_list: vec![authorization],
         };
-        let signature = TransactionSignature {
+        SignedEip7702TransactionRequest::from((transaction, sample_transaction_signature()))
+    }
+
+    fn sample_transaction_signature() -> TransactionSignature {
+        TransactionSignature {
             signature_y_parity: false,
             r: u256::from_str_hex(
                 "0xd93fc9ae934d4f72db91cb149e7e84b50ca83b5a8a7b873b0fdb009546e3af47",
@@ -436,8 +489,7 @@ mod eip7702 {
                 "0x786bfaf31af61eea6471dbb1bec7d94f73fb90887e4f04d0e9b85676c47ab02a",
             )
             .unwrap(),
-        };
-        SignedEip7702TransactionRequest::from((transaction, signature))
+        }
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -6,8 +6,9 @@ use ic_cketh_minter::checked_amount::CheckedAmountOf;
 use ic_cketh_minter::endpoints::events::{
     AccessListItem as CandidAccessListItem, Event as CandidEvent, EventSource as CandidEventSource,
     GetEventsResult, ReimbursementIndex as CandidReimbursementIndex,
+    SignedAuthorization as CandidSignedAuthorization,
     TransactionReceipt as CandidTransactionReceipt, TransactionStatus as CandidTransactionStatus,
-    UnsignedTransaction,
+    UnsignedSweeperTransaction, UnsignedTransaction,
 };
 use ic_cketh_minter::erc20::CkErc20Token;
 use ic_cketh_minter::eth_logs::{
@@ -23,7 +24,9 @@ use ic_cketh_minter::state::transactions::{
 };
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
-    AccessList, AccessListItem, Eip1559TransactionRequest, SignedEip1559TransactionRequest,
+    AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
+    SignedEip1559TransactionRequest, SignedSweepTransaction, SweepTransaction,
+    TransactionSignature,
 };
 use ic_stable_structures::Memory;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
@@ -127,7 +130,9 @@ fn map_unsigned_transaction(tx: UnsignedTransaction) -> Eip1559TransactionReques
     }
 }
 
-fn map_signed_transaction(raw_transaction: &str) -> SignedEip1559TransactionRequest {
+fn decode_signed_transaction(
+    raw_transaction: &str,
+) -> (Eip1559TransactionRequest, TransactionSignature) {
     use ethers_core::types::transaction::eip2718::TypedTransaction;
     use ethnum::u256;
     use ic_ethereum_types::Address;
@@ -196,7 +201,36 @@ fn map_signed_transaction(raw_transaction: &str) -> SignedEip1559TransactionRequ
         s: map_ethers_u256(decoded_sig.s),
     };
 
-    SignedEip1559TransactionRequest::from((request, signature))
+    (request, signature)
+}
+fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
+    let (transaction, signature) = decode_signed_transaction(raw_transaction);
+    SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
+}
+
+fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTransaction {
+    SweepTransaction::new(
+        map_unsigned_transaction(tx.transaction),
+        map_authorizations(tx.authorization_list),
+    )
+}
+
+fn map_authorizations(authorizations: Vec<CandidSignedAuthorization>) -> Vec<SignedAuthorization> {
+    fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
+        ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
+    }
+
+    authorizations
+        .into_iter()
+        .map(|authorization| SignedAuthorization {
+            chain_id: authorization.chain_id.0.to_u64().unwrap(),
+            delegate: authorization.delegate.parse().unwrap(),
+            nonce: authorization.nonce.try_into().unwrap(),
+            y_parity: authorization.y_parity,
+            r: map_signature_component(&authorization.r),
+            s: map_signature_component(&authorization.s),
+        })
+        .collect()
 }
 
 fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
@@ -305,7 +339,9 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 raw_transaction,
             } => ET::SignedTransaction {
                 withdrawal_id: map_nat(withdrawal_id),
-                transaction: map_signed_transaction(&raw_transaction),
+                transaction: SignedEip1559TransactionRequest::from(decode_signed_transaction(
+                    &raw_transaction,
+                )),
             },
             EventPayload::ReplacedTransaction {
                 withdrawal_id,
@@ -328,6 +364,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 data,
                 max_transaction_fee,
                 created_at,
+                authorizations,
             } => ET::AcceptedSweepRequest(SweepRequest {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
@@ -335,27 +372,28 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 data: data.into_vec(),
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,
+                authorizations: map_authorizations(authorizations),
             }),
             EventPayload::CreatedSweeperTransaction {
                 sweep_id,
                 transaction,
             } => ET::CreatedSweeperTransaction {
                 sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                transaction: map_unsigned_transaction(transaction),
+                transaction: map_unsigned_sweeper_transaction(transaction),
             },
             EventPayload::SignedSweeperTransaction {
                 sweep_id,
                 raw_transaction,
             } => ET::SignedSweeperTransaction {
                 sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                transaction: map_signed_transaction(&raw_transaction),
+                transaction: map_signed_sweep_transaction(&raw_transaction),
             },
             EventPayload::ReplacedSweeperTransaction {
                 sweep_id,
                 transaction,
             } => ET::ReplacedSweeperTransaction {
                 sweep_id: SweepId(sweep_id.0.to_u64().unwrap()),
-                transaction: map_unsigned_transaction(transaction),
+                transaction: map_unsigned_sweeper_transaction(transaction),
             },
             EventPayload::FinalizedSweeperTransaction {
                 sweep_id,

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -25,8 +25,8 @@ use ic_cketh_minter::state::transactions::{
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
     AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
-    SignedEip1559TransactionRequest, SignedSweepTransaction, SweepTransaction,
-    TransactionSignature,
+    SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
+    SweepTransaction, TransactionSignature,
 };
 use ic_stable_structures::Memory;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
@@ -204,6 +204,18 @@ fn decode_signed_transaction(
     (request, signature)
 }
 fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
+    const EIP_7702_TRANSACTION_TYPE: u8 = 4;
+
+    let raw_bytes = hex::decode(raw_transaction.trim_start_matches("0x"))
+        .expect("BUG: sent sweep transaction is not hex-encoded");
+    if raw_bytes.first() == Some(&EIP_7702_TRANSACTION_TYPE) {
+        let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
+            .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
+        return SignedSweepTransaction::from((
+            SweepTransaction::Eip7702(signed.transaction().clone()),
+            signed.signature().clone(),
+        ));
+    }
     let (transaction, signature) = decode_signed_transaction(raw_transaction);
     SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
 }

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -24,7 +24,7 @@ use ic_cketh_minter::state::transactions::{
 };
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
-    AccessList, AccessListItem, Eip1559TransactionRequest, SignedAuthorization,
+    AccessList, AccessListItem, DelegatingSweep, Eip1559TransactionRequest, SignedAuthorization,
     SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
     SweepTransaction, TransactionSignature,
 };
@@ -214,7 +214,10 @@ fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction
         let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
             .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
         return SignedSweepTransaction::from((
-            SweepTransaction::Eip7702(signed.transaction().clone()),
+            SweepTransaction::Eip7702(
+                DelegatingSweep::new(signed.transaction().clone())
+                    .expect("BUG: sent EIP-7702 sweep installs no delegation"),
+            ),
             signed.signature().clone(),
         ));
     }

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -204,9 +204,11 @@ fn decode_signed_transaction(
     (request, signature)
 }
 fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
+    use std::str::FromStr;
+
     const EIP_7702_TRANSACTION_TYPE: u8 = 4;
 
-    let raw_bytes = hex::decode(raw_transaction.trim_start_matches("0x"))
+    let raw_bytes = ethers_core::types::Bytes::from_str(raw_transaction)
         .expect("BUG: sent sweep transaction is not hex-encoded");
     if raw_bytes.first() == Some(&EIP_7702_TRANSACTION_TYPE) {
         let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)


### PR DESCRIPTION
## Why

- A deposit address holds ERC-20 tokens but no code, so it cannot sweep itself.
- The minter delegates it to the sweeper contract with an EIP-7702 authorization.
- The cheapest carrier for that authorization is the sweep that needs it: the first sweep touching an address installs the delegation on the way.
- The delegation persists, so every later sweep of that address is a plain EIP-1559 transaction.
- `deposit_from_cex_demo` measures 94'932 gas for the first sweep of an address against 63'252 for the next.

## What

- The sweeper lane sends either transaction type, and a sweep carries the signed authorizations it must install.
- Two no-op refactorings come first: finalizing and fee-bumping stop being EIP-1559-only.
- That is also what gives EIP-7702 fee-bumping for free, with no machinery of its own.
- Authorizations are held in the request rather than derived while the transaction is built, so no replay and no fee bump ever re-signs one.
- An authorization covers the chain, the delegate and the authority's nonce — nothing of the outer transaction.
- A single place decides which type a sweep becomes, from whether anything is left to install.

## Scope

- Nothing enqueues a sweep yet, so nothing builds an authorization in production.
- Choosing which addresses still need delegating belongs to the sweep-queue source, along with reading each address' delegation from the chain.
- Hence the request carries signed authorizations rather than a "needs delegation" flag.
- The batch-dependent gas limit a delegating sweep needs is deferred with it: #11237's flat 100'000 does not cover one.

## Candid compatibility

- Needs the `CI_OVERRIDE_DIDC_CHECK` label.
- Two sweeper event cases change the type of their `transaction` field, and a third gains a required field.
- Neither is a Candid subtype on a returned variant.
- Those cases only reached the interface with #11144 and have never been released, so no deployed canister has emitted them and no client can be reading them.



[DEFI-2917]: https://dfinity.atlassian.net/browse/DEFI-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

