### PR TITLE
feat(cketh): expose per-token minimum deposit amounts in MinterInfo

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -250,6 +250,10 @@ type MinterInfo = record {
     // This might be less that the actual amount available on the `minter_address()`.
     erc20_balances : opt vec record { erc20_contract_address: text; balance: nat};
 
+    // Minimum balance, in each token's own units, that a deposit address must hold for the
+    // balance scan to treat it as a deposit candidate. A smaller balance is never detected.
+    minimum_deposit_amounts : opt vec record { erc20_contract_address: text; minimum_deposit_amount: nat};
+
     // Last scraped block number for logs of the ETH helper contract.
     last_eth_scraped_block_number: opt nat;
 

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -196,8 +196,8 @@ fn scan_outcome(
 }
 
 /// Minimum balance for `token` to count as a scan candidate; a token absent from
-/// [`MIN_DEPOSITS`] never counts.
-fn min_deposit(token: &Address) -> Erc20Value {
+/// `MIN_DEPOSITS` never counts.
+pub fn min_deposit(token: &Address) -> Erc20Value {
     MIN_DEPOSITS
         .iter()
         .find(|(contract, _)| contract == token)

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -63,6 +63,12 @@ pub struct Erc20Balance {
     pub balance: Nat,
 }
 
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, CandidType, Deserialize)]
+pub struct Erc20MinimumDeposit {
+    pub erc20_contract_address: String,
+    pub minimum_deposit_amount: Nat,
+}
+
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct MinterInfo {
     pub minter_address: Option<String>,
@@ -80,6 +86,7 @@ pub struct MinterInfo {
     pub eth_balance: Option<Nat>,
     pub last_gas_fee_estimate: Option<GasFeeEstimate>,
     pub erc20_balances: Option<Vec<Erc20Balance>>,
+    pub minimum_deposit_amounts: Option<Vec<Erc20MinimumDeposit>>,
     pub last_eth_scraped_block_number: Option<Nat>,
     pub last_erc20_scraped_block_number: Option<Nat>,
     pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -4,7 +4,7 @@ use dashboard::DashboardTemplate;
 use ic_canister_log::log;
 use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
 use ic_cketh_minter::address::{AddressValidationError, validate_address_as_destination};
-use ic_cketh_minter::balance_scan::balance_scan;
+use ic_cketh_minter::balance_scan::{balance_scan, min_deposit};
 use ic_cketh_minter::deposit::{refresh_latest_block_height, scrape_logs};
 use ic_cketh_minter::endpoints::ckerc20::{
     RetrieveErc20Request, WithdrawErc20Arg, WithdrawErc20Error,
@@ -15,8 +15,9 @@ use ic_cketh_minter::endpoints::events::{
 use ic_cketh_minter::endpoints::{
     AddCkErc20Token, DecodeLedgerMemoArgs, DecodeLedgerMemoResult, DepositErc20Arg,
     DepositErc20Error, DepositErc20Response, DepositMode, Eip1559TransactionPrice,
-    Eip1559TransactionPriceArg, Erc20Balance, GasFeeEstimate, MinterInfo, RetrieveEthRequest,
-    RetrieveEthStatus, WithdrawalArg, WithdrawalDetail, WithdrawalError, WithdrawalSearchParameter,
+    Eip1559TransactionPriceArg, Erc20Balance, Erc20MinimumDeposit, GasFeeEstimate, MinterInfo,
+    RetrieveEthRequest, RetrieveEthStatus, WithdrawalArg, WithdrawalDetail, WithdrawalError,
+    WithdrawalSearchParameter,
 };
 use ic_cketh_minter::erc20::CkTokenSymbol;
 use ic_cketh_minter::eth_logs::{
@@ -284,26 +285,34 @@ async fn eip_1559_transaction_price(
 #[query]
 async fn get_minter_info() -> MinterInfo {
     read_state(|s| {
-        let (erc20_balances, supported_ckerc20_tokens) = if s.is_ckerc20_feature_active() {
-            let (balances, tokens) = s
-                .supported_ck_erc20_tokens()
-                .map(|token| {
-                    (
-                        Erc20Balance {
-                            erc20_contract_address: token.erc20_contract_address.to_string(),
-                            balance: s
-                                .erc20_balances
-                                .balance_of(&token.erc20_contract_address)
-                                .into(),
-                        },
-                        endpoints::CkErc20Token::from(token),
-                    )
-                })
-                .unzip();
-            (Some(balances), Some(tokens))
-        } else {
-            (None, None)
-        };
+        let (erc20_balances, supported_ckerc20_tokens, minimum_deposit_amounts) =
+            if s.is_ckerc20_feature_active() {
+                let (balances, tokens) = s
+                    .supported_ck_erc20_tokens()
+                    .map(|token| {
+                        (
+                            Erc20Balance {
+                                erc20_contract_address: token.erc20_contract_address.to_string(),
+                                balance: s
+                                    .erc20_balances
+                                    .balance_of(&token.erc20_contract_address)
+                                    .into(),
+                            },
+                            endpoints::CkErc20Token::from(token),
+                        )
+                    })
+                    .unzip();
+                let minimum_deposit_amounts = s
+                    .supported_ck_erc20_tokens()
+                    .map(|token| Erc20MinimumDeposit {
+                        erc20_contract_address: token.erc20_contract_address.to_string(),
+                        minimum_deposit_amount: min_deposit(&token.erc20_contract_address).into(),
+                    })
+                    .collect();
+                (Some(balances), Some(tokens), Some(minimum_deposit_amounts))
+            } else {
+                (None, None, None)
+            };
 
         let LogScrapingInfo {
             eth_helper_contract_address,
@@ -335,6 +344,7 @@ async fn get_minter_info() -> MinterInfo {
                 },
             ),
             erc20_balances,
+            minimum_deposit_amounts,
             last_eth_scraped_block_number,
             last_erc20_scraped_block_number,
             last_deposit_with_subaccount_scraped_block_number,

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -4,7 +4,7 @@ use ic_cketh_minter::blocklist::SAMPLE_BLOCKED_ADDRESS;
 use ic_cketh_minter::endpoints::CandidBlockTag::Finalized;
 use ic_cketh_minter::endpoints::events::{EventPayload, EventSource};
 use ic_cketh_minter::endpoints::{
-    AddCkErc20Token, CkErc20Token, Erc20Balance, MinterInfo, WithdrawalDetail,
+    AddCkErc20Token, CkErc20Token, Erc20Balance, Erc20MinimumDeposit, MinterInfo, WithdrawalDetail,
     WithdrawalSearchParameter,
 };
 use ic_cketh_minter::memo::MintMemo;
@@ -2055,6 +2055,15 @@ fn should_retrieve_minter_info() {
         })
         .collect();
 
+    const USD_STABLECOIN_MINIMUM_DEPOSIT: u64 = 10_000_000;
+    let minimum_deposit_amounts = supported_ckerc20_tokens
+        .iter()
+        .map(|token| Erc20MinimumDeposit {
+            erc20_contract_address: token.erc20_contract_address.clone(),
+            minimum_deposit_amount: Nat::from(USD_STABLECOIN_MINIMUM_DEPOSIT),
+        })
+        .collect();
+
     let info_at_start = ckerc20.cketh.get_minter_info();
     assert_eq!(
         info_at_start,
@@ -2079,6 +2088,7 @@ fn should_retrieve_minter_info() {
             eth_balance: Some(Nat::from(0_u8)),
             last_gas_fee_estimate: None,
             erc20_balances: Some(erc20_balances),
+            minimum_deposit_amounts: Some(minimum_deposit_amounts),
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_deposit_with_subaccount_scraped_block_number: Some(

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1220,6 +1220,7 @@ fn should_retrieve_minter_info() {
             eth_balance: Some(Nat::from(0_u8)),
             last_gas_fee_estimate: None,
             erc20_balances: None,
+            minimum_deposit_amounts: None,
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_deposit_with_subaccount_scraped_block_number: Some(


### PR DESCRIPTION
Balance-scan filter 1 only treats a deposit address as a scan candidate once its balance reaches a per-token minimum, so a smaller deposit is silently never detected and never credited. For the CEX deposit flow that threshold was invisible: a user could send a small amount to their deposit address, see nothing happen, and have no way to find out why.

`get_minter_info` now reports `minimum_deposit_amounts` — the minimum for each supported ckERC20 token, in that token's own units — so users and frontends can show the threshold alongside the deposit address. It is `null` while the ckERC20 feature is inactive, matching the existing per-token fields.

The thresholds are still the hard-coded rate snapshot; they will start tracking live prices once DEFI-2961's daily exchange-rate refresh lands, and this endpoint will reflect that automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
