### PR TITLE
fix(cketh): recover a signature against the key that made it

### DIFF
--- a/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
@@ -104,13 +104,32 @@ fn derive_address(
     chain_code: &[u8; 32],
     derivation_path: Vec<ByteBuf>,
 ) -> Address {
+    ecdsa_public_key_to_address(&derive_public_key(
+        master_public_key,
+        chain_code,
+        &derivation_path,
+    ))
+}
+
+/// The public key the minter signs with under `derivation_path`, derived non-hardened from its
+/// master threshold-ECDSA key.
+///
+/// Every address in the derivation tree is this key's address, and every signature the minter makes
+/// under that path verifies against it — which is why recovering a signature's parity must use it
+/// and not the master key (an empty path derives to the master key itself, so the main address is
+/// the one case where the two coincide).
+pub fn derive_public_key(
+    master_public_key: &PublicKey,
+    chain_code: &[u8; 32],
+    derivation_path: &[ByteBuf],
+) -> PublicKey {
     let derivation_path = DerivationPath::new(
         derivation_path
-            .into_iter()
-            .map(|index| DerivationIndex(index.into_vec()))
+            .iter()
+            .map(|index| DerivationIndex(index.to_vec()))
             .collect(),
     );
-    let (derived_public_key, _derived_chain_code) =
-        master_public_key.derive_subkey_with_chain_code(&derivation_path, chain_code);
-    ecdsa_public_key_to_address(&derived_public_key)
+    master_public_key
+        .derive_subkey_with_chain_code(&derivation_path, chain_code)
+        .0
 }

--- a/rs/ethereum/cketh/minter/src/deposit_address/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/tests.rs
@@ -141,3 +141,93 @@ fn master_private_key() -> (PrivateKey, [u8; 32]) {
 fn account(owner: Principal, subaccount: Option<Subaccount>) -> Account {
     Account { owner, subaccount }
 }
+
+mod derive_public_key {
+    use crate::deposit_address::{
+        DepositAddressSchema, deposit_address, derive_public_key, sweeper_derivation_path,
+    };
+    use crate::{MAIN_DERIVATION_PATH, address::ecdsa_public_key_to_address};
+    use candid::Principal;
+    use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
+    use icrc_ledger_types::icrc1::account::Account;
+    use serde_bytes::ByteBuf;
+
+    const CHAIN_CODE: [u8; 32] = [7_u8; 32];
+
+    #[test]
+    fn should_derive_the_key_whose_address_is_the_deposit_address() {
+        let master = master_private_key().public_key();
+        let account = account();
+
+        for schema in [DepositAddressSchema::CkErc20, DepositAddressSchema::CkEth] {
+            let path = super::super::deposit_derivation_path(schema, &account);
+            let derived = derive_public_key(&master, &CHAIN_CODE, &path);
+
+            assert_eq!(
+                &ecdsa_public_key_to_address(&derived),
+                deposit_address(&master, &CHAIN_CODE, schema, &account).as_address()
+            );
+        }
+    }
+
+    #[test]
+    fn should_derive_the_master_key_for_the_main_address() {
+        let master = master_private_key().public_key();
+
+        assert_eq!(
+            derive_public_key(&master, &CHAIN_CODE, &MAIN_DERIVATION_PATH),
+            master
+        );
+    }
+
+    /// A signature made under a derivation path only recovers against the key derived along that
+    /// same path: recovering it against the master key finds no parity bit at all, which is why
+    /// `compute_recovery_id` derives before recovering.
+    #[test]
+    fn should_recover_a_derived_signature_only_against_the_derived_key() {
+        let master = master_private_key();
+        let digest = [0x42_u8; 32];
+
+        for path in [
+            super::super::deposit_derivation_path(DepositAddressSchema::CkErc20, &account()),
+            sweeper_derivation_path(),
+        ] {
+            let (signing_key, _chain_code) =
+                master.derive_subkey_with_chain_code(&to_derivation_path(&path), &CHAIN_CODE);
+            let signature = signing_key.sign_digest_with_ecdsa(&digest);
+
+            let derived_public_key = derive_public_key(&master.public_key(), &CHAIN_CODE, &path);
+            assert_eq!(derived_public_key, signing_key.public_key());
+            assert!(
+                derived_public_key
+                    .try_recovery_from_digest(&digest, &signature)
+                    .is_ok()
+            );
+            assert!(
+                master
+                    .public_key()
+                    .try_recovery_from_digest(&digest, &signature)
+                    .is_err()
+            );
+        }
+    }
+
+    fn master_private_key() -> PrivateKey {
+        PrivateKey::generate_from_seed(b"ck-deposit-address-derivation")
+    }
+
+    fn account() -> Account {
+        Account {
+            owner: Principal::from_slice(&[1, 2, 3, 4]),
+            subaccount: Some([9_u8; 32]),
+        }
+    }
+
+    fn to_derivation_path(path: &[ByteBuf]) -> DerivationPath {
+        DerivationPath::new(
+            path.iter()
+                .map(|index| DerivationIndex(index.to_vec()))
+                .collect(),
+        )
+    }
+}

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -29,7 +29,6 @@ use crate::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use ic_management_canister_types_private::DerivationPath;
 
 /// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
 /// with the real delegate sweep call.
@@ -189,7 +188,7 @@ async fn sign_transactions_batch() {
             .map(|(sweep_id, tx)| async move {
                 (
                     sweep_id,
-                    crate::tx::sign(tx, DerivationPath::new(sweeper_derivation_path())).await,
+                    crate::tx::sign(tx, sweeper_derivation_path()).await,
                 )
             }),
     )

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -13,6 +13,7 @@ use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 use minicbor::{Decode, Encode};
 use rlp::{Rlp, RlpStream};
+use serde_bytes::ByteBuf;
 
 const SET_CODE_TX_ID: u8 = 4;
 const EIP7702_AUTHORIZATION_MAGIC: u8 = 5;
@@ -82,10 +83,7 @@ impl Authorization {
         Hash(ic_sha3::Keccak256::hash(bytes))
     }
 
-    pub async fn sign(
-        self,
-        derivation_path: DerivationPath,
-    ) -> Result<SignedAuthorization, String> {
+    pub async fn sign(self, derivation_path: Vec<ByteBuf>) -> Result<SignedAuthorization, String> {
         if self.chain_id == 0 {
             return Err(
                 "BUG: EIP-7702 authorization chain_id must be set explicitly and never 0"
@@ -94,10 +92,14 @@ impl Authorization {
         }
         let hash = self.hash();
         let key_name = read_state(|s| s.ecdsa_key_name.clone());
-        let signature = crate::management::sign_with_ecdsa(key_name, derivation_path, hash.0)
-            .await
-            .map_err(|e| format!("failed to sign authorization: {e}"))?;
-        let recid = compute_recovery_id(&hash, &signature).await;
+        let signature = crate::management::sign_with_ecdsa(
+            key_name,
+            DerivationPath::new(derivation_path.clone()),
+            hash.0,
+        )
+        .await
+        .map_err(|e| format!("failed to sign authorization: {e}"))?;
+        let recid = compute_recovery_id(&hash, &signature, &derivation_path).await;
         if recid.is_x_reduced() {
             return Err("BUG: affine x-coordinate of r is reduced which is so unlikely to happen that it's probably a bug".to_string());
         }

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -19,6 +19,7 @@ pub use signed::{SignableTransaction, Signed, TransactionSignature, sign};
 pub use sweep::{DelegatingSweep, SignedSweepTransaction, SweepTransaction};
 
 use crate::{
+    deposit_address::derive_public_key,
     eth_rpc::Hash,
     eth_rpc_client::{
         MIN_ATTACHED_CYCLES, MultiCallError, StrictMajorityByKey, ToReducedWithStrategy, rpc_client,
@@ -26,7 +27,7 @@ use crate::{
     guard::TimerGuard,
     logs::{DEBUG, INFO},
     numeric::{GasAmount, Wei, WeiPerGas},
-    state::{TaskType, lazy_call_ecdsa_public_key, mutate_state, read_state},
+    state::{TaskType, lazy_call_ecdsa_public_key_with_chain_code, mutate_state, read_state},
 };
 use candid::Nat;
 use ethnum::u256;
@@ -36,6 +37,7 @@ use ic_ethereum_types::Address;
 use ic_secp256k1::RecoveryId;
 use minicbor::{Decode, Encode};
 use rlp::RlpStream;
+use serde_bytes::ByteBuf;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Decode, Encode)]
 #[cbor(transparent)]
@@ -177,8 +179,17 @@ pub fn encode_u256<T: Into<u256>>(stream: &mut RlpStream, value: T) {
     stream.append(&value.to_be_bytes()[leading_empty_bytes..].as_ref());
 }
 
-async fn compute_recovery_id(digest: &Hash, signature: &[u8]) -> RecoveryId {
-    let ecdsa_public_key = lazy_call_ecdsa_public_key().await;
+/// The parity bit of a signature made under `derivation_path`.
+///
+/// Recovery only succeeds against the public key that produced the signature, so the master key is
+/// derived along the same path first.
+async fn compute_recovery_id(
+    digest: &Hash,
+    signature: &[u8],
+    derivation_path: &[ByteBuf],
+) -> RecoveryId {
+    let (master_public_key, chain_code) = lazy_call_ecdsa_public_key_with_chain_code().await;
+    let ecdsa_public_key = derive_public_key(&master_public_key, &chain_code, derivation_path);
     debug_assert!(
         ecdsa_public_key.verify_signature_prehashed(&digest.0, signature),
         "failed to verify signature prehashed, digest: {:?}, signature: {:?}, public_key: {:?}",

--- a/rs/ethereum/cketh/minter/src/tx/signed.rs
+++ b/rs/ethereum/cketh/minter/src/tx/signed.rs
@@ -9,6 +9,7 @@ use ic_ethereum_types::Address;
 use ic_management_canister_types_private::DerivationPath;
 use minicbor::{Decode, Encode};
 use rlp::RlpStream;
+use serde_bytes::ByteBuf;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default, Decode, Encode)]
 pub struct TransactionSignature {
@@ -213,14 +214,18 @@ impl<T: SignableTransaction> Signed<T> {
 /// [`Signed`] transaction.
 pub async fn sign<T: SignableTransaction>(
     transaction: T,
-    derivation_path: DerivationPath,
+    derivation_path: Vec<ByteBuf>,
 ) -> Result<Signed<T>, String> {
     let hash = transaction.hash();
     let key_name = read_state(|s| s.ecdsa_key_name.clone());
-    let signature = crate::management::sign_with_ecdsa(key_name, derivation_path, hash.0)
-        .await
-        .map_err(|e| format!("failed to sign tx: {e}"))?;
-    let recid = compute_recovery_id(&hash, &signature).await;
+    let signature = crate::management::sign_with_ecdsa(
+        key_name,
+        DerivationPath::new(derivation_path.clone()),
+        hash.0,
+    )
+    .await
+    .map_err(|e| format!("failed to sign tx: {e}"))?;
+    let recid = compute_recovery_id(&hash, &signature, &derivation_path).await;
     if recid.is_x_reduced() {
         return Err("BUG: affine x-coordinate of r is reduced which is so unlikely to happen that it's probably a bug".to_string());
     }

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -27,7 +27,6 @@ use evm_rpc_types::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use ic_management_canister_types_private::DerivationPath;
 use icrc_ledger_client_cdk::{CdkRuntime, ICRC1Client};
 use icrc_ledger_types::icrc1::{
     account::Account,
@@ -326,7 +325,7 @@ async fn sign_transactions_batch() {
             .map(|(withdrawal_id, tx)| async move {
                 (
                     withdrawal_id,
-                    crate::tx::sign(tx, DerivationPath::new(MAIN_DERIVATION_PATH)).await,
+                    crate::tx::sign(tx, MAIN_DERIVATION_PATH).await,
                 )
             }),
     )


### PR DESCRIPTION
## Why

`compute_recovery_id` recovers a signature's parity bit against `lazy_call_ecdsa_public_key()` — the minter's *master* key — while `sign` and `Authorization::sign` sign under a caller-supplied derivation path. Recovery only ever succeeds against the key that produced the signature, so signing under anything but the empty main path finds no parity at all: `try_recovery_from_digest` returns an error and the `unwrap_or_else` traps. The `debug_assert!` above it fails first in debug builds.

Nothing calls it with a non-empty path yet, so this is latent today. It stops being latent with the first EIP-7702 authorization, which is signed by a deposit address' own key by definition — and a tuple that does not `ecrecover` to that address is skipped silently by the protocol, leaving the batch's inner call to hit a code-less address and revert the whole sweep.

## What

Recovery now derives the master key along the same path before recovering. The derivation is shared with address derivation rather than duplicated: `deposit_address::derive_public_key` becomes the single place a subkey is computed, and address derivation is that key's address. The key a signature is recovered against is therefore, by construction, the key whose address it belongs to.

The signing functions now take the path as `Vec<ByteBuf>` — the form `MAIN_DERIVATION_PATH`, `sweeper_derivation_path()` and `deposit_derivation_path()` already produce — and build the management-canister `DerivationPath` themselves. That is the structural half of the fix: one owner for both uses of the path, so the signing key and the recovery key cannot drift apart again. Call sites lose a wrapper.

An empty path derives to the master key, so the main address and every withdrawal are unaffected.

## Tests

Three pure unit tests, no canister involved. The one that pins the bug signs a digest with a key derived along a deposit path and asserts recovery succeeds against the derived key and fails against the master key, so it demonstrates the trap rather than asserting the new code agrees with itself.


[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

