### PR TITLE
feat(cketh): enqueue a batched sweep from the sweep queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,6 +7405,7 @@ dependencies = [
  "icrc-ledger-types",
  "maplit",
  "minicbor",
+ "mockall",
  "num-bigint 0.4.6",
  "num-traits",
  "phantom_newtype",

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -89,7 +89,8 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
     # Size is currently at 923_414 bytes.
     "ic-ckbtc-minter.wasm.gz": 10,
     # Size when constraint addded: 1_230_630 bytes
-    "ic-cketh-minter.wasm.gz": 13,
+    # Size is currently at 1_309_035 bytes.
+    "ic-cketh-minter.wasm.gz": 14,
     # The orchestrator needs to embed 3 wasms at compile time
     # (ICRC1 index, ICRC1 ledger, and ICRC1 archive) and size is
     # therefore strictly controlled.

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -116,6 +116,7 @@ rust_test(
         "@crate_index//:flate2",
         "@crate_index//:ic-agent",
         "@crate_index//:maplit",
+        "@crate_index//:mockall",
         "@crate_index//:proptest",
         "@crate_index//:rand",
         "@crate_index//:tempfile",

--- a/rs/ethereum/cketh/minter/Cargo.toml
+++ b/rs/ethereum/cketh/minter/Cargo.toml
@@ -69,6 +69,7 @@ ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/rep
 ic-ledger-suite-orchestrator-test-utils = { path = "../../ledger-suite-orchestrator/test_utils" }
 ic-management-canister-types = { workspace = true }
 maplit = { workspace = true }
+mockall = { workspace = true }
 pocket-ic = { path = "../../../../packages/pocket-ic" }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/rs/ethereum/cketh/minter/src/attestation/mod.rs
+++ b/rs/ethereum/cketh/minter/src/attestation/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
 use crate::eth_logs::encode_principal;
 use crate::eth_rpc::Hash;
-use crate::tx::{TransactionSignature, sign_digest};
+use crate::tx::{EcdsaSigner, TransactionSignature};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use minicbor::{Decode, Encode};
@@ -96,12 +96,14 @@ impl AttestationRequest {
 ///
 /// # Errors
 /// * a description of why the threshold-ECDSA signature could not be produced.
-pub async fn sign_attestation(
+pub(crate) async fn sign_attestation<S: EcdsaSigner>(
+    signer: &S,
     request: &AttestationRequest,
 ) -> Result<TransactionSignature, String> {
-    sign_digest(
-        &request.digest(),
-        &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account),
-    )
-    .await
+    signer
+        .sign_digest(
+            &request.digest(),
+            &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account),
+        )
+        .await
 }

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -43,6 +43,11 @@ pub const REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL: Duration = Duration::from_secs(3
 pub const BALANCE_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 pub const SWEEPER_FUNDING_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);
+/// How often the minter turns detected deposits into a sweep. Deliberately far shorter than
+/// [`PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL`]: under the decided design the mint follows the
+/// sweep, so this interval is part of a user's crediting latency, and enqueueing is cheap — it
+/// signs, but sends nothing.
+pub const SWEEP_ENQUEUE_INTERVAL: Duration = Duration::from_secs(60);
 pub const PROCESS_REIMBURSEMENT: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_SWEEPER_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -39,7 +39,7 @@ use ic_cketh_minter::state::transactions::{
 use ic_cketh_minter::state::{
     STATE, State, lazy_call_ecdsa_public_key, mutate_state, read_state, transactions,
 };
-use ic_cketh_minter::sweep::process_sweeper_transactions;
+use ic_cketh_minter::sweep::{enqueue_batched_sweep, process_sweeper_transactions};
 use ic_cketh_minter::sweeper::fund_sweeper_address;
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::lazy_refresh_gas_fee_estimate;
@@ -50,7 +50,7 @@ use ic_cketh_minter::withdraw::{
 use ic_cketh_minter::{
     BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, PROCESS_REIMBURSEMENT,
     PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL,
-    SCRAPING_ETH_LOGS_INTERVAL, SWEEPER_FUNDING_INTERVAL, state, storage,
+    SCRAPING_ETH_LOGS_INTERVAL, SWEEP_ENQUEUE_INTERVAL, SWEEPER_FUNDING_INTERVAL, state, storage,
 };
 use ic_cketh_minter::{endpoints, erc20};
 use ic_ethereum_types::Address;
@@ -106,6 +106,9 @@ fn setup_timers() {
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
         process_retrieve_eth_requests().await;
+    });
+    ic_cdk_timers::set_timer_interval(SWEEP_ENQUEUE_INTERVAL, async || {
+        enqueue_batched_sweep().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
         process_sweeper_transactions().await;

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -1023,4 +1023,5 @@ pub enum TaskType {
     BalanceScan,
     SweeperFunding,
     SweeperSend,
+    SweeperEnqueue,
 }

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -278,6 +278,27 @@ impl State {
         ))
     }
 
+    pub fn attestation_requests<I: IntoIterator<Item = Account>>(
+        &self,
+        accounts: I,
+    ) -> Option<Vec<AttestationRequest>> {
+        let deposit_helper = *self
+            .log_scrapings
+            .contract_address(LogScrapingId::EthOrErc20DepositWithSubaccount)?;
+        Some(
+            accounts
+                .into_iter()
+                .map(|account| {
+                    AttestationRequest::new(
+                        self.ethereum_network.chain_id(),
+                        deposit_helper,
+                        account,
+                    )
+                })
+                .collect(),
+        )
+    }
+
     /// The attestation `account`'s ckERC20 deposit address has already signed for the configuration
     /// this minter runs against, if any: signing another would cost a threshold-ECDSA signature for
     /// the same digest.

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -8,11 +8,12 @@ use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::eth_logs_scraping::LogScrapingId::Erc20DepositWithoutSubaccount;
 use crate::state::transactions::{Reimbursed, ReimbursementIndex, WithdrawalRequest};
-use crate::storage::{record_event, with_event_iter};
+use crate::storage::{record_event_at, with_event_iter};
 
 /// Updates the state to reflect the given state transition.
 // public because it's used in tests since process_event
 // requires canister infrastructure to retrieve time
+// (see also `process_event_at`, which takes the time as an argument)
 pub fn apply_state_transition(state: &mut State, payload: &EventType) {
     match payload {
         EventType::Init(init_arg) => {
@@ -237,8 +238,16 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
 
 /// Records the given event payload in the event log and updates the state to reflect the change.
 pub fn process_event(state: &mut State, payload: EventType) {
+    process_event_at(ic_cdk::api::time(), state, payload);
+}
+
+/// [`process_event`] stamped at `timestamp` rather than at the current IC time.
+///
+/// Retrieving the time is the one thing in recording an event that needs a canister, so taking it as
+/// an argument is what puts a code path that records events under unit test.
+pub fn process_event_at(timestamp: u64, state: &mut State, payload: EventType) {
     apply_state_transition(state, &payload);
-    record_event(payload);
+    record_event_at(timestamp, payload);
 }
 
 /// Recomputes the minter state from the event log.

--- a/rs/ethereum/cketh/minter/src/storage.rs
+++ b/rs/ethereum/cketh/minter/src/storage.rs
@@ -48,13 +48,16 @@ thread_local! {
 
 /// Appends the event to the event log.
 pub fn record_event(payload: EventType) {
+    record_event_at(ic_cdk::api::time(), payload);
+}
+
+/// [`record_event`] stamped at `timestamp` rather than at the current IC time.
+///
+/// For a caller that already holds the time of the message it is recording for — and for a unit
+/// test, which has no canister to ask for it.
+pub fn record_event_at(timestamp: u64, payload: EventType) {
     EVENTS
-        .with(|events| {
-            events.borrow().append(&Event {
-                timestamp: ic_cdk::api::time(),
-                payload,
-            })
-        })
+        .with(|events| events.borrow().append(&Event { timestamp, payload }))
         .expect("recording an event should succeed");
 }
 

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     numeric::{TransactionCount, TransactionNonce, Wei},
     state::{
         State, TaskType,
-        audit::{EventType, process_event},
+        audit::{EventType, process_event, process_event_at},
         automatic_deposits::SweepTarget,
         mutate_state, read_state,
         transactions::{CreateSweepTransactionError, PipelineRequest, SweepRequest, SweptDeposit},
@@ -346,9 +346,25 @@ pub async fn enqueue_batched_sweep() {
         return;
     };
 
+    let context = SweepContext {
+        sweeper_contract,
+        gas_fee_estimate,
+        created_at: ic_cdk::api::time(),
+    };
     for batch in batches {
-        enqueue_token_sweep(batch, sweeper_contract, &gas_fee_estimate).await;
+        enqueue_token_sweep(batch, &context).await;
     }
+}
+
+/// What every sweep enqueued in one tick shares: the delegate they authorize and send to, what their
+/// gas costs, and the time they are decided at.
+///
+/// The time is carried rather than read because reading it needs a canister, and every sweep of one
+/// tick is decided at the same instant anyway.
+struct SweepContext {
+    sweeper_contract: Address,
+    gas_fee_estimate: GasFeeEstimate,
+    created_at: u64,
 }
 
 /// The sweep queue folded into one batch per token, each holding that token's queued deposits in
@@ -384,8 +400,7 @@ fn sweep_batches_by_token(state: &State) -> BTreeMap<Address, Vec<SweepTarget>> 
 /// for, or when the sweep would prepay more than [`max_sweep_transaction_fee`].
 async fn enqueue_token_sweep(
     (token, targets): (Address, Vec<SweepTarget>),
-    sweeper_contract: Address,
-    gas_fee_estimate: &GasFeeEstimate,
+    context: &SweepContext,
 ) {
     let Some(requests) = attestation_requests(&targets) else {
         log!(
@@ -395,7 +410,7 @@ async fn enqueue_token_sweep(
         return;
     };
 
-    let prepared = prepare_deposits(&targets, &requests, sweeper_contract).await;
+    let prepared = prepare_deposits(&targets, &requests, context).await;
     if prepared.is_empty() {
         log!(
             INFO,
@@ -407,15 +422,16 @@ async fn enqueue_token_sweep(
     let batch = SweepBatch::from(prepared);
     let mut request = SweepRequest {
         id: read_state(|s| s.next_sweep_id),
-        destination: sweeper_contract,
+        destination: context.sweeper_contract,
         amount: Wei::ZERO,
         data: encode_sweep_erc20_batch(&batch.items, &batch.tokens),
         max_transaction_fee: Wei::ZERO,
-        created_at: ic_cdk::api::time(),
+        created_at: context.created_at,
         authorizations: batch.authorizations,
         deposits: batch.deposits,
     };
-    request.max_transaction_fee = gas_fee_estimate
+    request.max_transaction_fee = context
+        .gas_fee_estimate
         .clone()
         .to_price(request.gas_limit())
         .max_transaction_fee();
@@ -431,11 +447,18 @@ async fn enqueue_token_sweep(
     }
     log!(
         INFO,
-        "[enqueue_batched_sweep]: sweeping {} deposits of {token} from {} addresses, via {sweeper_contract}",
+        "[enqueue_batched_sweep]: sweeping {} deposits of {token} from {} addresses, via {}",
         request.deposits.len(),
-        request.authorizations.len()
+        request.authorizations.len(),
+        context.sweeper_contract
     );
-    mutate_state(|s| process_event(s, EventType::AcceptedSweepRequest(request)));
+    mutate_state(|s| {
+        process_event_at(
+            context.created_at,
+            s,
+            EventType::AcceptedSweepRequest(request),
+        )
+    });
 }
 
 /// The most a single sweep may prepay: the balance the sweeper address is kept above, so that a
@@ -548,13 +571,13 @@ struct PreparedDeposit {
 async fn prepare_deposits(
     targets: &[SweepTarget],
     requests: &BTreeMap<Account, AttestationRequest>,
-    sweeper_contract: Address,
+    context: &SweepContext,
 ) -> Vec<PreparedDeposit> {
-    let attestations = sign_attestations_batch(requests).await;
+    let attestations = sign_attestations_batch(requests, context).await;
     // Only the attested accounts: a deposit that could not be attested drops out of the sweep
     // anyway, so authorizing it would spend a signature on nothing.
     let addresses = attested_addresses(targets, &attestations);
-    let authorizations = sign_authorizations_batch(&addresses, sweeper_contract).await;
+    let authorizations = sign_authorizations_batch(&addresses, context).await;
     prepared_deposits(targets, &attestations, &authorizations)
 }
 
@@ -588,6 +611,7 @@ fn prepared_deposits(
 /// have yet cost a signature, and each is recorded the moment it exists.
 async fn sign_attestations_batch(
     requests: &BTreeMap<Account, AttestationRequest>,
+    context: &SweepContext,
 ) -> BTreeMap<Account, TransactionSignature> {
     let mut attestations: BTreeMap<Account, TransactionSignature> = read_state(|s| {
         requests
@@ -612,7 +636,8 @@ async fn sign_attestations_batch(
         match result {
             Ok(attestation) => {
                 mutate_state(|s| {
-                    process_event(
+                    process_event_at(
+                        context.created_at,
                         s,
                         EventType::AttestedDepositAddress {
                             request: request.clone(),
@@ -652,12 +677,12 @@ fn attested_addresses(
 /// fixed at 0, so nothing a sweep does can invalidate it — see [`delegation_authorization`].
 async fn sign_authorizations_batch(
     addresses: &BTreeMap<Account, DepositAddress>,
-    sweeper_contract: Address,
+    context: &SweepContext,
 ) -> BTreeMap<Account, SignedAuthorization> {
     let chain_id = read_state(State::ethereum_network).chain_id();
     let signed = join_all(addresses.keys().map(|account| {
         let account = *account;
-        let authorization = delegation_authorization(chain_id, sweeper_contract);
+        let authorization = delegation_authorization(chain_id, context.sweeper_contract);
         async move {
             (
                 account,

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -35,8 +35,8 @@ use crate::{
     },
     sweeper_contract::{SweepItem, encode_sweep_erc20_batch},
     tx::{
-        Authorization, GasFeeEstimate, SignedAuthorization, TransactionSignature,
-        lazy_refresh_gas_fee_estimate,
+        Authorization, EcdsaSigner, GasFeeEstimate, IcEcdsaSigner, SignedAuthorization,
+        TransactionSignature, lazy_refresh_gas_fee_estimate,
     },
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
@@ -347,6 +347,7 @@ pub async fn enqueue_batched_sweep() {
     };
 
     let context = SweepContext {
+        signer: IcEcdsaSigner,
         sweeper_contract,
         gas_fee_estimate,
         created_at: ic_cdk::api::time(),
@@ -356,12 +357,14 @@ pub async fn enqueue_batched_sweep() {
     }
 }
 
-/// What every sweep enqueued in one tick shares: the delegate they authorize and send to, what their
-/// gas costs, and the time they are decided at.
+/// What every sweep enqueued in one tick shares: the delegate they authorize and send to, the key
+/// that signs for them, what their gas costs, and the time they are decided at.
 ///
-/// The time is carried rather than read because reading it needs a canister, and every sweep of one
-/// tick is decided at the same instant anyway.
-struct SweepContext {
+/// Generic over the signer, and carrying the time rather than reading it, because those are the two
+/// things the enqueue path needs a canister for; everything else it does is arithmetic over state,
+/// so a test that supplies both drives the real code.
+struct SweepContext<S> {
+    signer: S,
     sweeper_contract: Address,
     gas_fee_estimate: GasFeeEstimate,
     created_at: u64,
@@ -398,9 +401,9 @@ fn sweep_batches_by_token(state: &State) -> BTreeMap<Address, Vec<SweepTarget>> 
 ///
 /// Skips the token — leaving its deposits queued for the next tick — when nothing could be signed
 /// for, or when the sweep would prepay more than [`max_sweep_transaction_fee`].
-async fn enqueue_token_sweep(
+async fn enqueue_token_sweep<S: EcdsaSigner>(
     (token, targets): (Address, Vec<SweepTarget>),
-    context: &SweepContext,
+    context: &SweepContext<S>,
 ) {
     let Some(requests) = attestation_requests(&targets) else {
         log!(
@@ -568,10 +571,10 @@ struct PreparedDeposit {
 /// Everything the queued `targets` need signed, in target order. Each threshold-ECDSA signature is
 /// an outcall, so the attestations are signed in one batch and the authorizations in another, one of
 /// each per deposit address rather than per queued token.
-async fn prepare_deposits(
+async fn prepare_deposits<S: EcdsaSigner>(
     targets: &[SweepTarget],
     requests: &BTreeMap<Account, AttestationRequest>,
-    context: &SweepContext,
+    context: &SweepContext<S>,
 ) -> Vec<PreparedDeposit> {
     let attestations = sign_attestations_batch(requests, context).await;
     // Only the attested accounts: a deposit that could not be attested drops out of the sweep
@@ -609,9 +612,9 @@ fn prepared_deposits(
 /// signed. An attestation is signed once per address and reused by every later sweep — it names the
 /// account and the helper, neither of which a sweep changes — so only the ones the minter does not
 /// have yet cost a signature, and each is recorded the moment it exists.
-async fn sign_attestations_batch(
+async fn sign_attestations_batch<S: EcdsaSigner>(
     requests: &BTreeMap<Account, AttestationRequest>,
-    context: &SweepContext,
+    context: &SweepContext<S>,
 ) -> BTreeMap<Account, TransactionSignature> {
     let mut attestations: BTreeMap<Account, TransactionSignature> = read_state(|s| {
         requests
@@ -627,7 +630,11 @@ async fn sign_attestations_batch(
             .iter()
             .filter(|(account, _request)| !attestations.contains_key(*account))
             .map(|(account, request)| async move {
-                (*account, request, sign_attestation(request).await)
+                (
+                    *account,
+                    request,
+                    sign_attestation(&context.signer, request).await,
+                )
             }),
     )
     .await;
@@ -675,9 +682,9 @@ fn attested_addresses(
 ///
 /// Every address is signed afresh: the tuple names the chain and the delegate, and its nonce is
 /// fixed at 0, so nothing a sweep does can invalidate it — see [`delegation_authorization`].
-async fn sign_authorizations_batch(
+async fn sign_authorizations_batch<S: EcdsaSigner>(
     addresses: &BTreeMap<Account, DepositAddress>,
-    context: &SweepContext,
+    context: &SweepContext<S>,
 ) -> BTreeMap<Account, SignedAuthorization> {
     let chain_id = read_state(State::ethereum_network).chain_id();
     let signed = join_all(addresses.keys().map(|account| {
@@ -687,10 +694,10 @@ async fn sign_authorizations_batch(
             (
                 account,
                 authorization
-                    .sign(deposit_derivation_path(
-                        DepositAddressSchema::CkErc20,
-                        &account,
-                    ))
+                    .sign(
+                        &context.signer,
+                        deposit_derivation_path(DepositAddressSchema::CkErc20, &account),
+                    )
                     .await,
             )
         }

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -63,8 +63,8 @@ use std::collections::{BTreeMap, BTreeSet};
 /// batch of twenty: the second doubling saves ~2%, one transaction's intrinsic gas spread over the
 /// extra deposits. A wider batch does not pay for what it costs — `sweepErc20Batch` has no
 /// per-item error handling, so it doubles how many deposits one revert drops (see
-/// [`next_batch_of`]), and it doubles what a single sweep prepays against the sweeper's low-water
-/// mark (see [`max_sweep_transaction_fee`]).
+/// [`sweep_batches_by_token`]), and it doubles what a single sweep prepays against the sweeper's
+/// low-water mark (see [`max_sweep_transaction_fee`]).
 const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
@@ -351,8 +351,8 @@ pub async fn enqueue_batched_sweep() {
     }
 }
 
-/// The sweep queue folded into one batch per token, each holding at most
-/// [`MAX_DEPOSITS_PER_SWEEP`] of that token's queued deposits.
+/// The sweep queue folded into one batch per token, each holding that token's queued deposits in
+/// queue order, up to [`MAX_DEPOSITS_PER_SWEEP`] of them.
 ///
 /// One sweep per token, never a batch spanning several. The delegate's batch entry point runs its
 /// whole token list against every deposit address it touches, so a mixed batch pays a `balanceOf` at
@@ -362,26 +362,20 @@ pub async fn enqueue_batched_sweep() {
 /// [`MAX_DEPOSITS_PER_SWEEP`] bound a sweep's gas at all. It costs one transaction's 21'000
 /// intrinsic gas per token, which a multi-token sweep pays anyway in the cold storage write each
 /// token's balance at the minter needs.
-fn sweep_batches_by_token(state: &State) -> BTreeMap<Address, Vec<SweepTarget>> {
-    let mut queued: BTreeMap<Address, Vec<SweepTarget>> = BTreeMap::new();
-    for target in state.automatic_deposits.sweep_targets_iter() {
-        queued.entry(target.token()).or_default().push(target);
-    }
-    queued
-        .into_iter()
-        .map(|(token, queued)| (token, next_batch_of(queued)))
-        .collect()
-}
-
-/// Which of one token's queued deposits go into the next sweep of it: its deposits in queue order,
-/// up to [`MAX_DEPOSITS_PER_SWEEP`].
 ///
 /// Every deposit gets one sweep and no more. `sweepErc20Batch` has no per-item error handling, so
 /// whatever makes a sweep revert — one address blacklisted for the token, say — reverts every batch
 /// that deposit is in; a failed sweep therefore drops its whole batch from the queue rather than
 /// leaving anything behind to retry (DEFI-2981).
-fn next_batch_of(queued: Vec<SweepTarget>) -> Vec<SweepTarget> {
-    queued.into_iter().take(MAX_DEPOSITS_PER_SWEEP).collect()
+fn sweep_batches_by_token(state: &State) -> BTreeMap<Address, Vec<SweepTarget>> {
+    let mut batches: BTreeMap<Address, Vec<SweepTarget>> = BTreeMap::new();
+    for target in state.automatic_deposits.sweep_targets_iter() {
+        let batch = batches.entry(target.token()).or_default();
+        if batch.len() < MAX_DEPOSITS_PER_SWEEP {
+            batch.push(target);
+        }
+    }
+    batches
 }
 
 /// Enqueue one sweep of `token`, moving as many of `targets` as could be signed for.

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -405,6 +405,9 @@ async fn enqueue_token_sweep<S: EcdsaSigner>(
     (token, targets): (Address, Vec<SweepTarget>),
     context: &SweepContext<S>,
 ) {
+    if targets.is_empty() {
+        return;
+    }
     let Some(requests) = attestation_requests(&targets) else {
         log!(
             DEBUG,

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -55,9 +55,17 @@ use std::collections::{BTreeMap, BTreeSet};
 /// This is what bounds a sweep's gas, but only because the batch carries a single token: the
 /// delegate applies its whole token list to every address, so a one-token batch pays one balance
 /// check and at most one transfer per address and [`SweepRequest::gas_limit`] stays linear in the
-/// batch — ~3.4M gas at twenty deposits. A batch spanning several tokens would grow as their
-/// product instead, which is why [`sweep_batches_by_token`] never builds one.
-const MAX_DEPOSITS_PER_SWEEP: usize = 20;
+/// batch — ~1.7M gas at ten deposits. A batch spanning several tokens would grow as their product
+/// instead, which is why [`sweep_batches_by_token`] never builds one.
+///
+/// Ten, because that is where batching has bought what it can. `deposit_from_cex_demo`'s measured
+/// attested scenarios put a deposit at 98'000 gas alone, 60'943 in a batch of ten and 59'645 in a
+/// batch of twenty: the second doubling saves ~2%, one transaction's intrinsic gas spread over the
+/// extra deposits. A wider batch does not pay for what it costs — `sweepErc20Batch` has no
+/// per-item error handling, so it doubles how many deposits one revert drops (see
+/// [`next_batch_of`]), and it doubles what a single sweep prepays against the sweeper's low-water
+/// mark (see [`max_sweep_transaction_fee`]).
+const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -8,19 +8,36 @@
 //! (`latest_transaction_count`, `finalized_transaction_count`, `send_signed_transactions`,
 //! `fetch_finalized_receipts`), but signing with the sweeper derivation path (`[3]`) and reading
 //! the sweeper address' own transaction count.
+//!
+//! [`enqueue_batched_sweep`] is what feeds it: it takes the deposits the balance scan queued, signs
+//! one delegation authorization and one ownership attestation per address, and enqueues one
+//! [`SweepRequest`] per token, whose call data sweeps that token from every address in the batch
+//! through the deployed delegate.
+
+#[cfg(test)]
+mod tests;
 
 use crate::{
-    deposit_address::sweeper_derivation_path,
+    attestation::{AttestationRequest, sign_attestation},
+    deposit_address::{
+        DepositAddress, DepositAddressSchema, deposit_derivation_path, sweeper_derivation_path,
+    },
+    eth_rpc_client::responses::{TransactionReceipt, TransactionStatus},
     guard::TimerGuard,
     logs::{DEBUG, INFO},
-    numeric::{GasAmount, TransactionCount},
+    numeric::{TransactionCount, TransactionNonce, Wei},
     state::{
         State, TaskType,
         audit::{EventType, process_event},
+        automatic_deposits::SweepTarget,
         mutate_state, read_state,
-        transactions::{CreateSweepTransactionError, PipelineRequest},
+        transactions::{CreateSweepTransactionError, PipelineRequest, SweepRequest, SweptDeposit},
     },
-    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate},
+    sweeper_contract::{SweepItem, encode_sweep_erc20_batch},
+    tx::{
+        Authorization, GasFeeEstimate, SignedAuthorization, TransactionSignature,
+        lazy_refresh_gas_fee_estimate,
+    },
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -29,10 +46,18 @@ use crate::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
+use std::collections::{BTreeMap, BTreeSet};
 
-/// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
-/// with the real delegate sweep call.
-pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+/// Deposits swept in one transaction, which with one token per sweep is also the addresses it
+/// touches.
+///
+/// This is what bounds a sweep's gas, but only because the batch carries a single token: the
+/// delegate applies its whole token list to every address, so a one-token batch pays one balance
+/// check and at most one transfer per address and [`SweepRequest::gas_limit`] stays linear in the
+/// batch — ~3.4M gas at twenty deposits. A batch spanning several tokens would grow as their
+/// product instead, which is why [`sweep_batches_by_token`] never builds one.
+const MAX_DEPOSITS_PER_SWEEP: usize = 20;
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
@@ -148,7 +173,7 @@ fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
         match request.create_transaction(
             nonce,
             gas_fee_estimate.clone(),
-            SWEEP_TRANSACTION_GAS_LIMIT,
+            request.gas_limit(),
             ethereum_network,
         ) {
             Ok(transaction) => {
@@ -171,6 +196,8 @@ fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
                     INFO,
                     "[process_sweeper_transactions]: Sweep {sweep_id:?} has prepaid gas {allowed_max_transaction_fee:?}, below the current transaction fee {actual_max_transaction_fee:?}. Sweep moved back to end of queue."
                 );
+                // TODO(DEFI-2933): a sweep whose prepaid allowance stays below the current fee
+                // reschedules indefinitely, and only a fee drop gets it moving again.
                 mutate_state(|s| s.sweeper_transactions.reschedule_request(sweep_id));
             }
         }
@@ -240,12 +267,21 @@ async fn finalize_transactions_batch(sender: Address) {
             });
             if let Some(receipts) = fetch_finalized_receipts(txs_to_finalize).await {
                 for (sweep_id, transaction_receipt) in receipts {
+                    let transaction_receipt = TransactionReceipt::from(transaction_receipt);
+                    if transaction_receipt.status == TransactionStatus::Failure {
+                        log!(
+                            INFO,
+                            "[process_sweeper_transactions]: sweep {sweep_id:?} FAILED in transaction {}, burning {:?}. It moved nothing.",
+                            transaction_receipt.transaction_hash,
+                            transaction_receipt.gas_used
+                        );
+                    }
                     mutate_state(|s| {
                         process_event(
                             s,
                             EventType::FinalizedSweeperTransaction {
                                 sweep_id,
-                                transaction_receipt: transaction_receipt.into(),
+                                transaction_receipt,
                             },
                         );
                     });
@@ -258,5 +294,432 @@ async fn finalize_transactions_batch(sender: Address) {
                 "[process_sweeper_transactions]: failed to get finalized transaction count: {e:?}"
             );
         }
+    }
+}
+
+/// Enqueue a sweep of everything the balance scan has queued, one transaction per token, each
+/// moving up to [`MAX_DEPOSITS_PER_SWEEP`] deposits.
+///
+/// Each deposit contributes an ownership attestation and an EIP-7702 authorization delegating its
+/// address (see [`sign_authorizations_batch`]), so every sweep is a type-`0x04` transaction.
+pub async fn enqueue_batched_sweep() {
+    let _guard = match TimerGuard::new(TaskType::SweeperEnqueue) {
+        Ok(guard) => guard,
+        Err(e) => {
+            log!(
+                DEBUG,
+                "Failed retrieving timer guard to enqueue a batched sweep: {e:?}",
+            );
+            return;
+        }
+    };
+
+    let Some(sweeper_contract) = read_state(|s| s.sweeper_contract_address) else {
+        log!(
+            DEBUG,
+            "[enqueue_batched_sweep]: SKIPPING: no sweeper contract address is configured"
+        );
+        return;
+    };
+    let batches = read_state(sweep_batches_by_token);
+    if batches.is_empty() {
+        return;
+    }
+
+    // Fetched before anything is signed: nothing about the estimate depends on the signatures,
+    // and an unavailable one drops every sweep — along with each threshold-ECDSA signature it
+    // would have cost.
+    // TODO(DEFI-2933): gate this on the gas the sweeper address has actually been prepaid.
+    let Some(gas_fee_estimate) = lazy_refresh_gas_fee_estimate().await else {
+        log!(
+            INFO,
+            "[enqueue_batched_sweep]: SKIPPING: failed retrieving gas fee estimate"
+        );
+        return;
+    };
+
+    for batch in batches {
+        enqueue_token_sweep(batch, sweeper_contract, &gas_fee_estimate).await;
+    }
+}
+
+/// The sweep queue folded into one batch per token, each holding at most
+/// [`MAX_DEPOSITS_PER_SWEEP`] of that token's queued deposits.
+///
+/// One sweep per token, never a batch spanning several. The delegate's batch entry point runs its
+/// whole token list against every deposit address it touches, so a mixed batch pays a `balanceOf` at
+/// every `(address, token)` pair — including the pairs holding nothing, which is most of them once
+/// several tokens are supported — and its gas grows as addresses × tokens rather than with the
+/// deposits it moves. Grouping keeps that product equal to the addresses, which is what lets
+/// [`MAX_DEPOSITS_PER_SWEEP`] bound a sweep's gas at all. It costs one transaction's 21'000
+/// intrinsic gas per token, which a multi-token sweep pays anyway in the cold storage write each
+/// token's balance at the minter needs.
+fn sweep_batches_by_token(state: &State) -> BTreeMap<Address, Vec<SweepTarget>> {
+    let mut queued: BTreeMap<Address, Vec<SweepTarget>> = BTreeMap::new();
+    for target in state.automatic_deposits.sweep_targets_iter() {
+        queued.entry(target.token()).or_default().push(target);
+    }
+    queued
+        .into_iter()
+        .map(|(token, queued)| (token, next_batch_of(queued)))
+        .collect()
+}
+
+/// Which of one token's queued deposits go into the next sweep of it: its deposits in queue order,
+/// up to [`MAX_DEPOSITS_PER_SWEEP`].
+///
+/// Every deposit gets one sweep and no more. `sweepErc20Batch` has no per-item error handling, so
+/// whatever makes a sweep revert — one address blacklisted for the token, say — reverts every batch
+/// that deposit is in; a failed sweep therefore drops its whole batch from the queue rather than
+/// leaving anything behind to retry (DEFI-2981).
+fn next_batch_of(queued: Vec<SweepTarget>) -> Vec<SweepTarget> {
+    queued.into_iter().take(MAX_DEPOSITS_PER_SWEEP).collect()
+}
+
+/// Enqueue one sweep of `token`, moving as many of `targets` as could be signed for.
+///
+/// Skips the token — leaving its deposits queued for the next tick — when nothing could be signed
+/// for, or when the sweep would prepay more than [`max_sweep_transaction_fee`].
+async fn enqueue_token_sweep(
+    (token, targets): (Address, Vec<SweepTarget>),
+    sweeper_contract: Address,
+    gas_fee_estimate: &GasFeeEstimate,
+) {
+    let Some(requests) = attestation_requests(&targets) else {
+        log!(
+            DEBUG,
+            "[enqueue_batched_sweep]: SKIPPING: no deposit helper with subaccount is configured"
+        );
+        return;
+    };
+
+    let prepared = prepare_deposits(&targets, &requests, sweeper_contract).await;
+    if prepared.is_empty() {
+        log!(
+            INFO,
+            "[enqueue_batched_sweep]: SKIPPING the {token} sweep: none of its {} queued deposits could be signed for",
+            targets.len()
+        );
+        return;
+    }
+    let batch = SweepBatch::from(prepared);
+    let mut request = SweepRequest {
+        id: read_state(|s| s.next_sweep_id),
+        destination: sweeper_contract,
+        amount: Wei::ZERO,
+        data: encode_sweep_erc20_batch(&batch.items, &batch.tokens),
+        max_transaction_fee: Wei::ZERO,
+        created_at: ic_cdk::api::time(),
+        authorizations: batch.authorizations,
+        deposits: batch.deposits,
+    };
+    request.max_transaction_fee = gas_fee_estimate
+        .clone()
+        .to_price(request.gas_limit())
+        .max_transaction_fee();
+    let ceiling = read_state(max_sweep_transaction_fee);
+    if request.max_transaction_fee > ceiling {
+        log!(
+            INFO,
+            "[enqueue_batched_sweep]: SKIPPING the {token} sweep of {} deposits: it would prepay {:?}, above the {ceiling:?} a single sweep may lock",
+            request.deposits.len(),
+            request.max_transaction_fee
+        );
+        return;
+    }
+    log!(
+        INFO,
+        "[enqueue_batched_sweep]: sweeping {} deposits of {token} from {} addresses, via {sweeper_contract}",
+        request.deposits.len(),
+        request.authorizations.len()
+    );
+    mutate_state(|s| process_event(s, EventType::AcceptedSweepRequest(request)));
+}
+
+/// The most a single sweep may prepay: the balance the sweeper address is kept above, so that a
+/// sweep is payable out of the funding the funding task maintains.
+///
+/// The EVM demands `gas_limit × max_fee_per_gas` up front, and a sweep the sweeper cannot pay for is
+/// unrecoverable rather than merely wasted: the pipeline has already committed the sweep's nonce,
+/// sending fails with `InsufficientFunds` and is retried forever, resubmission cannot lower the fee
+/// because it already sits at the sweep's own allowance, and every later sweep on the lane waits
+/// behind that nonce. No receipt ever arrives, so nothing counts it as a failed sweep either.
+/// Refusing to enqueue is the one place this is cheap to catch: the deposits stay queued and the
+/// next tick tries again, at whatever the fee is then.
+///
+/// The mark is not a guarantee — the balance dips below it between fundings, which no enqueue-time
+/// check can see — but a sweep that fits under it is payable whenever the funding task has done its
+/// job, and one that does not fit is a sweep this minter should not be building.
+///
+/// Against mainnet's 0.03 ETH minimum withdrawal amount, a full single-token batch prepays ~0.07 ETH
+/// at 10 gwei, inside the 0.15 ETH mark, so the ceiling does not bind. A minter configured with a
+/// much smaller minimum withdrawal amount has a proportionally smaller mark, and its full batches
+/// are refused at that fee until it drops — visible in the log above, and DEFI-2933's calibration to
+/// settle, rather than something to paper over by sending a sweep that cannot be paid for.
+fn max_sweep_transaction_fee(state: &State) -> Wei {
+    state.sweeper_funding_config().low_water_mark
+}
+
+/// The attestation each of the `targets` needs signed, keyed by the account it names. One per
+/// account: all of an account's tokens sit at the one deposit address the attestation covers, and
+/// the request itself names no token. `None` while the deposit helper it binds to is unknown.
+fn attestation_requests(targets: &[SweepTarget]) -> Option<BTreeMap<Account, AttestationRequest>> {
+    read_state(|s| {
+        targets
+            .iter()
+            .map(|target| {
+                let account = target.account();
+                s.attestation_request(account)
+                    .map(|request| (account, request))
+            })
+            .collect()
+    })
+}
+
+/// What one sweep carries, assembled from what its deposits contributed.
+///
+/// A deposit address is derived per account, so all of an account's tokens share one address, one
+/// attestation and one authorization: `items` and `authorizations` hold one entry per account, while
+/// `deposits` keeps one per `(account, token)`, which is the granularity the sweep queue is keyed
+/// at. With one token per sweep an account contributes a single deposit anyway; keying by it is what
+/// makes that an invariant of the call data rather than a property of how the batch was picked. A
+/// second item for the same address would make the delegate walk it twice over the token list, and a
+/// second copy of its authorization would cost intrinsic gas for a tuple the first copy already
+/// applied.
+struct SweepBatch {
+    items: Vec<SweepItem>,
+    /// The distinct tokens the batch sweeps, which is one: the delegate applies the whole list to
+    /// every item, so [`sweep_batches_by_token`] gives each sweep a single token. Derived from the
+    /// deposits rather than taken on trust, so the list cannot disagree with them.
+    tokens: Vec<Address>,
+    authorizations: Vec<SignedAuthorization>,
+    deposits: Vec<SweptDeposit>,
+}
+
+impl From<Vec<PreparedDeposit>> for SweepBatch {
+    fn from(prepared: Vec<PreparedDeposit>) -> Self {
+        let mut items = BTreeMap::new();
+        let mut authorizations = BTreeMap::new();
+        let mut tokens = BTreeSet::new();
+        let mut deposits = Vec::with_capacity(prepared.len());
+        for PreparedDeposit {
+            target,
+            attestation,
+            authorization,
+        } in prepared
+        {
+            let account = target.account();
+            authorizations.entry(account).or_insert(authorization);
+            items.entry(account).or_insert_with(|| SweepItem {
+                deposit: target.address(),
+                account,
+                attestation,
+            });
+            tokens.insert(target.token());
+            deposits.push(SweptDeposit {
+                account,
+                erc20_contract_address: target.token(),
+                address: target.address(),
+            });
+        }
+        Self {
+            items: items.into_values().collect(),
+            tokens: tokens.into_iter().collect(),
+            authorizations: authorizations.into_values().collect(),
+            deposits,
+        }
+    }
+}
+
+/// What one deposit contributes to a sweep: the attestation naming the account it credits, and the
+/// EIP-7702 authorization delegating its address. All of an account's deposits carry the same pair,
+/// since they share one deposit address.
+struct PreparedDeposit {
+    target: SweepTarget,
+    attestation: TransactionSignature,
+    authorization: SignedAuthorization,
+}
+
+/// Everything the queued `targets` need signed, in target order. Each threshold-ECDSA signature is
+/// an outcall, so the attestations are signed in one batch and the authorizations in another, one of
+/// each per deposit address rather than per queued token.
+async fn prepare_deposits(
+    targets: &[SweepTarget],
+    requests: &BTreeMap<Account, AttestationRequest>,
+    sweeper_contract: Address,
+) -> Vec<PreparedDeposit> {
+    let attestations = sign_attestations_batch(requests).await;
+    // Only the attested accounts: a deposit that could not be attested drops out of the sweep
+    // anyway, so authorizing it would spend a signature on nothing.
+    let addresses = attested_addresses(targets, &attestations);
+    let authorizations = sign_authorizations_batch(&addresses, sweeper_contract).await;
+    prepared_deposits(targets, &attestations, &authorizations)
+}
+
+/// The targets that got everything they need: their account's attestation and its authorization.
+///
+/// A deposit missing either drops out of the sweep rather than sinking it, since nothing the others
+/// contribute depends on it — and it must drop out: solc guards the delegate call with
+/// `extcodesize`, so an address that ends up with no code reverts, and one such item reverts the
+/// whole batch.
+fn prepared_deposits(
+    targets: &[SweepTarget],
+    attestations: &BTreeMap<Account, TransactionSignature>,
+    authorizations: &BTreeMap<Account, SignedAuthorization>,
+) -> Vec<PreparedDeposit> {
+    targets
+        .iter()
+        .filter_map(|target| {
+            let account = target.account();
+            Some(PreparedDeposit {
+                target: *target,
+                attestation: attestations.get(&account)?.clone(),
+                authorization: authorizations.get(&account)?.clone(),
+            })
+        })
+        .collect()
+}
+
+/// The attestation of each request, keyed by the account it names, missing where it could not be
+/// signed. An attestation is signed once per address and reused by every later sweep — it names the
+/// account and the helper, neither of which a sweep changes — so only the ones the minter does not
+/// have yet cost a signature, and each is recorded the moment it exists.
+async fn sign_attestations_batch(
+    requests: &BTreeMap<Account, AttestationRequest>,
+) -> BTreeMap<Account, TransactionSignature> {
+    let mut attestations: BTreeMap<Account, TransactionSignature> = read_state(|s| {
+        requests
+            .keys()
+            .filter_map(|account| {
+                s.attestation(*account)
+                    .map(|attestation| (*account, attestation.clone()))
+            })
+            .collect()
+    });
+    let signed = join_all(
+        requests
+            .iter()
+            .filter(|(account, _request)| !attestations.contains_key(*account))
+            .map(|(account, request)| async move {
+                (*account, request, sign_attestation(request).await)
+            }),
+    )
+    .await;
+    let mut errors = Vec::new();
+    for (account, request, result) in signed {
+        match result {
+            Ok(attestation) => {
+                mutate_state(|s| {
+                    process_event(
+                        s,
+                        EventType::AttestedDepositAddress {
+                            request: request.clone(),
+                            signature: attestation.clone(),
+                        },
+                    )
+                });
+                attestations.insert(account, attestation);
+            }
+            Err(e) => errors.push(format!("{account:?}: {e}")),
+        }
+    }
+    if !errors.is_empty() {
+        log!(
+            INFO,
+            "[enqueue_batched_sweep]: leaving out the deposits this sweep could not attest: {errors:?}"
+        );
+    }
+    attestations
+}
+
+/// The deposit address of every target whose account got an attestation, keyed by that account.
+fn attested_addresses(
+    targets: &[SweepTarget],
+    attestations: &BTreeMap<Account, TransactionSignature>,
+) -> BTreeMap<Account, DepositAddress> {
+    targets
+        .iter()
+        .filter(|target| attestations.contains_key(&target.account()))
+        .map(|target| (target.account(), target.address()))
+        .collect()
+}
+
+/// One authorization per account, keyed by it, missing where it could not be signed.
+///
+/// Every address is signed afresh: the tuple names the chain and the delegate, and its nonce is
+/// fixed at 0, so nothing a sweep does can invalidate it — see [`delegation_authorization`].
+async fn sign_authorizations_batch(
+    addresses: &BTreeMap<Account, DepositAddress>,
+    sweeper_contract: Address,
+) -> BTreeMap<Account, SignedAuthorization> {
+    let chain_id = read_state(State::ethereum_network).chain_id();
+    let signed = join_all(addresses.keys().map(|account| {
+        let account = *account;
+        let authorization = delegation_authorization(chain_id, sweeper_contract);
+        async move {
+            (
+                account,
+                authorization
+                    .sign(deposit_derivation_path(
+                        DepositAddressSchema::CkErc20,
+                        &account,
+                    ))
+                    .await,
+            )
+        }
+    }))
+    .await;
+    let mut authorizations = BTreeMap::new();
+    let mut errors = Vec::new();
+    for (account, result) in signed {
+        match result {
+            Ok(authorization) => {
+                authorizations.insert(account, authorization);
+            }
+            Err(e) => errors.push(format!("{account:?}: {e}")),
+        }
+    }
+    if !errors.is_empty() {
+        log!(
+            INFO,
+            "[enqueue_batched_sweep]: leaving out the deposits this sweep could not authorize: {errors:?}"
+        );
+    }
+    authorizations
+}
+
+/// The tuple every deposit address signs to delegate its code to `sweeper_contract`: the minter's
+/// chain, that delegate, and **nonce 0**, whatever nonce the address actually holds.
+///
+/// Applying an EIP-7702 authorization increments the authority's nonce, and nothing else ever
+/// touches a deposit address' nonce — the minter never broadcasts a transaction from a deposit key,
+/// it only signs attestation digests and authorization tuples with it, and receiving an ERC-20
+/// transfer spends no nonce. So a deposit address holds nonce 0 exactly while it has never been
+/// delegated, and a tuple signed for nonce 0 either
+///
+/// * installs the delegation, the address never having had one; or
+/// * is skipped, the address already being delegated and its nonce no longer matching. The
+///   transaction stays valid, the delegation designator already in place is untouched, and the
+///   delegated call works.
+///
+/// Both outcomes are correct, in every ordering of the sweeps that carry them, with nothing stored
+/// and nothing read from chain. That is what lets a sweep authorize every address it touches instead
+/// of tracking which ones are delegated: two sweeps of the same address in one round each carry
+/// their own tuple, the second one is skipped, and neither has to wait for the other. The price is
+/// the tuple's intrinsic gas — 12'500 for a skipped one, which [`SweepRequest::gas_limit`] budgets
+/// for every address.
+///
+/// The one thing this forecloses is **re-delegation**: an address delegated to an earlier sweeper
+/// contract holds nonce >= 1, so a nonce-0 tuple naming the new one is skipped and its code keeps
+/// pointing at the old contract. Its sweeps still execute, through that old delegate, which is
+/// harmless while the helper it calls is unchanged and reverts if it is not. Supporting
+/// re-delegation would mean reading the authority's real nonce for exactly those addresses — the
+/// ones whose stored authorization names a different delegate, which is itself the signal that the
+/// address is delegated to something else.
+fn delegation_authorization(chain_id: u64, sweeper_contract: Address) -> Authorization {
+    Authorization {
+        chain_id,
+        delegate: sweeper_contract,
+        nonce: TransactionNonce::ZERO,
     }
 }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -17,15 +17,16 @@ use crate::tx::{EcdsaSigner, GasFeeEstimate, SignedAuthorization, TransactionSig
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
+use mockall::mock;
 use serde_bytes::ByteBuf;
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 mod enqueue_token_sweep {
     use super::{
         CREATED_AT, MockSigner, account, attestation_of, authorization_of, context,
-        deposit_address, enqueue_token_sweep, enqueued_sweep, enqueued_sweeps, gas_fee_estimate,
-        install, queued_state, queued_targets_len, sweeper_contract, transaction_signature, usdc,
+        deposit_address, enqueue_token_sweep, enqueued_sweep, enqueued_sweeps, expect_once,
+        gas_fee_estimate, install, queued_state, queued_targets_len, refusing, signing_anything,
+        sweeper_contract, transaction_signature, usdc,
     };
     use crate::numeric::{Wei, WeiPerGas};
     use crate::state::audit::{EventType, apply_state_transition};
@@ -39,15 +40,12 @@ mod enqueue_token_sweep {
     #[tokio::test]
     async fn should_be_no_op_when_targets_empty() {
         install(queued_state(&[(0, usdc())]));
-        let context = context(MockSigner::default());
+        // An empty mock: a token with nothing queued must ask for no signature, and a request
+        // nothing expects fails the test.
+        let context = context(MockSigner::new());
 
         enqueue_token_sweep((usdc(), vec![]), &context).await;
 
-        assert_eq!(
-            context.signer.signed.borrow().clone(),
-            vec![],
-            "a token with nothing queued must cost no signature"
-        );
         assert_eq!(enqueued_sweeps(), vec![]);
         assert_eq!(read_state(|s| s.next_sweep_id), SweepId(0));
         assert_eq!(
@@ -63,15 +61,10 @@ mod enqueue_token_sweep {
         // Without the helper there is no attestation preimage, so no deposit address can prove which
         // account it credits and the delegate would refuse every item of the batch.
         init_state(initial_state());
-        let context = context(MockSigner::default());
+        let context = context(MockSigner::new());
 
         enqueue_token_sweep((usdc(), targets), &context).await;
 
-        assert_eq!(
-            context.signer.signed.borrow().clone(),
-            vec![],
-            "an unconfigured helper must cost no signature"
-        );
         assert_eq!(enqueued_sweeps(), vec![]);
         assert_eq!(read_state(|s| s.next_sweep_id), SweepId(0));
     }
@@ -80,7 +73,7 @@ mod enqueue_token_sweep {
     async fn should_sweep_every_queued_deposit_of_the_token() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
 
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+        enqueue_token_sweep((usdc(), targets), &context(signing_anything())).await;
 
         let sweep = enqueued_sweep();
         assert_eq!(sweep.id, SweepId(0));
@@ -126,32 +119,32 @@ mod enqueue_token_sweep {
     #[tokio::test]
     async fn should_sign_over_the_attestation_and_the_authorization_of_every_address() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
-        let context = context(MockSigner::default());
-
-        enqueue_token_sweep((usdc(), targets), &context).await;
-
-        // What the signer is asked for is the sweep's whole cryptographic cost: one attestation
-        // digest per account, and one authorization tuple per deposit address.
-        let signed = context.signer.signed.borrow().clone();
-        assert_eq!(signed.len(), 4);
-        for expected in [
+        let mut signer = MockSigner::new();
+        // The sweep's whole cryptographic cost: one attestation digest per account, one
+        // authorization tuple per deposit address, and nothing else. Each must be asked for exactly
+        // once, and a request outside them has no expectation to match.
+        for signable in [
             attestation_of(0),
             attestation_of(1),
             authorization_of(0),
             authorization_of(1),
         ] {
-            assert!(
-                signed.contains(&expected),
-                "the signer was never asked for {expected:?}, only for {signed:?}"
-            );
+            expect_once(&mut signer, signable, Ok(transaction_signature()));
         }
+
+        enqueue_token_sweep((usdc(), targets), &context(signer)).await;
+
+        assert_eq!(
+            swept_accounts(&enqueued_sweep()),
+            vec![account(0), account(1)]
+        );
     }
 
     #[tokio::test]
     async fn should_record_the_attestation_it_signed() {
         let targets = install(queued_state(&[(0, usdc())]));
 
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+        enqueue_token_sweep((usdc(), targets), &context(signing_anything())).await;
 
         // An attestation outlives the sweep that paid for it, so it is recorded rather than
         // recomputed: this is what lets the next sweep of the address skip the signature.
@@ -175,15 +168,18 @@ mod enqueue_token_sweep {
             },
         );
         let targets = install(state);
-        let context = context(MockSigner::default());
-
-        enqueue_token_sweep((usdc(), targets), &context).await;
-
-        assert_eq!(
-            context.signer.signed.borrow().clone(),
-            vec![authorization_of(0)],
-            "only the authorization should have cost a signature"
+        let mut signer = MockSigner::new();
+        // Only the authorization. Nothing expects the attestation, so asking for it fails the test:
+        // it names the account and the helper, neither of which a sweep changes, and the minter
+        // already holds a signature over that digest.
+        expect_once(
+            &mut signer,
+            authorization_of(0),
+            Ok(transaction_signature()),
         );
+
+        enqueue_token_sweep((usdc(), targets), &context(signer)).await;
+
         assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(0)]);
     }
 
@@ -191,10 +187,10 @@ mod enqueue_token_sweep {
     async fn should_take_the_deposits_it_sweeps_out_of_the_queue() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
 
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+        enqueue_token_sweep((usdc(), targets), &context(signing_anything())).await;
 
-        // A deposit gets one sweep and no more: taken by this one, it is no longer a target the
-        // next tick would sweep again. The entry itself stays, attributed to the sweep, so that its
+        // A deposit gets one sweep and no more: taken by this one, it is no longer a target the next
+        // tick would sweep again. The entry itself stays, attributed to the sweep, so that its
         // outcome can be applied to it.
         assert_eq!(queued_targets_len(), 0);
         assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 2);
@@ -204,7 +200,7 @@ mod enqueue_token_sweep {
     async fn should_advance_the_next_sweep_id() {
         let targets = install(queued_state(&[(0, usdc())]));
 
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+        enqueue_token_sweep((usdc(), targets), &context(signing_anything())).await;
 
         // The next token's sweep in the same tick reads this, so it must not reuse the id.
         assert_eq!(read_state(|s| s.next_sweep_id), SweepId(1));
@@ -214,11 +210,7 @@ mod enqueue_token_sweep {
     async fn should_leave_out_a_deposit_whose_attestation_could_not_be_signed() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
 
-        enqueue_token_sweep(
-            (usdc(), targets),
-            &context(MockSigner::refusing(&[attestation_of(0)])),
-        )
-        .await;
+        enqueue_token_sweep((usdc(), targets), &context(refusing(&[attestation_of(0)]))).await;
 
         assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(1)]);
     }
@@ -229,7 +221,7 @@ mod enqueue_token_sweep {
 
         enqueue_token_sweep(
             (usdc(), targets),
-            &context(MockSigner::refusing(&[authorization_of(0)])),
+            &context(refusing(&[authorization_of(0)])),
         )
         .await;
 
@@ -244,7 +236,7 @@ mod enqueue_token_sweep {
 
         enqueue_token_sweep(
             (usdc(), targets),
-            &context(MockSigner::refusing(&[authorization_of(0)])),
+            &context(refusing(&[authorization_of(0)])),
         )
         .await;
 
@@ -259,20 +251,24 @@ mod enqueue_token_sweep {
     #[tokio::test]
     async fn should_not_authorize_an_address_it_could_not_attest() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
-        let context = context(MockSigner::refusing(&[attestation_of(0)]));
-
-        enqueue_token_sweep((usdc(), targets), &context).await;
-
-        // Account 0 drops out of the sweep either way, so authorizing it would spend a
-        // threshold-ECDSA signature on nothing.
-        assert!(
-            !context
-                .signer
-                .signed
-                .borrow()
-                .contains(&authorization_of(0)),
-            "an unattested address must not cost an authorization"
+        let mut signer = MockSigner::new();
+        expect_once(
+            &mut signer,
+            attestation_of(0),
+            Err("no attestation".to_string()),
         );
+        expect_once(&mut signer, attestation_of(1), Ok(transaction_signature()));
+        expect_once(
+            &mut signer,
+            authorization_of(1),
+            Ok(transaction_signature()),
+        );
+        // Nothing expects account 0's authorization: it drops out of the sweep either way, so
+        // authorizing it would spend a threshold-ECDSA signature on nothing.
+
+        enqueue_token_sweep((usdc(), targets), &context(signer)).await;
+
+        assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(1)]);
     }
 
     #[tokio::test]
@@ -281,10 +277,7 @@ mod enqueue_token_sweep {
 
         enqueue_token_sweep(
             (usdc(), targets),
-            &context(MockSigner::refusing(&[
-                attestation_of(0),
-                attestation_of(1),
-            ])),
+            &context(refusing(&[attestation_of(0), attestation_of(1)])),
         )
         .await;
 
@@ -294,7 +287,7 @@ mod enqueue_token_sweep {
     #[tokio::test]
     async fn should_skip_the_token_when_the_sweep_would_prepay_above_the_ceiling() {
         let targets = install(queued_state(&[(0, usdc())]));
-        let mut context = context(MockSigner::default());
+        let mut context = context(signing_anything());
         // A fee this high puts the prepayment far above the low-water mark the sweeper address is
         // kept above, so this is a sweep the minter could not pay for.
         context.gas_fee_estimate = GasFeeEstimate {
@@ -313,7 +306,7 @@ mod enqueue_token_sweep {
     async fn should_price_the_sweep_at_the_gas_estimate() {
         let targets = install(queued_state(&[(0, usdc())]));
 
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+        enqueue_token_sweep((usdc(), targets), &context(signing_anything())).await;
 
         let sweep = enqueued_sweep();
         assert_eq!(
@@ -795,39 +788,61 @@ fn derivation_path(index: u8) -> Vec<ByteBuf> {
     deposit_derivation_path(DepositAddressSchema::CkErc20, &account(index))
 }
 
-/// A digest and the derivation path it is signed under: all an [`EcdsaSigner`] is told, and so all a
-/// [`MockSigner`] can decide on.
+/// A digest and the derivation path it is signed under: all an [`EcdsaSigner`] is told, and so all
+/// an expectation on [`MockSigner`] can match on.
 type Signable = (Hash, Vec<ByteBuf>);
 
-/// An [`EcdsaSigner`] that signs every digest as [`transaction_signature`], except the ones it is
-/// told to refuse, and records everything it was asked to sign.
-#[derive(Default)]
-struct MockSigner {
-    refused: Vec<Signable>,
-    signed: RefCell<Vec<Signable>>,
-}
+mock! {
+    pub Signer {}
 
-impl MockSigner {
-    /// A signer whose threshold-ECDSA call fails for exactly the given signables.
-    fn refusing(refused: &[Signable]) -> Self {
-        Self {
-            refused: refused.to_vec(),
-            signed: RefCell::default(),
-        }
+    impl EcdsaSigner for Signer {
+        async fn sign_digest(
+            &self,
+            digest: &Hash,
+            derivation_path: &[ByteBuf],
+        ) -> Result<TransactionSignature, String>;
     }
 }
 
-impl EcdsaSigner for MockSigner {
-    async fn sign_digest(
-        &self,
-        digest: &Hash,
-        derivation_path: &[ByteBuf],
-    ) -> Result<TransactionSignature, String> {
-        let signable = (*digest, derivation_path.to_vec());
-        self.signed.borrow_mut().push(signable.clone());
-        if self.refused.contains(&signable) {
-            return Err(format!("no signature for {signable:?}"));
-        }
-        Ok(transaction_signature())
-    }
+/// A signer that answers whatever it is asked with [`transaction_signature`].
+///
+/// For a test whose subject is not which signatures a sweep spends. Where that *is* the subject,
+/// name the signables one at a time with [`expect_once`] instead: a request nothing expects then
+/// fails the test, so what a sweep must not sign needs no assertion of its own.
+fn signing_anything() -> MockSigner {
+    let mut signer = MockSigner::new();
+    signer
+        .expect_sign_digest()
+        .returning(|_digest, _derivation_path| Ok(transaction_signature()));
+    signer
+}
+
+/// A signer that answers anything but `refused`, whose threshold-ECDSA call fails.
+fn refusing(refused: &[Signable]) -> MockSigner {
+    let refused = refused.to_vec();
+    let mut signer = MockSigner::new();
+    signer
+        .expect_sign_digest()
+        .withf(move |digest, derivation_path| {
+            refused.contains(&(*digest, derivation_path.to_vec()))
+        })
+        .returning(|_digest, _derivation_path| Err("no signature".to_string()));
+    signer
+        .expect_sign_digest()
+        .returning(|_digest, _derivation_path| Ok(transaction_signature()));
+    signer
+}
+
+/// Have `signer` answer `signable` with `answer`, exactly once — and require that it be asked, which
+/// the mock checks when it is dropped.
+fn expect_once(
+    signer: &mut MockSigner,
+    signable: Signable,
+    answer: Result<TransactionSignature, String>,
+) {
+    signer
+        .expect_sign_digest()
+        .withf(move |digest, derivation_path| (*digest, derivation_path.to_vec()) == signable)
+        .times(1)
+        .return_once(move |_digest, _derivation_path| answer);
 }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,0 +1,410 @@
+use super::{
+    MAX_DEPOSITS_PER_SWEEP, PreparedDeposit, SweepBatch, attested_addresses,
+    delegation_authorization, prepared_deposits, sweep_batches_by_token,
+};
+use crate::deposit_address::DepositAddress;
+use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
+use crate::state::State;
+use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::automatic_deposits::SweepTarget;
+use crate::state::event::AutomaticDeposit;
+use crate::state::transactions::{SweepId, SweptDeposit};
+use crate::test_fixtures::{deposit_helper, state_with_deposit_helper, transaction_signature};
+use crate::tx::SignedAuthorization;
+use candid::Principal;
+use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeMap;
+
+mod sweep_batch {
+    use super::{
+        SweepBatch, account, authorization, deposit_address, prepared_for, queued_targets, usdc,
+        usdt,
+    };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn should_name_a_multi_token_account_once_in_the_call_data() {
+        let targets = queued_targets(&[(0, usdc()), (0, usdt()), (1, usdc())]);
+
+        let batch = SweepBatch::from(prepared_for(&targets));
+
+        assert_eq!(
+            batch
+                .items
+                .iter()
+                .map(|item| (item.deposit, item.account))
+                .collect::<Vec<_>>(),
+            vec![
+                (deposit_address(0), account(0)),
+                (deposit_address(1), account(1))
+            ]
+        );
+        assert_eq!(batch.tokens, vec![usdc(), usdt()]);
+        assert_eq!(batch.authorizations, vec![authorization(); 2]);
+    }
+
+    #[test]
+    fn should_keep_one_deposit_per_account_and_token() {
+        let targets = queued_targets(&[(0, usdc()), (0, usdt()), (1, usdc())]);
+
+        let batch = SweepBatch::from(prepared_for(&targets));
+
+        assert_eq!(
+            batch
+                .deposits
+                .iter()
+                .map(|deposit| (deposit.account, deposit.erc20_contract_address))
+                .collect::<Vec<_>>(),
+            vec![
+                (account(0), usdc()),
+                (account(0), usdt()),
+                (account(1), usdc())
+            ]
+        );
+    }
+
+    #[test]
+    fn should_authorize_every_address_it_sweeps_exactly_once() {
+        let targets = queued_targets(&[(0, usdc()), (0, usdt()), (1, usdc())]);
+
+        let batch = SweepBatch::from(prepared_for(&targets));
+
+        let addresses: BTreeSet<_> = batch
+            .deposits
+            .iter()
+            .map(|deposit| deposit.address)
+            .collect();
+        assert_eq!(addresses.len(), 2);
+        assert_eq!(batch.authorizations.len(), addresses.len());
+    }
+
+    #[test]
+    fn should_authorize_an_address_again_in_a_second_sweep_of_the_same_round() {
+        // Each token is its own sweep, so an address holding two of them is swept twice in one
+        // round. Both tuples are signed for nonce 0: the first installs the delegation, the second
+        // is skipped, and neither sweep waits for the other.
+        let usdc_sweep = SweepBatch::from(prepared_for(&queued_targets(&[(0, usdc())])));
+        let usdt_sweep = SweepBatch::from(prepared_for(&queued_targets(&[(0, usdt())])));
+
+        assert_eq!(usdc_sweep.authorizations, vec![authorization()]);
+        assert_eq!(usdt_sweep.authorizations, vec![authorization()]);
+    }
+}
+
+mod sweep_batches_by_token {
+    use super::{
+        MAX_DEPOSITS_PER_SWEEP, account, authorization, deposit_address, fail_a_sweep_of,
+        queued_state, sweep_batches_by_token, sweeper_contract, usdc, usdt,
+    };
+    use crate::numeric::{Wei, WeiPerGas};
+    use crate::state::sweeper_funding::SweeperFundingConfig;
+    use crate::state::transactions::{SweepId, SweepRequest, SweptDeposit};
+    use crate::tx::GasFeeEstimate;
+
+    #[test]
+    fn should_batch_a_token_at_a_time() {
+        let state = queued_state(&[(0, usdc()), (0, usdt()), (1, usdt())]);
+
+        let batches = sweep_batches_by_token(&state);
+
+        assert_eq!(
+            batches.keys().copied().collect::<Vec<_>>(),
+            vec![usdc(), usdt()]
+        );
+        assert_eq!(
+            batches[&usdc()]
+                .iter()
+                .map(|target| target.account())
+                .collect::<Vec<_>>(),
+            vec![account(0)]
+        );
+        // The account holding both tokens is swept once per token, in different transactions.
+        assert_eq!(
+            batches[&usdt()]
+                .iter()
+                .map(|target| (target.account(), target.address()))
+                .collect::<Vec<_>>(),
+            vec![
+                (account(0), deposit_address(0)),
+                (account(1), deposit_address(1))
+            ]
+        );
+    }
+
+    #[test]
+    fn should_leave_out_a_deposit_whose_sweep_failed() {
+        let mut state = queued_state(&[(0, usdc()), (1, usdc()), (2, usdc())]);
+        fail_a_sweep_of(&mut state, &[(1, usdc())]);
+
+        let batches = sweep_batches_by_token(&state);
+
+        assert_eq!(
+            batches[&usdc()]
+                .iter()
+                .map(|target| target.account())
+                .collect::<Vec<_>>(),
+            vec![account(0), account(2)]
+        );
+    }
+
+    #[test]
+    fn should_cap_every_token_batch_on_its_own() {
+        let queued: Vec<_> = (0..u8::try_from(MAX_DEPOSITS_PER_SWEEP).unwrap() + 3)
+            .flat_map(|index| [(index, usdc()), (index, usdt())])
+            .collect();
+
+        let batches = sweep_batches_by_token(&queued_state(&queued));
+
+        assert_eq!(batches[&usdc()].len(), MAX_DEPOSITS_PER_SWEEP);
+        assert_eq!(batches[&usdt()].len(), MAX_DEPOSITS_PER_SWEEP);
+    }
+
+    #[test]
+    fn should_keep_a_full_batch_within_what_a_single_sweep_may_prepay() {
+        // Mainnet's minimum withdrawal amount, which is what sets the sweeper's funding: a target
+        // of ten of them, and a low-water mark of half the target.
+        let funding =
+            SweeperFundingConfig::for_minimum_withdrawal_amount(Wei::new(30_000_000_000_000_000))
+                .expect("BUG: the target must not overflow");
+
+        let prepaid = GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::from(10_000_000_000_u64),
+            max_priority_fee_per_gas: WeiPerGas::from(1_000_000_000_u64),
+        }
+        .to_price(full_batch_request().gas_limit())
+        .max_transaction_fee();
+
+        assert!(
+            prepaid <= funding.low_water_mark,
+            "a full single-token batch prepays {prepaid:?}, above the {:?} a sweep may lock, so \
+             every sweep would be refused at 10 gwei",
+            funding.low_water_mark
+        );
+    }
+
+    /// A sweep of a full batch of addresses holding one token, each carrying its authorization: the
+    /// most gas [`MAX_DEPOSITS_PER_SWEEP`] deposits can come to.
+    fn full_batch_request() -> SweepRequest {
+        let deposits = u8::try_from(MAX_DEPOSITS_PER_SWEEP).expect("BUG: the cap must fit a u8");
+        SweepRequest {
+            id: SweepId(0),
+            destination: sweeper_contract(),
+            amount: Wei::ZERO,
+            data: vec![],
+            max_transaction_fee: Wei::ZERO,
+            created_at: 0,
+            authorizations: (0..deposits).map(|_| authorization()).collect(),
+            deposits: (0..deposits)
+                .map(|index| SweptDeposit {
+                    account: account(index),
+                    erc20_contract_address: usdc(),
+                    address: deposit_address(index),
+                })
+                .collect(),
+        }
+    }
+}
+
+mod prepared_deposits {
+    use super::{
+        account, authorization, authorized, deposit_address, prepared_deposits, queued_targets,
+        transaction_signature, usdc, usdt,
+    };
+    use crate::tx::TransactionSignature;
+    use icrc_ledger_types::icrc1::account::Account;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_drop_a_deposit_whose_authorization_could_not_be_signed() {
+        let targets = queued_targets(&[(0, usdc()), (1, usdc())]);
+        let attestations = attested(&[0, 1]);
+        // Only account 1's authorization came back.
+        let authorizations = authorized(&[1]);
+
+        let prepared = prepared_deposits(&targets, &attestations, &authorizations);
+
+        // Sweeping account 0 without it risks calling an address whose code was never installed,
+        // and that reverts the whole batch.
+        assert_eq!(
+            prepared
+                .iter()
+                .map(|deposit| deposit.target.address())
+                .collect::<Vec<_>>(),
+            vec![deposit_address(1)]
+        );
+        assert_eq!(
+            prepared[0].authorization,
+            authorization(),
+            "the deposit that is kept must carry the authorization this sweep installs"
+        );
+    }
+
+    #[test]
+    fn should_keep_every_deposit_of_an_authorized_account() {
+        let targets = queued_targets(&[(0, usdc()), (0, usdt())]);
+
+        let prepared = prepared_deposits(&targets, &attested(&[0]), &authorized(&[0]));
+
+        assert_eq!(prepared.len(), 2);
+    }
+
+    #[test]
+    fn should_drop_a_deposit_whose_attestation_could_not_be_signed() {
+        let targets = queued_targets(&[(0, usdc()), (1, usdc())]);
+
+        let prepared = prepared_deposits(&targets, &attested(&[1]), &authorized(&[0, 1]));
+
+        assert_eq!(
+            prepared
+                .iter()
+                .map(|deposit| deposit.target.address())
+                .collect::<Vec<_>>(),
+            vec![deposit_address(1)]
+        );
+    }
+
+    fn attested(indices: &[u8]) -> BTreeMap<Account, TransactionSignature> {
+        indices
+            .iter()
+            .map(|index| (account(*index), transaction_signature()))
+            .collect()
+    }
+}
+
+mod delegation_authorization {
+    use super::{delegation_authorization, sweeper_contract};
+    use crate::numeric::TransactionNonce;
+
+    #[test]
+    fn should_authorize_the_configured_delegate_at_nonce_zero() {
+        let authorization = delegation_authorization(11155111, sweeper_contract());
+
+        // Nonce 0 is what makes the tuple correct whether or not the address is already delegated,
+        // so it is never read from chain and never anything else.
+        assert_eq!(authorization.nonce, TransactionNonce::ZERO);
+        assert_eq!(authorization.delegate, sweeper_contract());
+        assert_eq!(authorization.chain_id, 11155111);
+    }
+}
+
+mod attested_addresses {
+    use super::{account, attested_addresses, deposit_address, queued_targets, usdc, usdt};
+    use crate::test_fixtures::transaction_signature;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_hold_one_address_per_attested_account() {
+        let targets = queued_targets(&[(0, usdc()), (0, usdt()), (1, usdc())]);
+        let attestations = BTreeMap::from([(account(0), transaction_signature())]);
+
+        // Account 1 has no attestation, so authorizing its address would spend a signature on a
+        // deposit that drops out of the sweep anyway.
+        assert_eq!(
+            attested_addresses(&targets, &attestations),
+            BTreeMap::from([(account(0), deposit_address(0))])
+        );
+    }
+}
+
+/// The sweep queue of a state holding one funded pair per given `(account index, token)`, each at
+/// its account's [`deposit_address`].
+fn queued_targets(pairs: &[(u8, Address)]) -> Vec<SweepTarget> {
+    let state = queued_state(pairs);
+    state.automatic_deposits.sweep_targets_iter().collect()
+}
+
+/// A state whose deposit helper is configured, so every queued account has an attestation request,
+/// and whose sweep queue holds one funded pair per given `(account index, token)`.
+fn queued_state(pairs: &[(u8, Address)]) -> State {
+    let mut state = state_with_deposit_helper(deposit_helper());
+    for (index, token) in pairs {
+        apply_state_transition(
+            &mut state,
+            &EventType::AutomaticDepositReceived(AutomaticDeposit {
+                owner: account(*index).owner,
+                subaccount: account(*index).subaccount,
+                address: deposit_address(*index),
+                erc20_contract_address: *token,
+                last_scanned_block: BlockNumber::new(900),
+                scan_count: 1,
+                scanned_balance: Erc20Value::new(1_000),
+            }),
+        );
+    }
+    state
+}
+
+/// Take the given `(account index, token)` pairs into a sweep and have that sweep fail, which is how
+/// a queued deposit comes to have a failure to its name.
+fn fail_a_sweep_of(state: &mut State, pairs: &[(u8, Address)]) {
+    let deposits: Vec<_> = pairs
+        .iter()
+        .map(|(index, token)| SweptDeposit {
+            account: account(*index),
+            erc20_contract_address: *token,
+            address: deposit_address(*index),
+        })
+        .collect();
+    let sweep_id = SweepId(0);
+    state
+        .automatic_deposits
+        .record_sweep_scheduled(sweep_id, &deposits);
+    state
+        .automatic_deposits
+        .record_sweep_failed(sweep_id, &deposits);
+}
+
+/// One [`PreparedDeposit`] per target, all attested and all authorized.
+fn prepared_for(targets: &[SweepTarget]) -> Vec<PreparedDeposit> {
+    targets
+        .iter()
+        .map(|target| PreparedDeposit {
+            target: *target,
+            attestation: transaction_signature(),
+            authorization: authorization(),
+        })
+        .collect()
+}
+
+/// An authorization for the account of every given index.
+fn authorized(indices: &[u8]) -> BTreeMap<Account, SignedAuthorization> {
+    indices
+        .iter()
+        .map(|index| (account(*index), authorization()))
+        .collect()
+}
+
+fn authorization() -> SignedAuthorization {
+    SignedAuthorization {
+        chain_id: 11155111,
+        delegate: sweeper_contract(),
+        nonce: TransactionNonce::ZERO,
+        y_parity: transaction_signature().signature_y_parity,
+        r: transaction_signature().r,
+        s: transaction_signature().s,
+    }
+}
+
+fn account(index: u8) -> Account {
+    Account {
+        owner: Principal::from_slice(&[index]),
+        subaccount: Some([index; 32]),
+    }
+}
+
+fn deposit_address(index: u8) -> DepositAddress {
+    DepositAddress::new(Address::new([index; 20]))
+}
+
+fn sweeper_contract() -> Address {
+    Address::new([0xde; 20])
+}
+
+fn usdc() -> Address {
+    Address::new([0xaa; 20])
+}
+
+fn usdt() -> Address {
+    Address::new([0xbb; 20])
+}

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,20 +1,310 @@
 use super::{
-    MAX_DEPOSITS_PER_SWEEP, PreparedDeposit, SweepBatch, attested_addresses,
-    delegation_authorization, prepared_deposits, sweep_batches_by_token,
+    MAX_DEPOSITS_PER_SWEEP, PreparedDeposit, SweepBatch, SweepContext, attested_addresses,
+    delegation_authorization, enqueue_token_sweep, prepared_deposits, sweep_batches_by_token,
 };
-use crate::deposit_address::DepositAddress;
-use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
-use crate::state::State;
+use crate::deposit_address::{DepositAddress, DepositAddressSchema, deposit_derivation_path};
+use crate::eth_rpc::Hash;
+use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::automatic_deposits::SweepTarget;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::{SweepId, SweptDeposit};
-use crate::test_fixtures::{deposit_helper, state_with_deposit_helper, transaction_signature};
-use crate::tx::SignedAuthorization;
+use crate::state::transactions::{SweepId, SweepRequest, SweptDeposit};
+use crate::state::{State, read_state};
+use crate::test_fixtures::{
+    deposit_helper, init_state, state_with_deposit_helper, transaction_signature,
+};
+use crate::tx::{EcdsaSigner, GasFeeEstimate, SignedAuthorization, TransactionSignature};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
+use serde_bytes::ByteBuf;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
+
+mod enqueue_token_sweep {
+    use super::{
+        CREATED_AT, MockSigner, account, attestation_of, authorization_of, context,
+        deposit_address, enqueue_token_sweep, enqueued_sweep, enqueued_sweeps, gas_fee_estimate,
+        install, queued_state, queued_targets_len, sweeper_contract, transaction_signature, usdc,
+    };
+    use crate::numeric::{Wei, WeiPerGas};
+    use crate::state::audit::{EventType, apply_state_transition};
+    use crate::state::read_state;
+    use crate::state::transactions::{SweepId, SweepRequest, SweptDeposit};
+    use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
+    use crate::test_fixtures::{init_state, initial_state};
+    use crate::tx::GasFeeEstimate;
+    use icrc_ledger_types::icrc1::account::Account;
+
+    #[tokio::test]
+    async fn should_sweep_every_queued_deposit_of_the_token() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        let sweep = enqueued_sweep();
+        assert_eq!(sweep.id, SweepId(0));
+        assert_eq!(sweep.destination, sweeper_contract());
+        assert_eq!(sweep.amount, Wei::ZERO, "an ERC-20 sweep moves no ETH");
+        assert_eq!(sweep.created_at, CREATED_AT);
+        assert_eq!(
+            sweep.deposits,
+            vec![
+                SweptDeposit {
+                    account: account(0),
+                    erc20_contract_address: usdc(),
+                    address: deposit_address(0),
+                },
+                SweptDeposit {
+                    account: account(1),
+                    erc20_contract_address: usdc(),
+                    address: deposit_address(1),
+                },
+            ]
+        );
+        assert_eq!(
+            sweep.data,
+            encode_sweep_erc20_batch(
+                &[
+                    SweepItem {
+                        deposit: deposit_address(0),
+                        account: account(0),
+                        attestation: transaction_signature(),
+                    },
+                    SweepItem {
+                        deposit: deposit_address(1),
+                        account: account(1),
+                        attestation: transaction_signature(),
+                    },
+                ],
+                &[usdc()],
+            ),
+            "every attested address must reach the call data carrying its own attestation"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_sign_over_the_attestation_and_the_authorization_of_every_address() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+        let context = context(MockSigner::default());
+
+        enqueue_token_sweep((usdc(), targets), &context).await;
+
+        // What the signer is asked for is the sweep's whole cryptographic cost: one attestation
+        // digest per account, and one authorization tuple per deposit address.
+        let signed = context.signer.signed.borrow().clone();
+        assert_eq!(signed.len(), 4);
+        for expected in [
+            attestation_of(0),
+            attestation_of(1),
+            authorization_of(0),
+            authorization_of(1),
+        ] {
+            assert!(
+                signed.contains(&expected),
+                "the signer was never asked for {expected:?}, only for {signed:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_record_the_attestation_it_signed() {
+        let targets = install(queued_state(&[(0, usdc())]));
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        // An attestation outlives the sweep that paid for it, so it is recorded rather than
+        // recomputed: this is what lets the next sweep of the address skip the signature.
+        assert_eq!(
+            read_state(|s| s.attestation(account(0)).cloned()),
+            Some(transaction_signature())
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reuse_a_stored_attestation_instead_of_signing_it_again() {
+        let mut state = queued_state(&[(0, usdc())]);
+        let request = state
+            .attestation_request(account(0))
+            .expect("BUG: the deposit helper is configured");
+        apply_state_transition(
+            &mut state,
+            &EventType::AttestedDepositAddress {
+                request,
+                signature: transaction_signature(),
+            },
+        );
+        let targets = install(state);
+        let context = context(MockSigner::default());
+
+        enqueue_token_sweep((usdc(), targets), &context).await;
+
+        assert_eq!(
+            context.signer.signed.borrow().clone(),
+            vec![authorization_of(0)],
+            "only the authorization should have cost a signature"
+        );
+        assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(0)]);
+    }
+
+    #[tokio::test]
+    async fn should_take_the_deposits_it_sweeps_out_of_the_queue() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        // A deposit gets one sweep and no more: taken by this one, it is no longer a target the
+        // next tick would sweep again. The entry itself stays, attributed to the sweep, so that its
+        // outcome can be applied to it.
+        assert_eq!(queued_targets_len(), 0);
+        assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 2);
+    }
+
+    #[tokio::test]
+    async fn should_advance_the_next_sweep_id() {
+        let targets = install(queued_state(&[(0, usdc())]));
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        // The next token's sweep in the same tick reads this, so it must not reuse the id.
+        assert_eq!(read_state(|s| s.next_sweep_id), SweepId(1));
+    }
+
+    #[tokio::test]
+    async fn should_skip_the_token_when_no_deposit_helper_is_configured() {
+        let targets = install(queued_state(&[(0, usdc())]));
+        // Without the helper the attestation preimage is unknown, so nothing can be attested.
+        init_state(initial_state());
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        assert_eq!(enqueued_sweeps(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn should_leave_out_a_deposit_whose_attestation_could_not_be_signed() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep(
+            (usdc(), targets),
+            &context(MockSigner::refusing(&[attestation_of(0)])),
+        )
+        .await;
+
+        assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(1)]);
+    }
+
+    #[tokio::test]
+    async fn should_leave_out_a_deposit_whose_authorization_could_not_be_signed() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep(
+            (usdc(), targets),
+            &context(MockSigner::refusing(&[authorization_of(0)])),
+        )
+        .await;
+
+        // solc guards the delegate call with `extcodesize`, so sweeping an address whose code was
+        // never installed would revert the whole batch.
+        assert_eq!(swept_accounts(&enqueued_sweep()), vec![account(1)]);
+    }
+
+    #[tokio::test]
+    async fn should_still_record_the_attestation_of_a_deposit_it_could_not_authorize() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep(
+            (usdc(), targets),
+            &context(MockSigner::refusing(&[authorization_of(0)])),
+        )
+        .await;
+
+        // Account 0 drops out of this sweep, but its attestation was signed and is good forever:
+        // losing it would make the next sweep pay for it again.
+        assert_eq!(
+            read_state(|s| s.attestation(account(0)).cloned()),
+            Some(transaction_signature())
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_authorize_an_address_it_could_not_attest() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+        let context = context(MockSigner::refusing(&[attestation_of(0)]));
+
+        enqueue_token_sweep((usdc(), targets), &context).await;
+
+        // Account 0 drops out of the sweep either way, so authorizing it would spend a
+        // threshold-ECDSA signature on nothing.
+        assert!(
+            !context
+                .signer
+                .signed
+                .borrow()
+                .contains(&authorization_of(0)),
+            "an unattested address must not cost an authorization"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_skip_the_token_when_nothing_could_be_signed_for() {
+        let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
+
+        enqueue_token_sweep(
+            (usdc(), targets),
+            &context(MockSigner::refusing(&[
+                attestation_of(0),
+                attestation_of(1),
+            ])),
+        )
+        .await;
+
+        assert_eq!(enqueued_sweeps(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn should_skip_the_token_when_the_sweep_would_prepay_above_the_ceiling() {
+        let targets = install(queued_state(&[(0, usdc())]));
+        let mut context = context(MockSigner::default());
+        // A fee this high puts the prepayment far above the low-water mark the sweeper address is
+        // kept above, so this is a sweep the minter could not pay for.
+        context.gas_fee_estimate = GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::from(10_000_000_000_000_u64),
+            max_priority_fee_per_gas: WeiPerGas::from(1_000_000_000_u64),
+        };
+
+        enqueue_token_sweep((usdc(), targets), &context).await;
+
+        // The deposits stay queued for the next tick, at whatever the fee is then.
+        assert_eq!(enqueued_sweeps(), vec![]);
+        assert_eq!(queued_targets_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_price_the_sweep_at_the_gas_estimate() {
+        let targets = install(queued_state(&[(0, usdc())]));
+
+        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
+
+        let sweep = enqueued_sweep();
+        assert_eq!(
+            sweep.max_transaction_fee,
+            gas_fee_estimate()
+                .to_price(sweep.gas_limit())
+                .max_transaction_fee()
+        );
+        assert_ne!(sweep.max_transaction_fee, Wei::ZERO);
+    }
+
+    /// The accounts a sweep names, in the order its call data sweeps them.
+    fn swept_accounts(sweep: &SweepRequest) -> Vec<Account> {
+        sweep
+            .deposits
+            .iter()
+            .map(|deposit| deposit.account)
+            .collect()
+    }
+}
 
 mod sweep_batch {
     use super::{
@@ -407,4 +697,108 @@ fn usdc() -> Address {
 
 fn usdt() -> Address {
     Address::new([0xbb; 20])
+}
+
+/// The IC time the sweeps a test enqueues are created at.
+const CREATED_AT: u64 = 1_699_527_697_000_000_000;
+
+/// A [`SweepContext`] over `signer`, at a gas fee the ceiling does not refuse.
+fn context<S>(signer: S) -> SweepContext<S> {
+    SweepContext {
+        signer,
+        sweeper_contract: sweeper_contract(),
+        gas_fee_estimate: gas_fee_estimate(),
+        created_at: CREATED_AT,
+    }
+}
+
+fn gas_fee_estimate() -> GasFeeEstimate {
+    GasFeeEstimate {
+        base_fee_per_gas: WeiPerGas::from(10_000_000_000_u64),
+        max_priority_fee_per_gas: WeiPerGas::from(1_000_000_000_u64),
+    }
+}
+
+/// Install `state` so `read_state` sees it, and hand back its sweep queue — which is what the
+/// enqueue path is given.
+fn install(state: State) -> Vec<SweepTarget> {
+    let targets = state.automatic_deposits.sweep_targets_iter().collect();
+    init_state(state);
+    targets
+}
+
+/// How many queued deposits are still sweep targets, i.e. what the next tick would batch.
+fn queued_targets_len() -> usize {
+    read_state(|s| s.automatic_deposits.sweep_targets_iter().count())
+}
+
+/// The sweeps the enqueue path has put on the sweeper pipeline.
+fn enqueued_sweeps() -> Vec<SweepRequest> {
+    read_state(|s| s.sweeper_transactions.requests_iter().cloned().collect())
+}
+
+/// The single sweep the enqueue path has put on the sweeper pipeline.
+fn enqueued_sweep() -> SweepRequest {
+    let mut sweeps = enqueued_sweeps();
+    assert_eq!(sweeps.len(), 1, "expected exactly one sweep: {sweeps:?}");
+    sweeps.remove(0)
+}
+
+/// What the signer is asked for when the account at `index` attests to owning its deposit address.
+fn attestation_of(index: u8) -> Signable {
+    let request = read_state(|s| s.attestation_request(account(index)))
+        .expect("BUG: the deposit helper must be configured");
+    (request.digest(), derivation_path(index))
+}
+
+/// What the signer is asked for when the deposit address of `index` delegates its code to the
+/// sweeper contract. Every address signs the same tuple — nonce 0 on the one chain and delegate —
+/// so only the derivation path tells two of these apart.
+fn authorization_of(index: u8) -> Signable {
+    let chain_id = read_state(State::ethereum_network).chain_id();
+    (
+        delegation_authorization(chain_id, sweeper_contract()).hash(),
+        derivation_path(index),
+    )
+}
+
+fn derivation_path(index: u8) -> Vec<ByteBuf> {
+    deposit_derivation_path(DepositAddressSchema::CkErc20, &account(index))
+}
+
+/// A digest and the derivation path it is signed under: all an [`EcdsaSigner`] is told, and so all a
+/// [`MockSigner`] can decide on.
+type Signable = (Hash, Vec<ByteBuf>);
+
+/// An [`EcdsaSigner`] that signs every digest as [`transaction_signature`], except the ones it is
+/// told to refuse, and records everything it was asked to sign.
+#[derive(Default)]
+struct MockSigner {
+    refused: Vec<Signable>,
+    signed: RefCell<Vec<Signable>>,
+}
+
+impl MockSigner {
+    /// A signer whose threshold-ECDSA call fails for exactly the given signables.
+    fn refusing(refused: &[Signable]) -> Self {
+        Self {
+            refused: refused.to_vec(),
+            signed: RefCell::default(),
+        }
+    }
+}
+
+impl EcdsaSigner for MockSigner {
+    async fn sign_digest(
+        &self,
+        digest: &Hash,
+        derivation_path: &[ByteBuf],
+    ) -> Result<TransactionSignature, String> {
+        let signable = (*digest, derivation_path.to_vec());
+        self.signed.borrow_mut().push(signable.clone());
+        if self.refused.contains(&signable) {
+            return Err(format!("no signature for {signable:?}"));
+        }
+        Ok(transaction_signature())
+    }
 }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -37,6 +37,46 @@ mod enqueue_token_sweep {
     use icrc_ledger_types::icrc1::account::Account;
 
     #[tokio::test]
+    async fn should_be_no_op_when_targets_empty() {
+        install(queued_state(&[(0, usdc())]));
+        let context = context(MockSigner::default());
+
+        enqueue_token_sweep((usdc(), vec![]), &context).await;
+
+        assert_eq!(
+            context.signer.signed.borrow().clone(),
+            vec![],
+            "a token with nothing queued must cost no signature"
+        );
+        assert_eq!(enqueued_sweeps(), vec![]);
+        assert_eq!(read_state(|s| s.next_sweep_id), SweepId(0));
+        assert_eq!(
+            queued_targets_len(),
+            1,
+            "nothing may be taken off the queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_be_no_op_when_helper_deposit_smart_contract_not_configured() {
+        let targets = install(queued_state(&[(0, usdc())]));
+        // Without the helper there is no attestation preimage, so no deposit address can prove which
+        // account it credits and the delegate would refuse every item of the batch.
+        init_state(initial_state());
+        let context = context(MockSigner::default());
+
+        enqueue_token_sweep((usdc(), targets), &context).await;
+
+        assert_eq!(
+            context.signer.signed.borrow().clone(),
+            vec![],
+            "an unconfigured helper must cost no signature"
+        );
+        assert_eq!(enqueued_sweeps(), vec![]);
+        assert_eq!(read_state(|s| s.next_sweep_id), SweepId(0));
+    }
+
+    #[tokio::test]
     async fn should_sweep_every_queued_deposit_of_the_token() {
         let targets = install(queued_state(&[(0, usdc()), (1, usdc())]));
 
@@ -168,17 +208,6 @@ mod enqueue_token_sweep {
 
         // The next token's sweep in the same tick reads this, so it must not reuse the id.
         assert_eq!(read_state(|s| s.next_sweep_id), SweepId(1));
-    }
-
-    #[tokio::test]
-    async fn should_skip_the_token_when_no_deposit_helper_is_configured() {
-        let targets = install(queued_state(&[(0, usdc())]));
-        // Without the helper the attestation preimage is unknown, so nothing can be attested.
-        init_state(initial_state());
-
-        enqueue_token_sweep((usdc(), targets), &context(MockSigner::default())).await;
-
-        assert_eq!(enqueued_sweeps(), vec![]);
     }
 
     #[tokio::test]

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
@@ -36,9 +36,15 @@ pub struct SweepItem {
 /// sweeps every `token` balance held by every `item`'s deposit address to the minter's main address
 /// through the deposit helper.
 ///
-/// The tokens apply to every item, so a batch mixing addresses that hold different tokens pays a
-/// `balanceOf` call per pair that holds nothing.
-/// TODO(DEFI-2980): group a batch by token so every pair in it holds a balance.
+/// The tokens apply to every item, so a batch mixing addresses that hold different tokens would pay
+/// a `balanceOf` call per pair that holds nothing, and its gas would grow as addresses × tokens.
+/// The minter therefore sends one token per batch (see `sweep::sweep_batches_by_token`), which is
+/// what keeps a sweep's gas linear in the addresses it touches.
+///
+/// `sweepErc20Batch` has no per-item error handling either, so one address whose transfer reverts —
+/// blacklisted for that token, say — takes the whole batch down with it and blocks every other
+/// deposit in it.
+/// TODO: catch the per-item revert in the delegate, or split a failing batch and retry the halves.
 ///
 /// See the [Contract ABI Specification](https://docs.soliditylang.org/en/develop/abi-spec.html#contract-abi-specification):
 /// both arguments are dynamic, so the head holds one offset each and the two blocks follow.

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -1,6 +1,6 @@
 use super::{
-    AccessList, AccessListItem, SignableTransaction, Signed, StorageKey, TransactionPrice,
-    TransactionSignature, encode_u256,
+    AccessList, AccessListItem, EcdsaSigner, SignableTransaction, Signed, StorageKey,
+    TransactionPrice, TransactionSignature, encode_u256,
 };
 use crate::{
     checked_amount::CheckedAmountOf,
@@ -81,14 +81,18 @@ impl Authorization {
         Hash(ic_sha3::Keccak256::hash(bytes))
     }
 
-    pub async fn sign(self, derivation_path: Vec<ByteBuf>) -> Result<SignedAuthorization, String> {
+    pub(crate) async fn sign<S: EcdsaSigner>(
+        self,
+        signer: &S,
+        derivation_path: Vec<ByteBuf>,
+    ) -> Result<SignedAuthorization, String> {
         if self.chain_id == 0 {
             return Err(
                 "BUG: EIP-7702 authorization chain_id must be set explicitly and never 0"
                     .to_string(),
             );
         }
-        let signature = super::sign_digest(&self.hash(), &derivation_path).await?;
+        let signature = signer.sign_digest(&self.hash(), &derivation_path).await?;
         Ok(SignedAuthorization {
             chain_id: self.chain_id,
             delegate: self.delegate,

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -179,6 +179,38 @@ pub fn encode_u256<T: Into<u256>>(stream: &mut RlpStream, value: T) {
     stream.append(&value.to_be_bytes()[leading_empty_bytes..].as_ref());
 }
 
+/// The threshold-ECDSA signing the minter does, as a thin wrapper over the IC primitive that does
+/// it: [`IcEcdsaSigner`] forwards to [`sign_digest`] and nothing else.
+///
+/// Signing is the only part of deciding what to sign that leaves the canister, so this is the seam
+/// a unit test mocks. Deliberately nothing but the primitive lives behind it — no business logic and
+/// no state mutation — so that everything a caller does with a signature stays under test when the
+/// signature itself is faked.
+pub(crate) trait EcdsaSigner {
+    /// `digest` signed with the minter's ECDSA key under `derivation_path`.
+    ///
+    /// # Errors
+    /// * a description of why the threshold-ECDSA signature could not be produced.
+    async fn sign_digest(
+        &self,
+        digest: &Hash,
+        derivation_path: &[ByteBuf],
+    ) -> Result<TransactionSignature, String>;
+}
+
+/// The [`EcdsaSigner`] every signature the minter really makes goes through.
+pub(crate) struct IcEcdsaSigner;
+
+impl EcdsaSigner for IcEcdsaSigner {
+    async fn sign_digest(
+        &self,
+        digest: &Hash,
+        derivation_path: &[ByteBuf],
+    ) -> Result<TransactionSignature, String> {
+        sign_digest(digest, derivation_path).await
+    }
+}
+
 /// Sign `digest` with the minter's ECDSA key under `derivation_path`, resolving the signature's
 /// parity bit against the key that made it.
 pub(crate) async fn sign_digest(


### PR DESCRIPTION
## Why

- Detected deposits sat in the sweep queue with nothing turning them into a transaction.

## What

- A minute task folds the sweep queue into one batch per token, capped at 20 deposits each.
- One sweep per token, never a mixed batch: the delegate's batch entry point runs its whole token list against every address it touches, so a mixed batch would pay for the full cross product of balance checks.
- Each batch signs one attestation and one EIP-7702 authorization per deposit address; stored attestations are reused instead of re-signed.
- Every authorization is signed for nonce 0, whatever the address holds: it either installs the delegation or is skipped because one is already installed, so no delegation state needs tracking or chain reads.
- The signed batch becomes a sweep request that the existing sweeper pipeline prices, signs, sends, and finalizes.
- A deposit whose attestation or authorization cannot be signed is left out of the batch and offered again on the next tick.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
