### PR TITLE
test(cketh): teach the live harness to deploy and drive the sweep contracts

### DIFF
--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -19,6 +19,14 @@ use std::time::{Duration, Instant};
 /// `eth_sendTransaction` without any local signing.
 pub const DEV_ACCOUNT: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
 
+/// The chain the harness pretends to be, matching the `EthereumNetwork::Mainnet` the fixture
+/// installs the minter with.
+pub const CHAIN_ID: u64 = 1;
+
+/// Seconds between blocks on the harness' chain. Fast enough that a test does not wait on it, slow
+/// enough that a block still holds several transactions.
+const BLOCK_TIME_SECS: &str = "1";
+
 /// The whole supply minted to the deployer when deploying a [`deploy_mock_erc20`] token.
 const TOKEN_SUPPLY: u128 = 1_000_000_000;
 
@@ -52,7 +60,18 @@ impl Anvil {
     /// trails `latest` by two blocks instead of the default 64 (2 epochs x 32 slots) — which is what
     /// lets a test drive the minter at its production `BlockTag::Finalized`.
     pub fn start_mainnet_like() -> Self {
-        Self::start_with_args(&["--chain-id", "1", "--slots-in-an-epoch", "1"])
+        // Interval mining, so the chain advances on its own. By default anvil only mines when it
+        // receives a transaction, which leaves a chain that looks frozen to everything reading
+        // it: the balance scan measures its backoff in elapsed *blocks*, so no scan after the
+        // first is ever due, and `finalized` never moves at all.
+        Self::start_with_args(&[
+            "--chain-id",
+            "1",
+            "--slots-in-an-epoch",
+            "1",
+            "--block-time",
+            BLOCK_TIME_SECS,
+        ])
     }
 
     fn start_with_args(extra_args: &[&str]) -> Self {
@@ -223,6 +242,126 @@ impl Anvil {
         let receipt = self.await_receipt(&hash);
         assert!(status_ok(&receipt), "deployment reverted");
         address_from_hex(receipt["contractAddress"].as_str().unwrap())
+    }
+
+    /// A plain `eth_call` against `to`, for reading contract state in assertions.
+    pub fn call(&self, to: &Address, data: &[u8]) -> Vec<u8> {
+        from_hex(
+            self.rpc(
+                "eth_call",
+                serde_json::json!([
+                    {"to": to_hex(to.as_ref()), "input": to_hex(data)},
+                    "latest"
+                ]),
+            )
+            .as_str()
+            .unwrap(),
+        )
+    }
+
+    /// The ETH balance of `address`, so a test can see the sweeper pay for its own gas.
+    pub fn balance(&self, address: &Address) -> u128 {
+        let balance = self.rpc(
+            "eth_getBalance",
+            serde_json::json!([to_hex(address.as_ref()), "latest"]),
+        );
+        let balance = balance.as_str().unwrap();
+        u128::from_str_radix(balance.trim_start_matches("0x"), 16)
+            .unwrap_or_else(|e| panic!("not a u128 balance {balance}: {e}"))
+    }
+
+    /// Every transaction `sender` has sent, oldest first, with what each did on chain.
+    pub fn transactions_of(&self, sender: &Address) -> Vec<SentTransaction> {
+        let head = self.block_number();
+        let mut sent = Vec::new();
+        for height in 0..=head {
+            let block = self.rpc(
+                "eth_getBlockByNumber",
+                serde_json::json!([format!("0x{height:x}"), true]),
+            );
+            let Some(transactions) = block["transactions"].as_array() else {
+                continue;
+            };
+            for transaction in transactions {
+                if transaction["from"].as_str() != Some(&to_hex(sender.as_ref())) {
+                    continue;
+                }
+                let hash = transaction["hash"].as_str().unwrap().to_string();
+                let receipt = self.rpc("eth_getTransactionReceipt", serde_json::json!([&hash]));
+                sent.push(SentTransaction {
+                    succeeded: status_ok(&receipt),
+                    gas_used: hex_u64(&receipt["gasUsed"]),
+                    gas_limit: hex_u64(&transaction["gas"]),
+                    transaction_type: hex_u64(&transaction["type"]),
+                    hash,
+                });
+            }
+        }
+        sent
+    }
+
+    /// The receipt of the most recent transaction `sender` sent, searching back from the chain head,
+    /// together with the gas the transaction was allowed. A reverted sweep whose `gasUsed` equals its
+    /// `gas` ran out of gas; one below it hit a `require`.
+    pub fn last_transaction_of(&self, sender: &Address) -> Option<SentTransaction> {
+        let head = self.block_number();
+        for height in (0..=head).rev() {
+            let block = self.rpc(
+                "eth_getBlockByNumber",
+                serde_json::json!([format!("0x{height:x}"), true]),
+            );
+            let Some(transactions) = block["transactions"].as_array() else {
+                continue;
+            };
+            for transaction in transactions {
+                if transaction["from"].as_str() != Some(&to_hex(sender.as_ref())) {
+                    continue;
+                }
+                let hash = transaction["hash"].as_str().unwrap().to_string();
+                let receipt = self.rpc("eth_getTransactionReceipt", serde_json::json!([&hash]));
+                return Some(SentTransaction {
+                    succeeded: status_ok(&receipt),
+                    gas_used: hex_u64(&receipt["gasUsed"]),
+                    gas_limit: hex_u64(&transaction["gas"]),
+                    transaction_type: hex_u64(&transaction["type"]),
+                    hash,
+                });
+            }
+        }
+        None
+    }
+
+    /// The height of the chain's latest block.
+    pub fn block_number(&self) -> u64 {
+        let number = self.rpc("eth_blockNumber", serde_json::json!([]));
+        let number = number.as_str().unwrap();
+        u64::from_str_radix(number.trim_start_matches("0x"), 16)
+            .unwrap_or_else(|e| panic!("not a u64 block number {number}: {e}"))
+    }
+
+    /// How many transactions `address` has sent, so a test can pin that a batch really was one
+    /// transaction. An EIP-7702 authority's nonce also advances when one of its own authorizations
+    /// is applied, which is how a swept deposit address ends up with a nonce of 1 without ever
+    /// having sent anything.
+    pub fn transaction_count(&self, address: &Address) -> u64 {
+        let count = self.rpc(
+            "eth_getTransactionCount",
+            serde_json::json!([to_hex(address.as_ref()), "latest"]),
+        );
+        let count = count.as_str().unwrap();
+        u64::from_str_radix(count.trim_start_matches("0x"), 16)
+            .unwrap_or_else(|e| panic!("not a u64 transaction count {count}: {e}"))
+    }
+
+    /// Credits `address` with `wei` of ETH (foundry's `anvil_setBalance`). The minter's sweeper
+    /// address is funded this way rather than through the ckETH burn-and-withdraw pipeline, which is
+    /// a separate concern from sweeping.
+    pub fn set_balance(&self, address: &Address, wei: u128) {
+        self.rpc(
+            "anvil_setBalance",
+            serde_json::json!([to_hex(address.as_ref()), format!("0x{wei:x}")]),
+        );
+        assert_eq!(self.balance(address), wei, "the balance should be credited");
     }
 
     fn await_receipt(&self, tx_hash: &str) -> Value {
@@ -425,4 +564,63 @@ fn from_hex(hex_str: &str) -> Vec<u8> {
 
 pub fn address_from_hex(hex_str: &str) -> Address {
     Address::new(from_hex(hex_str).try_into().unwrap())
+}
+
+/// The two contracts a sweep goes through, deployed on the node before the fixture is built so the
+/// minter can be installed already knowing where they are.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct SweepContracts {
+    /// The real `DepositHelperWithSubaccount.sol`, which the sweep transfers through and whose
+    /// `ReceivedEthOrErc20` event the minter's unchanged deposit pipeline mints from.
+    pub helper: Address,
+    /// The EIP-7702 delegate every deposit address delegates to.
+    pub delegate: Address,
+}
+
+/// Compiles and deploys the real deposit helper and the attested sweeper delegate, wiring the
+/// delegate to that helper exactly as production does.
+pub fn deploy_sweep_contracts(anvil: &Anvil, minter: &Address) -> SweepContracts {
+    let deployer = address_from_hex(DEV_ACCOUNT);
+    let helper = anvil.deploy(
+        &deployer,
+        &deploy_code(
+            &compile("CKDEPOSIT_SOL", "CkDeposit"),
+            &[address_token(minter)],
+        ),
+    );
+    assert_eq!(
+        &decode_address(&anvil.call(&helper, &call("getMinterAddress()", &[]))),
+        minter,
+        "the helper should pay out to the minter's main address"
+    );
+    let delegate = anvil.deploy(
+        &deployer,
+        &deploy_code(
+            &compile("CKSWEEPER_ATTESTED_SOL", "CkSweeperAttested"),
+            &[address_token(&helper)],
+        ),
+    );
+    SweepContracts { helper, delegate }
+}
+
+fn decode_address(data: &[u8]) -> Address {
+    Address::new(
+        <[u8; 20]>::try_from(&data[12..32]).expect("a 32-byte word holds a 20-byte address"),
+    )
+}
+
+/// What a transaction the harness went looking for actually did on chain.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct SentTransaction {
+    pub hash: String,
+    pub succeeded: bool,
+    pub gas_used: u64,
+    pub gas_limit: u64,
+    /// EIP-2718 type: `2` for EIP-1559, `4` for the EIP-7702 transaction a first sweep rides.
+    pub transaction_type: u64,
+}
+
+fn hex_u64(value: &Value) -> u64 {
+    let raw = value.as_str().unwrap_or("0x0");
+    u64::from_str_radix(raw.trim_start_matches("0x"), 16).unwrap_or(0)
 }

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -176,6 +176,11 @@ impl CkErc20Setup {
         self
     }
 
+    pub fn add_support_for_subaccount_helper(mut self, helper: Address) -> Self {
+        self.cketh = self.cketh.add_support_for_subaccount_helper(helper);
+        self
+    }
+
     /// Advance the refresh timer and answer the resulting `eth_getBlockByNumber("latest")` with
     /// `block`, so the minter's latest block height becomes `block`, then settle the reply. The
     /// mock matches the full `["latest", false]` request, so concurrent `eth_getBlockByNumber`

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::anvil::Anvil;
+use crate::anvil::{Anvil, SweepContracts};
 use crate::events::MinterEventAssert;
 use crate::flow::{
     ApprovalFlow, DepositFlow, DepositParams, LedgerTransactionAssert, WithdrawalFlow,
@@ -100,6 +100,9 @@ pub const USDC_ERC20_CONTRACT_ADDRESS: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0c
 pub const USDC_ERC20_CONTRACT_ADDRESS_LOWERCASE: &str =
     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 pub const MINTER_ADDRESS: &str = "0x30a14171b7c4c93ff5213f82eeb74f7c7e3f1ebc";
+/// The minter's dedicated sweeper address, derived from the same test key as [`MINTER_ADDRESS`]
+/// under the sweeper derivation path. Hardcoded because no endpoint reports it yet; a test that
+/// funds it asserts the sweep really was sent from here, so a stale value fails loudly.
 pub const SWEEPER_ADDRESS: &str = "0x07e326c6604e3801270fc52ffb7ad3d6c5dfe89c";
 pub const DEFAULT_WITHDRAWAL_DESTINATION_ADDRESS: &str =
     "0x221E931fbFcb9bd54DdD26cE6f5e29E98AdD01C0";
@@ -169,9 +172,15 @@ impl CkEthSetup {
     }
 
     pub fn add_support_for_subaccount(self) -> Self {
-        self.upgrade_minter_to_add_deposit_with_subaccount_helper_contract(
-            DEPOSIT_WITH_SUBACCOUNT_HELPER_CONTRACT_ADDRESS.to_string(),
+        self.add_support_for_subaccount_helper(
+            Address::from_str(DEPOSIT_WITH_SUBACCOUNT_HELPER_CONTRACT_ADDRESS).unwrap(),
         )
+    }
+
+    /// Points the minter at a specific deposit helper, for a harness that deploys its own rather
+    /// than mocking the mainnet one.
+    pub fn add_support_for_subaccount_helper(self, helper: Address) -> Self {
+        self.upgrade_minter_to_add_deposit_with_subaccount_helper_contract(helper.to_string())
     }
 
     pub fn deposit<T: Into<DepositParams>>(self, params: T) -> DepositFlow {
@@ -862,7 +871,13 @@ enum EthereumBackend {
     /// canisters themselves are created and installed in the same order as for
     /// [`EthereumBackend::Mocked`] — only their init args differ; [`crate::live`] is the one
     /// that switches the PocketIC instance to live outcalls, once its whole fixture is built.
-    Anvil(Arc<Anvil>),
+    ///
+    /// `sweep_contracts` are already deployed on that node when set, so the minter is installed
+    /// knowing which delegate its deposit addresses delegate to.
+    Anvil {
+        anvil: Arc<Anvil>,
+        sweep_contracts: Option<SweepContracts>,
+    },
 }
 
 impl EthereumBackend {
@@ -870,7 +885,7 @@ impl EthereumBackend {
         InstallArgs {
             override_provider: match self {
                 EthereumBackend::Mocked => None,
-                EthereumBackend::Anvil(anvil) => Some(OverrideProvider {
+                EthereumBackend::Anvil { anvil, .. } => Some(OverrideProvider {
                     override_url: Some(RegexSubstitution {
                         pattern: ".*".into(),
                         replacement: anvil.url().to_string(),
@@ -886,7 +901,17 @@ impl EthereumBackend {
             // The mocked responses replay a historical mainnet snapshot, long since finalized.
             EthereumBackend::Mocked => CandidBlockTag::Finalized,
             // A fresh anvil chain has no finalized blocks, so track its "latest" head instead.
-            EthereumBackend::Anvil(_) => CandidBlockTag::Latest,
+            EthereumBackend::Anvil { .. } => CandidBlockTag::Latest,
+        }
+    }
+
+    /// The delegate the minter sweeps through, if this backend has one deployed.
+    fn sweeper_contract_address(&self) -> Option<String> {
+        match self {
+            EthereumBackend::Mocked => None,
+            EthereumBackend::Anvil {
+                sweep_contracts, ..
+            } => sweep_contracts.map(|contracts| contracts.delegate.to_string()),
         }
     }
 
@@ -894,7 +919,7 @@ impl EthereumBackend {
         match self {
             // The block the mocked JSON-RPC responses are canned to scrape logs from onward.
             EthereumBackend::Mocked => LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into(),
-            EthereumBackend::Anvil(_) => 0_u8.into(),
+            EthereumBackend::Anvil { .. } => 0_u8.into(),
         }
     }
 }
@@ -914,7 +939,7 @@ fn install_minter(env: &PocketIc, canisters: &CkEthCanisters, backend: &Ethereum
         minimum_withdrawal_amount: CKETH_MINIMUM_WITHDRAWAL_AMOUNT.into(),
         last_scraped_block_number: backend.last_scraped_block_number(),
         evm_rpc_id: Some(canisters.evm_rpc_id),
-        ethereum_sweeper_contract_address: None,
+        ethereum_sweeper_contract_address: backend.sweeper_contract_address(),
         next_sweeper_transaction_nonce: None,
     };
     env.install_canister(

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -4,9 +4,10 @@
 //!
 //! [`LiveSetup`] is generic over the fixture it wraps, so the facilities every live test needs live
 //! in one place: buying minter time, depositing through the production helper contract, reading the
-//! minter's canister log, and arranging state on anvil. The two flavours differ only in
-//! what they build and seed — [`LiveSetup::new_balance_scan`] for the ckERC20 balance scan,
-//! [`LiveSetup::new_funding`] for sweeper fee funding.
+//! minter's canister log, and arranging state on anvil. The flavours differ only in what they build
+//! and seed — [`LiveSetup::new_balance_scan`] for the ckERC20 balance scan,
+//! [`LiveSetup::new_funding`] for sweeper fee funding, and [`LiveSetup::new_sweep`] for the sweep
+//! of detected ckERC20 deposits.
 //!
 //! The whole fixture is built on an ordinary (non-live) PocketIC instance, exactly as the mocked
 //! fixtures are: `await_call` ticks deterministically, and every setup call completes in a bounded
@@ -46,8 +47,10 @@
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::PrincipalId;
 use ic_cketh_minter::PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL;
+use ic_cketh_minter::endpoints::events::Event;
 use ic_cketh_minter::endpoints::{
-    DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode, DepositStatus,
+    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode,
+    DepositStatus,
 };
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
@@ -60,11 +63,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::anvil::{
-    Anvil, DEV_ACCOUNT, address_from_hex, deploy_deposit_helper, deploy_mock_erc20, deposit_eth,
-    erc20_balance_slot, u256_be,
+    Anvil, DEV_ACCOUNT, SweepContracts, address_from_hex, deploy_deposit_helper, deploy_mock_erc20,
+    deploy_sweep_contracts, deposit_eth, erc20_balance_slot, u256_be,
 };
 use crate::ckerc20::{CkErc20Setup, Erc20Token};
-use crate::{CkEthSetup, EthereumBackend, minter_wasm, switch_to_live};
+use crate::{CkEthSetup, EthereumBackend, MINTER_ADDRESS, minter_wasm, switch_to_live};
 
 /// Deposited for a test principal, so funding has deposit-backed ETH to spend. Comfortably above the
 /// 0.3 ETH funding target that the fixture's minimum withdrawal amount implies.
@@ -140,6 +143,8 @@ pub struct LiveSetup<S> {
     /// The production deposit helper, for fixtures that deposit. Deployed only where it is needed:
     /// it costs a minter upgrade, which a test that never deposits should not pay for.
     deposit_helper: Option<Address>,
+    /// The contracts a sweep goes through, for the fixture that deploys them.
+    sweep_contracts: Option<SweepContracts>,
 }
 
 impl LiveSetup<CkErc20Setup> {
@@ -148,9 +153,47 @@ impl LiveSetup<CkErc20Setup> {
     /// then switches the instance to live outcalls.
     pub fn new_balance_scan() -> Self {
         let anvil = Arc::new(Anvil::start_mainnet_like());
-        let cketh = CkEthSetup::new(EthereumBackend::Anvil(Arc::clone(&anvil)));
+        let cketh = CkEthSetup::new(EthereumBackend::Anvil {
+            anvil: Arc::clone(&anvil),
+            sweep_contracts: None,
+        });
         let ckerc20 = CkErc20Setup::with_cketh(cketh).add_supported_erc20_tokens();
         Self::go_live(ckerc20, anvil)
+    }
+
+    /// Like [`Self::new_balance_scan`], but with the real deposit helper and the attested sweeper
+    /// delegate deployed on the node first, so the minter is installed knowing both, and with the
+    /// minter's dedicated sweeper address pre-funded with `sweeper_gas_wei` of ETH.
+    ///
+    /// Funding the sweeper directly is a shortcut: in production its gas comes from a ckETH burn
+    /// out of the minter's fee account, which is a separate pipeline from sweeping.
+    pub fn new_sweep(sweeper: &Address, sweeper_gas_wei: u128) -> Self {
+        let anvil = Arc::new(Anvil::start_mainnet_like());
+        // The helper pays out to the minter's main address, which the minter only derives once
+        // installed. It is only ever read back out of the helper event, never by the helper
+        // itself, so the deployment can name the address the test asserts against.
+        let contracts = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
+        let cketh = CkEthSetup::new(EthereumBackend::Anvil {
+            anvil: Arc::clone(&anvil),
+            sweep_contracts: Some(contracts),
+        });
+        let ckerc20 = CkErc20Setup::with_cketh(cketh)
+            .add_supported_erc20_tokens()
+            .add_support_for_subaccount_helper(contracts.helper);
+        let mut setup = Self::go_live(ckerc20, anvil);
+        setup.sweep_contracts = Some(contracts);
+        setup.anvil.set_balance(sweeper, sweeper_gas_wei);
+        setup
+    }
+
+    /// The ckERC20 token the orchestrator spawned for `symbol`, whose ledger the mint lands on.
+    pub fn ckerc20_token(&self, symbol: &str) -> CkErc20Token {
+        self.fixture.find_ckerc20_token(symbol)
+    }
+
+    /// `account`'s balance on `ledger_id`, i.e. what the deposit was credited.
+    pub fn balance_of_ledger(&self, ledger_id: Principal, account: impl Into<Account>) -> Nat {
+        self.fixture.balance_of_ledger(ledger_id, account)
     }
 
     /// A distinct non-anonymous depositing principal for `seed`, so a test can register several
@@ -276,7 +319,10 @@ impl LiveSetup<CkEthSetup> {
     /// a test could read the pre-burn numbers.
     pub fn new_funding() -> Self {
         let anvil = Arc::new(Anvil::start_mainnet_like());
-        let cketh = CkEthSetup::new(EthereumBackend::Anvil(Arc::clone(&anvil)));
+        let cketh = CkEthSetup::new(EthereumBackend::Anvil {
+            anvil: Arc::clone(&anvil),
+            sweep_contracts: None,
+        });
         let setup = Self::go_live(cketh, anvil).with_deposit_helper();
 
         // Funding may only spend ETH the minter received through deposits, so it needs a real one.
@@ -338,7 +384,24 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
             anvil,
             minter_address,
             deposit_helper: None,
+            sweep_contracts: None,
         }
+    }
+
+    /// The contracts the sweep goes through, if this harness deployed them.
+    pub fn sweep_contracts(&self) -> SweepContracts {
+        self.sweep_contracts
+            .expect("BUG: this harness was built without sweeping")
+    }
+
+    /// The owned anvil node, so a test can read balances and code straight off the chain.
+    pub fn anvil(&self) -> &Anvil {
+        &self.anvil
+    }
+
+    /// The audit events the minter has recorded, to see how far a sweep got.
+    pub fn minter_events(&self) -> Vec<Event> {
+        self.cketh().get_all_events()
     }
 
     /// Polls until `observe` produces a value, or fails with what the minter was doing. The shape
@@ -462,7 +525,7 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
     ///
     /// `what` is rendered only on failure, so it can read state that is worth knowing at that point
     /// and would say nothing at the start.
-    fn drive_until(
+    pub fn drive_until(
         &self,
         max_ticks: u32,
         what: impl Fn(&Self) -> String,


### PR DESCRIPTION
## Why

- The live harness could scan balances on anvil, but nothing test-side could run a sweep against a real chain: no sweep contracts on the node, and no way to read what a sweep did.

## What

- `LiveSetup::new_sweep` deploys the real deposit helper and the attested sweeper delegate on the harness' anvil before installing the minter, so the minter starts knowing both, and pre-funds the sweeper address with ETH (a shortcut for the funding pipeline, which has its own end-to-end test).
- The anvil client learns to read what a sweep did: an address' code (for delegation designators), the transactions an address sent with their type, status, and gas, and to set an ETH balance.
- anvil now mines on an interval, so block-based scan backoffs and the `finalized` tag advance on their own instead of freezing whenever no test transaction lands.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
