### PR TITLE
perf(cketh): stop making a detected deposit wait to be swept

### DIFF
--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -110,6 +110,8 @@ fn setup_timers() {
     ic_cdk_timers::set_timer_interval(SWEEP_ENQUEUE_INTERVAL, async || {
         enqueue_batched_sweep().await;
     });
+    // A freshly enqueued sweep does not wait for this tick: `enqueue_batched_sweep` kicks the
+    // pipeline itself.
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
         process_sweeper_transactions().await;
     });

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -48,6 +48,7 @@ use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
 /// Deposits swept in one transaction, which with one token per sweep is also the addresses it
 /// touches.
@@ -349,6 +350,11 @@ pub async fn enqueue_batched_sweep() {
     for batch in batches {
         enqueue_token_sweep(batch, sweeper_contract, &gas_fee_estimate).await;
     }
+    // Send them now rather than at the send task's next tick: the mint follows the sweep, so every
+    // interval spent waiting here is crediting latency a user sees.
+    ic_cdk_timers::set_timer(Duration::from_secs(0), async {
+        process_sweeper_transactions().await;
+    });
 }
 
 /// The sweep queue folded into one batch per token, each holding at most


### PR DESCRIPTION
## Why

- A freshly enqueued sweep waited for the send task's next interval before being sent, and under the decided design the mint follows the sweep — so that wait is crediting latency a user sees.

## What

- `enqueue_batched_sweep` kicks the send task immediately after enqueueing, instead of leaving the new sweeps for its next tick.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
