### PR TITLE
chore: assert that an ingress induction debit implies a paused execution

### DIFF
--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -263,11 +263,7 @@ impl CanisterState {
 
     /// Returns true if the canister has a paused execution or paused install code.
     pub fn has_paused_execution_or_install_code(&self) -> bool {
-        use ExecutionTask::*;
-        matches!(
-            self.system_state.task_queue.paused_or_aborted_task(),
-            Some(PausedExecution { .. }) | Some(PausedInstallCode(_))
-        )
+        self.system_state.has_paused_execution_or_install_code()
     }
 
     /// Returns true if there is at least one message in the canister's output
@@ -284,6 +280,9 @@ impl CanisterState {
     /// credit. It is strictly about ensuring that canisters are retained in the
     /// subnet schedule for as long as they have long-running executions or heap
     /// delta or install code debits.
+    ///
+    /// A pending ingress induction cycles debit implies a paused execution (see
+    /// `SystemState::check_invariants()`) and hence needs no condition of its own.
     pub fn must_be_in_schedule(&self) -> bool {
         self.scheduler_state.heap_delta_debit.get() > 0
             || self.scheduler_state.install_code_debit.get() > 0

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -990,11 +990,23 @@ impl SystemState {
         self.next_snapshot_id
     }
 
+    /// Returns true if the canister has a paused execution or paused install code.
+    pub fn has_paused_execution_or_install_code(&self) -> bool {
+        matches!(
+            self.task_queue.paused_or_aborted_task(),
+            Some(ExecutionTask::PausedExecution { .. }) | Some(ExecutionTask::PausedInstallCode(_))
+        )
+    }
+
     /// Records the given amount as debit that will be charged from the balance
     /// at some point in the future.
     ///
-    /// Precondition:
+    /// Preconditions:
     /// - `charge <= self.debited_balance()`.
+    /// - `self.has_paused_execution_or_install_code()`, i.e. the charge is only
+    ///   postponed in order to avoid modifying the balance of a canister with an
+    ///   unfinished execution. This is the only way the debit becomes positive and
+    ///   `check_invariants()` relies on it.
     pub fn add_postponed_charge_to_ingress_induction_cycles_debit(&mut self, charge: Cycles) {
         assert!(
             charge <= self.debited_balance(),
@@ -2301,6 +2313,24 @@ impl SystemState {
                 self.canister_id(),
                 output_queue_reserved_slots,
                 input_queue_requests + unresponded_call_contexts
+            ));
+        }
+
+        // A pending ingress induction cycles debit is only ever accumulated while the
+        // canister has a paused execution (see
+        // `add_postponed_charge_to_ingress_induction_cycles_debit()`) and is applied
+        // when that execution finishes or is aborted. This is what guarantees that the
+        // debit is always applied: `CanisterState::is_cold()` keeps a canister with a
+        // pending debit in the hot pool, so `abort_all_paused_executions()` is bound to
+        // apply the debit at the latest in the checkpoint round at the end of the
+        // current checkpoint interval.
+        if !self.ingress_induction_cycles_debit.is_zero()
+            && !self.has_paused_execution_or_install_code()
+        {
+            return Err(format!(
+                "Invariant broken: Canister {}: Pending ingress induction cycles debit of {} without a paused execution",
+                self.canister_id(),
+                self.ingress_induction_cycles_debit
             ));
         }
 

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -857,6 +857,25 @@ fn canister_state_ingress_induction_cycles_debit() {
     );
 }
 
+#[test]
+fn canister_state_ingress_induction_cycles_debit_requires_paused_execution() {
+    let system_state = &mut CanisterStateFixture::new().canister_state.system_state;
+
+    // A pending debit without a paused execution breaks the invariant: nothing would
+    // be bound to apply the debit.
+    system_state.add_postponed_charge_to_ingress_induction_cycles_debit(Cycles::new(42));
+    assert_matches!(
+        system_state.check_invariants(),
+        Err(msg) if msg.contains("Pending ingress induction cycles debit")
+    );
+
+    // With a paused execution the invariant holds.
+    system_state
+        .task_queue
+        .enqueue(ExecutionTask::PausedInstallCode(PausedExecutionId(0)));
+    assert_eq!(Ok(()), system_state.check_invariants());
+}
+
 const INITIAL_CYCLES: Cycles = Cycles::new(1 << 36);
 
 #[test]


### PR DESCRIPTION
A pending `ingress_induction_cycles_debit` implies a paused execution, but that invariant was documented nowhere and asserted nowhere: the debit only ever becomes positive while the canister has a paused execution or paused install code, because that is the only case in which `charge_ingress_induction_cost()` postpones the charge.

The invariant pins down where a postponed charge may originate. It is *not* what bounds the debit in time. That bound comes from `CanisterState::is_cold()`, which rejects any pending debit and thereby keeps the canister in the hot pool until the debit is applied: `abort_all_paused_executions()` visits every hot canister and `ExecutionEnvironment::abort_canister()` applies a pending debit whether or not a paused task is present, so the debit is charged at the latest in the checkpoint round ending the current checkpoint interval.

Check the invariant in `SystemState::check_invariants()`, spell out the precondition on `add_postponed_charge_to_ingress_induction_cycles_debit()` and note in `must_be_in_schedule()` why it needs no condition for the debit. Also move `has_paused_execution_or_install_code()` to `SystemState`, which owns both the debit and the task queue, and delegate to it from `CanisterState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
