### PR TITLE
fix: lower the consumed cycles gauge on a full refund

### DIFF
--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -2162,8 +2162,10 @@ impl SystemState {
             ConsumingCycles::Refund => {}
         }
 
-        // Skip if the consumed cycles are zero and no metric updates are needed.
-        if prepayment - refund == NominalCycles::zero() {
+        // Skip only if there is nothing to record at all. Note that a refund equal to
+        // its prepayment still has to lower the gauge by the refunded amount, even
+        // though it contributes nothing to the monotonic counter.
+        if prepayment == NominalCycles::zero() && refund == NominalCycles::zero() {
             return;
         }
 

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -921,6 +921,10 @@ fn full_refund_resets_consumed_cycles() {
         let mut system_state = CanisterStateFixture::new().canister_state.system_state;
         let use_case = T::cycles_use_case();
         let ctx = format!("{use_case:?} with {cost_schedule:?} cost schedule");
+        // An earlier prepayment for the same use case that is never refunded, so the
+        // gauges must fall back to it (rather than all the way down to zero) once the
+        // prepayment below is refunded in full.
+        let outstanding_cycles = CompoundCycles::<T>::new(Cycles::from(500_u128), cost_schedule);
         let cycles_to_consume = Cycles::from(1000_u128);
         let prepaid_cycles = CompoundCycles::<T>::new(cycles_to_consume, cost_schedule);
         // The cost schedule only waives the real amount charged to the balance;
@@ -931,27 +935,33 @@ fn full_refund_resets_consumed_cycles() {
             "{ctx}"
         );
 
+        system_state.consume_cycles(outstanding_cycles);
         system_state.consume_cycles(prepaid_cycles);
         assert_eq!(
             system_state.balance(),
-            INITIAL_CYCLES - prepaid_cycles.real(),
+            INITIAL_CYCLES - outstanding_cycles.real() - prepaid_cycles.real(),
             "{ctx}"
         );
         assert_eq!(
             system_state.canister_metrics().consumed_cycles(),
-            prepaid_cycles.nominal(),
+            outstanding_cycles.nominal() + prepaid_cycles.nominal(),
             "{ctx}"
         );
 
         // Refund the whole prepayment, e.g. because nothing was transmitted or executed.
         system_state.refund_cycles(prepaid_cycles, prepaid_cycles);
 
-        // Nothing was consumed in the end, so the balance and the gauges must be
-        // back to where they started.
-        assert_eq!(system_state.balance(), INITIAL_CYCLES, "{ctx}");
+        // Nothing was consumed by this prepayment in the end, so the balance and the
+        // gauges must be back to where they were before it, i.e. only the outstanding
+        // prepayment is left.
+        assert_eq!(
+            system_state.balance(),
+            INITIAL_CYCLES - outstanding_cycles.real(),
+            "{ctx}"
+        );
         assert_eq!(
             system_state.canister_metrics().consumed_cycles(),
-            NominalCycles::zero(),
+            outstanding_cycles.nominal(),
             "{ctx}"
         );
         assert_eq!(
@@ -959,10 +969,11 @@ fn full_refund_resets_consumed_cycles() {
                 .canister_metrics()
                 .consumed_cycles_by_use_cases()
                 .get(&use_case),
-            Some(&NominalCycles::zero()),
+            Some(&outstanding_cycles.nominal()),
             "{ctx}"
         );
-        // And the monotonic counter must not have moved either.
+        // And the monotonic counter must not have moved at all: for a refundable use
+        // case it is bumped at refund time only, by `prepayment - refund`.
         assert_eq!(
             system_state
                 .canister_metrics()

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -30,8 +30,8 @@ use ic_types::methods::{Callback, WasmClosure};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::{CountBytes, Time};
 use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, Instructions, NominalCycles,
-    NominalCyclesTesting,
+    CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, CyclesUseCaseRefundableKind,
+    Instructions, NominalCycles, NominalCyclesTesting, RequestAndResponseTransmission,
 };
 use ic_wasm_types::CanisterModule;
 use prometheus::IntCounter;
@@ -910,6 +910,76 @@ fn update_balance_and_consumed_cycles_by_use_case_correctly() {
             .unwrap(),
         (prepaid_cycles - refund).nominal()
     );
+}
+
+/// A full refund (i.e. a refund equal to its prepayment) must still lower the
+/// consumed cycles gauges by the refunded amount, even though it contributes
+/// nothing to the monotonic counters.
+#[test]
+fn full_refund_resets_consumed_cycles() {
+    fn test<T: CyclesUseCaseRefundableKind>(cost_schedule: CanisterCyclesCostSchedule) {
+        let mut system_state = CanisterStateFixture::new().canister_state.system_state;
+        let use_case = T::cycles_use_case();
+        let ctx = format!("{use_case:?} with {cost_schedule:?} cost schedule");
+        let cycles_to_consume = Cycles::from(1000_u128);
+        let prepaid_cycles = CompoundCycles::<T>::new(cycles_to_consume, cost_schedule);
+        // The cost schedule only waives the real amount charged to the balance;
+        // the nominal amount recorded in the metrics is the same either way.
+        assert_eq!(
+            prepaid_cycles.nominal(),
+            NominalCycles::new(cycles_to_consume.get()),
+            "{ctx}"
+        );
+
+        system_state.consume_cycles(prepaid_cycles);
+        assert_eq!(
+            system_state.balance(),
+            INITIAL_CYCLES - prepaid_cycles.real(),
+            "{ctx}"
+        );
+        assert_eq!(
+            system_state.canister_metrics().consumed_cycles(),
+            prepaid_cycles.nominal(),
+            "{ctx}"
+        );
+
+        // Refund the whole prepayment, e.g. because nothing was transmitted or executed.
+        system_state.refund_cycles(prepaid_cycles, prepaid_cycles);
+
+        // Nothing was consumed in the end, so the balance and the gauges must be
+        // back to where they started.
+        assert_eq!(system_state.balance(), INITIAL_CYCLES, "{ctx}");
+        assert_eq!(
+            system_state.canister_metrics().consumed_cycles(),
+            NominalCycles::zero(),
+            "{ctx}"
+        );
+        assert_eq!(
+            system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases()
+                .get(&use_case),
+            Some(&NominalCycles::zero()),
+            "{ctx}"
+        );
+        // And the monotonic counter must not have moved either.
+        assert_eq!(
+            system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases_as_counters()
+                .get(&use_case),
+            Some(&NominalCycles::zero()),
+            "{ctx}"
+        );
+    }
+
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        test::<Instructions>(cost_schedule);
+        test::<RequestAndResponseTransmission>(cost_schedule);
+    }
 }
 
 #[test]


### PR DESCRIPTION
`SystemState::observe_consumed_cycles_with_use_case()` maintains two kinds of metrics: the gauges (`consumed_cycles` and `consumed_cycles_by_use_cases`), which are raised by the prepayment and lowered by the refund; and the monotonic counters (`consumed_cycles_by_use_cases_as_counters`), which for the refundable use cases (`Instructions` and `RequestAndResponseTransmission`) are only bumped at refund time, by `prepayment - refund`.

The early return conflated the two: for a refund equal to its prepayment it skipped the update altogether, so the gauges kept the prepayment even though nothing was consumed in the end. The inflated value also outlives the canister, as `CanisterManager::delete_canister()` folds `consumed_cycles_by_use_cases` into the subnet level metrics.

Skip only if there is nothing to record at all, i.e. if both the prepayment and the refund are zero. Non-refundable use cases are unaffected, as a zero prepayment implies a zero refund for them, and `NominalCycles` saturates on subtraction, so a refund against a freshly created entry cannot underflow.

Tests: the new `full_refund_resets_consumed_cycles` refunds a prepayment in full and checks that the balance and both gauges are back to where they started and that the counter did not move. It covers both refundable use cases under both cost schedules. The gauges are kept in nominal cycles, which the cost schedule does not affect, so a full refund under `Free` hits the same skipped update; it is in fact the more interesting case, as `Free` waives the real amount and hence leaves the metrics as the only observable of the prepayment. The assertion on the balance after the prepayment (which drops by the real amount under `Normal` and stays put under `Free`) pins down that difference. Each of the four combinations fails without the fix.