### PR TITLE
feat(system-tests): let the driver reach the local ic-gateway by name over verified HTTPS

### DIFF
--- a/rs/tests/driver/src/driver/dev_root_ca.rs
+++ b/rs/tests/driver/src/driver/dev_root_ca.rs
@@ -1,0 +1,94 @@
+//! The dev root CA: the certificate authority that every *dev* IC-OS image
+//! already trusts.
+//!
+//! Shared by the two things that care about it: the local backend, which puts it
+//! in the driver's own trust store (`LocalBackend::install_dev_root_ca`), and the
+//! IC gateway, which issues its TLS leaf from it
+//! (`IcGatewayVm::load_or_create_local_playnet`). It lives in its own module
+//! rather than in either of those because it belongs to neither — what trusts it
+//! is the IC-OS images.
+
+use anyhow::{Context, Result};
+use rcgen::{CertificateParams, KeyPair};
+use rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey, pkcs8::EncodePrivateKey};
+use std::fs;
+
+use crate::driver::test_env_api::get_dependency_path_from_env;
+
+/// The dev root CA, loaded ready to sign with.
+///
+/// `ic-os/{guestos,hostos}/context/Dockerfile` installs
+/// `ic-os/components/networking/dev-certs/canister_http_test_ca.cert` into
+/// `/usr/local/share/ca-certificates` and runs `update-ca-certificates` — in the
+/// `output_dev` stage only, so a production image trusts nothing extra. Its
+/// private key is checked in beside it, which is how a test can serve HTTPS that
+/// a node accepts without any node-side configuration; `canister_http` and
+/// `ckbtc` already rely on this, and its `README.md` documents the use.
+///
+/// The certificate and the key reach us as runfiles, provided to the local
+/// backend's variant of every system test by `_local_only_deps` in
+/// `rs/tests/system_tests.bzl`. Reading either on the Farm backend would panic,
+/// and must not happen: Farm uses a playnet certificate.
+pub(crate) struct DevRootCa {
+    /// PEM of the checked-in CA certificate, exactly as it sits in the images'
+    /// trust store. This is what the gateway serves as its chain.
+    pub(crate) cert_pem: String,
+    /// The same CA as an `rcgen` issuer.
+    pub(crate) cert: rcgen::Certificate,
+    pub(crate) key: KeyPair,
+}
+
+/// The PEM of the dev root CA certificate. See [`DevRootCa`].
+pub(crate) fn dev_root_ca_cert_pem() -> Result<String> {
+    let path = get_dependency_path_from_env("ENV_DEPS__DEV_ROOT_CA_CERT_PATH");
+    fs::read_to_string(&path).with_context(|| {
+        format!(
+            "reading the dev root CA certificate from {}",
+            path.display()
+        )
+    })
+}
+
+/// Loads the dev root CA so `rcgen` can issue certificates from it.
+pub(crate) fn dev_root_ca() -> Result<DevRootCa> {
+    let cert_pem = dev_root_ca_cert_pem()?;
+    let key_path = get_dependency_path_from_env("ENV_DEPS__DEV_ROOT_CA_KEY_PATH");
+    let key_pkcs1_pem = fs::read_to_string(&key_path)
+        .with_context(|| format!("reading the dev root CA key from {}", key_path.display()))?;
+
+    // The checked-in key is PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`), which
+    // `rcgen` loads only under its `aws_lc_rs` backend; under `ring` it takes
+    // PKCS#8 only. Which of the two is compiled in is not ours to decide: both
+    // features are on, and `rcgen` prefers `aws_lc_rs` when they are — but only
+    // because `rustls-acme` happens to enable it, four crates away (see
+    // `cargo tree -i rcgen -e features`). Re-encoding to PKCS#8 works under either
+    // backend, so it does not matter if that ever changes; relying on the feature
+    // would turn an unrelated dependency edit into a runtime failure in every
+    // local gateway test.
+    let key_pkcs8_pem = RsaPrivateKey::from_pkcs1_pem(&key_pkcs1_pem)
+        .context("parsing the dev root CA key as PKCS#1")?
+        .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+        .context("re-encoding the dev root CA key as PKCS#8")?;
+    let key = KeyPair::from_pem(&key_pkcs8_pem).context("loading the dev root CA key")?;
+
+    // `from_ca_cert_pem` extracts what is needed to act as an issuer, of which
+    // `signed_by` uses one thing: the subject name, which becomes the leaf's
+    // issuer. (It carries the CA's subject key identifier across too, but that
+    // reaches the leaf as an authority key identifier only when
+    // `use_authority_key_identifier_extension` is set, and `CertificateParams::new`
+    // leaves it false — the leaf's only extension is its SAN.) `self_signed` then
+    // re-signs the CA merely to obtain an `rcgen::Certificate` to pass as that
+    // issuer; the result is not the checked-in certificate byte for byte and is
+    // never served. What makes the chain verify is the issuer name plus the
+    // signature, both of which are the real CA's.
+    let cert = CertificateParams::from_ca_cert_pem(&cert_pem)
+        .context("parsing the dev root CA certificate")?
+        .self_signed(&key)
+        .context("loading the dev root CA certificate as an issuer")?;
+
+    Ok(DevRootCa {
+        cert_pem,
+        cert,
+        key,
+    })
+}

--- a/rs/tests/driver/src/driver/dev_root_ca.rs
+++ b/rs/tests/driver/src/driver/dev_root_ca.rs
@@ -4,9 +4,10 @@
 //! Shared by the two things that care about it: the local backend, which puts it
 //! in the driver's own trust store (`LocalBackend::install_dev_root_ca`), and the
 //! IC gateway, which issues its TLS leaf from it
-//! (`IcGatewayVm::load_or_create_local_playnet`). It lives in its own module
-//! rather than in either of those because it belongs to neither — what trusts it
-//! is the IC-OS images.
+//! (`IcGatewayVm::load_or_create_local_playnet`). Its own module because neither
+//! consumer can host it: `local_backend` would own the `rcgen`/`rsa` issuance
+//! machinery it never calls, and `ic_gateway_vm` would make the backend depend on
+//! the gateway.
 
 use anyhow::{Context, Result};
 use rcgen::{CertificateParams, KeyPair};
@@ -71,16 +72,9 @@ pub(crate) fn dev_root_ca() -> Result<DevRootCa> {
         .context("re-encoding the dev root CA key as PKCS#8")?;
     let key = KeyPair::from_pem(&key_pkcs8_pem).context("loading the dev root CA key")?;
 
-    // `from_ca_cert_pem` extracts what is needed to act as an issuer, of which
-    // `signed_by` uses one thing: the subject name, which becomes the leaf's
-    // issuer. (It carries the CA's subject key identifier across too, but that
-    // reaches the leaf as an authority key identifier only when
-    // `use_authority_key_identifier_extension` is set, and `CertificateParams::new`
-    // leaves it false — the leaf's only extension is its SAN.) `self_signed` then
-    // re-signs the CA merely to obtain an `rcgen::Certificate` to pass as that
-    // issuer; the result is not the checked-in certificate byte for byte and is
-    // never served. What makes the chain verify is the issuer name plus the
-    // signature, both of which are the real CA's.
+    // `self_signed` re-signs the CA only to get an `rcgen::Certificate` to pass to
+    // `signed_by` as the issuer. The result is *not* the checked-in certificate byte
+    // for byte and is never served -- `cert_pem` above is what goes on the wire.
     let cert = CertificateParams::from_ca_cert_pem(&cert_pem)
         .context("parsing the dev root CA certificate")?
         .self_signed(&key)

--- a/rs/tests/driver/src/driver/ic_gateway_vm.rs
+++ b/rs/tests/driver/src/driver/ic_gateway_vm.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use slog::{Logger, info};
 use std::{
     fs,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::Path,
     time::Duration,
 };
@@ -148,37 +148,6 @@ impl DeployedIcGatewayVm {
     /// Retrieves the underlying VM.
     pub fn get_vm(&self) -> AllocatedVm {
         self.vm.clone()
-    }
-
-    /// Returns a custom DNS resolution override for reaching the gateway at the
-    /// given `url`, if one is needed for the active system-test backend.
-    ///
-    /// On the [`SystemTestBackend::Local`] backend the gateway's domain is
-    /// `<name>.ic.net`, which the group's `dnsmasq` resolves for the *VMs* — but
-    /// not for the driver, which sits in the group's network namespace yet reads
-    /// the host's `/etc/resolv.conf`, whose nameserver is unreachable from there.
-    /// Nor does `dnsmasq` answer for the per-canister subdomains
-    /// `<canister_id>.<name>.ic.net`, since it is served a hosts file, which has
-    /// no wildcards. A driver-side client therefore has to resolve the requested
-    /// host itself. This returns `(host, [vm_ipv6]:443)` for the host of `url`,
-    /// to be passed to `reqwest`'s `.resolve(host, addr)`.
-    ///
-    /// Note that `resolve` overrides only the *exact* host passed to it (it does
-    /// *not* apply to subdomains), so the host of the actual request URL — e.g.
-    /// `<canister_id>.<name>.ic.net` — must be used, not the apex domain. On the
-    /// [`SystemTestBackend::Farm`] backend DNS resolves the gateway domain, so no
-    /// override is needed and `None` is returned.
-    ///
-    /// The certificate needs no equivalent workaround: see
-    /// [`Self::root_certificate`].
-    pub fn resolve_override_for_url(&self, url: &Url) -> Option<(String, SocketAddr)> {
-        match SystemTestBackend::read_attribute(&self.env) {
-            SystemTestBackend::Local => {
-                let host = url.host_str()?.to_string();
-                Some((host, SocketAddr::new(IpAddr::V6(self.vm.ipv6), 443)))
-            }
-            SystemTestBackend::Farm => None,
-        }
     }
 
     /// The extra trust anchor a client needs in order to verify the gateway's
@@ -381,29 +350,22 @@ sudo networkctl reconfigure enp2s0
             self.universal_vm.name,
             health_url.as_str()
         );
-        // The driver does not use the group's `dnsmasq` as its resolver — it is in
-        // the group's network namespace but reads the host's `/etc/resolv.conf`,
-        // whose nameserver is unreachable from there — so on the Local backend it
-        // has to resolve the gateway domain itself. The certificate needs no such
-        // workaround: it is issued by the dev root CA, which is added as a trust
-        // anchor rather than skipping verification altogether.
-        let (resolve, root_cert) = match backend {
-            SystemTestBackend::Local => {
-                let resolve = Some((
-                    ic_gateway_fqdn.clone(),
-                    SocketAddr::new(IpAddr::V6(vm_ipv6), 443),
-                ));
-                let cert = reqwest::Certificate::from_pem(dev_root_ca_cert_pem()?.as_bytes())
-                    .context("parsing the dev root CA certificate as a trust anchor")?;
-                (resolve, Some(cert))
-            }
-            SystemTestBackend::Farm => (None, None),
+        // The gateway domain resolves for the driver as well as for the VMs — the
+        // wildcard record above, plus the resolver
+        // `LocalBackend::install_group_resolv_conf` gave the driver — so the only
+        // thing the Local backend needs here is the trust anchor for a certificate
+        // the dev root CA issued rather than a public one.
+        let root_cert = match backend {
+            SystemTestBackend::Local => Some(
+                reqwest::Certificate::from_pem(dev_root_ca_cert_pem()?.as_bytes())
+                    .context("parsing the dev root CA certificate as a trust anchor")?,
+            ),
+            SystemTestBackend::Farm => None,
         };
         block_on(await_status_is_healthy(
             &env.logger(),
             health_url,
             msg,
-            resolve,
             root_cert,
         ))
     }
@@ -455,10 +417,9 @@ sudo networkctl reconfigure enp2s0
     ///
     /// The certificate covers the apex domain and both the `*.<domain>` and
     /// `*.raw.<domain>` wildcards, matching the records the Farm path creates, so
-    /// the gateway can also serve canister subdomains. Only the apex is
-    /// registered with the group's `dnsmasq` though (see
-    /// [`Self::configure_dns_records`]), so a subdomain still has to be resolved
-    /// by the client -- see [`DeployedIcGatewayVm::resolve_override_for_url`].
+    /// the gateway can also serve canister subdomains. The group's `dnsmasq`
+    /// resolves those subdomains to match, via the wildcard record
+    /// [`Self::configure_dns_records`] registers.
     fn load_or_create_local_playnet(
         &self,
         env: &TestEnv,
@@ -534,28 +495,22 @@ sudo networkctl reconfigure enp2s0
         let mut records = match SystemTestBackend::read_attribute(env) {
             SystemTestBackend::Local => {
                 // The group's `dnsmasq` is the local replacement for Farm's
-                // playnet DNS. Only the apex is registered, because dnsmasq's
-                // `--addn-hosts` file is a hosts file and so has no wildcards.
-                // Driver-side clients cope by resolving the exact request host
-                // themselves, see
-                // `DeployedIcGatewayVm::resolve_override_for_url`. Clients *inside*
-                // a VM cannot: `prometheus_vm` writes `<canister id>.raw.<domain>`
-                // scrape targets that the Prometheus VM resolves through this
-                // dnsmasq, and those have never resolved on this backend — the
-                // domain was an equally unresolvable `.local` name before. Fixing
-                // it means `--address=/<domain>/<addr>` on dnsmasq's command line,
-                // which `SIGHUP` does not re-read, so it would have to be known at
-                // `start_dnsmasq` time or cost a restart.
+                // playnet DNS, and a wildcard record is the local equivalent of the
+                // three records the Farm arm below creates: `--address` answers for
+                // the apex *and every subdomain at any depth*, which covers both
+                // the `*` and the `*.raw` `CNAME`s. So the per-canister hosts
+                // `<canister id>.<domain>` and `<canister id>.raw.<domain>` resolve
+                // here too — for driver-side clients and for clients inside a VM
+                // (`prometheus_vm` writes scrape targets of exactly that shape).
                 let group_name = GroupSetup::read_attribute(env).infra_group_name;
                 let backend = LocalBackend::from_test_env(env)?;
-                let addrs = playnet
+                let addrs: Vec<IpAddr> = playnet
                     .aaaa_records
                     .iter()
                     .map(|addr| IpAddr::V6(*addr))
-                    .chain(playnet.a_records.iter().map(|addr| IpAddr::V4(*addr)));
-                for addr in addrs {
-                    backend.add_dns_record(&group_name, ic_gateway_fqdn, addr)?;
-                }
+                    .chain(playnet.a_records.iter().map(|addr| IpAddr::V4(*addr)))
+                    .collect();
+                backend.add_wildcard_dns_record(&group_name, ic_gateway_fqdn, &addrs)?;
                 return Ok(());
             }
             SystemTestBackend::Farm => {
@@ -943,7 +898,6 @@ async fn await_status_is_healthy(
     logger: &Logger,
     url: Url,
     msg: String,
-    resolve: Option<(String, SocketAddr)>,
     root_cert: Option<reqwest::Certificate>,
 ) -> Result<()> {
     info!(logger, "Waiting for IcGatewayVm to become healthy ...");
@@ -951,12 +905,8 @@ async fn await_status_is_healthy(
     let request = Request::new(Method::GET, url);
     retry_with_msg_async!(&msg, logger, READY_TIMEOUT, RETRY_INTERVAL, || async {
         let mut builder = Client::builder();
-        // On the Local backend the driver cannot resolve the gateway domain, so
-        // point it at the VM directly, and trust the CA that issued the
-        // certificate.
-        if let Some((domain, addr)) = resolve.as_ref() {
-            builder = builder.resolve(domain, *addr);
-        }
+        // On the Local backend the certificate is issued by the dev root CA, so
+        // add it as a trust anchor rather than skipping verification.
         if let Some(cert) = root_cert.as_ref() {
             builder = builder.add_root_certificate(cert.clone());
         }

--- a/rs/tests/driver/src/driver/ic_gateway_vm.rs
+++ b/rs/tests/driver/src/driver/ic_gateway_vm.rs
@@ -282,11 +282,12 @@ sudo networkctl reconfigure enp2s0
     /// Loads existing configuration or, on the Local backend, issues a
     /// certificate for a deterministic in-group domain from the dev root CA.
     ///
-    /// The Local backend has no playnet TLS service. Signing with the CA that
-    /// every dev IC-OS image already trusts (see [`DevRootCa`]), rather than
+    /// The Local backend has no playnet TLS service. Signing with the CA that every
+    /// dev IC-OS image already trusts (see
+    /// [`DevRootCa`](crate::driver::dev_root_ca::DevRootCa)), rather than
     /// self-signing, means a *node* can reach the gateway over HTTPS with no
-    /// node-side configuration — which is what lets a nested node register
-    /// through the gateway exactly as it does on Farm.
+    /// node-side configuration — which is what lets a nested node register through
+    /// the gateway exactly as it does on Farm.
     ///
     /// The certificate covers the apex domain and both the `*.<domain>` and
     /// `*.raw.<domain>` wildcards, matching the records the Farm path creates, so

--- a/rs/tests/driver/src/driver/ic_gateway_vm.rs
+++ b/rs/tests/driver/src/driver/ic_gateway_vm.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use crate::{
     driver::{
-        dev_root_ca::{dev_root_ca, dev_root_ca_cert_pem},
+        dev_root_ca::dev_root_ca,
         farm::{
             Certificate, DemoCertificate, DnsRecord, DnsRecordType, HostFeature, PlaynetCertificate,
         },
@@ -68,36 +68,6 @@ impl DeployedIcGatewayVm {
     /// Retrieves the underlying VM.
     pub fn get_vm(&self) -> AllocatedVm {
         self.vm.clone()
-    }
-
-    /// The extra trust anchor a client needs in order to verify the gateway's
-    /// TLS certificate, if any.
-    ///
-    /// On the [`SystemTestBackend::Local`] backend the certificate is issued by
-    /// the dev root CA (see [`DevRootCa`]) rather than by a public one, so a
-    /// driver-side client has to add that CA to its roots:
-    /// `builder.add_root_certificate(cert)`. `reqwest` *adds* it to the
-    /// platform's roots rather than replacing them, so the client keeps trusting
-    /// everything it trusted before. On [`SystemTestBackend::Farm`] the playnet
-    /// certificate chains to a public CA and `None` is returned.
-    ///
-    /// This covers the gateway only. Clients that dial an API boundary node
-    /// directly still need `danger_accept_invalid_certs`, and for a different
-    /// reason: `IcNodeSnapshot::get_public_url` hands them an IP-literal URL, which
-    /// no name in the node's certificate can match. (Whether that certificate has a
-    /// CA at all depends on the test — under `with_api_boundary_nodes_playnet` it
-    /// is issued by `LocalApiBoundaryNodesPlaynet`'s ephemeral CA, and otherwise the
-    /// node self-signs it via `generate_ic_boundary_tls_cert`.)
-    pub fn root_certificate(&self) -> Result<Option<reqwest::Certificate>> {
-        match SystemTestBackend::read_attribute(&self.env) {
-            SystemTestBackend::Local => {
-                let cert_pem = dev_root_ca_cert_pem()?;
-                let cert = reqwest::Certificate::from_pem(cert_pem.as_bytes())
-                    .context("parsing the dev root CA certificate as a trust anchor")?;
-                Ok(Some(cert))
-            }
-            SystemTestBackend::Farm => Ok(None),
-        }
     }
 }
 
@@ -270,24 +240,7 @@ sudo networkctl reconfigure enp2s0
             self.universal_vm.name,
             health_url.as_str()
         );
-        // The gateway domain resolves for the driver as well as for the VMs — the
-        // wildcard record above, plus the resolver
-        // `LocalBackend::install_group_resolv_conf` gave the driver — so the only
-        // thing the Local backend needs here is the trust anchor for a certificate
-        // the dev root CA issued rather than a public one.
-        let root_cert = match backend {
-            SystemTestBackend::Local => Some(
-                reqwest::Certificate::from_pem(dev_root_ca_cert_pem()?.as_bytes())
-                    .context("parsing the dev root CA certificate as a trust anchor")?,
-            ),
-            SystemTestBackend::Farm => None,
-        };
-        block_on(await_status_is_healthy(
-            &env.logger(),
-            health_url,
-            msg,
-            root_cert,
-        ))
+        block_on(await_status_is_healthy(&env.logger(), health_url, msg))
     }
 
     /// Loads existing playnet configuration or creates a new one.
@@ -814,23 +767,12 @@ async fn await_dns_propagation(logger: &Logger, base_domain: &str) -> Result<()>
     .await
 }
 
-async fn await_status_is_healthy(
-    logger: &Logger,
-    url: Url,
-    msg: String,
-    root_cert: Option<reqwest::Certificate>,
-) -> Result<()> {
+async fn await_status_is_healthy(logger: &Logger, url: Url, msg: String) -> Result<()> {
     info!(logger, "Waiting for IcGatewayVm to become healthy ...");
 
     let request = Request::new(Method::GET, url);
     retry_with_msg_async!(&msg, logger, READY_TIMEOUT, RETRY_INTERVAL, || async {
-        let mut builder = Client::builder();
-        // On the Local backend the certificate is issued by the dev root CA, so
-        // add it as a trust anchor rather than skipping verification.
-        if let Some(cert) = root_cert.as_ref() {
-            builder = builder.add_root_certificate(cert.clone());
-        }
-        let client = builder.build()?;
+        let client = Client::builder().build()?;
         let response = client
             .execute(request.try_clone().unwrap())
             .await

--- a/rs/tests/driver/src/driver/ic_gateway_vm.rs
+++ b/rs/tests/driver/src/driver/ic_gateway_vm.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, anyhow, bail};
 use http::{Method, StatusCode};
 use rcgen::{CertificateParams, KeyPair};
 use reqwest::{Client, Request};
-use rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey, pkcs8::EncodePrivateKey};
 use serde::{Deserialize, Serialize};
 use slog::{Logger, info};
 use std::{
@@ -16,6 +15,7 @@ use url::Url;
 
 use crate::{
     driver::{
+        dev_root_ca::{dev_root_ca, dev_root_ca_cert_pem},
         farm::{
             Certificate, DemoCertificate, DnsRecord, DnsRecordType, HostFeature, PlaynetCertificate,
         },
@@ -44,86 +44,6 @@ const IC_GATEWAY_AAAA_RECORDS_CREATED_EVENT_NAME: &str = "ic_gateway_aaaa_record
 const IC_GATEWAY_A_RECORDS_CREATED_EVENT_NAME: &str = "ic_gateway_a_records_created_event";
 const READY_TIMEOUT: Duration = Duration::from_secs(360);
 const RETRY_INTERVAL: Duration = Duration::from_secs(5);
-
-/// The dev root CA: the certificate authority that every *dev* IC-OS image
-/// already trusts, loaded ready to sign with.
-///
-/// `ic-os/{guestos,hostos}/context/Dockerfile` installs
-/// `ic-os/components/networking/dev-certs/canister_http_test_ca.cert` into
-/// `/usr/local/share/ca-certificates` and runs `update-ca-certificates` — in the
-/// `output_dev` stage only, so a production image trusts nothing extra. Its
-/// private key is checked in beside it, which is how a test can serve HTTPS that
-/// a node accepts without any node-side configuration; `canister_http` and
-/// `ckbtc` already rely on this, and its `README.md` documents the use.
-///
-/// The certificate and the key reach us as runfiles, provided to the local
-/// backend's variant of every system test by `_local_only_deps` in
-/// `rs/tests/system_tests.bzl`. Reading either on the Farm backend would panic,
-/// and must not happen: Farm uses a playnet certificate.
-struct DevRootCa {
-    /// PEM of the checked-in CA certificate, exactly as it sits in the images'
-    /// trust store. This is what the gateway serves as its chain and what a
-    /// driver-side client adds as a trust anchor.
-    cert_pem: String,
-    /// The same CA as an `rcgen` issuer.
-    cert: rcgen::Certificate,
-    key: KeyPair,
-}
-
-/// The PEM of the dev root CA certificate. See [`DevRootCa`].
-fn dev_root_ca_cert_pem() -> Result<String> {
-    let path = get_dependency_path_from_env("ENV_DEPS__DEV_ROOT_CA_CERT_PATH");
-    fs::read_to_string(&path).with_context(|| {
-        format!(
-            "reading the dev root CA certificate from {}",
-            path.display()
-        )
-    })
-}
-
-/// Loads the dev root CA so `rcgen` can issue certificates from it.
-fn dev_root_ca() -> Result<DevRootCa> {
-    let cert_pem = dev_root_ca_cert_pem()?;
-    let key_path = get_dependency_path_from_env("ENV_DEPS__DEV_ROOT_CA_KEY_PATH");
-    let key_pkcs1_pem = fs::read_to_string(&key_path)
-        .with_context(|| format!("reading the dev root CA key from {}", key_path.display()))?;
-
-    // The checked-in key is PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`), which
-    // `rcgen` loads only under its `aws_lc_rs` backend; under `ring` it takes
-    // PKCS#8 only. Which of the two is compiled in is not ours to decide: both
-    // features are on, and `rcgen` prefers `aws_lc_rs` when they are — but only
-    // because `rustls-acme` happens to enable it, four crates away (see
-    // `cargo tree -i rcgen -e features`). Re-encoding to PKCS#8 works under either
-    // backend, so it does not matter if that ever changes; relying on the feature
-    // would turn an unrelated dependency edit into a runtime failure in every
-    // local gateway test.
-    let key_pkcs8_pem = RsaPrivateKey::from_pkcs1_pem(&key_pkcs1_pem)
-        .context("parsing the dev root CA key as PKCS#1")?
-        .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-        .context("re-encoding the dev root CA key as PKCS#8")?;
-    let key = KeyPair::from_pem(&key_pkcs8_pem).context("loading the dev root CA key")?;
-
-    // `from_ca_cert_pem` extracts what is needed to act as an issuer, of which
-    // `signed_by` uses one thing: the subject name, which becomes the leaf's
-    // issuer. (It carries the CA's subject key identifier across too, but that
-    // reaches the leaf as an authority key identifier only when
-    // `use_authority_key_identifier_extension` is set, and `CertificateParams::new`
-    // leaves it false — the leaf's only extension is its SAN.) `self_signed` then
-    // re-signs the CA merely to obtain an `rcgen::Certificate` to pass as that
-    // issuer; the result is not the checked-in certificate byte for byte and is
-    // never served. What makes the chain verify is the issuer name plus the
-    // signature, both of which are the real CA's.
-    let cert = CertificateParams::from_ca_cert_pem(&cert_pem)
-        .context("parsing the dev root CA certificate")?
-        .self_signed(&key)
-        .context("loading the dev root CA certificate as an issuer")?;
-
-    Ok(DevRootCa {
-        cert_pem,
-        cert,
-        key,
-    })
-}
 
 /// Represents an IC HTTP Gateway VM, it is a wrapper around Farm's Universal VM.
 #[derive(Debug)]

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -69,10 +69,16 @@ const NIP_IO_DOMAIN: &str = "ipv6.nip.io";
 /// `DNS=` servers the group's `dnsmasq` answers on.
 pub const IN_GROUP_DOMAIN_SUFFIX: &str = "ic.net";
 
-/// How long [`LocalBackend::stop_dnsmasq`] waits for `dnsmasq` to exit after
-/// `SIGTERM` before resorting to `SIGKILL`. It normally exits within
-/// milliseconds; this only bounds the wait if it wedges.
+/// How long [`LocalBackend::stop_dnsmasq`] waits for `dnsmasq` to exit, applied
+/// once after `SIGTERM` and again after the `SIGKILL` that follows if the first
+/// wait runs out. It normally exits within milliseconds; this only bounds the
+/// wait if it wedges. Outlasting the second wait means `SIGKILL` did not take
+/// effect, which no further signal is going to fix.
 const DNSMASQ_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often [`LocalBackend::await_dnsmasq_exit`] re-checks whether `dnsmasq` is
+/// gone. Short enough that a restart is not noticeably delayed by the poll.
+const DNSMASQ_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 /// Environment variables holding the runfiles paths of the split OVMF (UEFI)
 /// firmware images, provided by the `@ovmf` Bazel repo (extracted from the
@@ -1153,42 +1159,82 @@ impl LocalBackend {
         let bridge = Self::bridge_name(group_name);
         let prefix = Self::group_ipv6_prefix(group_name);
         let ipv4_prefix = Self::group_ipv4_prefix(group_name);
-        self.stop_dnsmasq(&bridge);
+        // Propagate a stop that could not be confirmed rather than starting a
+        // second `dnsmasq`: the one still holding port 53 would make the new one
+        // fail to bind, and `start_dnsmasq`'s error would then point at the wrong
+        // thing.
+        self.stop_dnsmasq(&bridge)?;
         self.start_dnsmasq(group_name, &bridge, &prefix, &ipv4_prefix)
     }
 
     /// Stop the group's `dnsmasq`, if running, and wait for it to exit. It runs as
-    /// the current user, so it is signalled directly via its pid-file.
-    /// Best-effort and idempotent.
+    /// the current user, so it is signalled directly via its pid-file. Idempotent,
+    /// and reports whether the exit could be *confirmed*.
     ///
-    /// The wait matters for [`restart_dnsmasq`](Self::restart_dnsmasq): returning
-    /// while the old instance still holds UDP port 53 on the name-server addresses
-    /// would make the new one fail to bind.
-    fn stop_dnsmasq(&self, bridge: &str) {
+    /// The wait is what makes [`restart_dnsmasq`](Self::restart_dnsmasq) sound:
+    /// returning while the old instance still holds UDP port 53 on the name-server
+    /// addresses would make the new one fail to bind. Signals are delivered
+    /// asynchronously, `SIGKILL` included, so each one is followed by its own wait
+    /// and an unconfirmed exit is an error rather than something to start a second
+    /// `dnsmasq` on top of.
+    ///
+    /// The pid-file is removed either way: it names a process we have given up on,
+    /// so keeping it would only mislead the next caller.
+    fn stop_dnsmasq(&self, bridge: &str) -> Result<()> {
         let pid_path = self.dnsmasq_pid_path(bridge);
-        if let Ok(contents) = std::fs::read_to_string(&pid_path)
+        let stopped = if let Ok(contents) = std::fs::read_to_string(&pid_path)
             && let Ok(pid) = contents.trim().parse::<i32>()
             && Self::dnsmasq_is_alive(pid, &pid_path)
         {
             // SIGTERM lets dnsmasq remove its pid-file on exit.
             let _ = Command::new("kill").arg(pid.to_string()).status();
-            let deadline = Instant::now() + DNSMASQ_STOP_TIMEOUT;
-            while Self::dnsmasq_is_alive(pid, &pid_path) {
-                if Instant::now() >= deadline {
-                    warn!(
-                        self.logger,
-                        "dnsmasq (pid {pid}) did not exit within {DNSMASQ_STOP_TIMEOUT:?} \
-                         of SIGTERM; sending SIGKILL"
-                    );
-                    let _ = Command::new("kill")
-                        .args(["-KILL", &pid.to_string()])
-                        .status();
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(20));
+            let terminated = Self::await_dnsmasq_exit(pid, &pid_path);
+            if terminated.is_err() {
+                warn!(
+                    self.logger,
+                    "dnsmasq (pid {pid}) did not exit within {DNSMASQ_STOP_TIMEOUT:?} of \
+                     SIGTERM; sending SIGKILL"
+                );
+                let _ = Command::new("kill")
+                    .args(["-KILL", &pid.to_string()])
+                    .status();
+                Self::await_dnsmasq_exit(pid, &pid_path).context("dnsmasq survived SIGKILL")
+            } else {
+                terminated
             }
-        }
+        } else {
+            // No pid-file, or it names something that is not a `dnsmasq` of ours
+            // any more; either way there is nothing holding the port.
+            Ok(())
+        };
         let _ = std::fs::remove_file(&pid_path);
+        stopped.with_context(|| format!("stopping the dnsmasq of {bridge}"))
+    }
+
+    /// Wait up to [`DNSMASQ_STOP_TIMEOUT`] for `pid` to stop being a `dnsmasq` of
+    /// ours, per [`dnsmasq_is_alive`](Self::dnsmasq_is_alive).
+    ///
+    /// That observes the process's `argv` going away, which the kernel does while
+    /// tearing the process down — a hair *before* it closes its files. So in
+    /// principle a sample could land in between and read an exiting `dnsmasq` as
+    /// gone while its sockets are still open. Two reasons not to chase that: the
+    /// window is microseconds of non-blocking kernel work against a poll every
+    /// [`DNSMASQ_STOP_POLL_INTERVAL`], and the backstop is loud rather than silent —
+    /// `dnsmasq` refuses to start at all when it cannot bind, so `start_dnsmasq`
+    /// surfaces that error instead of leaving a half-working resolver behind.
+    ///
+    /// Waiting for the pid to disappear outright would be worse, not better:
+    /// `dnsmasq` daemonizes, so it lingers as a zombie until whatever it was
+    /// reparented to reaps it, which under a sandbox is not guaranteed to be prompt.
+    fn await_dnsmasq_exit(pid: i32, pid_path: &Path) -> Result<()> {
+        let deadline = Instant::now() + DNSMASQ_STOP_TIMEOUT;
+        while Self::dnsmasq_is_alive(pid, pid_path) {
+            if Instant::now() >= deadline {
+                bail!("dnsmasq (pid {pid}) was still running {DNSMASQ_STOP_TIMEOUT:?} later");
+            }
+            std::thread::sleep(DNSMASQ_STOP_POLL_INTERVAL);
+        }
+        Ok(())
     }
 
     /// Whether `pid` is a live `dnsmasq` that this backend started with
@@ -1307,9 +1353,12 @@ impl LocalBackend {
             self.logger,
             "Deleting local group {group_name} (bridge {bridge})"
         );
+        // Best-effort here, unlike in `restart_dnsmasq`: the bridge and its
+        // addresses are deleted just below, so a `dnsmasq` that outlives its
+        // SIGKILL has nothing left to serve and nothing left to hold.
 
         // Stop `dnsmasq` before removing the bridge it listens on.
-        self.stop_dnsmasq(&bridge);
+        let _ = self.stop_dnsmasq(&bridge);
 
         // Best effort: stop every VM QEMU process started for this group. Each
         // VM records its pid under `working_dir/vms/<vm>/qemu.pid`; killing it

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -37,7 +37,7 @@ use network::systemd::IPV6_NAME_SERVERS;
 use serde::{Deserialize, Serialize};
 use slog::{Logger, info, warn};
 use std::collections::HashMap;
-use std::ffi::CString;
+use std::ffi::{CString, OsString};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{IpAddr, Ipv6Addr};
 use std::os::unix::ffi::OsStrExt;
@@ -252,6 +252,12 @@ impl LocalBackend {
     /// Run a short shell `script` via `/bin/sh -c` to completion, returning an
     /// error if it cannot be spawned or exits non-zero (`what` describes the
     /// operation, for error context).
+    ///
+    /// Only for scripts whose every word is a literal or backend-derived
+    /// (interface and bridge names, addresses of the group's own prefixes). Any
+    /// command taking a value a *test* supplies — a VM name, a domain — belongs
+    /// in [`run_command`](Self::run_command) instead, which never lets a shell
+    /// see it.
     fn run_shell(script: &str, what: &str) -> Result<()> {
         let output = Command::new("/bin/sh")
             .arg("-c")
@@ -269,6 +275,41 @@ impl LocalBackend {
             );
         }
         Ok(())
+    }
+
+    /// Run `command` to completion, returning an error if it cannot be spawned or
+    /// exits non-zero (`what` describes the operation, for error context).
+    ///
+    /// The argv-passing counterpart of [`run_shell`](Self::run_shell), and the one
+    /// to prefer: the arguments reach the kernel as a vector, so no word-splitting,
+    /// globbing or metacharacter interpretation stands between what the caller
+    /// wrote and what the program receives, and paths need no quoting.
+    fn run_command(command: &mut Command, what: &str) -> Result<()> {
+        let output = command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("spawning the command for {what}"))?;
+        if !output.status.success() {
+            bail!(
+                "operation '{what}' failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    /// The single argument `<option><path>`, e.g. `--pid-file=/run/x.pid`.
+    ///
+    /// Built as an [`OsString`] rather than through `Path::display`, which is
+    /// lossy: a path that is not valid UTF-8 reaches the program unchanged instead
+    /// of with U+FFFD substituted into it.
+    fn path_arg(option: &str, path: &Path) -> OsString {
+        let mut arg = OsString::from(option);
+        arg.push(path);
+        arg
     }
 
     /// Put the driver into a network namespace it fully owns and arrange for its
@@ -1144,11 +1185,7 @@ impl LocalBackend {
         // these are *command-line* options, which is why registering one has to
         // restart `dnsmasq`; see `add_wildcard_dns_record`. Empty on the first
         // start, since `create_group` truncates the file it reads.
-        let wildcard_args: String = self
-            .dnsmasq_wildcard_args(bridge)?
-            .into_iter()
-            .map(|arg| format!(" {arg}"))
-            .collect();
+        let wildcard_args = self.dnsmasq_wildcard_args(bridge)?;
 
         info!(
             self.logger,
@@ -1196,32 +1233,74 @@ impl LocalBackend {
         // gated on `getuid() == 0` and would otherwise `setgroups(2)` — denied in
         // the driver's user namespace — and drop to a user/group id that is
         // unmapped there.
+        //
+        // `dnsmasq` is spawned directly rather than through a shell, so every
+        // argument reaches it as one argv entry. That matters for the `--address`
+        // options above all: their names originate in a test-supplied VM name
+        // (`IcGatewayVm::new`), and a shell would word-split and metacharacter-expand
+        // them on the way. It also drops the quoting question for the paths, which
+        // the working directory could otherwise raise by containing a space.
         let dnsmasq_path = get_dependency_path_from_env("ENV_DEPS__DNSMASQ_PATH");
-        let dnsmasq_script = format!(
-            "exec {dnsmasq_path:?} \
-                 --conf-file=/dev/null \
-                 --pid-file={pid} \
-                 --dhcp-leasefile={lease} \
-                 --log-facility={log} \
-                 --bind-interfaces \
-                 --interface={bridge} \
-                 --except-interface=lo \
-                 --enable-ra \
-                 --dhcp-range={prefix},ra-only \
-                 --dhcp-range={ipv4_prefix}.2,{ipv4_prefix}.254,255.255.255.0,1h \
-                 --ra-param={bridge},10,1800 \
-                 --no-resolv \
-                 --no-hosts \
-                 --addn-hosts={hosts} \
-                 --synth-domain={NIP_IO_DOMAIN},{prefix}/64\
-                 {wildcard_args}",
-            pid = pid_path.display(),
-            lease = lease_path.display(),
-            log = log_path.display(),
-            hosts = hosts_path.display(),
-        );
-        Self::run_shell(&dnsmasq_script, "start dnsmasq")?;
+        let mut dnsmasq = Command::new(&dnsmasq_path);
+        dnsmasq
+            .arg("--conf-file=/dev/null")
+            .arg(Self::path_arg("--pid-file=", &pid_path))
+            .arg(Self::path_arg("--dhcp-leasefile=", &lease_path))
+            .arg(Self::path_arg("--log-facility=", &log_path))
+            .arg("--bind-interfaces")
+            .arg(format!("--interface={bridge}"))
+            .arg("--except-interface=lo")
+            .arg("--enable-ra")
+            .arg(format!("--dhcp-range={prefix},ra-only"))
+            .arg(format!(
+                "--dhcp-range={ipv4_prefix}.2,{ipv4_prefix}.254,255.255.255.0,1h"
+            ))
+            .arg(format!("--ra-param={bridge},10,1800"))
+            .arg("--no-resolv")
+            .arg("--no-hosts")
+            .arg(Self::path_arg("--addn-hosts=", &hosts_path))
+            .arg(format!("--synth-domain={NIP_IO_DOMAIN},{prefix}/64"))
+            .args(&wildcard_args);
+        Self::run_command(&mut dnsmasq, "start dnsmasq")?;
 
+        Ok(())
+    }
+
+    /// Reject a `name` that cannot be stored as a DNS record, before
+    /// [`add_dns_record`](Self::add_dns_record) or
+    /// [`add_wildcard_dns_record`](Self::add_wildcard_dns_record) persists it.
+    ///
+    /// Both record files are line-based — one `<address> <name>` pair per line —
+    /// and [`dnsmasq_wildcard_args`](Self::dnsmasq_wildcard_args) splits a line
+    /// back apart on whitespace. So a name containing a space would not fail to
+    /// register, it would register a *different* record, and one containing a
+    /// newline would register a second record nobody asked for. Names reach here
+    /// from test-supplied VM names (`IcGatewayVm::new`) and API BN domains, which
+    /// nothing upstream validates; failing here is the difference between a clear
+    /// error at registration and an unresolvable name six minutes into a test.
+    ///
+    /// Accepted is a plain ASCII hostname: dot-separated non-empty labels of
+    /// letters, digits, `-` and `_`, no label starting or ending with `-`, no
+    /// label over 63 bytes and no name over 253 (RFC 1035 §2.3.4's limits, with
+    /// the leading-digit relaxation of RFC 1123 §2.1 and the `_` that service
+    /// labels use in practice).
+    fn validate_dns_name(name: &str) -> Result<()> {
+        let is_valid_label = |label: &str| {
+            !label.is_empty()
+                && label.len() <= 63
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+                && label
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        };
+        if name.is_empty() || name.len() > 253 || !name.split('.').all(is_valid_label) {
+            bail!(
+                "refusing to register {name:?} as a DNS record: expected dot-separated \
+                 ASCII labels of letters, digits, '-' and '_' (none starting or ending \
+                 with '-'), each at most 63 bytes and at most 253 bytes in total"
+            );
+        }
         Ok(())
     }
 
@@ -1237,7 +1316,11 @@ impl LocalBackend {
     /// [`add_wildcard_dns_record`](Self::add_wildcard_dns_record) when the
     /// subdomains of `name` have to resolve as well; a hosts file has no
     /// wildcards.
+    ///
+    /// `name` must be a plain ASCII hostname, per
+    /// [`validate_dns_name`](Self::validate_dns_name).
     pub fn add_dns_record(&self, group_name: &str, name: &str, addr: IpAddr) -> Result<()> {
+        Self::validate_dns_name(name)?;
         let bridge = Self::bridge_name(group_name);
         let hosts_path = self.dnsmasq_hosts_path(&bridge);
 
@@ -1293,12 +1376,17 @@ impl LocalBackend {
     /// the hosts-shaped files and `--servers-file`, and a servers-file admits
     /// nothing but `server` and `rev-server`. Prefer `add_dns_record` when an exact
     /// name is enough.
+    ///
+    /// `name` must be a plain ASCII hostname, per
+    /// [`validate_dns_name`](Self::validate_dns_name); it is what ends up in an
+    /// `--address` option on `dnsmasq`'s command line.
     pub fn add_wildcard_dns_record(
         &self,
         group_name: &str,
         name: &str,
         addrs: &[IpAddr],
     ) -> Result<()> {
+        Self::validate_dns_name(name)?;
         if addrs.is_empty() {
             return Ok(());
         }
@@ -2462,6 +2550,61 @@ fn has_gpt_header(path: &Path) -> Result<bool> {
         Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
         Err(err) => {
             Err(err).with_context(|| format!("reading the GPT signature of {}", path.display()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalBackend;
+
+    #[test]
+    fn accepts_the_names_the_backend_registers() {
+        for name in [
+            // `IcGatewayVm::load_or_create_local_playnet`.
+            "ic-gateway.ic.net",
+            "ic-gateway-3.ic.net",
+            // `InternetComputer::setup_api_bn_local_playnet`.
+            "apibn-0.ic.net",
+            // Leading digits and `_` labels are legal in practice.
+            "0.example.com",
+            "_acme-challenge.example.com",
+            &format!("{}.example.com", "a".repeat(63)),
+        ] {
+            assert!(
+                LocalBackend::validate_dns_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_names_that_would_corrupt_a_record_file_or_a_command_line() {
+        for name in [
+            // Splits the `<address> <name>` line the wrong way when read back.
+            "ic gateway.ic.net",
+            "ic\tgateway.ic.net",
+            // Appends a record nobody asked for.
+            "ic-gateway.ic.net\n2001:db8::1 evil.ic.net",
+            // Shell metacharacters. No shell sees these any more, now that
+            // `start_dnsmasq` passes argv directly — but they are not DNS names
+            // either, so they have no business in a record file.
+            "ic-gateway.ic.net; touch /tmp/pwned",
+            "$(id).ic.net",
+            "`id`.ic.net",
+            // Malformed as a name.
+            "",
+            ".",
+            "ic-gateway..ic.net",
+            "-gateway.ic.net",
+            "gateway-.ic.net",
+            &format!("{}.example.com", "a".repeat(64)),
+            &format!("{}.example.com", vec!["a"; 127].join(".")),
+        ] {
+            assert!(
+                LocalBackend::validate_dns_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
         }
     }
 }

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -99,6 +99,14 @@ const DNSMASQ_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// nor `SSL_CERT_DIR` set — defers to `openssl_probe::probe()`, and this is the
 /// first candidate in its Linux list. `rs/tests/BUILD.bazel` builds a bundle at the
 /// same path for the colocated driver image, for the same reason.
+///
+/// Being *first* in that list is what makes hard-coding it safe rather than merely
+/// convenient: if this file exists, it is the one `probe()` returns, so the mount
+/// cannot end up on a bundle the verifier ignores. The remaining exposure is a
+/// platform that does not have it at all (RHEL keeps its bundle under
+/// `/etc/pki/...`), where this fails loudly on the read rather than silently — and
+/// `SSL_CERT_FILE` is the supported way out, since
+/// [`system_ca_bundle`](LocalBackend::system_ca_bundle) honours it.
 const DEFAULT_SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
 
 /// Environment variables holding the runfiles paths of the split OVMF (UEFI)
@@ -438,8 +446,9 @@ impl LocalBackend {
     }
 
     /// Path of the generated CA bundle
-    /// [`install_dev_root_ca`](Self::install_dev_root_ca) bind-mounts over
-    /// [`SYSTEM_CA_BUNDLE`]. Same placement, and for the same reasons, as
+    /// [`install_dev_root_ca`](Self::install_dev_root_ca) bind-mounts over the
+    /// system one ([`system_ca_bundle`](Self::system_ca_bundle)). Same placement,
+    /// and for the same reasons, as
     /// [`generated_resolv_conf_path`](Self::generated_resolv_conf_path).
     fn generated_ca_bundle_path() -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -483,7 +492,8 @@ impl LocalBackend {
     }
 
     /// Put the dev root CA in the driver's own trust store, by bind-mounting a copy
-    /// of [`SYSTEM_CA_BUNDLE`] with that CA appended over the original.
+    /// of the system CA bundle ([`system_ca_bundle`](Self::system_ca_bundle)) with
+    /// that CA appended over the original.
     ///
     /// This is what lets a driver-side client verify the local IC gateway's
     /// certificate without any code of its own: the CA is simply one of the roots
@@ -502,10 +512,17 @@ impl LocalBackend {
     /// namespace altogether: it isolates the mount *table*, not file contents.
     ///
     /// Shadowing the bundle rather than the whole directory is then the better of
-    /// what is left. It reaches OpenSSL's `CApath` consumers, which look up
-    /// `<subject hash>.0` symlinks and would miss a plainly named file (though
-    /// `rustls-native-certs` would have read one, since it loads every regular file
-    /// in the directory), and it avoids reproducing the directory's ~240 entries.
+    /// what is left: the bundle is what `rustls-native-certs` reads for the driver's
+    /// own clients, and what OpenSSL and `curl` read by default on Debian, whose
+    /// default `CAfile` is this same path. It also avoids reproducing the
+    /// directory's ~240 entries.
+    ///
+    /// The limitation that leaves, since it is easy to assume otherwise: a consumer
+    /// using `CApath` *alone* resolves `<subject hash>.0` symlinks and never scans
+    /// the bundle, so it does not see this CA. Nothing in the driver's process tree
+    /// works that way today — and a plainly named file in the directory would not
+    /// have helped it either, since only a hash-named symlink would, which is what
+    /// `update-ca-certificates` generates and what this cannot create.
     ///
     /// Appending, never replacing: the original bytes are copied verbatim first, so
     /// this can only widen the driver's trust, never narrow it. That matters,
@@ -531,8 +548,12 @@ impl LocalBackend {
     fn install_dev_root_ca() -> Result<()> {
         let bundle_path = Self::system_ca_bundle()?;
         let bundle_path_display = bundle_path.display();
-        let mut bundle = std::fs::read_to_string(&bundle_path)
-            .with_context(|| format!("reading the system CA bundle {bundle_path_display}"))?;
+        let mut bundle = std::fs::read_to_string(&bundle_path).with_context(|| {
+            format!(
+                "reading the system CA bundle {bundle_path_display} (a platform that keeps \
+                 its bundle elsewhere can point SSL_CERT_FILE at it)"
+            )
+        })?;
         let dev_root_ca_pem = dev_root_ca_cert_pem()?;
         // Guard the separator rather than trusting the bundle to end in a newline:
         // `-----END CERTIFICATE----------BEGIN CERTIFICATE-----` parses as neither,

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -29,8 +29,10 @@ use network::systemd::IPV6_NAME_SERVERS;
 use serde::{Deserialize, Serialize};
 use slog::{Logger, info, warn};
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{IpAddr, Ipv6Addr};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
@@ -230,10 +232,13 @@ impl LocalBackend {
     /// `ip`/`dnsmasq` operations to run with `CAP_NET_ADMIN`/`CAP_NET_RAW`/
     /// `CAP_NET_BIND_SERVICE` over that namespace — without any *host* capability
     ///
-    /// `unshare(CLONE_NEWUSER | CLONE_NEWNET)` creates a private user namespace,
-    /// in which the caller holds a full capability set (it is the namespace's
-    /// creator), plus a network namespace owned by it — so every RTNETLINK
-    /// operation on the new netns succeeds.
+    /// `unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET)` creates a private
+    /// user namespace, in which the caller holds a full capability set (it is the
+    /// namespace's creator), plus a mount and a network namespace owned by it — so
+    /// every RTNETLINK operation on the new netns succeeds, and the driver can
+    /// give itself a resolver for that netns (see
+    /// [`install_group_resolv_conf`](Self::install_group_resolv_conf)) without
+    /// touching anything outside its own process tree.
     /// We keep the caller's uid/gid unchanged (an *identity* mapping) so
     /// files, `/dev/kvm` and `/dev/net/tun` are accessed exactly as before, then
     /// raise the three networking capabilities into the process's *ambient* set
@@ -251,18 +256,23 @@ impl LocalBackend {
     /// run before any thread is spawned — in particular before the group's
     /// async (threaded) logger is built. Running it before the tokio runtime and the task
     /// subprocesses also puts the whole process tree — task subprocesses, QEMU,
-    /// `dnsmasq` — into the same namespaces and lets them inherit the ambient
-    /// capabilities (`unshare`/`fork`/`exec` all preserve both).
+    /// `dnsmasq` — into the same namespaces (so they resolve names through the
+    /// group's `dnsmasq` as well) and lets them inherit the ambient capabilities
+    /// (`unshare`/`fork`/`exec` all preserve both).
     pub fn ensure_administrable_netns() -> Result<()> {
         let uid = nix::unistd::geteuid().as_raw();
         let gid = nix::unistd::getegid().as_raw();
         // SAFETY: `unshare` only affects the calling (single) thread/process; it
-        // touches no user-space state.
-        if unsafe { libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNET) } != 0 {
+        // touches no user-space state. The kernel creates the user namespace
+        // first, so the mount and network namespaces are both owned by it and the
+        // caller holds `CAP_SYS_ADMIN`/`CAP_NET_ADMIN` over them.
+        if unsafe { libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNS | libc::CLONE_NEWNET) }
+            != 0
+        {
             return Err(anyhow!(std::io::Error::last_os_error())).context(
-                "unshare(CLONE_NEWUSER | CLONE_NEWNET) failed; the local backend needs \
-                 to create a private user+network namespace to administer its \
-                 networking without host capabilities",
+                "unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET) failed; the local \
+                 backend needs to create a private user+mount+network namespace to \
+                 administer its networking without host capabilities",
             );
         }
         // Map the caller's uid/gid into the new user namespace so it keeps its
@@ -305,6 +315,120 @@ impl LocalBackend {
         // needs `CAP_NET_ADMIN`, so it fails fast (with the `ip` error) if the
         // ambient capabilities did not take effect.
         Self::run_shell("ip link set dev lo up", "bring up lo in the owned netns")?;
+        // Finally, give the driver itself a resolver, now that it owns a mount
+        // namespace to install one in.
+        Self::install_group_resolv_conf()?;
+        Ok(())
+    }
+
+    /// Path of the generated `resolv.conf`
+    /// [`install_group_resolv_conf`](Self::install_group_resolv_conf) bind-mounts
+    /// over `/etc/resolv.conf`.
+    ///
+    /// It lives in the process's temp dir — under Bazel that is the test's own
+    /// scratch dir, which the runner cleans up — because it is written before the
+    /// group dir exists; see
+    /// [`ensure_administrable_netns`](Self::ensure_administrable_netns) for why
+    /// that has to run so early. The pid keeps concurrent drivers from sharing a
+    /// file, even though each one mounts it only in its own namespace.
+    fn generated_resolv_conf_path() -> PathBuf {
+        std::env::temp_dir().join(format!("system-test-resolv.conf.{}", std::process::id()))
+    }
+
+    /// Point the driver's own name resolution at the group's `dnsmasq`, by
+    /// bind-mounting a generated `resolv.conf` naming [`IPV6_NAME_SERVERS`] over
+    /// `/etc/resolv.conf` in the private mount namespace
+    /// [`ensure_administrable_netns`](Self::ensure_administrable_netns) just
+    /// created.
+    ///
+    /// Without this the driver has no resolver at all: it sits in the group's
+    /// network namespace but reads the *host's* `/etc/resolv.conf`, whose
+    /// nameserver is unreachable from there, so every lookup fails. The group's
+    /// `dnsmasq` binds those very [`IPV6_NAME_SERVERS`] on the group bridge inside
+    /// this netns (see [`create_group`](Self::create_group)), so pointing at them
+    /// makes the driver resolve the in-group names ([`IN_GROUP_DOMAIN_SUFFIX`],
+    /// [`NIP_IO_DOMAIN`]) exactly like the VMs do — which is what lets a
+    /// driver-side client reach the IC gateway by name rather than having to
+    /// resolve the host for itself.
+    ///
+    /// `/` is remounted `MS_REC | MS_PRIVATE` first, so the bind mount cannot
+    /// propagate back out. A host that leaves `/` shared — the systemd default —
+    /// would otherwise have its real `/etc/resolv.conf` replaced for as long as
+    /// the mount lived.
+    ///
+    /// Four details worth knowing:
+    ///
+    /// * `mount(2)` needs `CAP_SYS_ADMIN` over the mount namespace's *user*
+    ///   namespace, which the caller holds as that namespace's creator. Mounting
+    ///   here, in-process, is what keeps `CAP_SYS_ADMIN` out of the ambient set
+    ///   the unprivileged children inherit — they have no business mounting
+    ///   anything.
+    /// * glibc reads at most `MAXNS` (3) nameservers, so the fourth line is
+    ///   ignored. Harmless, since all four addresses are the same `dnsmasq`;
+    ///   writing all four keeps the file identical to what the guests are
+    ///   configured with.
+    /// * `/etc/nsswitch.conf` resolves `hosts` through `files` before `dns`, so
+    ///   `/etc/hosts` — and with it `localhost` — keeps working.
+    /// * Until [`create_group`](Self::create_group) has run, no bridge holds these
+    ///   addresses, so a lookup before that fails fast instead of hanging.
+    ///   Nothing resolves a name that early.
+    fn install_group_resolv_conf() -> Result<()> {
+        // Stop mount propagation out of this namespace before mounting anything
+        // into it.
+        Self::mount(
+            None,
+            "/",
+            libc::MS_REC | libc::MS_PRIVATE,
+            "making / private in the owned mount namespace",
+        )?;
+
+        let contents: String = IPV6_NAME_SERVERS
+            .iter()
+            .map(|name_server| format!("nameserver {name_server}\n"))
+            .collect();
+        let path = Self::generated_resolv_conf_path();
+        std::fs::write(&path, contents)
+            .with_context(|| format!("writing the generated resolv.conf {}", path.display()))?;
+
+        Self::mount(
+            Some(&path),
+            "/etc/resolv.conf",
+            libc::MS_BIND,
+            "bind-mounting the generated resolv.conf over /etc/resolv.conf",
+        )
+    }
+
+    /// `mount(2)`, which the `nix` crate cannot offer here because the workspace
+    /// builds it without its `mount` feature.
+    ///
+    /// `source` is `None` for a propagation change, which takes none; the
+    /// filesystem type and the mount data are always `NULL`, because every call
+    /// site is either a bind mount or a propagation change and neither uses them.
+    fn mount(source: Option<&Path>, target: &str, flags: libc::c_ulong, what: &str) -> Result<()> {
+        let source = source
+            .map(|source| CString::new(source.as_os_str().as_bytes()))
+            .transpose()
+            .with_context(|| format!("{what}: the source path contains a NUL byte"))?;
+        let target = CString::new(target).expect("mount target contains a NUL byte");
+        // SAFETY: both strings are NUL-terminated and outlive the call. A NULL
+        // source is what `mount(2)` expects for a propagation change (the kernel
+        // never looks at it), and a NULL filesystem type and data are what it
+        // expects for a bind mount.
+        let rc = unsafe {
+            libc::mount(
+                source.as_ref().map_or(std::ptr::null(), |s| s.as_ptr()),
+                target.as_ptr(),
+                std::ptr::null(),
+                flags,
+                std::ptr::null(),
+            )
+        };
+        if rc != 0 {
+            return Err(anyhow!(std::io::Error::last_os_error())).context(format!(
+                "{what} failed (mount(2) follows the target symlink, so a target that \
+                 dangles is reported as a missing file rather than as a bad source)"
+            ));
+        }
         Ok(())
     }
 

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -52,19 +52,27 @@ use std::time::{Duration, Instant};
 const NIP_IO_DOMAIN: &str = "ipv6.nip.io";
 
 /// The domain suffix under which the group's `dnsmasq` answers for names the
-/// driver registers explicitly with [`LocalBackend::add_dns_record`], as opposed
-/// to the addresses it synthesises under [`NIP_IO_DOMAIN`].
+/// driver registers explicitly with [`LocalBackend::add_dns_record`] or
+/// [`LocalBackend::add_wildcard_dns_record`], as opposed to the addresses it
+/// synthesises under [`NIP_IO_DOMAIN`].
 ///
-/// Resolvable only from inside a test group. Used for the API boundary nodes
-/// (`apibn-{idx}.ic.net`, see `InternetComputer::setup_api_bn_local_playnet`) and
-/// for the IC gateway (`<vm name>.ic.net`, see
-/// `IcGatewayVm::load_or_create_local_playnet`). On Farm those names are handed
-/// out without DNS records, or replaced by a playnet FQDN.
+/// Resolvable from inside a test group, and from the driver, which shares the
+/// group's resolver (see [`LocalBackend::install_group_resolv_conf`]). Used for
+/// the API boundary nodes (`apibn-{idx}.ic.net`, see
+/// `InternetComputer::setup_api_bn_local_playnet`) and for the IC gateway
+/// (`<vm name>.ic.net`, see `IcGatewayVm::load_or_create_local_playnet`). On Farm
+/// those names are handed out without DNS records, or replaced by a playnet
+/// FQDN.
 ///
 /// It must not be a `.local` name: both GuestOS and HostOS resolve through
 /// `systemd-resolved`, which routes `*.local` to mDNS and never to the unicast
 /// `DNS=` servers the group's `dnsmasq` answers on.
 pub const IN_GROUP_DOMAIN_SUFFIX: &str = "ic.net";
+
+/// How long [`LocalBackend::stop_dnsmasq`] waits for `dnsmasq` to exit after
+/// `SIGTERM` before resorting to `SIGKILL`. It normally exits within
+/// milliseconds; this only bounds the wait if it wedges.
+const DNSMASQ_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Environment variables holding the runfiles paths of the split OVMF (UEFI)
 /// firmware images, provided by the `@ovmf` Bazel repo (extracted from the
@@ -820,6 +828,13 @@ impl LocalBackend {
         );
         Self::run_shell(&create_script, "create group bridge")?;
 
+        // Truncate the two files the group's DNS records live in, both to drop
+        // records an interrupted run left behind and so they exist before
+        // `dnsmasq` starts. They deliberately survive a `dnsmasq` *restart* (see
+        // `add_wildcard_dns_record`), which is why this happens here rather than
+        // in `start_dnsmasq`.
+        self.reset_dns_records(&bridge)?;
+
         // Start `dnsmasq`. Non-IC-node VMs (e.g. universal VMs) SLAAC their
         // global address from its RA; IC GuestOS nodes use a static config instead.
         // The same `dnsmasq` also serves DHCPv4 on the group's IPv4 `/24` for
@@ -846,6 +861,64 @@ impl LocalBackend {
             .working_dir
             .join("dnsmasq")
             .join(format!("{bridge}.hosts"))
+    }
+
+    /// Path of the file the group's *wildcard* DNS records are accumulated in by
+    /// [`add_wildcard_dns_record`](Self::add_wildcard_dns_record), and turned into
+    /// `--address` options by
+    /// [`dnsmasq_wildcard_args`](Self::dnsmasq_wildcard_args).
+    ///
+    /// Deliberately shaped like the `--addn-hosts` file next to it — one
+    /// `<address> <name>` pair per line — even though `dnsmasq` never reads it
+    /// itself.
+    fn dnsmasq_wildcards_path(&self, bridge: &str) -> PathBuf {
+        self.active_local_backend
+            .working_dir
+            .join("dnsmasq")
+            .join(format!("{bridge}.wildcards"))
+    }
+
+    /// Create the group's `dnsmasq` working dir and truncate both DNS record
+    /// files, so they exist and are empty before `dnsmasq` first starts. Called
+    /// from [`create_group`](Self::create_group); see the comment there for why
+    /// not from [`start_dnsmasq`](Self::start_dnsmasq).
+    fn reset_dns_records(&self, bridge: &str) -> Result<()> {
+        let dnsmasq_dir = self.active_local_backend.working_dir.join("dnsmasq");
+        std::fs::create_dir_all(&dnsmasq_dir).with_context(|| {
+            format!("creating dnsmasq working dir at {}", dnsmasq_dir.display())
+        })?;
+        for path in [
+            self.dnsmasq_hosts_path(bridge),
+            self.dnsmasq_wildcards_path(bridge),
+        ] {
+            std::fs::write(&path, "").with_context(|| format!("truncating {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    /// The `--address=/<name>/<addr>` options for the wildcard records registered
+    /// for `bridge` so far, read back from
+    /// [`dnsmasq_wildcards_path`](Self::dnsmasq_wildcards_path).
+    fn dnsmasq_wildcard_args(&self, bridge: &str) -> Result<Vec<String>> {
+        let path = self.dnsmasq_wildcards_path(bridge);
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            // A group that never got as far as `reset_dns_records` has no
+            // wildcards to serve.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
+            Err(err) => return Err(err).with_context(|| format!("reading {}", path.display())),
+        };
+        contents
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                let (addr, name) =
+                    line.trim().split_once(char::is_whitespace).ok_or_else(|| {
+                        anyhow!("malformed wildcard record {line:?} in {}", path.display())
+                    })?;
+                Ok(format!("--address=/{}/{addr}", name.trim()))
+            })
+            .collect()
     }
 
     /// Spawn a minimal `dnsmasq` on `bridge` serving three roles:
@@ -876,11 +949,15 @@ impl LocalBackend {
         let log_path = dnsmasq_dir.join(format!("{bridge}.log"));
         // Remove a stale pid-file from a previous interrupted run.
         let _ = std::fs::remove_file(&pid_path);
-        // Truncate the hosts-file, both to drop any records such a run left and
-        // so it exists before `dnsmasq` starts: a missing `--addn-hosts` file is
-        // tolerated, but relying on it being picked up later is needless risk.
-        std::fs::write(&hosts_path, "")
-            .with_context(|| format!("creating {}", hosts_path.display()))?;
+        // The wildcard records registered so far. Unlike the `--addn-hosts` file,
+        // these are *command-line* options, which is why registering one has to
+        // restart `dnsmasq`; see `add_wildcard_dns_record`. Empty on the first
+        // start, since `create_group` truncates the file it reads.
+        let wildcard_args: String = self
+            .dnsmasq_wildcard_args(bridge)?
+            .into_iter()
+            .map(|arg| format!(" {arg}"))
+            .collect();
 
         info!(
             self.logger,
@@ -898,13 +975,19 @@ impl LocalBackend {
         // (`enp2s0`). `dnsmasq` daemonizes (writing its pid-file) and is
         // signalled via it in teardown.
         //
-        // DNS: `--no-resolv --no-hosts` keeps the resolver hermetic — it neither
-        // reads the driver host's `/etc/resolv.conf` nor its `/etc/hosts`. With
-        // no upstream server left to forward to, anything it cannot answer is
-        // REFUSED rather than leaked. It answers from two sources:
+        // DNS: `--no-resolv --no-hosts` keeps the resolver hermetic — it reads
+        // neither `/etc/resolv.conf` nor `/etc/hosts`. Both matter: with no
+        // upstream server left to forward to, anything it cannot answer is REFUSED
+        // rather than leaked — and `/etc/resolv.conf` in this mount namespace is
+        // the generated file naming *these very addresses*
+        // (`install_group_resolv_conf`), so reading it would make `dnsmasq` forward
+        // to itself. It answers from three sources:
         //
         // * `--addn-hosts` — records tests register through
         //   [`add_dns_record`](Self::add_dns_record).
+        // * `--address` — the wildcard records tests register through
+        //   [`add_wildcard_dns_record`](Self::add_wildcard_dns_record), each
+        //   answering for a name *and every subdomain of it*.
         // * `--synth-domain` — synthesises `<address>.ipv6.nip.io` for the
         //   group's `/64`, with `:` written as `-`, mirroring the public
         //   `nip.io` wildcard service that tests use to name a VM by its
@@ -939,7 +1022,8 @@ impl LocalBackend {
                  --no-resolv \
                  --no-hosts \
                  --addn-hosts={hosts} \
-                 --synth-domain={NIP_IO_DOMAIN},{prefix}/64",
+                 --synth-domain={NIP_IO_DOMAIN},{prefix}/64\
+                 {wildcard_args}",
             pid = pid_path.display(),
             lease = lease_path.display(),
             log = log_path.display(),
@@ -958,7 +1042,10 @@ impl LocalBackend {
     /// accumulate across calls.
     ///
     /// This is how the local backend replaces Farm's playnet DNS: see
-    /// `InternetComputer::setup_api_bn_local_playnet`.
+    /// `InternetComputer::setup_api_bn_local_playnet`. Use
+    /// [`add_wildcard_dns_record`](Self::add_wildcard_dns_record) when the
+    /// subdomains of `name` have to resolve as well; a hosts file has no
+    /// wildcards.
     pub fn add_dns_record(&self, group_name: &str, name: &str, addr: IpAddr) -> Result<()> {
         let bridge = Self::bridge_name(group_name);
         let hosts_path = self.dnsmasq_hosts_path(&bridge);
@@ -996,17 +1083,146 @@ impl LocalBackend {
         Ok(())
     }
 
-    /// Stop the group's `dnsmasq`, if running. It runs as the current user, so
-    /// it is signalled directly via its pid-file. Best-effort and idempotent.
+    /// Register a *wildcard* DNS record with the group's `dnsmasq`, so that
+    /// `name` **and every subdomain of it, at any depth** resolve to `addrs` — on
+    /// every VM in the group, and in the driver, which shares their resolver (see
+    /// [`install_group_resolv_conf`](Self::install_group_resolv_conf)).
+    ///
+    /// This is the local replacement for the apex record plus the `*` and `*.raw`
+    /// `CNAME`s Farm's playnet DNS serves for the IC gateway, whose per-canister
+    /// subdomains (`<canister id>.<domain>`, `<canister id>.raw.<domain>`) clients
+    /// are expected to reach; see `IcGatewayVm::configure_dns_records`. Mixing
+    /// address families in `addrs` is fine — `dnsmasq` answers each query type
+    /// from the matching `--address` option — and takes the whole set at once
+    /// because a single record is what costs a restart, not a single address.
+    ///
+    /// It does cost a `dnsmasq` restart, unlike
+    /// [`add_dns_record`](Self::add_dns_record), because a wildcard needs
+    /// `--address`, and nothing re-reads a *command-line* option: `SIGHUP` re-reads
+    /// the hosts-shaped files and `--servers-file`, and a servers-file admits
+    /// nothing but `server` and `rev-server`. Prefer `add_dns_record` when an exact
+    /// name is enough.
+    pub fn add_wildcard_dns_record(
+        &self,
+        group_name: &str,
+        name: &str,
+        addrs: &[IpAddr],
+    ) -> Result<()> {
+        if addrs.is_empty() {
+            return Ok(());
+        }
+        let bridge = Self::bridge_name(group_name);
+        let wildcards_path = self.dnsmasq_wildcards_path(&bridge);
+
+        info!(
+            self.logger,
+            "Registering wildcard DNS record {name} (and its subdomains) -> {addrs:?} \
+             with the dnsmasq of group {group_name}"
+        );
+
+        let mut wildcards_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&wildcards_path)
+            .with_context(|| format!("opening {}", wildcards_path.display()))?;
+        for addr in addrs {
+            writeln!(wildcards_file, "{addr} {name}")
+                .with_context(|| format!("appending to {}", wildcards_path.display()))?;
+        }
+        drop(wildcards_file);
+
+        self.restart_dnsmasq(group_name)
+    }
+
+    /// Stop and restart the group's `dnsmasq` so it picks up command-line options
+    /// derived from state that changed since it started — currently only the
+    /// wildcard records of
+    /// [`add_wildcard_dns_record`](Self::add_wildcard_dns_record).
+    ///
+    /// The record files are left alone (they are truncated once, by
+    /// [`create_group`](Self::create_group)), so records registered before the
+    /// restart survive it.
+    ///
+    /// Restarting is safe for VMs that are already up: IC GuestOS nodes are
+    /// statically configured and never consult the RA; a VM that SLAAC'd its
+    /// address holds it for the `--dhcp-range ... ra-only` lifetime, which far
+    /// outlives the gap; DHCPv4 leases live in the lease-file `dnsmasq` re-reads at
+    /// startup; and the only real loss is its DNS cache. A guest that happens to
+    /// query during the gap retries.
+    fn restart_dnsmasq(&self, group_name: &str) -> Result<()> {
+        let bridge = Self::bridge_name(group_name);
+        let prefix = Self::group_ipv6_prefix(group_name);
+        let ipv4_prefix = Self::group_ipv4_prefix(group_name);
+        self.stop_dnsmasq(&bridge);
+        self.start_dnsmasq(group_name, &bridge, &prefix, &ipv4_prefix)
+    }
+
+    /// Stop the group's `dnsmasq`, if running, and wait for it to exit. It runs as
+    /// the current user, so it is signalled directly via its pid-file.
+    /// Best-effort and idempotent.
+    ///
+    /// The wait matters for [`restart_dnsmasq`](Self::restart_dnsmasq): returning
+    /// while the old instance still holds UDP port 53 on the name-server addresses
+    /// would make the new one fail to bind.
     fn stop_dnsmasq(&self, bridge: &str) {
         let pid_path = self.dnsmasq_pid_path(bridge);
         if let Ok(contents) = std::fs::read_to_string(&pid_path)
             && let Ok(pid) = contents.trim().parse::<i32>()
+            && Self::dnsmasq_is_alive(pid, &pid_path)
         {
             // SIGTERM lets dnsmasq remove its pid-file on exit.
             let _ = Command::new("kill").arg(pid.to_string()).status();
+            let deadline = Instant::now() + DNSMASQ_STOP_TIMEOUT;
+            while Self::dnsmasq_is_alive(pid, &pid_path) {
+                if Instant::now() >= deadline {
+                    warn!(
+                        self.logger,
+                        "dnsmasq (pid {pid}) did not exit within {DNSMASQ_STOP_TIMEOUT:?} \
+                         of SIGTERM; sending SIGKILL"
+                    );
+                    let _ = Command::new("kill")
+                        .args(["-KILL", &pid.to_string()])
+                        .status();
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
         }
         let _ = std::fs::remove_file(&pid_path);
+    }
+
+    /// Whether `pid` is a live `dnsmasq` that this backend started with
+    /// `pid_path`, decided by looking for the `--pid-file=<pid_path>` argument
+    /// [`start_dnsmasq`](Self::start_dnsmasq) passed it in
+    /// `/proc/<pid>/cmdline`.
+    ///
+    /// That one check settles both of the questions
+    /// [`stop_dnsmasq`](Self::stop_dnsmasq) has to answer before it signals:
+    ///
+    /// * **Is it still ours?** The pid comes from a pid-file that a `dnsmasq` which
+    ///   died on its own never got to remove, so it can name a pid the kernel has
+    ///   since handed to something else — and `stop_dnsmasq` escalates to
+    ///   `SIGKILL`, which is not a signal to send to a stranger. The pid-file path
+    ///   is unique per group, so nothing else carries it in its `argv`.
+    /// * **Is it still running?** A zombie's `cmdline` reads back empty, so this
+    ///   answers `false` for one — which is what we want, since a zombie holds no
+    ///   sockets. `dnsmasq` does become one briefly: it daemonizes, so it is not a
+    ///   child of this process and lingers until whoever it was reparented to reaps
+    ///   it.
+    ///
+    /// The process *name* is no help here, which is worth knowing before reaching
+    /// for it: Bazel links the `dnsmasq` runfiles entry under a hashed basename, so
+    /// `/proc/<pid>/comm` holds a 15-character truncation of that hash rather than
+    /// anything resembling `dnsmasq`.
+    fn dnsmasq_is_alive(pid: i32, pid_path: &Path) -> bool {
+        let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
+            return false;
+        };
+        // `cmdline` is NUL-separated and `--pid-file=<path>` is passed as a single
+        // word, so searching the raw bytes cannot match across two arguments.
+        let mut needle = b"--pid-file=".to_vec();
+        needle.extend_from_slice(pid_path.as_os_str().as_bytes());
+        cmdline.windows(needle.len()).any(|word| word == needle)
     }
 
     /// Path of a VM's QEMU pid-file (written via `-pidfile` in [`start_vm`]).

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -526,9 +526,9 @@ impl LocalBackend {
     ///
     /// Appending, never replacing: the original bytes are copied verbatim first, so
     /// this can only widen the driver's trust, never narrow it. That matters,
-    /// because the driver has clients that need the public roots ([`Farm::new`] and
-    /// the log-upload client in `group.rs`), and because `dfx` and every other child
-    /// inherits this mount too.
+    /// because the driver has clients that need the public roots
+    /// ([`Farm::new`](crate::driver::farm::Farm::new) and the log-upload client in
+    /// `group.rs`), and because `dfx` and every other child inherits this mount too.
     ///
     /// What is being trusted deserves saying plainly: a CA whose private key is
     /// checked into a public repository, valid until 2122, becomes trusted by every

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -88,9 +88,9 @@ const DNSMASQ_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 /// gone. Short enough that a restart is not noticeably delayed by the poll.
 const DNSMASQ_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// The bundle the driver's own TLS clients read their root certificates from, and
-/// which [`LocalBackend::install_dev_root_ca`] shadows with a copy that also
-/// contains the dev root CA.
+/// Where the driver's own TLS clients read their root certificates from when the
+/// environment does not say otherwise; see
+/// [`system_ca_bundle`](LocalBackend::system_ca_bundle).
 ///
 /// This exact path is load-bearing, through a chain worth spelling out because
 /// nothing type-checks it: `reqwest::ClientBuilder::build` constructs a
@@ -99,7 +99,7 @@ const DNSMASQ_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// nor `SSL_CERT_DIR` set — defers to `openssl_probe::probe()`, and this is the
 /// first candidate in its Linux list. `rs/tests/BUILD.bazel` builds a bundle at the
 /// same path for the colocated driver image, for the same reason.
-const SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
+const DEFAULT_SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
 
 /// Environment variables holding the runfiles paths of the split OVMF (UEFI)
 /// firmware images, provided by the `@ovmf` Bazel repo (extracted from the
@@ -363,7 +363,7 @@ impl LocalBackend {
         // that neither depends on the other having run first.
         Self::mount(
             None,
-            "/",
+            Path::new("/"),
             libc::MS_REC | libc::MS_PRIVATE,
             "making / private in the owned mount namespace",
         )?;
@@ -431,7 +431,7 @@ impl LocalBackend {
 
         Self::mount(
             Some(&path),
-            "/etc/resolv.conf",
+            Path::new("/etc/resolv.conf"),
             libc::MS_BIND,
             "bind-mounting the generated resolv.conf over /etc/resolv.conf",
         )
@@ -446,6 +446,40 @@ impl LocalBackend {
             "system-test-ca-certificates.crt.{}",
             std::process::id()
         ))
+    }
+
+    /// The CA bundle `rustls-native-certs` will actually read, which is the file
+    /// [`install_dev_root_ca`](Self::install_dev_root_ca) has to append to.
+    ///
+    /// Mirrors `rustls_native_certs::load_native_certs`: `SSL_CERT_FILE` names the
+    /// bundle whenever it is set, and `openssl_probe`'s first Linux candidate
+    /// ([`DEFAULT_SYSTEM_CA_BUNDLE`]) is used otherwise.
+    ///
+    /// Honouring that variable is not politeness. CI runners set it — Namespace points
+    /// it at its own worker bundle — and an earlier version of this code *refused to
+    /// run* when it was set, which passed locally and failed every `_local` target
+    /// there. Appending to whichever bundle the environment designates works in both
+    /// places, and keeps whatever roots that bundle carries.
+    ///
+    /// `SSL_CERT_DIR` set *without* `SSL_CERT_FILE` is the one shape this cannot
+    /// serve: `rustls-native-certs` then reads only those directories and no bundle at
+    /// all, so there is no file to append to — and a new file cannot be added to a
+    /// directory the driver does not own, for the reasons in
+    /// [`install_dev_root_ca`](Self::install_dev_root_ca). Nothing sets it that way
+    /// today; if something starts to, this fails loudly rather than quietly leaving
+    /// the CA out.
+    fn system_ca_bundle() -> Result<PathBuf> {
+        if let Some(file) = std::env::var_os("SSL_CERT_FILE") {
+            return Ok(PathBuf::from(file));
+        }
+        if let Some(dirs) = std::env::var_os("SSL_CERT_DIR") {
+            bail!(
+                "SSL_CERT_DIR is set ({dirs:?}) without SSL_CERT_FILE, so the driver's \
+                 TLS clients would read only those directories and never a CA bundle, \
+                 leaving nowhere to install the dev root CA"
+            );
+        }
+        Ok(PathBuf::from(DEFAULT_SYSTEM_CA_BUNDLE))
     }
 
     /// Put the dev root CA in the driver's own trust store, by bind-mounting a copy
@@ -495,24 +529,10 @@ impl LocalBackend {
     /// by `LocalApiBoundaryNodesPlaynet`'s ephemeral CA, and otherwise the node
     /// self-signs it via `generate_ic_boundary_tls_cert`.)
     fn install_dev_root_ca() -> Result<()> {
-        // When either of these is set, `rustls-native-certs` loads *only* what they
-        // name and skips the platform store altogether — so an inherited value would
-        // silently make the mount below invisible. It checks neither for existence,
-        // so being set at all is enough. Nothing sets them today (no `env_inherit` in
-        // `rs/tests` mentions them); this is insurance against something that would
-        // otherwise be very hard to diagnose.
-        for var in ["SSL_CERT_FILE", "SSL_CERT_DIR"] {
-            if let Some(value) = std::env::var_os(var) {
-                bail!(
-                    "{var} is set ({value:?}), which would make the driver's TLS clients \
-                     read only what it names and so never see the dev root CA this \
-                     installs in {SYSTEM_CA_BUNDLE}"
-                );
-            }
-        }
-
-        let mut bundle = std::fs::read_to_string(SYSTEM_CA_BUNDLE)
-            .with_context(|| format!("reading the system CA bundle {SYSTEM_CA_BUNDLE}"))?;
+        let bundle_path = Self::system_ca_bundle()?;
+        let bundle_path_display = bundle_path.display();
+        let mut bundle = std::fs::read_to_string(&bundle_path)
+            .with_context(|| format!("reading the system CA bundle {bundle_path_display}"))?;
         let dev_root_ca_pem = dev_root_ca_cert_pem()?;
         // Guard the separator rather than trusting the bundle to end in a newline:
         // `-----END CERTIFICATE----------BEGIN CERTIFICATE-----` parses as neither,
@@ -534,7 +554,7 @@ impl LocalBackend {
 
         Self::mount(
             Some(&path),
-            SYSTEM_CA_BUNDLE,
+            &bundle_path,
             libc::MS_BIND,
             "bind-mounting the generated CA bundle over the system one",
         )?;
@@ -543,11 +563,11 @@ impl LocalBackend {
         // unreachable — a mount that did not take, a short write, a stale target —
         // and none of that surfaces until a TLS handshake fails, six minutes into a
         // test, in a retry loop. One extra read turns that into an error here.
-        let installed = std::fs::read_to_string(SYSTEM_CA_BUNDLE)
-            .with_context(|| format!("reading back {SYSTEM_CA_BUNDLE}"))?;
+        let installed = std::fs::read_to_string(&bundle_path)
+            .with_context(|| format!("reading back {bundle_path_display}"))?;
         if !installed.contains(&dev_root_ca_pem) {
             bail!(
-                "the dev root CA is missing from {SYSTEM_CA_BUNDLE} after mounting {} \
+                "the dev root CA is missing from {bundle_path_display} after mounting {} \
                  over it",
                 path.display()
             );
@@ -561,12 +581,13 @@ impl LocalBackend {
     /// `source` is `None` for a propagation change, which takes none; the
     /// filesystem type and the mount data are always `NULL`, because every call
     /// site is either a bind mount or a propagation change and neither uses them.
-    fn mount(source: Option<&Path>, target: &str, flags: libc::c_ulong, what: &str) -> Result<()> {
+    fn mount(source: Option<&Path>, target: &Path, flags: libc::c_ulong, what: &str) -> Result<()> {
         let source = source
             .map(|source| CString::new(source.as_os_str().as_bytes()))
             .transpose()
             .with_context(|| format!("{what}: the source path contains a NUL byte"))?;
-        let target = CString::new(target).expect("mount target contains a NUL byte");
+        let target =
+            CString::new(target.as_os_str().as_bytes()).expect("mount target contains a NUL byte");
         // SAFETY: both strings are NUL-terminated and outlive the call. A NULL
         // source is what `mount(2)` expects for a propagation change (the kernel
         // never looks at it), and a NULL filesystem type and data are what it

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -13,11 +13,19 @@
 //! issuance, HTTP file upload, multi-tenant scheduling); those operations warn
 //! and return dummy values or `bail!`.
 //!
+//! The driver also gives itself a private view of two `/etc` files, in the mount
+//! namespace [`LocalBackend::ensure_administrable_netns`] creates: a
+//! `resolv.conf` naming the group's own `dnsmasq`, and a CA bundle that also
+//! trusts the dev root CA. Together they are what let a driver-side client reach
+//! the group's IC gateway by name over verified HTTPS, exactly as it would on
+//! Farm, with no per-client configuration.
+//!
 //! In the QEMU command line built by [`LocalBackend::start_vm`], each virtio/PCIe
 //! device sits behind its own `pcie-root-port` so the guest's predictable
 //! interface names stay deterministic (primary NIC -> `enp1s0`, IPv4 NIC ->
 //! `enp2s0`).
 
+use crate::driver::dev_root_ca::dev_root_ca_cert_pem;
 use crate::driver::farm::{VMCreateResponse, VmSpec};
 use crate::driver::resource::DiskImage;
 use crate::driver::test_env::{TestEnv, TestEnvAttribute};
@@ -79,6 +87,19 @@ const DNSMASQ_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 /// How often [`LocalBackend::await_dnsmasq_exit`] re-checks whether `dnsmasq` is
 /// gone. Short enough that a restart is not noticeably delayed by the poll.
 const DNSMASQ_STOP_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// The bundle the driver's own TLS clients read their root certificates from, and
+/// which [`LocalBackend::install_dev_root_ca`] shadows with a copy that also
+/// contains the dev root CA.
+///
+/// This exact path is load-bearing, through a chain worth spelling out because
+/// nothing type-checks it: `reqwest::ClientBuilder::build` constructs a
+/// `rustls_platform_verifier::Verifier`, whose Unix implementation calls
+/// `rustls_native_certs::load_native_certs`, which — with neither `SSL_CERT_FILE`
+/// nor `SSL_CERT_DIR` set — defers to `openssl_probe::probe()`, and this is the
+/// first candidate in its Linux list. `rs/tests/BUILD.bazel` builds a bundle at the
+/// same path for the colocated driver image, for the same reason.
+const SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
 
 /// Environment variables holding the runfiles paths of the split OVMF (UEFI)
 /// firmware images, provided by the `@ovmf` Bazel repo (extracted from the
@@ -246,6 +267,12 @@ impl LocalBackend {
     /// `ip`/`dnsmasq` operations to run with `CAP_NET_ADMIN`/`CAP_NET_RAW`/
     /// `CAP_NET_BIND_SERVICE` over that namespace — without any *host* capability
     ///
+    /// It also installs the per-group `/etc` overrides that make that namespace
+    /// usable from the driver's own code — a resolver
+    /// ([`install_group_resolv_conf`](Self::install_group_resolv_conf)) and a trust
+    /// store ([`install_dev_root_ca`](Self::install_dev_root_ca)) — so the name is
+    /// narrower than what the function does.
+    ///
     /// `unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET)` creates a private
     /// user namespace, in which the caller holds a full capability set (it is the
     /// namespace's creator), plus a mount and a network namespace owned by it — so
@@ -329,9 +356,21 @@ impl LocalBackend {
         // needs `CAP_NET_ADMIN`, so it fails fast (with the `ip` error) if the
         // ambient capabilities did not take effect.
         Self::run_shell("ip link set dev lo up", "bring up lo in the owned netns")?;
-        // Finally, give the driver itself a resolver, now that it owns a mount
-        // namespace to install one in.
+        // Detach the mount namespace's propagation before mounting anything into
+        // it, so neither install below can escape. A host that leaves `/` shared —
+        // the systemd default — would otherwise have the real files replaced for as
+        // long as the mount lived. Done here rather than inside either installer so
+        // that neither depends on the other having run first.
+        Self::mount(
+            None,
+            "/",
+            libc::MS_REC | libc::MS_PRIVATE,
+            "making / private in the owned mount namespace",
+        )?;
+        // Finally the two per-group `/etc` overrides, which are what make the
+        // driver resolve and trust the group's own services.
         Self::install_group_resolv_conf()?;
+        Self::install_dev_root_ca()?;
         Ok(())
     }
 
@@ -365,11 +404,6 @@ impl LocalBackend {
     /// driver-side client reach the IC gateway by name rather than having to
     /// resolve the host for itself.
     ///
-    /// `/` is remounted `MS_REC | MS_PRIVATE` first, so the bind mount cannot
-    /// propagate back out. A host that leaves `/` shared — the systemd default —
-    /// would otherwise have its real `/etc/resolv.conf` replaced for as long as
-    /// the mount lived.
-    ///
     /// Four details worth knowing:
     ///
     /// * `mount(2)` needs `CAP_SYS_ADMIN` over the mount namespace's *user*
@@ -387,15 +421,6 @@ impl LocalBackend {
     ///   addresses, so a lookup before that fails fast instead of hanging.
     ///   Nothing resolves a name that early.
     fn install_group_resolv_conf() -> Result<()> {
-        // Stop mount propagation out of this namespace before mounting anything
-        // into it.
-        Self::mount(
-            None,
-            "/",
-            libc::MS_REC | libc::MS_PRIVATE,
-            "making / private in the owned mount namespace",
-        )?;
-
         let contents: String = IPV6_NAME_SERVERS
             .iter()
             .map(|name_server| format!("nameserver {name_server}\n"))
@@ -410,6 +435,117 @@ impl LocalBackend {
             libc::MS_BIND,
             "bind-mounting the generated resolv.conf over /etc/resolv.conf",
         )
+    }
+
+    /// Path of the generated CA bundle
+    /// [`install_dev_root_ca`](Self::install_dev_root_ca) bind-mounts over
+    /// [`SYSTEM_CA_BUNDLE`]. Same placement, and for the same reasons, as
+    /// [`generated_resolv_conf_path`](Self::generated_resolv_conf_path).
+    fn generated_ca_bundle_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "system-test-ca-certificates.crt.{}",
+            std::process::id()
+        ))
+    }
+
+    /// Put the dev root CA in the driver's own trust store, by bind-mounting a copy
+    /// of [`SYSTEM_CA_BUNDLE`] with that CA appended over the original.
+    ///
+    /// This is what lets a driver-side client verify the local IC gateway's
+    /// certificate without any code of its own: the CA is simply one of the roots
+    /// every TLS client in the process tree already loads. The guests arrive at the
+    /// same place by a different route — `update-ca-certificates` in the `output_dev`
+    /// stage of the IC-OS Dockerfiles, see [`dev_root_ca_cert_pem`] — so the driver
+    /// and the nodes end up trusting the gateway on the same terms.
+    ///
+    /// A bind mount is the mechanism because the obvious alternative cannot work. A
+    /// mount namespace isolates the mount *table*, not file contents, so dropping a
+    /// `.crt` into `/etc/ssl/certs` the way `update-ca-certificates` does would
+    /// escape the namespace and mutate the container — and the driver is
+    /// unprivileged there in any case. Shadowing the *bundle* rather than the
+    /// directory leaves OpenSSL's hashed-symlink `CApath` layout intact for whatever
+    /// reads it that way.
+    ///
+    /// Appending, never replacing: the original bytes are copied verbatim first, so
+    /// this can only widen the driver's trust, never narrow it. That matters,
+    /// because the driver has clients that need the public roots ([`Farm::new`] and
+    /// the log-upload client in `group.rs`), and because `dfx` and every other child
+    /// inherits this mount too.
+    ///
+    /// What is being trusted deserves saying plainly: a CA whose private key is
+    /// checked into a public repository, valid until 2122, becomes trusted by every
+    /// TLS client in the driver's process tree. That is acceptable only because the
+    /// tree lives in a network namespace with no route off the host (see
+    /// [`ensure_administrable_netns`](Self::ensure_administrable_netns)), so the only
+    /// servers it can reach are the group's own VMs. Giving the local backend
+    /// outbound connectivity would invalidate that reasoning, not just this comment.
+    ///
+    /// This covers the gateway only. Clients that dial an API boundary node directly
+    /// still need `danger_accept_invalid_certs`, for an unrelated reason:
+    /// `IcNodeSnapshot::get_public_url` hands them an IP-literal URL, which no name
+    /// in the node's certificate can match. (Whether that certificate has a CA at
+    /// all depends on the test — under `with_api_boundary_nodes_playnet` it is issued
+    /// by `LocalApiBoundaryNodesPlaynet`'s ephemeral CA, and otherwise the node
+    /// self-signs it via `generate_ic_boundary_tls_cert`.)
+    fn install_dev_root_ca() -> Result<()> {
+        // When either of these is set, `rustls-native-certs` loads *only* what they
+        // name and skips the platform store altogether — so an inherited value would
+        // silently make the mount below invisible. It checks neither for existence,
+        // so being set at all is enough. Nothing sets them today (no `env_inherit` in
+        // `rs/tests` mentions them); this is insurance against something that would
+        // otherwise be very hard to diagnose.
+        for var in ["SSL_CERT_FILE", "SSL_CERT_DIR"] {
+            if let Some(value) = std::env::var_os(var) {
+                bail!(
+                    "{var} is set ({value:?}), which would make the driver's TLS clients \
+                     read only what it names and so never see the dev root CA this \
+                     installs in {SYSTEM_CA_BUNDLE}"
+                );
+            }
+        }
+
+        let mut bundle = std::fs::read_to_string(SYSTEM_CA_BUNDLE)
+            .with_context(|| format!("reading the system CA bundle {SYSTEM_CA_BUNDLE}"))?;
+        let dev_root_ca_pem = dev_root_ca_cert_pem()?;
+        // Guard the separator rather than trusting the bundle to end in a newline:
+        // `-----END CERTIFICATE----------BEGIN CERTIFICATE-----` parses as neither,
+        // and a PEM that fails to parse is reported by `rustls-platform-verifier`
+        // through `log::warn!` — for which the driver installs no implementation, so
+        // it would go nowhere.
+        if !bundle.ends_with('\n') {
+            bundle.push('\n');
+        }
+        bundle.push_str(&dev_root_ca_pem);
+
+        let path = Self::generated_ca_bundle_path();
+        std::fs::write(&path, &bundle)
+            .with_context(|| format!("writing the generated CA bundle {}", path.display()))?;
+        // `write` honours the umask, and this shadows a world-readable file that
+        // every child in the tree reads.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("making {} world-readable", path.display()))?;
+
+        Self::mount(
+            Some(&path),
+            SYSTEM_CA_BUNDLE,
+            libc::MS_BIND,
+            "bind-mounting the generated CA bundle over the system one",
+        )?;
+
+        // Read it back. Every step above can succeed while leaving the CA
+        // unreachable — a mount that did not take, a short write, a stale target —
+        // and none of that surfaces until a TLS handshake fails, six minutes into a
+        // test, in a retry loop. One extra read turns that into an error here.
+        let installed = std::fs::read_to_string(SYSTEM_CA_BUNDLE)
+            .with_context(|| format!("reading back {SYSTEM_CA_BUNDLE}"))?;
+        if !installed.contains(&dev_root_ca_pem) {
+            bail!(
+                "the dev root CA is missing from {SYSTEM_CA_BUNDLE} after mounting {} \
+                 over it",
+                path.display()
+            );
+        }
+        Ok(())
     }
 
     /// `mount(2)`, which the `nix` crate cannot offer here because the workspace

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -1264,11 +1264,16 @@ impl LocalBackend {
         let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
             return false;
         };
-        // `cmdline` is NUL-separated and `--pid-file=<path>` is passed as a single
-        // word, so searching the raw bytes cannot match across two arguments.
-        let mut needle = b"--pid-file=".to_vec();
-        needle.extend_from_slice(pid_path.as_os_str().as_bytes());
-        cmdline.windows(needle.len()).any(|word| word == needle)
+        // `cmdline` is NUL-separated, so split it and compare *whole* arguments.
+        // A substring search over the raw bytes would be weaker in a way that
+        // matters here, since a false positive gets something signalled: it would
+        // also accept our argument embedded in a longer one, or our path as the
+        // prefix of a longer path.
+        let mut expected = b"--pid-file=".to_vec();
+        expected.extend_from_slice(pid_path.as_os_str().as_bytes());
+        cmdline
+            .split(|byte| *byte == 0)
+            .any(|arg| arg == expected.as_slice())
     }
 
     /// Path of a VM's QEMU pid-file (written via `-pidfile` in [`start_vm`]).

--- a/rs/tests/driver/src/driver/local_backend.rs
+++ b/rs/tests/driver/src/driver/local_backend.rs
@@ -458,13 +458,20 @@ impl LocalBackend {
     /// stage of the IC-OS Dockerfiles, see [`dev_root_ca_cert_pem`] — so the driver
     /// and the nodes end up trusting the gateway on the same terms.
     ///
-    /// A bind mount is the mechanism because the obvious alternative cannot work. A
-    /// mount namespace isolates the mount *table*, not file contents, so dropping a
-    /// `.crt` into `/etc/ssl/certs` the way `update-ca-certificates` does would
-    /// escape the namespace and mutate the container — and the driver is
-    /// unprivileged there in any case. Shadowing the *bundle* rather than the
-    /// directory leaves OpenSSL's hashed-symlink `CApath` layout intact for whatever
-    /// reads it that way.
+    /// A bind mount over an *existing* entry is the only option, which is worth
+    /// spelling out because two simpler-looking routes are dead ends. Adding a new
+    /// file beside the bundle fails on `mount(2)`, which will not create a directory
+    /// entry: the target has to exist already, and the driver cannot create one —
+    /// `/etc/ssl/certs` belongs to root, root is not mapped into the driver's user
+    /// namespace, and so the `CAP_DAC_OVERRIDE` it holds there does not apply to it.
+    /// Writing the file for real, the way `update-ca-certificates` does, escapes the
+    /// namespace altogether: it isolates the mount *table*, not file contents.
+    ///
+    /// Shadowing the bundle rather than the whole directory is then the better of
+    /// what is left. It reaches OpenSSL's `CApath` consumers, which look up
+    /// `<subject hash>.0` symlinks and would miss a plainly named file (though
+    /// `rustls-native-certs` would have read one, since it loads every regular file
+    /// in the directory), and it avoids reproducing the directory's ~240 entries.
     ///
     /// Appending, never replacing: the original bytes are copied verbatim first, so
     /// this can only widen the driver's trust, never narrow it. That matters,

--- a/rs/tests/driver/src/driver/mod.rs
+++ b/rs/tests/driver/src/driver/mod.rs
@@ -4,6 +4,7 @@ pub mod bootstrap;
 pub mod config;
 pub mod constants;
 pub mod context;
+mod dev_root_ca;
 pub mod driver_setup;
 pub mod dsl;
 pub mod event;

--- a/rs/tests/nns/nns_dapp_test.rs
+++ b/rs/tests/nns/nns_dapp_test.rs
@@ -66,12 +66,11 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
     let dapp_url = format!("https://{canister_id}.{ic_gateway_domain}");
     let log = env.logger();
 
-    // On the Local backend the driver cannot resolve the gateway domain (nor its
-    // per-canister subdomains), so resolve the requested host directly to the
-    // gateway VM, and trust the CA that issued its certificate.
+    // On the Local backend the gateway's certificate is issued by the dev root CA
+    // rather than by a public one, so trust that CA. Its domain — and, thanks to
+    // the group's wildcard record, this canister's subdomain of it — resolves on
+    // both backends, so nothing else is needed.
     let ic_gateway = env.get_deployed_ic_gateway(IC_GATEWAY_VM_NAME).unwrap();
-    let parsed_dapp_url = Url::parse(&dapp_url).unwrap();
-    let resolve_override = ic_gateway.resolve_override_for_url(&parsed_dapp_url);
     let root_cert = ic_gateway.root_certificate().unwrap();
 
     block_on(async {
@@ -85,9 +84,6 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     .use_rustls_tls()
                     .https_only(true)
                     .http1_only();
-                if let Some((domain, addr)) = &resolve_override {
-                    builder = builder.resolve(domain, *addr);
-                }
                 if let Some(cert) = &root_cert {
                     builder = builder.add_root_certificate(cert.clone());
                 }

--- a/rs/tests/nns/nns_dapp_test.rs
+++ b/rs/tests/nns/nns_dapp_test.rs
@@ -66,13 +66,6 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
     let dapp_url = format!("https://{canister_id}.{ic_gateway_domain}");
     let log = env.logger();
 
-    // On the Local backend the gateway's certificate is issued by the dev root CA
-    // rather than by a public one, so trust that CA. Its domain — and, thanks to
-    // the group's wildcard record, this canister's subdomain of it — resolves on
-    // both backends, so nothing else is needed.
-    let ic_gateway = env.get_deployed_ic_gateway(IC_GATEWAY_VM_NAME).unwrap();
-    let root_cert = ic_gateway.root_certificate().unwrap();
-
     block_on(async {
         ic_system_test_driver::retry_with_msg_async!(
             format!("get html from {}", dapp_url),
@@ -80,14 +73,11 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
             secs(600),
             secs(30),
             async || {
-                let mut builder = reqwest::Client::builder()
+                let client = reqwest::Client::builder()
                     .use_rustls_tls()
                     .https_only(true)
-                    .http1_only();
-                if let Some(cert) = &root_cert {
-                    builder = builder.add_root_certificate(cert.clone());
-                }
-                let client = builder.build()?;
+                    .http1_only()
+                    .build()?;
 
                 let resp = client
                     .get(dapp_url.clone())

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -316,11 +316,14 @@ def system_test(
     _local_only_deps["ENV_DEPS__OVMF_CODE_PATH"] = "//:OVMF_CODE_4M.fd"
     _local_only_deps["ENV_DEPS__OVMF_VARS_PATH"] = "//:OVMF_VARS_4M.fd"
 
-    # The dev root CA, which the local backend's ic-gateway uses to issue its TLS
-    # certificate: every dev IC-OS image installs this CA into
+    # The dev root CA. Every dev IC-OS image installs it into
     # /usr/local/share/ca-certificates in the `output_dev` stage of the GuestOS and
-    # HostOS Dockerfiles, so a node trusts the gateway with no node-side config.
-    # See `IcGatewayVm::load_or_create_local_playnet`.
+    # HostOS Dockerfiles, so a node trusts the local ic-gateway with no node-side
+    # config. Two consumers: the gateway issues its TLS certificate from it (see
+    # `IcGatewayVm::load_or_create_local_playnet`, which needs the key), and the
+    # driver installs the cert into its own trust store at startup for the same
+    # reason a node has it (`LocalBackend::install_dev_root_ca`) -- so the cert is
+    # read by *every* local target, not just the ones that stand up a gateway.
     #
     # Local-only on purpose. The Farm backend uses a playnet certificate and never
     # reads these, and a runtime dep reaches *every* variant's runfiles -- which for


### PR DESCRIPTION
Third PR in the stack. Builds on #11270 (the local ic-gateway serving a dev-CA
certificate on a resolvable domain) and #11265 (nested nodes registering through
it).

On the Local backend, a driver-side client could not reach the gateway the way it
does on Farm. Two workarounds covered for that — `resolve_override_for_url` for
the name, and `root_certificate()` + `add_root_certificate` for the certificate —
and both had to be repeated at every call site. This PR makes name resolution and
trust properties of the *environment* instead, so all of it goes away. Neither
`nns_dapp_test` nor the sdk asset helper now carries any backend-specific client
setup: they build a plain client and GET the URL.

### 1. The driver had no resolver at all

`ensure_administrable_netns` puts the driver in a network namespace it owns, but
not a *mount* namespace — so it kept reading the host's `/etc/resolv.conf`, whose
nameserver is unreachable from that netns. Driver-side DNS was not merely
overridden by the `.resolve()` callers; it was dead.

It now unshares `CLONE_NEWNS` as well and bind-mounts a generated `resolv.conf`
naming `IPV6_NAME_SERVERS` over `/etc/resolv.conf`, so the driver resolves
in-group names through the group's own `dnsmasq` exactly like the VMs do —
`dnsmasq` already binds those addresses on the group bridge inside that very
netns.

### 2. `dnsmasq` answered no wildcards

`add_dns_record` appends to the `--addn-hosts` file, which holds exact names
only. Farm's playnet DNS gives the gateway domain an apex record plus `*` and
`*.raw` CNAMEs, because clients address canisters as `<canister id>.<domain>`
and `<canister id>.raw.<domain>`. Locally those subdomains resolved nowhere —
for clients inside a VM as much as for the driver.

`add_wildcard_dns_record` answers for a name and every subdomain of it at any
depth: one `--address` option covering all three Farm records. It takes the whole
address set at once because a *record*, not an address, is what costs a restart.

A restart is what it costs, since `--address` is a command-line option and
nothing re-reads those (`SIGHUP` re-reads the hosts-shaped files and
`--servers-file`, and a servers-file admits nothing but `server`/`rev-server`).
So the records live in a file `start_dnsmasq` turns back into options,
`create_group` takes over truncating them, and `stop_dnsmasq` now waits for
`dnsmasq` to exit — it binds its listeners before daemonizing, so a restart
racing the old instance for UDP port 53 fails outright. Restarting is safe for
VMs already up: GuestOS nodes are statically configured and never consult the RA,
a SLAAC'd address outlives the gap by far, DHCPv4 leases live in the lease-file
`dnsmasq` re-reads at startup, and the only real loss is its DNS cache.

### 3. Trust was configured per client, not per environment

Every dev IC-OS image trusts the dev root CA, via `update-ca-certificates` in the
`output_dev` stage of the GuestOS and HostOS Dockerfiles. The driver did not, so
each of its clients had to add the CA to its own roots.

It now installs the CA once, at startup, by bind-mounting
`/etc/ssl/certs/ca-certificates.crt` with the CA appended over the original — in
the mount namespace section 1 already created. That path is load-bearing through
a chain nothing type-checks (`ClientBuilder::build` →
`rustls_platform_verifier::Verifier` → `rustls_native_certs` →
`openssl_probe::probe`), so the const carries it in a comment; `rs/tests/BUILD.bazel`
already builds a bundle at the same path for the colocated driver image for the
same reason.

It does not *set* `SSL_CERT_FILE`, which would be the wrong tool:
`rustls-native-certs` then loads only what that names and skips the platform store
entirely, so it would *narrow* the driver's trust rather than widen it, breaking
the clients that need public roots (`Farm::new`, and the log-upload client in
`group.rs`). `std::env::set_var` is also `unsafe` in edition 2024 and racy against
threads building clients, which a mount is not.

It does, however, **honour** the variable. `system_ca_bundle` resolves the bundle
the way `rustls_native_certs::load_native_certs` does — `SSL_CERT_FILE` when set,
`openssl_probe`'s first Linux candidate otherwise — and the append, the mount and
the read-back all target that path, so the runner's own roots are kept rather than
replaced. An earlier revision *refused* to run when the variable was set, which
passed locally and failed every `_local` target on CI, where the Namespace runner
sets it. Hard-coding the default is safe because it is `probe()`'s first candidate:
if it exists, it is the one chosen, so the mount cannot land on a bundle the
verifier ignores.

The one shape that still refuses is `SSL_CERT_DIR` without `SSL_CERT_FILE`:
`rustls-native-certs` then reads only those directories and no bundle at all, so
there is nothing to append to — and a file cannot be added to a directory the
driver does not own. It fails loudly rather than quietly omitting the CA.

What the mount does **not** reach: a consumer using OpenSSL `CApath` alone, which
resolves `<subject hash>.0` symlinks and never scans the bundle. Nothing in the
driver's process tree does that, and a plainly named file in the directory would
not have served it either — only a hash-named symlink would, which is what
`update-ca-certificates` generates and what a bind mount cannot create.

The append is verbatim-then-add, so it can only widen trust. The result is read
back before returning, because every step can succeed while leaving the CA
unreachable — a mount that did not take, a short write, a stale target — and none
of that would surface until a TLS handshake failed six minutes into a test.

## Verification

`rust-lint.sh`, `buildifier` and `bazel build //... --nobuild` all clean, and:

| target | |
|---|---|
| `//rs/tests/sdk:dfx_smoke_test_local` | PASSED 486.8s |
| `//rs/tests/nns:nns_dapp_test_local` | PASSED 483.2s |
| `//rs/tests/idx:basic_health_test_local` | PASSED 368.6s |
| `//rs/tests/sdk:dfx_smoke_test` (Farm regression) | PASSED 153.0s |
| `//rs/tests/nested:registration_local` | PASSED 824.0s |

The CI environment shape is covered too, reproduced locally with
`--test_env=SSL_CERT_FILE=<a bundle outside /etc>`: `dfx_smoke_test_local` (gateway)
and `basic_health_test_local` (no gateway — the majority case) both pass, the
shadowed file is left untouched on the host, and both pass again with the variable
unset.

The two gateway tests are the sharpest: each fetches
`https://<canister id>.ic-gateway.ic.net/…` with **no** resolve override and **no**
roots added, so they fail unless the mount, the wildcard, the trust store and the
certificate all hold. `basic_health_test_local` is the control — it stands up no
gateway, so it shows the unconditional trust-store install does not disturb the
~366 local targets that never touch one.

The logs confirm the chain rather than just a green tick: `dnsmasq` is started
exactly twice (`create_group` plus the one restart, with VMs already booted),
`await_status_is_healthy of ic-gateway` succeeds against the domain, and the
canister-subdomain asset fetch returns.

A few things were checked directly before writing the code, since each could have
sunk the approach:

- The bind mount works in a *nested* userns+mntns — the Bazel sandbox layer and
  then the driver's — with the host's files unaffected. `_local` tests
  deliberately run sandboxed with `requires-network` absent.
- `--address=/d/a` answers `d`, `x.d` and `x.raw.d` for both A and AAAA.
- glibc returns the AAAA when the paired A query comes back `REFUSED`, which is
  exactly what an IPv6-only wildcard produces — and the local gateway has no
  IPv4, so that is the real configuration rather than a corner case.
- The composed bundle verifies the dev CA *and* still verifies a public root, so
  the append really is additive.

## Not done here

**No `danger_accept_invalid_certs` call is removed.** All 14 in `rs/tests/` dial an
IC node or API boundary node — by IP literal, or by a domain registered with no
DNS server and pinned with `.resolve()` — or plain HTTP. A trust anchor cannot
help any of them, and none targets the gateway. The reasoning behind them moved
from `root_certificate()`'s doc to `install_dev_root_ca`'s rather than being
deleted with the method. `await_api_bn_healthy_async` and `status_async` likewise
keep their `.resolve()` calls: an API BN's domain comes from its registry record
and is registered with no DNS server on either backend, and nothing in the tree
overrides `uses_dns()`.

`prometheus_vm` writes `<canister id>.raw.<domain>` scrape targets, and those now
resolve — but the `ledger-canister` and `bitcoin-*`/`dogecoin-*` jobs are
`scheme: https` with no `tls_config`, unlike the neighbouring `nested_hosts` and
`node_exporter` jobs, so they would verify the dev-CA leaf against the *Prometheus
UVM's* stock trust store and fail. Finishing that means installing the CA there
too; those are mainnet canister ids that only exist on testnets, and it is a
separate, independently testable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

