### PR TITLE
feat: Do not route refunds to or from a cooling down subnet

### DIFF
--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -835,23 +835,22 @@ impl StreamBuilderImpl {
             match network_topology.route(refund.recipient().get()) {
                 Some(dst_subnet_id) => {
                     let is_loopback_stream = dst_subnet_id == self.subnet_id;
+                    let dst_subnet_topology = network_topology.subnets().get(&dst_subnet_id);
+                    let dst_subnet_type = dst_subnet_topology.map(|topology| topology.subnet_type);
 
                     // No refunds are routed while either this subnet (the source) or the
                     // destination subnet is cooling down; not even into the loopback stream.
                     // Retain them in the refund pool until neither subnet is cooling down
                     // anymore, rather than dropping them (which would lose their cycles).
-                    if own_subnet_is_cooling_down
-                        || network_topology.is_cooling_down(&dst_subnet_id)
-                    {
+                    let dst_subnet_is_cooling_down =
+                        dst_subnet_topology.is_some_and(|topology| topology.cooling_down);
+                    if own_subnet_is_cooling_down || dst_subnet_is_cooling_down {
                         self.metrics.cooling_down_skipped_refunds.inc();
                         return false;
                     }
 
-                    let is_engine_dst = !is_loopback_stream
-                        && network_topology
-                            .subnets()
-                            .get(&dst_subnet_id)
-                            .is_some_and(|t| t.subnet_type == SubnetType::CloudEngine);
+                    let is_engine_dst =
+                        !is_loopback_stream && dst_subnet_type == Some(SubnetType::CloudEngine);
                     let is_engine_src = !is_loopback_stream && own_is_engine;
                     if is_engine_dst || is_engine_src {
                         // A refund destined to cross the engine boundary should not exist: a

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -45,6 +45,9 @@ struct StreamBuilderMetrics {
     /// Output queues skipped because this subnet or their destination subnet was
     /// cooling down.
     pub cooling_down_skipped_queues: IntCounter,
+    /// Refunds skipped because this subnet or their destination subnet was cooling
+    /// down.
+    pub cooling_down_skipped_refunds: IntCounter,
     /// Critical error for payloads above the maximum supported size.
     pub critical_error_payload_too_large: IntCounter,
     /// Critical error for responses dropped due to destination not found.
@@ -67,6 +70,7 @@ const METRIC_ROUTED_MESSAGES: &str = "mr_routed_message_count";
 const METRIC_ROUTED_PAYLOAD_SIZES: &str = "mr_routed_payload_size_bytes";
 const METRIC_STREAM_MISROUTED_MESSAGES: &str = "mr_stream_misrouted_messages";
 const METRIC_COOLING_DOWN_SKIPPED_QUEUES: &str = "mr_cooling_down_skipped_queues";
+const METRIC_COOLING_DOWN_SKIPPED_REFUNDS: &str = "mr_cooling_down_skipped_refunds";
 
 const LABEL_TYPE: &str = "type";
 const LABEL_STATUS: &str = "status";
@@ -136,6 +140,12 @@ impl StreamBuilderMetrics {
             cooling down. Counted once per queue per round, so the same queue is counted \
             repeatedly for as long as either subnet keeps cooling down.",
         );
+        let cooling_down_skipped_refunds = metrics_registry.int_counter(
+            METRIC_COOLING_DOWN_SKIPPED_REFUNDS,
+            "Refunds skipped because this subnet or their destination subnet was cooling \
+            down. Counted once per refund per round, so the same refund is counted \
+            repeatedly for as long as either subnet keeps cooling down.",
+        );
         let critical_error_payload_too_large =
             metrics_registry.error_counter(CRITICAL_ERROR_PAYLOAD_TOO_LARGE);
         let critical_error_response_destination_not_found =
@@ -178,6 +188,7 @@ impl StreamBuilderMetrics {
             routed_payload_sizes,
             stream_misrouted_messages,
             cooling_down_skipped_queues,
+            cooling_down_skipped_refunds,
             critical_error_payload_too_large,
             critical_error_response_destination_not_found,
             critical_error_induct_response_failed,
@@ -806,8 +817,9 @@ impl StreamBuilderImpl {
 
     /// Routes up to `refund_limit` refunds per stream from `state` into `streams`.
     ///
-    /// Refunds that could not be routed due to reaching the per stream limit are
-    /// retained in `state`.
+    /// Refunds that could not be routed due to reaching the per stream limit, or
+    /// because this subnet or their destination subnet is cooling down, are retained
+    /// in `state`.
     fn route_refunds(
         &self,
         state: &mut ReplicatedState,
@@ -818,10 +830,23 @@ impl StreamBuilderImpl {
         let mut cycles_lost = Cycles::zero();
         let own_cost_schedule = state.get_own_cost_schedule();
         let own_is_engine = state.metadata.own_subnet_type == SubnetType::CloudEngine;
+        let own_subnet_is_cooling_down = network_topology.is_cooling_down(&self.subnet_id);
         state.take_refunds(|refund| {
             match network_topology.route(refund.recipient().get()) {
                 Some(dst_subnet_id) => {
                     let is_loopback_stream = dst_subnet_id == self.subnet_id;
+
+                    // No refunds are routed while either this subnet (the source) or the
+                    // destination subnet is cooling down; not even into the loopback stream.
+                    // Retain them in the refund pool until neither subnet is cooling down
+                    // anymore, rather than dropping them (which would lose their cycles).
+                    if own_subnet_is_cooling_down
+                        || network_topology.is_cooling_down(&dst_subnet_id)
+                    {
+                        self.metrics.cooling_down_skipped_refunds.inc();
+                        return false;
+                    }
+
                     let is_engine_dst = !is_loopback_stream
                         && network_topology
                             .subnets()

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -1432,6 +1432,12 @@ mod cooling_down {
             .unwrap_or_else(|| panic!("Counter not found: {METRIC_COOLING_DOWN_SKIPPED_QUEUES}"))
     }
 
+    /// Retrieves the `METRIC_COOLING_DOWN_SKIPPED_REFUNDS` counter's value.
+    fn fetch_cooling_down_skipped_refunds(metrics_registry: &MetricsRegistry) -> u64 {
+        fetch_int_counter(metrics_registry, METRIC_COOLING_DOWN_SKIPPED_REFUNDS)
+            .unwrap_or_else(|| panic!("Counter not found: {METRIC_COOLING_DOWN_SKIPPED_REFUNDS}"))
+    }
+
     /// Tests that a canister message to a cooling down subnet is retained in the
     /// sending canister's output queue -- rather than routed, rejected or dropped --
     /// and that it is routed as soon as the destination subnet stops cooling down.
@@ -1688,6 +1694,149 @@ mod cooling_down {
                 });
             }
         }
+    }
+
+    /// An anonymous refund of `ONE_TRILLION_CYCLES` to `recipient`.
+    fn one_trillion_refund(recipient: CanisterId) -> Refund {
+        Refund::anonymous(recipient, ONE_TRILLION_CYCLES)
+    }
+
+    /// Returns the refunds pooled in `state`, in priority order.
+    fn pooled_refunds(state: &ReplicatedState) -> Vec<Refund> {
+        state.refunds().iter().cloned().collect()
+    }
+
+    /// Tests that a refund to a canister hosted by a cooling down subnet is retained
+    /// in the refund pool -- rather than routed or dropped -- and that it is routed as
+    /// soon as the destination subnet stops cooling down.
+    ///
+    /// Exercised twice: with a remote subnet cooling down; and with `LOCAL_SUBNET`
+    /// itself cooling down, i.e. the loopback stream is not exempt either (which also
+    /// covers a cooling down source subnet, the source and the destination subnet
+    /// being one and the same for a loopback refund).
+    #[test]
+    fn build_streams_retains_refunds_to_cooling_down_subnet() {
+        for cooling_down_subnet in [COOLING_DOWN_SUBNET, LOCAL_SUBNET] {
+            with_test_replica_logger(|log| {
+                let (stream_builder, mut provided_state, metrics_registry) =
+                    if cooling_down_subnet == LOCAL_SUBNET {
+                        new_local_cooling_down_fixture(&log)
+                    } else {
+                        new_cooling_down_fixture(&log)
+                    };
+                provided_state.add_refund(COOLING_DOWN_CANISTER, ONE_TRILLION_CYCLES);
+
+                let mut result_state = stream_builder.build_streams(provided_state);
+
+                // Nothing was routed into the stream to the cooling down subnet and the
+                // refund is still in the refund pool.
+                assert_no_messages_routed(&result_state, cooling_down_subnet);
+                assert_eq!(
+                    vec![one_trillion_refund(COOLING_DOWN_CANISTER)],
+                    pooled_refunds(&result_state)
+                );
+
+                assert_routed_messages_eq(MetricVec::new(), &metrics_registry);
+                assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
+                assert_eq_critical_errors(0, 0, 0, &metrics_registry);
+
+                // And it is routed as soon as the subnet stops cooling down.
+                clear_cooling_down(&mut result_state, cooling_down_subnet);
+                let result_state = stream_builder.build_streams(result_state);
+                assert_eq!(
+                    vec![StreamMessage::from(one_trillion_refund(
+                        COOLING_DOWN_CANISTER
+                    ))],
+                    routed_messages(&result_state, cooling_down_subnet)
+                );
+                assert!(result_state.refunds().is_empty());
+                // The refund was not skipped again in this round.
+                assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
+            });
+        }
+    }
+
+    /// Tests that a refund to a canister hosted by a subnet that is not cooling down
+    /// is nevertheless retained in the refund pool while `LOCAL_SUBNET` (the source
+    /// subnet) is cooling down; and that it is routed as soon as `LOCAL_SUBNET` stops
+    /// cooling down.
+    #[test]
+    fn build_streams_retains_refunds_from_cooling_down_subnet() {
+        with_test_replica_logger(|log| {
+            let (stream_builder, mut provided_state, metrics_registry) =
+                new_local_cooling_down_fixture(&log);
+            provided_state.add_refund(OTHER_CANISTER, ONE_TRILLION_CYCLES);
+
+            let mut result_state = stream_builder.build_streams(provided_state);
+
+            // Nothing was routed into the stream to `OTHER_SUBNET` and the refund is
+            // still in the refund pool.
+            assert_no_messages_routed(&result_state, OTHER_SUBNET);
+            assert_eq!(
+                vec![one_trillion_refund(OTHER_CANISTER)],
+                pooled_refunds(&result_state)
+            );
+
+            assert_routed_messages_eq(MetricVec::new(), &metrics_registry);
+            assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
+            assert_eq_critical_errors(0, 0, 0, &metrics_registry);
+
+            // And it is routed as soon as the source subnet stops cooling down.
+            clear_cooling_down(&mut result_state, LOCAL_SUBNET);
+            let result_state = stream_builder.build_streams(result_state);
+            assert_eq!(
+                vec![StreamMessage::from(one_trillion_refund(OTHER_CANISTER))],
+                routed_messages(&result_state, OTHER_SUBNET)
+            );
+            assert!(result_state.refunds().is_empty());
+            // The refund was not skipped again in this round.
+            assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
+        });
+    }
+
+    /// Tests that only the refunds to the cooling down subnet are held back: refunds
+    /// to canisters hosted by subnets that are not cooling down (`OTHER_SUBNET` and
+    /// `LOCAL_SUBNET`, the latter via the loopback stream) are routed in the very same
+    /// round.
+    #[test]
+    fn build_streams_routes_refunds_to_other_subnets_while_one_is_cooling_down() {
+        with_test_replica_logger(|log| {
+            let (stream_builder, mut provided_state, metrics_registry) =
+                new_cooling_down_fixture(&log);
+            provided_state.add_refund(COOLING_DOWN_CANISTER, ONE_TRILLION_CYCLES);
+            provided_state.add_refund(OTHER_CANISTER, ONE_TRILLION_CYCLES);
+            provided_state.add_refund(SENDER_CANISTER, ONE_TRILLION_CYCLES);
+
+            let result_state = stream_builder.build_streams(provided_state);
+
+            // Only the refund to the cooling down subnet was held back.
+            assert_no_messages_routed(&result_state, COOLING_DOWN_SUBNET);
+            assert_eq!(
+                vec![one_trillion_refund(COOLING_DOWN_CANISTER)],
+                pooled_refunds(&result_state)
+            );
+            assert_eq!(
+                vec![StreamMessage::from(one_trillion_refund(OTHER_CANISTER))],
+                routed_messages(&result_state, OTHER_SUBNET)
+            );
+            assert_eq!(
+                vec![StreamMessage::from(one_trillion_refund(SENDER_CANISTER))],
+                routed_messages(&result_state, LOCAL_SUBNET)
+            );
+
+            assert_routed_messages_eq(
+                metric_vec(&[(
+                    &[
+                        (LABEL_TYPE, LABEL_VALUE_TYPE_REFUND),
+                        (LABEL_STATUS, LABEL_VALUE_STATUS_SUCCESS),
+                    ],
+                    2,
+                )]),
+                &metrics_registry,
+            );
+            assert_eq_critical_errors(0, 0, 0, &metrics_registry);
+            assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
+        });
     }
 }
 

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -439,7 +439,11 @@ pub struct SubnetTopology {
     ///    cooling down subnet can be emptied;
     ///  * it routes no messages from its canisters' output queues into streams
     ///    -- including its own loopback stream -- but retains them in output
-    ///    queues, so streams from the cooling down subnet can be emptied.
+    ///    queues, so streams from the cooling down subnet can be emptied;
+    ///  * (on all subnets) no refunds are routed to or from a cooling down
+    ///    subnet -- including into the cooling down subnet's own loopback
+    ///    stream -- but retained in the refund pool, so that their cycles are
+    ///    not lost.
     pub cooling_down: bool,
 }
 


### PR DESCRIPTION
Refunds in the refund pool are only routed into a stream if neither the source subnet nor the destination subnet is cooling down; not even into the loopback stream. They are retained in the refund pool until neither subnet is cooling down anymore, rather than being dropped (which would lose their cycles).

Unlike the subnet's own output queues (which are exempt from the source side of the check, so that a cooling down subnet can still respond to the calls it has already accepted), refunds have no such exemption.

Skipped refunds are counted in the new `mr_cooling_down_skipped_refunds` counter, once per refund per round, mirroring
`mr_cooling_down_skipped_queues`.