### PR TITLE
refactor: cleanup `get_replica_version_*` methods of registry helpers traits

### DIFF
--- a/rs/ic_os/guest_upgrade/server/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/server/src/lib.rs
@@ -2,7 +2,7 @@ use crate::service::DiskEncryptionKeyExchangeServiceImpl;
 use attestation::attestation_package::SevRootCertificateVerification;
 use config_types::TrustedExecutionEnvironmentConfig;
 use ic_interfaces_registry::RegistryClient;
-use ic_registry_client_helpers::subnet::SubnetRegistry;
+use ic_registry_client_helpers::replica_version::ReplicaVersionRegistry;
 use ic_types::ReplicaVersion;
 use server::DiskEncryptionKeyExchangeServer;
 use sev_guest::firmware::SevGuestFirmware;
@@ -143,7 +143,7 @@ impl DiskEncryptionKeyExchangeServerAgent {
         let registry_version = self.registry_client.get_latest_version();
         let expected_measurements = self
             .registry_client
-            .get_replica_version_record_from_version_id(replica_version, registry_version)
+            .get_replica_version_record(replica_version, registry_version)
             .map_err(|err| {
                 DiskEncryptionKeyExchangeError::ServerStartError(format!(
                     "Failed to get replica version record for {replica_version}: {err}"

--- a/rs/orchestrator/src/registry_helper.rs
+++ b/rs/orchestrator/src/registry_helper.rs
@@ -16,6 +16,7 @@ use ic_registry_client_helpers::{
     hostos_version::HostosRegistry,
     node::{NodeRecord, NodeRegistry},
     node_operator::NodeOperatorRegistry,
+    replica_version::ReplicaVersionRegistry,
     subnet::SubnetRegistry,
     unassigned_nodes::UnassignedNodeRegistry,
 };
@@ -137,7 +138,7 @@ impl RegistryHelper {
         version: RegistryVersion,
     ) -> OrchestratorResult<ReplicaVersionRecord> {
         self.registry_client
-            .get_replica_version_record_from_version_id(&replica_version_id, version)?
+            .get_replica_version_record(&replica_version_id, version)?
             .ok_or(OrchestratorError::ReplicaVersionMissingError(
                 replica_version_id,
                 version,

--- a/rs/registry/helpers/src/replica_version.rs
+++ b/rs/registry/helpers/src/replica_version.rs
@@ -1,7 +1,13 @@
 use crate::deserialize_registry_value;
 use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
-use ic_protobuf::registry::replica_version::v1::ReplicaVersionRecord;
-use ic_registry_keys::{REPLICA_VERSION_KEY_PREFIX, make_replica_version_key};
+use ic_protobuf::registry::{
+    replica_version::v1::ReplicaVersionRecord,
+    standard_engine_replica_version::v1::StandardEngineReplicaVersionRecord,
+};
+use ic_registry_keys::{
+    REPLICA_VERSION_KEY_PREFIX, make_replica_version_key,
+    make_standard_engine_replica_version_record_key,
+};
 use ic_types::registry::RegistryClientError;
 pub use ic_types::replica_version::ReplicaVersion;
 pub use ic_types::{NodeId, RegistryVersion, SubnetId};
@@ -17,6 +23,11 @@ pub trait ReplicaVersionRegistry {
         replica_version_id: &ReplicaVersion,
         version: RegistryVersion,
     ) -> RegistryClientResult<ReplicaVersionRecord>;
+
+    fn get_standard_engine_replica_version_record(
+        &self,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<StandardEngineReplicaVersionRecord>;
 
     /// Returns all guest launch measurements from all replica versions.
     ///
@@ -61,6 +72,14 @@ impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
     ) -> RegistryClientResult<ReplicaVersionRecord> {
         let bytes = self.get_value(&make_replica_version_key(replica_version_id), version);
         deserialize_registry_value::<ReplicaVersionRecord>(bytes)
+    }
+
+    fn get_standard_engine_replica_version_record(
+        &self,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<StandardEngineReplicaVersionRecord> {
+        let bytes = self.get_value(&make_standard_engine_replica_version_record_key(), version);
+        deserialize_registry_value::<StandardEngineReplicaVersionRecord>(bytes)
     }
 
     fn get_guest_launch_measurements(

--- a/rs/registry/helpers/src/subnet.rs
+++ b/rs/registry/helpers/src/subnet.rs
@@ -1,4 +1,4 @@
-use crate::deserialize_registry_value;
+use crate::{deserialize_registry_value, replica_version::ReplicaVersionRegistry};
 use ic_crypto_sha2::{DomainSeparationContext, Sha256};
 use ic_interfaces_registry::{
     RegistryClient, RegistryClientResult, RegistryClientVersionedResult, RegistryVersionedRecord,
@@ -7,15 +7,13 @@ use ic_limits::{INITIAL_NOTARY_DELAY, UNIT_DELAY_APP_SUBNET};
 use ic_protobuf::{
     registry::{
         node::v1::NodeRecord,
-        replica_version::v1::ReplicaVersionRecord,
         subnet::v1::{CatchUpPackageContents, SubnetListRecord, SubnetRecord, SubnetType},
     },
     types::v1::SubnetId as SubnetIdProto,
 };
 use ic_registry_keys::{
     DEFAULT_INITIAL_DKG_SUBNET_ID_KEY, ROOT_SUBNET_ID_KEY, make_catch_up_package_contents_key,
-    make_node_record_key, make_replica_version_key, make_subnet_list_record_key,
-    make_subnet_record_key,
+    make_node_record_key, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_registry_subnet_features::{ChainKeyConfig, SubnetFeatures};
 use ic_types::{
@@ -187,20 +185,6 @@ pub trait SubnetRegistry {
         subnet_id: SubnetId,
         version: RegistryVersion,
     ) -> RegistryClientResult<ReplicaVersion>;
-
-    /// Return the [ReplicaVersionRecord] of the subnet. See
-    /// [Self::get_replica_version].
-    fn get_replica_version_record(
-        &self,
-        subnet_id: SubnetId,
-        version: RegistryVersion,
-    ) -> RegistryClientResult<ReplicaVersionRecord>;
-
-    fn get_replica_version_record_from_version_id(
-        &self,
-        replica_version_id: &ReplicaVersion,
-        version: RegistryVersion,
-    ) -> RegistryClientResult<ReplicaVersionRecord>;
 
     /// Return the [RegistryVersion] at which the [SubnetRecord] for the provided
     /// [SubnetId] was last updated.
@@ -435,11 +419,6 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
         subnet_id: SubnetId,
         version: RegistryVersion,
     ) -> RegistryClientResult<ReplicaVersion> {
-        // Not imported at module level, because that would make calls to
-        // `get_replica_version_record` ambiguous between this trait and
-        // `SubnetRegistry`.
-        use crate::replica_version::ReplicaVersionRegistry;
-
         let bytes = self.get_value(&make_subnet_record_key(subnet_id), version);
         let Some(subnet_record) = deserialize_registry_value::<SubnetRecord>(bytes)? else {
             return Ok(None);
@@ -511,26 +490,6 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
             &resolved_replica_version_id,
             "using standard engine replica version",
         )
-    }
-
-    fn get_replica_version_record(
-        &self,
-        subnet_id: SubnetId,
-        version: RegistryVersion,
-    ) -> RegistryClientResult<ReplicaVersionRecord> {
-        let Some(replica_version) = self.get_replica_version(subnet_id, version)? else {
-            return Ok(None);
-        };
-        self.get_replica_version_record_from_version_id(&replica_version, version)
-    }
-
-    fn get_replica_version_record_from_version_id(
-        &self,
-        replica_version_id: &ReplicaVersion,
-        version: RegistryVersion,
-    ) -> RegistryClientResult<ReplicaVersionRecord> {
-        let bytes = self.get_value(&make_replica_version_key(replica_version_id), version);
-        deserialize_registry_value::<ReplicaVersionRecord>(bytes)
     }
 
     fn get_subnet_record_registry_version(
@@ -746,9 +705,14 @@ impl<T: RegistryClient + ?Sized> SubnetTransportRegistry for T {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use ic_protobuf::registry::standard_engine_replica_version::v1::StandardEngineReplicaVersionRecord;
+    use ic_protobuf::registry::{
+        replica_version::v1::ReplicaVersionRecord,
+        standard_engine_replica_version::v1::StandardEngineReplicaVersionRecord,
+    };
     use ic_registry_client_fake::FakeRegistryClient;
-    use ic_registry_keys::make_standard_engine_replica_version_record_key;
+    use ic_registry_keys::{
+        make_replica_version_key, make_standard_engine_replica_version_record_key,
+    };
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
     use ic_types::PrincipalId;
     use std::{str::FromStr, sync::Arc};
@@ -834,10 +798,10 @@ mod tests {
         );
 
         let result = registry.get_replica_version(subnet_id, version).unwrap();
-        assert_eq!(result, Some(replica_version));
+        assert_eq!(result, Some(replica_version.clone()));
 
         let result = registry
-            .get_replica_version_record(subnet_id, version)
+            .get_replica_version_record(&replica_version, version)
             .unwrap();
         assert_eq!(result, Some(replica_version_record))
     }
@@ -888,12 +852,17 @@ mod tests {
         registry.update_to_latest_version();
 
         // Step 2: Run the code under test.
+        let replica_version = registry
+            .get_replica_version(engine_subnet_id, RegistryVersion::from(2))
+            .unwrap()
+            .unwrap();
         let result = registry
-            .get_replica_version_record(engine_subnet_id, RegistryVersion::from(2))
+            .get_replica_version_record(&replica_version, RegistryVersion::from(2))
             .unwrap();
 
         // Step 3: Verify result(s). Blank resolves to "new" (deployment_progress
         // is 1.0), so this must be new_replica_version_record, not None.
+        assert_eq!(replica_version, ReplicaVersion::try_from("new").unwrap());
         assert_eq!(result, Some(new_replica_version_record));
     }
 

--- a/rs/registry/helpers/src/subnet.rs
+++ b/rs/registry/helpers/src/subnet.rs
@@ -8,15 +8,13 @@ use ic_protobuf::{
     registry::{
         node::v1::NodeRecord,
         replica_version::v1::ReplicaVersionRecord,
-        standard_engine_replica_version::v1::StandardEngineReplicaVersionRecord,
         subnet::v1::{CatchUpPackageContents, SubnetListRecord, SubnetRecord, SubnetType},
     },
     types::v1::SubnetId as SubnetIdProto,
 };
 use ic_registry_keys::{
     DEFAULT_INITIAL_DKG_SUBNET_ID_KEY, ROOT_SUBNET_ID_KEY, make_catch_up_package_contents_key,
-    make_node_record_key, make_replica_version_key,
-    make_standard_engine_replica_version_record_key, make_subnet_list_record_key,
+    make_node_record_key, make_replica_version_key, make_subnet_list_record_key,
     make_subnet_record_key,
 };
 use ic_registry_subnet_features::{ChainKeyConfig, SubnetFeatures};
@@ -437,6 +435,11 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
         subnet_id: SubnetId,
         version: RegistryVersion,
     ) -> RegistryClientResult<ReplicaVersion> {
+        // Not imported at module level, because that would make calls to
+        // `get_replica_version_record` ambiguous between this trait and
+        // `SubnetRegistry`.
+        use crate::replica_version::ReplicaVersionRegistry;
+
         let bytes = self.get_value(&make_subnet_record_key(subnet_id), version);
         let Some(subnet_record) = deserialize_registry_value::<SubnetRecord>(bytes)? else {
             return Ok(None);
@@ -481,7 +484,7 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
         }
 
         let Some(standard_engine_record) =
-            get_standard_engine_replica_version_record(self, version)?
+            self.get_standard_engine_replica_version_record(version)?
         else {
             return Err(DecodeError {
                 error: format!(
@@ -619,14 +622,6 @@ impl<T: RegistryClient + ?Sized> SubnetRegistry for T {
     }
 }
 
-fn get_standard_engine_replica_version_record<T: RegistryClient + ?Sized>(
-    client: &T,
-    version: RegistryVersion,
-) -> RegistryClientResult<StandardEngineReplicaVersionRecord> {
-    let bytes = client.get_value(&make_standard_engine_replica_version_record_key(), version);
-    deserialize_registry_value::<StandardEngineReplicaVersionRecord>(bytes)
-}
-
 /// Computes an engine's upgrade priority, a pseudo-random real/floating point
 /// number in the closed interval [0.0, 1.0].
 ///
@@ -751,7 +746,9 @@ impl<T: RegistryClient + ?Sized> SubnetTransportRegistry for T {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
+    use ic_protobuf::registry::standard_engine_replica_version::v1::StandardEngineReplicaVersionRecord;
     use ic_registry_client_fake::FakeRegistryClient;
+    use ic_registry_keys::make_standard_engine_replica_version_record_key;
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
     use ic_types::PrincipalId;
     use std::{str::FromStr, sync::Arc};


### PR DESCRIPTION
This PR moves the `get_standard_engine_replica_version_record` free function to a trait method of `ReplicaVersionRegistry` to follow existing style and make the method available to all holders of a `&dyn RegistryClient`.

It also removes `SubnetRegistry::get_replica_version_record_from_version_id` which was redundant with `ReplicaVersionRegistry::get_replica_version_record` and `SubnetRegistry::get_replica_version_record` which is a name clash only used in tests and that can be easily inlined at call sites.