### PR TITLE
fix: CON-1739 Validate consistency when receiving HTTP outcalls shares with a response body

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1613,7 +1613,7 @@ fn test_canister_http_with_diverging_responses() {
         decode_one(&reply).unwrap();
     let (reject_code, err) = http_response.unwrap_err();
     assert!(matches!(reject_code, RejectionCode::SysTransient));
-    let expected = "No consensus could be reached. Replicas had different responses. Details: request_id: 0, hashes: [e6c8425c65f944486ba0d4964182af8ba0de048ef67f15b7278eb0b5b19ae053: 2], [c5a0122c14f908190aacc5a940c15f2fab1c031a31a45d3581a8a9618b1dd6f2: 2], [6986941fba0203a7a8af16dfa6d9761bdcb3a8c86030324c3e063f8e25fe98db: 2], [5e3b4e1724709fd740dcb1474cbdb7c1288d98776c445017a3bbf9e51c194492: 2], [5349b5986aeb58f94a92e4c709aa2de2cd9f5678aa010c57bdf033e0708ecae6: 2], [1b504c536aab4deb8a62bbd49d622dd414311db9cdb7f5f5b65b285565a63177: 2], [6ce86a526e15a51ab36a86e62cdf83d6959edc80434415af606fb4982a43c5a4: 1]";
+    let expected = "No consensus could be reached. Replicas had different responses. Details: request_id: 0, hashes: [e254a598aa5bcf26e1e005d43592286d20aae878516406a8a4ff5c8d94462353: 2], [a7f217edef88e29acba3af7e11520ad31306ad59967b3fc1bf092984b8ac4239: 2], [9ea4ff851ba6e8f2c291dcdb4dbb89cb48526ee78ec88a0a6151e325988ed0dd: 2], [78a558c7325b3b8c080596aa9f7f9ca5a76fa47720de8cbf15c88f4ac4e7f589: 2], [60e97e80a834073f4e895a2a58f6ff35f2a22f75be0388ff7d241ed3d56dd513: 2], [08c21cdb50c0da7029246e3cf0a5a8556ac13032eb576b36d9c9a659c8bc51fb: 2], [7cd70d402bc453e8c0e09ccfdef9c00880585c25108da0efebd86c29d8372695: 1]";
     assert_eq!(err, expected);
 }
 

--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -269,7 +269,7 @@ mod tests {
     use ic_test_utilities_consensus::fake::FakeSigner;
     use ic_test_utilities_types::ids::node_test_id;
     use ic_types::{
-        CanisterId, ReplicaVersion,
+        ReplicaVersion,
         artifact::IdentifiableArtifact,
         canister_http::{
             CanisterHttpPaymentReceipt, CanisterHttpResponseContent, CanisterHttpResponseMetadata,
@@ -316,7 +316,6 @@ mod tests {
     fn fake_response(id: u64) -> CanisterHttpResponse {
         CanisterHttpResponse {
             id: CallbackId::from(id),
-            canister_id: CanisterId::from_u64(id),
             content: CanisterHttpResponseContent::Success(Vec::new()),
         }
     }

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -177,7 +177,6 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                 let _ = permit.send((
                     CanisterHttpResponse {
                         id: request_id,
-                        canister_id: request_sender,
                         content: CanisterHttpResponseContent::Reject(CanisterHttpReject {
                             reject_code: RejectCode::SysFatal,
                             message:
@@ -313,7 +312,6 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
             permit.send((
                 CanisterHttpResponse {
                     id: request_id,
-                    canister_id: request_sender,
                     content: match payload {
                         Ok(resp) => {
                             metrics
@@ -855,7 +853,6 @@ mod tests {
     ) -> CanisterHttpResponse {
         CanisterHttpResponse {
             id: CallbackId::from(request_id),
-            canister_id: ic_types::CanisterId::from(1),
             content: CanisterHttpResponseContent::Reject(CanisterHttpReject {
                 reject_code,
                 message: reject_message,
@@ -871,7 +868,6 @@ mod tests {
     ) -> CanisterHttpResponse {
         CanisterHttpResponse {
             id: CallbackId::from(request_id),
-            canister_id: ic_types::CanisterId::from(1),
             content: CanisterHttpResponseContent::Success(
                 Encode!(
                     &ic_management_canister_types_private::CanisterHttpResponsePayload {

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -20,7 +20,7 @@ use ic_test_utilities::artifact_pool_config::with_test_pool_config;
 use ic_test_utilities::state_manager::RefMockStateManager;
 use ic_test_utilities_registry::SubnetRecordBuilder;
 use ic_test_utilities_types::{
-    ids::{canister_test_id, node_test_id, subnet_test_id},
+    ids::{node_test_id, subnet_test_id},
     messages::RequestBuilder,
 };
 use ic_types::{
@@ -491,7 +491,6 @@ fn response_and_metadata(
 ) -> (CanisterHttpResponse, CanisterHttpResponseMetadata) {
     let response = CanisterHttpResponse {
         id: CallbackId::new(callback_id),
-        canister_id: canister_test_id(0),
         content,
     };
     let metadata = CanisterHttpResponseMetadata {

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -1121,7 +1121,6 @@ impl CanisterHttpPayloadBuilderImpl {
                         .filter(|share| !share.content.is_reject())
                         .map(|share| {
                             FlexibleCanisterHttpResponseWithProof::count_bytes_from_parts(
-                                &context.request.sender,
                                 share.content.content_size() as usize,
                                 share,
                             )

--- a/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
@@ -4,7 +4,7 @@ use crate::payload_builder::tests::{
 };
 use ic_error_types::RejectCode;
 use ic_interfaces::batch_payload::{BatchPayloadBuilder, PastPayload};
-use ic_test_utilities_types::ids::{canister_test_id, node_test_id};
+use ic_test_utilities_types::ids::node_test_id;
 use ic_types::{
     CountBytes, Height, NodeId, NumBytes, RegistryVersion, ReplicaVersion, Time,
     batch::ValidationContext,
@@ -276,7 +276,6 @@ fn build_fully_replicated(
 ) -> Scenario {
     let response = CanisterHttpResponse {
         id: callback_id,
-        canister_id: canister_test_id(0),
         content,
     };
     let metadata = make_metadata(&response);
@@ -316,7 +315,6 @@ fn build_non_replicated(
         .map(|content| {
             let response = CanisterHttpResponse {
                 id: callback_id,
-                canister_id: canister_test_id(0),
                 content,
             };
             let share = metadata_to_share(designated_node, &make_metadata(&response));
@@ -345,7 +343,6 @@ fn build_flexible(
             let content = maybe_content?;
             let response = CanisterHttpResponse {
                 id: callback_id,
-                canister_id: canister_test_id(0),
                 content,
             };
             let share = metadata_to_share(idx as u64, &make_metadata(&response));

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -40,7 +40,7 @@ use ic_test_utilities::state_manager::RefMockStateManager;
 use ic_test_utilities_consensus::fake::FakeContentSigner;
 use ic_test_utilities_registry::SubnetRecordBuilder;
 use ic_test_utilities_types::{
-    ids::{canister_test_id, node_id_to_u64, node_test_id, subnet_test_id},
+    ids::{node_id_to_u64, node_test_id, subnet_test_id},
     messages::RequestBuilder,
 };
 use ic_types::{
@@ -1768,7 +1768,6 @@ fn test_response_and_metadata_with_content(
 ) -> (CanisterHttpResponse, CanisterHttpResponseMetadata) {
     let response = CanisterHttpResponse {
         id: CallbackId::new(callback_id),
-        canister_id: canister_test_id(0),
         content,
     };
     let metadata = CanisterHttpResponseMetadata {

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -852,7 +852,7 @@ pub(crate) fn find_flexible_result(
 
     // 3. Even the smallest OK responses exceed the absolute payload limit?
     // Unseen responses could still submit small OK responses, so we account for them.
-    let num_unseen = committee.len().saturating_sub(seen_signers.len());
+    let num_unseen = committee.len().saturating_sub(all_shares.len());
     let min_known_ok_needed = min_responses.saturating_sub(num_unseen);
     if ok_candidates.len() >= min_known_ok_needed {
         let smallest_content_sum: usize = ok_candidates

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -1888,7 +1888,6 @@ pub mod test {
                         reject_code: RejectCode::SysTransient,
                         message: "A transient error occurred.".to_string(),
                     }),
-                    ..empty_canister_http_response(0)
                 };
 
                 let response_metadata = CanisterHttpResponseReceipt {
@@ -1976,7 +1975,6 @@ pub mod test {
                         reject_code: RejectCode::SysFatal,
                         message: "b".repeat(oversized_len),
                     }),
-                    ..empty_canister_http_response(callback_id.get())
                 };
 
                 let dishonest_hash = ic_types::crypto::crypto_hash(&dishonest_response);
@@ -2306,7 +2304,6 @@ pub mod test {
                 let response = CanisterHttpResponse {
                     id: CallbackId::from(0),
                     content: CanisterHttpResponseContent::Reject(reject_content),
-                    ..empty_canister_http_response(0)
                 };
 
                 let response_metadata = CanisterHttpResponseReceipt {

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -572,16 +572,6 @@ impl CanisterHttpPoolManagerImpl {
                             ));
                         }
 
-                        if response.canister_id != context.request.sender {
-                            return Some(CanisterHttpChangeAction::HandleInvalid(
-                                share.clone(),
-                                format!(
-                                    "Response is for canister {} rather than the requester {}",
-                                    response.canister_id, context.request.sender,
-                                ),
-                            ));
-                        }
-
                         if share.content.content_hash() != &ic_types::crypto::crypto_hash(response)
                         {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
@@ -799,7 +789,6 @@ pub mod test {
     fn empty_canister_http_response(id: u64) -> CanisterHttpResponse {
         CanisterHttpResponse {
             id: CallbackId::from(id),
-            canister_id: requester(),
             content: CanisterHttpResponseContent::Success(Vec::new()),
         }
     }
@@ -1732,7 +1721,6 @@ pub mod test {
                     let response_body_too_large = vec![0; oversized_len];
                     let response = CanisterHttpResponse {
                         id: CallbackId::from(0),
-                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(response_body_too_large),
                     };
 
@@ -1797,7 +1785,6 @@ pub mod test {
                     let response_body_ok = vec![0; max_response_bytes.get() as usize];
                     let response = CanisterHttpResponse {
                         id: CallbackId::from(0),
-                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(response_body_ok),
                     };
 
@@ -3258,51 +3245,6 @@ pub mod test {
                         if reason.starts_with("Response is for request ID")
                     );
                 }
-
-                // TEST 6: the attached response names a canister other than the requester --
-                // should be invalid.
-                {
-                    let mut canister_http_pool =
-                        CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
-
-                    let mut foreign_response = empty_canister_http_response(callback_id.get());
-                    let oddly_sized = ic_types::PrincipalId::new_self_authenticating(&[1, 2, 3]);
-                    assert_ne!(
-                        oddly_sized.as_slice().len(),
-                        requester().get_ref().as_slice().len(),
-                        "the point of this case is a principal of a different length"
-                    );
-                    foreign_response.canister_id =
-                        ic_types::CanisterId::try_from(oddly_sized).unwrap();
-
-                    let mut bad_share = share.clone();
-                    bad_share.content.metadata.content_hash = crypto_hash(&foreign_response);
-                    bad_share.signature = crypto
-                        .sign(
-                            &bad_share.content,
-                            committee_member,
-                            RegistryVersion::from(1),
-                        )
-                        .unwrap();
-
-                    canister_http_pool.insert(UnvalidatedArtifact {
-                        message: CanisterHttpResponseArtifact {
-                            share: bad_share,
-                            response: Some(foreign_response),
-                        },
-                        peer_id: committee_member,
-                        timestamp: UNIX_EPOCH,
-                    });
-
-                    let changes = pool_manager
-                        .validate_shares(&pool_manager.latest_state(), &canister_http_pool);
-
-                    assert_matches!(
-                        &changes[0],
-                        CanisterHttpChangeAction::HandleInvalid(_, reason)
-                        if reason.starts_with("Response is for canister")
-                    );
-                }
             })
         });
     }
@@ -3374,7 +3316,6 @@ pub mod test {
                         + 1) as usize;
                     let response = CanisterHttpResponse {
                         id: callback_id,
-                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(vec![0; oversized_len]),
                     };
 
@@ -3433,7 +3374,6 @@ pub mod test {
 
                     let response = CanisterHttpResponse {
                         id: callback_id,
-                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(vec![
                             0;
                             MAX_CANISTER_HTTP_RESPONSE_BYTES

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -561,6 +561,27 @@ impl CanisterHttpPoolManagerImpl {
                             ));
                         };
 
+                        if response.id != share.content.id() {
+                            return Some(CanisterHttpChangeAction::HandleInvalid(
+                                share.clone(),
+                                format!(
+                                    "Response is for request ID {} rather than the share's {}",
+                                    response.id,
+                                    share.content.id(),
+                                ),
+                            ));
+                        }
+
+                        if response.canister_id != context.request.sender {
+                            return Some(CanisterHttpChangeAction::HandleInvalid(
+                                share.clone(),
+                                format!(
+                                    "Response is for canister {} rather than the requester {}",
+                                    response.canister_id, context.request.sender,
+                                ),
+                            ));
+                        }
+
                         if share.content.content_hash() != &ic_types::crypto::crypto_hash(response)
                         {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
@@ -770,10 +791,15 @@ pub mod test {
         replicated_state
     }
 
+    /// The canister that makes the outcalls in these tests.
+    fn requester() -> ic_types::CanisterId {
+        ic_types::CanisterId::from(0)
+    }
+
     fn empty_canister_http_response(id: u64) -> CanisterHttpResponse {
         CanisterHttpResponse {
             id: CallbackId::from(id),
-            canister_id: ic_types::CanisterId::from(0),
+            canister_id: requester(),
             content: CanisterHttpResponseContent::Success(Vec::new()),
         }
     }
@@ -784,7 +810,9 @@ pub mod test {
         max_response_bytes: Option<NumBytes>,
     ) -> CanisterHttpRequestContext {
         CanisterHttpRequestContext {
-            request: ic_test_utilities_types::messages::RequestBuilder::new().build(),
+            request: ic_test_utilities_types::messages::RequestBuilder::new()
+                .sender(requester())
+                .build(),
             url: "".to_string(),
             max_response_bytes,
             headers: vec![],
@@ -1704,7 +1732,7 @@ pub mod test {
                     let response_body_too_large = vec![0; oversized_len];
                     let response = CanisterHttpResponse {
                         id: CallbackId::from(0),
-                        canister_id: ic_types::CanisterId::from(0),
+                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(response_body_too_large),
                     };
 
@@ -1769,7 +1797,7 @@ pub mod test {
                     let response_body_ok = vec![0; max_response_bytes.get() as usize];
                     let response = CanisterHttpResponse {
                         id: CallbackId::from(0),
-                        canister_id: ic_types::CanisterId::from(0),
+                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(response_body_ok),
                     };
 
@@ -3192,6 +3220,89 @@ pub mod test {
                         if reason == "is_reject does not match the response content"
                     );
                 }
+
+                // TEST 5: the attached response answers a *different* callback than the
+                // share it travels with -- should be invalid.
+                {
+                    let mut canister_http_pool =
+                        CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+                    let mut foreign_response = empty_canister_http_response(callback_id.get());
+                    foreign_response.id = CallbackId::from(callback_id.get() + 1);
+
+                    let mut bad_share = share.clone();
+                    bad_share.content.metadata.content_hash = crypto_hash(&foreign_response);
+                    bad_share.signature = crypto
+                        .sign(
+                            &bad_share.content,
+                            committee_member,
+                            RegistryVersion::from(1),
+                        )
+                        .unwrap();
+
+                    canister_http_pool.insert(UnvalidatedArtifact {
+                        message: CanisterHttpResponseArtifact {
+                            share: bad_share,
+                            response: Some(foreign_response),
+                        },
+                        peer_id: committee_member,
+                        timestamp: UNIX_EPOCH,
+                    });
+
+                    let changes = pool_manager
+                        .validate_shares(&pool_manager.latest_state(), &canister_http_pool);
+
+                    assert_matches!(
+                        &changes[0],
+                        CanisterHttpChangeAction::HandleInvalid(_, reason)
+                        if reason.starts_with("Response is for request ID")
+                    );
+                }
+
+                // TEST 6: the attached response names a canister other than the requester --
+                // should be invalid.
+                {
+                    let mut canister_http_pool =
+                        CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+                    let mut foreign_response = empty_canister_http_response(callback_id.get());
+                    let oddly_sized = ic_types::PrincipalId::new_self_authenticating(&[1, 2, 3]);
+                    assert_ne!(
+                        oddly_sized.as_slice().len(),
+                        requester().get_ref().as_slice().len(),
+                        "the point of this case is a principal of a different length"
+                    );
+                    foreign_response.canister_id =
+                        ic_types::CanisterId::try_from(oddly_sized).unwrap();
+
+                    let mut bad_share = share.clone();
+                    bad_share.content.metadata.content_hash = crypto_hash(&foreign_response);
+                    bad_share.signature = crypto
+                        .sign(
+                            &bad_share.content,
+                            committee_member,
+                            RegistryVersion::from(1),
+                        )
+                        .unwrap();
+
+                    canister_http_pool.insert(UnvalidatedArtifact {
+                        message: CanisterHttpResponseArtifact {
+                            share: bad_share,
+                            response: Some(foreign_response),
+                        },
+                        peer_id: committee_member,
+                        timestamp: UNIX_EPOCH,
+                    });
+
+                    let changes = pool_manager
+                        .validate_shares(&pool_manager.latest_state(), &canister_http_pool);
+
+                    assert_matches!(
+                        &changes[0],
+                        CanisterHttpChangeAction::HandleInvalid(_, reason)
+                        if reason.starts_with("Response is for canister")
+                    );
+                }
             })
         });
     }
@@ -3263,7 +3374,7 @@ pub mod test {
                         + 1) as usize;
                     let response = CanisterHttpResponse {
                         id: callback_id,
-                        canister_id: ic_types::CanisterId::from(0),
+                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(vec![0; oversized_len]),
                     };
 
@@ -3322,7 +3433,7 @@ pub mod test {
 
                     let response = CanisterHttpResponse {
                         id: callback_id,
-                        canister_id: ic_types::CanisterId::from(0),
+                        canister_id: requester(),
                         content: CanisterHttpResponseContent::Success(vec![
                             0;
                             MAX_CANISTER_HTTP_RESPONSE_BYTES

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -3817,11 +3817,12 @@ impl Operation for ProcessCanisterHttpInternal {
                     }
                     Ok((response, _payment_receipt)) => {
                         canister_http.pending.remove(&response.id);
-                        if let Some(context) = sm.canister_http_request_contexts().get(&response.id)
+                        if sm
+                            .canister_http_request_contexts()
+                            .contains_key(&response.id)
                         {
                             sm.mock_canister_http_response(
                                 response.id.get(),
-                                context.request.sender,
                                 vec![response.content; sm.nodes.len()],
                             );
                         }
@@ -3932,8 +3933,6 @@ fn process_mock_canister_https_response(
             canister_http_request_id,
         )));
     };
-    let canister_id = context.request.sender;
-
     let response_to_content = |response: &CanisterHttpResponse| match response {
         CanisterHttpResponse::CanisterHttpReply(reply) => {
             let response = HttpsOutcallResponse {
@@ -4016,11 +4015,7 @@ fn process_mock_canister_https_response(
             subnet.nodes.len(),
         )));
     }
-    subnet.mock_canister_http_response(
-        mock_canister_http_response.request_id,
-        canister_id,
-        contents,
-    );
+    subnet.mock_canister_http_response(mock_canister_http_response.request_id, contents);
     OpOut::NoOutput
 }
 

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -4,7 +4,6 @@ package types.v1;
 
 import "state/queues/v1/queues.proto";
 import "types/v1/errors.proto";
-import "types/v1/types.proto";
 
 message CanisterHttpPaymentReceipt {
   state.queues.v1.Cycles spent = 1;
@@ -22,9 +21,8 @@ message CanisterHttpRequest {
 }
 
 message CanisterHttpResponse {
+  reserved 2, 4;
   uint64 id = 1;
-  reserved 2;
-  types.v1.CanisterId canister_id = 4;
   CanisterHttpResponseContent content = 3;
 }
 

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -569,8 +569,6 @@ pub struct CanisterHttpRequest {
 pub struct CanisterHttpResponse {
     #[prost(uint64, tag = "1")]
     pub id: u64,
-    #[prost(message, optional, tag = "4")]
-    pub canister_id: ::core::option::Option<CanisterId>,
     #[prost(message, optional, tag = "3")]
     pub content: ::core::option::Option<CanisterHttpResponseContent>,
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2767,7 +2767,6 @@ impl StateMachine {
     pub fn mock_canister_http_response(
         &self,
         request_id: u64,
-        canister_id: CanisterId,
         contents: Vec<CanisterHttpResponseContent>,
     ) {
         assert_eq!(contents.len(), self.nodes.len());
@@ -2775,7 +2774,6 @@ impl StateMachine {
             let registry_version = self.registry_client.get_latest_version();
             let response = CanisterHttpResponse {
                 id: CanisterHttpRequestId::from(request_id),
-                canister_id,
                 content: content.clone(),
             };
             let receipt_share = CanisterHttpResponseReceipt {

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CanisterId, CountBytes, ReplicaVersion,
+    CountBytes, ReplicaVersion,
     canister_http::{
         CanisterHttpPaymentReceipt, CanisterHttpReject, CanisterHttpRequestId,
         CanisterHttpResponse, CanisterHttpResponseArtifact, CanisterHttpResponseContent,
@@ -203,17 +203,12 @@ impl FlexibleCanisterHttpResponseWithProof {
         response: &CanisterHttpResponse,
         proof: &CanisterHttpResponseShare,
     ) -> usize {
-        Self::count_bytes_from_parts(&response.canister_id, response.content.count_bytes(), proof)
+        Self::count_bytes_from_parts(response.content.count_bytes(), proof)
     }
 
     /// Same calculation as [`Self::count_bytes`] but from decomposed parts.
-    pub fn count_bytes_from_parts(
-        canister_id: &CanisterId,
-        content_size: usize,
-        proof: &CanisterHttpResponseShare,
-    ) -> usize {
-        let response_size = CanisterHttpResponse::count_bytes_from_parts(canister_id, content_size);
-        response_size + proof.count_bytes()
+    pub fn count_bytes_from_parts(content_size: usize, proof: &CanisterHttpResponseShare) -> usize {
+        CanisterHttpResponse::count_bytes_from_parts(content_size) + proof.count_bytes()
     }
 }
 
@@ -352,7 +347,6 @@ impl From<CanisterHttpResponseWithConsensus> for pb::CanisterHttpResponseWithCon
                 content: Some(pb::CanisterHttpResponseContent::from(
                     payload.content.content,
                 )),
-                canister_id: Some(pb::CanisterId::from(payload.content.canister_id)),
             }),
             hash: metadata.content_hash.get().0,
             replica_version: metadata.replica_version.into(),
@@ -387,10 +381,6 @@ impl TryFrom<pb::CanisterHttpResponseWithConsensus> for CanisterHttpResponseWith
             .response
             .ok_or(ProxyDecodeError::MissingField("response"))?;
         let id = CanisterHttpRequestId::new(response.id);
-        let canister_id = try_from_option_field(
-            response.canister_id,
-            "CanisterHttpResponseWithConsensus::canister_id",
-        )?;
 
         let mut signatures = BTreeMap::new();
         for signature in payload.signatures {
@@ -411,7 +401,6 @@ impl TryFrom<pb::CanisterHttpResponseWithConsensus> for CanisterHttpResponseWith
         Ok(CanisterHttpResponseWithConsensus {
             content: CanisterHttpResponse {
                 id,
-                canister_id,
                 content: try_from_option_field(
                     response.content,
                     "CanisterHttpResponseWithConsensus::content",
@@ -798,14 +787,8 @@ impl TryFrom<pb::CanisterHttpResponse> for CanisterHttpResponse {
 
     fn try_from(response: pb::CanisterHttpResponse) -> Result<Self, Self::Error> {
         let id = CanisterHttpRequestId::new(response.id);
-        let canister_id =
-            try_from_option_field(response.canister_id, "CanisterHttpResponse::canister_id")?;
         let content = try_from_option_field(response.content, "CanisterHttpResponse::content")?;
-        Ok(CanisterHttpResponse {
-            id,
-            canister_id,
-            content,
-        })
+        Ok(CanisterHttpResponse { id, content })
     }
 }
 
@@ -814,7 +797,6 @@ impl From<CanisterHttpResponse> for pb::CanisterHttpResponse {
         pb::CanisterHttpResponse {
             id: response.id.get(),
             content: Some(pb::CanisterHttpResponseContent::from(response.content)),
-            canister_id: Some(pb::CanisterId::from(response.canister_id)),
         }
     }
 }
@@ -859,7 +841,6 @@ mod tests {
     fn canister_http_response_conversion() {
         let response = CanisterHttpResponse {
             id: CanisterHttpRequestId::new(1),
-            canister_id: crate::CanisterId::from(42),
             content: CanisterHttpResponseContent::Reject(CanisterHttpReject {
                 reject_code: RejectCode::SysTransient,
                 message: "test reject".to_string(),
@@ -899,7 +880,6 @@ mod tests {
 
         let response = CanisterHttpResponse {
             id: CanisterHttpRequestId::new(2),
-            canister_id: crate::CanisterId::from(100),
             content: CanisterHttpResponseContent::Success(vec![1, 2, 3]),
         };
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -42,7 +42,7 @@
 //! the timestamp of a request plus the timeout interval. This condition is verifiable by the other nodes in the network.
 //! Once a timeout has made it into a finalized block, the request is answered with an error message.
 use crate::{
-    CanisterId, CountBytes, NumberOfNodes, RegistryVersion, ReplicaVersion, Time,
+    CountBytes, NumberOfNodes, RegistryVersion, ReplicaVersion, Time,
     artifact::{CanisterHttpResponseId, IdentifiableArtifact, PbArtifact},
     consensus::get_faults_tolerated,
     crypto::{BasicSigOf, CryptoHashOf},
@@ -56,9 +56,8 @@ use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_management_canister_types_private::{
     ALLOWED_HTTP_OUTCALLS_PRICING_VERSIONS, CanisterHttpRequestArgs,
-    DEFAULT_HTTP_OUTCALLS_PRICING_VERSION, DataSize, FlexibleCanisterHttpRequestArgs, HttpHeader,
-    HttpMethod, PRICING_VERSION_LEGACY, PRICING_VERSION_PAY_AS_YOU_GO, ReplicationCounts,
-    TransformContext,
+    DEFAULT_HTTP_OUTCALLS_PRICING_VERSION, FlexibleCanisterHttpRequestArgs, HttpHeader, HttpMethod,
+    PRICING_VERSION_LEGACY, PRICING_VERSION_PAY_AS_YOU_GO, ReplicationCounts, TransformContext,
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
@@ -967,25 +966,20 @@ pub struct CanisterHttpRequest {
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct CanisterHttpResponse {
     pub id: CanisterHttpRequestId,
-    pub canister_id: CanisterId,
     pub content: CanisterHttpResponseContent,
 }
 
 impl CanisterHttpResponse {
     /// Same calculation as `Self::count_bytes` but from decomposed parts.
-    pub fn count_bytes_from_parts(canister_id: &CanisterId, content_size: usize) -> usize {
-        size_of::<CanisterHttpRequestId>() + canister_id.get_ref().data_size() + content_size
+    pub const fn count_bytes_from_parts(content_size: usize) -> usize {
+        size_of::<CanisterHttpRequestId>() + content_size
     }
 }
 
 impl CountBytes for CanisterHttpResponse {
     fn count_bytes(&self) -> usize {
-        let CanisterHttpResponse {
-            id: _,
-            canister_id,
-            content,
-        } = &self;
-        Self::count_bytes_from_parts(canister_id, content.count_bytes())
+        let CanisterHttpResponse { id: _, content } = &self;
+        Self::count_bytes_from_parts(content.count_bytes())
     }
 }
 
@@ -1427,6 +1421,7 @@ impl PbArtifact for CanisterHttpResponseArtifact {
 #[cfg(test)]
 mod tests {
     use crate::{
+        CanisterId,
         crypto::{CryptoHash, SignedBytesWithoutDomainSeparator},
         messages::NO_DEADLINE,
         time::UNIX_EPOCH,

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -1054,13 +1054,12 @@ mod crypto_hash_stability {
     fn canister_http_response_stability() {
         let data = CanisterHttpResponse {
             id: CanisterHttpRequestId::from(42),
-            canister_id: ic_base_types::CanisterId::from_u64(42),
             content: CanisterHttpResponseContent::Success(vec![0x42; 16]),
         };
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "70d5cfb76e22ec392145fe3caae1458a7c2f395cde80c6090cfddc9174ced772",
+            "4553e1dd6e41fd9c7619ebdfc6dd307adb8539e4c379f8465b54bd8eab3941f5",
             "Hash of CanisterHttpResponse changed"
         );
     }


### PR DESCRIPTION
Validate that the response body is for the same callback ID as the surrounding share

Additionally, remove the unused canister ID field of the response struct.

Additionally, when finding a flexible result, derive the number of _unseen_ shares based on the number of _seen shares_ (not _seen signers_). This is more similar to what the validation side does, and prevents both sides from diverging if in the future, flexible outcalls might produce shares without a response attached.