### PR TITLE
chore: Rename config

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -222,11 +222,12 @@ pub struct Config {
     /// overridden at runtime by the registry's `maximum_state_delta`.
     pub default_subnet_heap_delta_capacity: NumBytes,
 
-    /// Dirty page overhead. The number of instructions to charge for each dirty
-    /// page created by a write to stable memory. The default value should be
+    /// The number of instructions to charge for every OS page of heap or stable
+    /// memory that a message touches: once when the page is first accessed and
+    /// once more when it is first written to. The default value should be
     /// replaced with the correct value at runtime when the hypervisor is
     /// created.
-    pub dirty_page_overhead: NumInstructions,
+    pub page_overhead: NumInstructions,
 
     /// If this flag is enabled, then execution of a slice will produce a log
     /// entry with the number of executed instructions and the duration.
@@ -281,7 +282,7 @@ impl Config {
             max_sandbox_count: DEFAULT_MAX_SANDBOX_COUNT,
             max_sandbox_idle_time: DEFAULT_MAX_SANDBOX_IDLE_TIME,
             default_subnet_heap_delta_capacity: SUBNET_HEAP_DELTA_CAPACITY,
-            dirty_page_overhead: NumInstructions::new(0),
+            page_overhead: NumInstructions::new(0),
             trace_execution: FlagStatus::Disabled,
             max_dirty_pages_without_optimization: DEFAULT_MAX_DIRTY_PAGES_WITHOUT_OPTIMIZATION,
             dirty_page_copy_overhead: DIRTY_PAGE_COPY_OVERHEAD,

--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -138,8 +138,8 @@ pub const DEFAULT_REFERENCE_SUBNET_SIZE: usize = 13;
 /// Reference subnet size for SEV-enabled application subnets.
 pub const SEV_REFERENCE_SUBNET_SIZE: usize = 7;
 
-/// Costs for each newly created dirty page in stable memory.
-pub const DEFAULT_DIRTY_PAGE_OVERHEAD: NumInstructions = NumInstructions::new(5_000);
+/// Cost of touching a single OS page of canister memory.
+pub const DEFAULT_PAGE_OVERHEAD: NumInstructions = NumInstructions::new(5_000);
 
 /// Accumulated priority reset interval, rounds.
 ///
@@ -276,8 +276,10 @@ pub struct SchedulerConfig {
     /// rounds until they are back under the allowed rate.
     pub install_code_rate_limit: NumInstructions,
 
-    /// Cost for each newly created dirty page in stable memory.
-    pub dirty_page_overhead: NumInstructions,
+    /// The number of instructions to charge for every OS page of heap or stable
+    /// memory that a message touches: once when the page is first accessed and
+    /// once more when it is first written to.
+    pub page_overhead: NumInstructions,
 
     /// Accumulated priority reset interval, rounds.
     pub accumulated_priority_reset_interval: ExecutionRound,
@@ -318,7 +320,7 @@ impl SchedulerConfig {
                 MAX_MESSAGE_DURATION_BEFORE_WARN_IN_SECONDS,
             heap_delta_rate_limit: NumBytes::from(75 * 1024 * 1024),
             install_code_rate_limit: MAX_INSTRUCTIONS_PER_SLICE,
-            dirty_page_overhead: DEFAULT_DIRTY_PAGE_OVERHEAD,
+            page_overhead: DEFAULT_PAGE_OVERHEAD,
             accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
             upload_wasm_chunk_instructions: DEFAULT_UPLOAD_CHUNK_INSTRUCTIONS,
             canister_snapshot_baseline_instructions:
@@ -366,7 +368,7 @@ impl SchedulerConfig {
             // This limit should be high enough (1000T) to effectively disable
             // rate-limiting for the system subnets.
             install_code_rate_limit: NumInstructions::from(1_000_000_000_000_000),
-            dirty_page_overhead: DEFAULT_DIRTY_PAGE_OVERHEAD,
+            page_overhead: DEFAULT_PAGE_OVERHEAD,
             accumulated_priority_reset_interval: ACCUMULATED_PRIORITY_RESET_INTERVAL,
             upload_wasm_chunk_instructions: NumInstructions::from(0),
             canister_snapshot_baseline_instructions: NumInstructions::from(0),

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -647,7 +647,7 @@ impl WasmtimeEmbedder {
             memories,
             &mut *store,
             self.log.clone(),
-            self.config.dirty_page_overhead,
+            self.config.page_overhead,
             subtract_instruction_counter,
         );
 

--- a/rs/embedders/tests/instrumentation.rs
+++ b/rs/embedders/tests/instrumentation.rs
@@ -296,7 +296,7 @@ fn deterministic_tracker_overhead(n_heap_wasm_pages: u64, n_stable_wasm_pages: u
 #[allow(clippy::field_reassign_with_default)]
 fn new_instance(wat: &str, instruction_limit: u64) -> WasmtimeInstance {
     let mut config = EmbeddersConfig::default();
-    config.dirty_page_overhead = SchedulerConfig::application_subnet().dirty_page_overhead;
+    config.page_overhead = SchedulerConfig::application_subnet().page_overhead;
     WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -308,7 +308,7 @@ fn new_instance(wat: &str, instruction_limit: u64) -> WasmtimeInstance {
 fn new_instance_for_stable_write(wat: &str, instruction_limit: u64) -> WasmtimeInstance {
     let mut config = EmbeddersConfig::default();
     config.metering_type = MeteringType::New;
-    config.dirty_page_overhead = SchedulerConfig::application_subnet().dirty_page_overhead;
+    config.page_overhead = SchedulerConfig::application_subnet().page_overhead;
     WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -800,9 +800,7 @@ fn run_charge_for_dirty_heap(wasm_memory_type: WasmMemoryType) {
         },
         wasm_memory_type,
     );
-    let cd = SchedulerConfig::application_subnet()
-        .dirty_page_overhead
-        .get();
+    let cd = SchedulerConfig::application_subnet().page_overhead.get();
 
     // Both stores target Wasm page 0 (bytes 0 and 4096 are within the 64KB page),
     // so only one heap page-first-write event occurs.
@@ -899,9 +897,7 @@ fn run_charge_for_dirty_stable64_test() {
 
     let system_api = instance.store_data().system_api().unwrap();
 
-    let cd = SchedulerConfig::application_subnet()
-        .dirty_page_overhead
-        .get();
+    let cd = SchedulerConfig::application_subnet().page_overhead.get();
 
     let csg = system_api_complexity::overhead_native::STABLE_GROW.get();
     let csw = system_api_complexity::overhead_native::STABLE64_WRITE.get()
@@ -999,9 +995,7 @@ fn run_charge_for_dirty_stable_test() {
 
     let system_api = instance.store_data().system_api().unwrap();
 
-    let cd = SchedulerConfig::application_subnet()
-        .dirty_page_overhead
-        .get();
+    let cd = SchedulerConfig::application_subnet().page_overhead.get();
 
     let csg = system_api_complexity::overhead_native::STABLE_GROW.get();
     let csw = system_api_complexity::overhead_native::STABLE_WRITE.get()
@@ -1118,9 +1112,9 @@ fn metering_wasm64_load_store_canister() {
             (memory i64 1000)
         )"#;
 
-    let dirty_page_overhead = NumInstructions::new(1000);
+    let page_overhead = NumInstructions::new(1000);
     let mut instance = WasmtimeInstanceBuilder::new()
-        .with_dirty_page_overhead(dirty_page_overhead)
+        .with_page_overhead(page_overhead)
         .with_wat(wat)
         .with_num_instructions(NumInstructions::new(10000))
         .build();
@@ -1179,7 +1173,7 @@ fn metering_wasm64_load_store_canister() {
         + 2 * store
         + load
         + drop
-        + overhead * dirty_page_overhead.get();
+        + overhead * page_overhead.get();
     assert_eq!(instr_used_wasm64, total_cost);
 
     // Compute cost in Wasm32 mode and compare.
@@ -1194,7 +1188,7 @@ fn metering_wasm64_load_store_canister() {
             (memory 1000)
         )"#;
     let mut instance = WasmtimeInstanceBuilder::new()
-        .with_dirty_page_overhead(dirty_page_overhead)
+        .with_page_overhead(page_overhead)
         .with_wat(wat_wasm32)
         .with_num_instructions(NumInstructions::new(10000))
         .build();
@@ -1249,7 +1243,7 @@ fn metering_wasm64_load_store_canister() {
         + 2 * store_wasm32
         + load_wasm32
         + drop_wasm32
-        + overhead * dirty_page_overhead.get();
+        + overhead * page_overhead.get();
     assert_eq!(wasm_32_instructions, total_cost_wasm32);
 
     // Check that the cost in Wasm64 mode is higher than in Wasm32 mode.

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -3655,10 +3655,10 @@ fn wasm_accessed_os_pages_count_deterministic_tracker() {
 #[cfg(target_os = "linux")]
 fn run_wasm_and_get_instructions_used(
     wat: &str,
-    dirty_page_overhead: NumInstructions,
+    page_overhead: NumInstructions,
 ) -> NumInstructions {
     let config = Config {
-        dirty_page_overhead,
+        page_overhead,
         ..Default::default()
     };
     let mut instance = WasmtimeInstanceBuilder::new()

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -1,7 +1,7 @@
 use ic_config::{
     embedders::Config as EmbeddersConfig,
     execution_environment::Config as HypervisorConfig,
-    subnet_config::{DEFAULT_DIRTY_PAGE_OVERHEAD, DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
+    subnet_config::{DEFAULT_PAGE_OVERHEAD, DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
 use ic_embedders::{
@@ -53,7 +53,7 @@ const OS_PAGES_PER_WASM_PAGE: usize =
 /// Returns the per-Wasm-page instruction charge applied by the deterministic
 /// memory tracker.
 fn dsm_charge_per_wasm_page() -> u64 {
-    OS_PAGES_PER_WASM_PAGE as u64 * DEFAULT_DIRTY_PAGE_OVERHEAD.get()
+    OS_PAGES_PER_WASM_PAGE as u64 * DEFAULT_PAGE_OVERHEAD.get()
 }
 
 lazy_static! {
@@ -1083,13 +1083,13 @@ mod tests {
         let wasm = wat2wasm(&wat).unwrap();
 
         let config = EmbeddersConfig {
-            dirty_page_overhead: match subnet_type {
+            page_overhead: match subnet_type {
                 SubnetType::System => SchedulerConfig::system_subnet(),
                 SubnetType::Application => SchedulerConfig::application_subnet(),
                 SubnetType::VerifiedApplication => SchedulerConfig::verified_application_subnet(),
                 SubnetType::CloudEngine => SchedulerConfig::cloud_engine(),
             }
-            .dirty_page_overhead,
+            .page_overhead,
             ..EmbeddersConfig::default()
         };
         let embedder = WasmtimeEmbedder::new(config, log.clone());

--- a/rs/execution_environment/EXECUTION_COST.md
+++ b/rs/execution_environment/EXECUTION_COST.md
@@ -30,7 +30,7 @@ Heap Memory Overhead
 --------------------
 
 Each Wasm heap memory page has an associated overhead defined
-by `DEFAULT_DIRTY_PAGE_OVERHEAD` and other costs.
+by `DEFAULT_PAGE_OVERHEAD` and other costs.
 
 1. ✅ Runs daily on CI.
 2. ✅ Results are available in [Grafana](https://grafana.mainnet.dfinity.network/d/benchmarks-embedders-heap/benchmarks3a-embedders-heap).
@@ -64,7 +64,7 @@ Stable Memory Overhead
 ----------------------
 
 Each Wasm stable memory page has an associated overhead defined
-by `DEFAULT_DIRTY_PAGE_OVERHEAD` and other costs.
+by `DEFAULT_PAGE_OVERHEAD` and other costs.
 
 1. ✅ Runs daily on CI.
 2. ✅ Results are available in [Grafana](https://grafana.mainnet.dfinity.network/d/benchmarks-embedders-stable-memory/benchmarks3a-embedders-stable-memory).

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -6,7 +6,7 @@ use ic_config::execution_environment::{
     CANISTER_GUARANTEED_CALLBACK_QUOTA, Config, SUBNET_CALLBACK_SOFT_LIMIT,
     SUBNET_MEMORY_RESERVATION,
 };
-use ic_config::subnet_config::{DEFAULT_DIRTY_PAGE_OVERHEAD, SubnetConfig};
+use ic_config::subnet_config::{DEFAULT_PAGE_OVERHEAD, SubnetConfig};
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::wasmtime_embedder::system_api::{ExecutionParameters, InstructionLimits};
 use ic_error_types::RejectCode;
@@ -75,13 +75,12 @@ lazy_static! {
 /// (e.g. read-only accesses or non-replicated execution).
 ///
 /// Each first-accessed Wasm page (64 KiB) triggers `mark_wasm_page_accessed`,
-/// which charges one instruction per OS page in-band via the SIGSEGV handler
-/// when the deterministic memory tracker is enabled.  The number of OS pages
-/// per Wasm page varies by platform (4 KiB pages on Linux, 16 KiB on
-/// arm64-darwin).
+/// which charges `page_overhead` instructions per OS page in-band via the
+/// SIGSEGV handler.  The number of OS pages per Wasm page varies by platform
+/// (4 KiB pages on Linux, 16 KiB on arm64-darwin).
 pub fn deterministic_tracker_overhead(n_wasm_pages: u64) -> u64 {
     const WASM_PAGE_SIZE: u64 = 65536;
-    n_wasm_pages * (WASM_PAGE_SIZE / ic_sys::PAGE_SIZE as u64) * DEFAULT_DIRTY_PAGE_OVERHEAD.get()
+    n_wasm_pages * (WASM_PAGE_SIZE / ic_sys::PAGE_SIZE as u64) * DEFAULT_PAGE_OVERHEAD.get()
 }
 
 /// Returns the extra instruction overhead charged by the deterministic memory
@@ -89,8 +88,8 @@ pub fn deterministic_tracker_overhead(n_wasm_pages: u64) -> u64 {
 /// execution (DirtyPageTracking::Track).
 ///
 /// Each first-written Wasm page triggers both `mark_wasm_page_accessed` and
-/// `mark_wasm_page_dirty` via the SIGSEGV handler, charging two instructions
-/// per OS page when the deterministic memory tracker is enabled.
+/// `mark_wasm_page_dirty` via the SIGSEGV handler, charging `page_overhead`
+/// instructions twice per OS page.
 pub fn deterministic_tracker_write_overhead(n_wasm_pages: u64) -> u64 {
     2 * deterministic_tracker_overhead(n_wasm_pages)
 }

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -267,7 +267,7 @@ impl CanisterManagerBuilder {
             self.subnet_id,
             no_op_logger(),
             Arc::clone(&cycles_account_manager),
-            SchedulerConfig::application_subnet().dirty_page_overhead,
+            SchedulerConfig::application_subnet().page_overhead,
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
             Arc::new(FakeStateManager::new()),
             Path::new("/tmp"),

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -361,13 +361,13 @@ impl Hypervisor {
         own_subnet_id: SubnetId,
         log: ReplicaLogger,
         cycles_account_manager: Arc<CyclesAccountManager>,
-        dirty_page_overhead: NumInstructions,
+        page_overhead: NumInstructions,
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
         state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
         temp_dir: &Path,
     ) -> Self {
         let mut embedder_config = config.embedders_config.clone();
-        embedder_config.dirty_page_overhead = dirty_page_overhead;
+        embedder_config.page_overhead = page_overhead;
 
         let wasm_executor: Arc<dyn WasmExecutor> = match config.canister_sandboxing_flag {
             FlagStatus::Enabled => {

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -331,7 +331,7 @@ fn setup_execution_helper(
             own_subnet_id,
             logger.clone(),
             Arc::clone(&cycles_account_manager),
-            scheduler_config.dirty_page_overhead,
+            scheduler_config.page_overhead,
             Arc::clone(&fd_factory),
             Arc::clone(&state_reader),
             temp_dir,

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -816,7 +816,7 @@ fn zero_instruction_overhead_config() -> SchedulerConfig {
         instruction_overhead_per_execution: NumInstructions::from(0),
         instruction_overhead_per_canister: NumInstructions::from(0),
         instruction_overhead_per_canister_for_finalization: NumInstructions::from(0),
-        dirty_page_overhead: NumInstructions::from(0),
+        page_overhead: NumInstructions::from(0),
         ..SchedulerConfig::application_subnet()
     }
 }

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -4812,7 +4812,7 @@ fn install_code_calls_canister_init_and_start() {
     // Linux, 4 on 16 KiB hosts such as arm64-darwin).
     let os_pages_per_wasm_page = WASM_PAGE_SIZE_IN_BYTES as u64 / PAGE_SIZE as u64;
     let dirty_heap_cost =
-        NumInstructions::from(2 * os_pages_per_wasm_page * 2 * test.dirty_heap_page_overhead());
+        NumInstructions::from(2 * os_pages_per_wasm_page * 2 * test.heap_page_overhead());
     assert_eq!(
         // Function is 1 instruction.
         DEFAULT_CREATE_EXECUTION_STATE_BASE_COST
@@ -5248,7 +5248,7 @@ fn ic0_trap_preserves_some_cycles() {
             + 2 * instruction_to_cost(&wasmparser::Operator::I32Const { value: 0 }, WasmMemoryType::Wasm32)
             + bytes_and_logging_cost(12) as u64 /* trap data */
             + 1 // Function is 1 instruction.
-            + os_pages_per_wasm_page * test.dirty_heap_page_overhead(),
+            + os_pages_per_wasm_page * test.heap_page_overhead(),
     );
     assert_eq!(err.code(), ErrorCode::CanisterCalledTrap);
     assert_eq!(
@@ -7924,7 +7924,7 @@ fn charge_for_dirty_pages() {
     test.ingress(canister_id, "test2", vec![]).unwrap();
     let i2 = test.canister_executed_instructions(canister_id);
 
-    let cdi = ic_config::subnet_config::SchedulerConfig::application_subnet().dirty_page_overhead;
+    let cdi = ic_config::subnet_config::SchedulerConfig::application_subnet().page_overhead;
     // test2 writes to the next Wasm page, i.e. (1 read + 1 write)x16=32 OS pages.
     assert_eq!((i2 - i1) - (i1 - i0), cdi * 32);
 }

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -39,9 +39,10 @@ const TEST_CANISTER_INSTALL_EXECUTION_INSTRUCTIONS: u64 = 0;
 /// Returns the extra instruction overhead charged in-band by the deterministic
 /// memory tracker for `n_wasm_pages` Wasm pages first written in replicated
 /// mode (DirtyPageTracking::Track). Each such page triggers both
-/// `mark_wasm_page_accessed` and `mark_wasm_page_dirty`, charging two
-/// instructions per OS page per Wasm page.  The OS page size varies by
-/// platform (4 KiB on Linux, 16 KiB on arm64-darwin).
+/// `mark_wasm_page_accessed` and `mark_wasm_page_dirty`, i.e. it is charged
+/// twice per OS page. The result is a page count, to be multiplied by
+/// `page_overhead`. The OS page size varies by platform (4 KiB on Linux, 16 KiB
+/// on arm64-darwin).
 fn deterministic_tracker_write_overhead(n_wasm_pages: u64) -> u64 {
     use ic_sys::PAGE_SIZE;
     const WASM_PAGE_SIZE: u64 = 65536;
@@ -1111,8 +1112,8 @@ fn test_subnet_size_ingress_induction_cost() {
 
 #[test]
 fn test_subnet_size_execute_message_cost() {
-    let dirty_page_overhead = ic_config::subnet_config::SchedulerConfig::application_subnet()
-        .dirty_page_overhead
+    let page_overhead = ic_config::subnet_config::SchedulerConfig::application_subnet()
+        .page_overhead
         .get();
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
@@ -1121,7 +1122,7 @@ fn test_subnet_size_execute_message_cost() {
     // memory tracker charges an extra 32 instructions in-band (accessed + dirty
     // for 1 Wasm page) when enabled.
     let reference_instructions_cost = inc_instruction_cost(HypervisorConfig::default())
-        + dirty_page_overhead * deterministic_tracker_write_overhead(1);
+        + page_overhead * deterministic_tracker_write_overhead(1);
     let reference_cost = calculate_execution_cost(
         &config,
         NumInstructions::from(reference_instructions_cost),
@@ -1131,7 +1132,7 @@ fn test_subnet_size_execute_message_cost() {
     // Check default cost.
     assert_eq!(
         reference_instructions_cost,
-        1019 + dirty_page_overhead * deterministic_tracker_write_overhead(1)
+        1019 + page_overhead * deterministic_tracker_write_overhead(1)
     );
     let simulated_cost = simulate_execute_message_cost(subnet_type, reference_subnet_size);
     assert_eq!(

--- a/rs/test_utilities/embedders/src/lib.rs
+++ b/rs/test_utilities/embedders/src/lib.rs
@@ -128,8 +128,8 @@ impl WasmtimeInstanceBuilder {
         }
     }
 
-    pub fn with_dirty_page_overhead(mut self, dirty_page_overhead: NumInstructions) -> Self {
-        self.config.dirty_page_overhead = dirty_page_overhead;
+    pub fn with_page_overhead(mut self, page_overhead: NumInstructions) -> Self {
+        self.config.page_overhead = page_overhead;
         self
     }
 

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -318,7 +318,7 @@ pub struct ExecutionTest {
     current_round: ExecutionRound,
 
     // Read-only fields.
-    dirty_heap_page_overhead: u64,
+    heap_page_overhead: u64,
     instruction_limits: InstructionLimits,
     install_code_instruction_limits: InstructionLimits,
     instruction_limit_per_query_message: NumInstructions,
@@ -355,8 +355,8 @@ impl ExecutionTest {
         Arc::clone(&self.exec_env)
     }
 
-    pub fn dirty_heap_page_overhead(&self) -> u64 {
-        self.dirty_heap_page_overhead
+    pub fn heap_page_overhead(&self) -> u64 {
+        self.heap_page_overhead
     }
 
     pub fn user_id(&self) -> UserId {
@@ -3121,17 +3121,17 @@ impl ExecutionTestBuilder {
             })
             .collect::<BTreeMap<_, _>>();
 
-        let dirty_page_overhead = match self.subnet_type {
-            SubnetType::Application => SchedulerConfig::application_subnet().dirty_page_overhead,
-            SubnetType::System => SchedulerConfig::system_subnet().dirty_page_overhead,
+        let page_overhead = match self.subnet_type {
+            SubnetType::Application => SchedulerConfig::application_subnet().page_overhead,
+            SubnetType::System => SchedulerConfig::system_subnet().page_overhead,
             SubnetType::VerifiedApplication => {
-                SchedulerConfig::verified_application_subnet().dirty_page_overhead
+                SchedulerConfig::verified_application_subnet().page_overhead
             }
-            SubnetType::CloudEngine => SchedulerConfig::cloud_engine().dirty_page_overhead,
+            SubnetType::CloudEngine => SchedulerConfig::cloud_engine().page_overhead,
         };
 
-        let dirty_heap_page_overhead = match self.execution_config.embedders_config.metering_type {
-            MeteringType::New => dirty_page_overhead.get(),
+        let heap_page_overhead = match self.execution_config.embedders_config.metering_type {
+            MeteringType::New => page_overhead.get(),
             _ => 0,
         };
 
@@ -3181,7 +3181,7 @@ impl ExecutionTestBuilder {
             subnet_memory_reservation,
             subnet_available_callbacks: self.execution_config.subnet_callback_soft_limit as i64,
             time: self.time,
-            dirty_heap_page_overhead,
+            heap_page_overhead,
             instruction_limits: InstructionLimits::new(
                 self.subnet_config
                     .scheduler_config


### PR DESCRIPTION
The `dirty_page_overhead` is now applied for written and accessed pages, so this PR renames it to `page_overhead`. 