### PR TITLE
perf: CON-1736 Only deserialize each public key once during basic signature batch verification

### DIFF
--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -126,25 +126,40 @@ impl BasicSigVerifierInternal {
         let mut sigs = Vec::with_capacity(inputs.len());
         let mut keys = Vec::with_capacity(inputs.len());
 
-        for (signer, signature, msg_bytes, registry_version) in inputs {
-            let pk_proto =
-                key_from_registry(registry, signer, KeyPurpose::NodeSigning, registry_version)?;
+        // Resolve each signer's public key at most once.
+        let mut resolved_keys: BTreeMap<(NodeId, RegistryVersion), ic_ed25519::PublicKey> =
+            BTreeMap::new();
 
-            let pubkey_alg = AlgorithmId::from(pk_proto.algorithm);
-            if pubkey_alg != AlgorithmId::Ed25519 {
-                return Err(CryptoError::AlgorithmNotSupported {
-                    algorithm: pubkey_alg,
-                    reason: "Only Ed25519 is supported in batched basic sig verification."
-                        .to_string(),
-                });
-            }
-            let pk = ic_ed25519::PublicKey::deserialize_raw(&pk_proto.key_value).map_err(|e| {
-                CryptoError::MalformedPublicKey {
-                    algorithm: AlgorithmId::Ed25519,
-                    key_bytes: Some(pk_proto.key_value),
-                    internal_error: e.to_string(),
+        for (signer, signature, msg_bytes, registry_version) in inputs {
+            let pk = match resolved_keys.get(&(signer, registry_version)) {
+                Some(pk) => *pk,
+                None => {
+                    let pk_proto = key_from_registry(
+                        registry,
+                        signer,
+                        KeyPurpose::NodeSigning,
+                        registry_version,
+                    )?;
+
+                    let pubkey_alg = AlgorithmId::from(pk_proto.algorithm);
+                    if pubkey_alg != AlgorithmId::Ed25519 {
+                        return Err(CryptoError::AlgorithmNotSupported {
+                            algorithm: pubkey_alg,
+                            reason: "Only Ed25519 is supported in batched basic sig verification."
+                                .to_string(),
+                        });
+                    }
+                    let pk = ic_ed25519::PublicKey::deserialize_raw(&pk_proto.key_value).map_err(
+                        |e| CryptoError::MalformedPublicKey {
+                            algorithm: AlgorithmId::Ed25519,
+                            key_bytes: Some(pk_proto.key_value),
+                            internal_error: e.to_string(),
+                        },
+                    )?;
+                    resolved_keys.insert((signer, registry_version), pk);
+                    pk
                 }
-            })?;
+            };
 
             msgs.push(msg_bytes);
             sigs.push(signature.get_ref().0.as_slice());

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -532,6 +532,35 @@ mod verify_sigs_batch {
     }
 
     #[test]
+    fn should_resolve_a_repeated_signers_key_at_each_entrys_own_registry_version() {
+        // The same signer twice, at two different registry versions, only one of which has
+        // its key. Resolving a signer's key once per signer (rather than once per signer
+        // and registry version) would let the entry at REG_V2 satisfy the one at REG_V1,
+        // so this fails whichever order the two are batched in.
+        let crypto = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_node_id(NODE_1)
+            .build();
+
+        let msg = SignableMock::new(b"Hello World!".to_vec());
+        let sig = crypto.sign_basic(&msg).unwrap();
+        let at = |registry_version| BasicSigBatchEntry {
+            signer: NODE_1,
+            signature: &sig,
+            message: &msg,
+            registry_version,
+        };
+
+        for inputs in [vec![at(REG_V2), at(REG_V1)], vec![at(REG_V1), at(REG_V2)]] {
+            assert_matches!(
+                crypto.verify_basic_sig_batch_multi_msg(&inputs),
+                Err(CryptoError::PublicKeyNotFound { node_id, registry_version, .. })
+                if node_id == NODE_1 && registry_version == REG_V1
+            );
+        }
+    }
+
+    #[test]
     fn should_correctly_verify_batch_with_same_message_on_different_signers() {
         let (crypto_1, crypto_2) = two_node_crypto_components();
 


### PR DESCRIPTION
In https://github.com/dfinity/ic/pull/10339, we introduced batched signature verification with multiple messages, which has a performance advantage over verifying basic signatures one-by-one.

Before this PR, we would retrieve and deserialize the public key corresponding to each share, for every signature. However, on a 13 node subnet (assuming the keys didn't change between registry versions) there should be at most 13 distinct public keys, versus hundreds of signatures.

With this PR, we therefore start caching the public keys such that they are only deserialized once per batch verification call. This leads to a performance improvement of ~30%:

**Before:**
```sql
canister_http_payload_verification/mixed_subnet34
                        time:   [164.42 ms 165.38 ms 166.94 ms]
canister_http_payload_verification/many_replicated_responses_subnet34
                        time:   [238.21 ms 239.94 ms 241.61 ms]
canister_http_payload_verification/many_non_replicated_responses_subnet34
                        time:   [11.312 ms 11.445 ms 11.581 ms]
canister_http_payload_verification/many_divergence_responses_subnet34
                        time:   [123.06 ms 124.48 ms 125.90 ms]
canister_http_payload_verification/many_flexible_responses_subnet34
                        time:   [250.74 ms 253.05 ms 255.39 ms]
```
**After:**
```sql
canister_http_payload_verification/mixed_subnet34
                        time:   [113.35 ms 114.86 ms 116.37 ms]
                        change: [-31.653% -30.551% -29.541%] (p = 0.00 < 0.05)
                        Performance has improved.
canister_http_payload_verification/many_replicated_responses_subnet34
                        time:   [162.37 ms 164.22 ms 166.11 ms]
                        change: [-32.449% -31.557% -30.632%] (p = 0.00 < 0.05)
                        Performance has improved.
canister_http_payload_verification/many_non_replicated_responses_subnet34
                        time:   [8.5594 ms 8.6648 ms 8.7755 ms]
                        change: [-25.682% -24.295% -22.975%] (p = 0.00 < 0.05)
                        Performance has improved.
canister_http_payload_verification/many_divergence_responses_subnet34
                        time:   [84.374 ms 85.448 ms 86.600 ms]
                        change: [-32.562% -31.356% -30.202%] (p = 0.00 < 0.05)
                        Performance has improved.
canister_http_payload_verification/many_flexible_responses_subnet34
                        time:   [197.89 ms 199.66 ms 201.42 ms]
                        change: [-22.172% -21.097% -20.031%] (p = 0.00 < 0.05)
                        Performance has improved.
```