### PR TITLE
chore: Remove temporary metric

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -27,7 +27,6 @@ use ic_metrics::buckets::{decimal_buckets_with_zero, exponential_buckets};
 use ic_replicated_state::canister_state::execution_state::{
     SandboxMemory, SandboxMemoryHandle, SandboxMemoryOwner, WasmBinary, WasmExecutionMode,
 };
-use ic_replicated_state::metrics::instructions_buckets;
 use ic_replicated_state::{
     EmbedderCache, ExecutionState, ExportedFunctions, Memory, PageMap, ReplicatedState,
     page_map::allocated_pages_count,
@@ -157,7 +156,6 @@ struct SandboxedExecutionMetrics {
     mprotect_count: HistogramVec,
     copy_page_count: HistogramVec,
     sigsegv_handler_duration: HistogramVec,
-    dmt_projected_message_cost: HistogramVec,
 }
 
 impl SandboxedExecutionMetrics {
@@ -411,12 +409,6 @@ impl SandboxedExecutionMetrics {
                 decimal_buckets_with_zero(-4, 1),
                 &["api_type", "memory_type"],
             ),
-            dmt_projected_message_cost: metrics_registry.histogram_vec(
-                "sandboxed_execution_dmt_projected_message_cost",
-                "Cost of a message when the DMT charges for all page accesses.",
-                instructions_buckets(), /* same as scheduler_instructions_consumed_per_message for comparison */
-                &["api_type", "memory_type"],
-            ),
         }
     }
 
@@ -501,10 +493,6 @@ impl SandboxedExecutionMetrics {
         self.sigsegv_handler_duration
             .with_label_values(&[api_type_label, "stable"])
             .observe(instance_stats.stable_sigsegv_handler_duration.as_secs_f64());
-
-        self.dmt_projected_message_cost
-            .with_label_values(&[api_type_label, "both"])
-            .observe(instance_stats.dmt_projected_message_cost as f64);
 
         self.allocated_pages.set(allocated_pages_count() as i64);
     }
@@ -1709,7 +1697,7 @@ impl SandboxedExecutionController {
                 });
                 return WasmExecutionResult::Paused(slice, paused);
             }
-            CompletionResult::Finished(mut exec_output) => {
+            CompletionResult::Finished(exec_output) => {
                 let execution_status = match exec_output.wasm.wasm_result.clone() {
                     Ok(Some(WasmResult::Reply(_))) => "Success",
                     Ok(Some(WasmResult::Reject(_))) => "Reject",
@@ -1721,19 +1709,6 @@ impl SandboxedExecutionController {
                     execution_status,
                     execution_state.wasm_execution_mode.as_str(),
                 );
-                // Temporary metric: How much will the message cost when we charge via DMT.
-                let instructions_used = message_instruction_limit
-                    .saturating_sub(&exec_output.wasm.num_instructions_left);
-                let stable_writes = exec_output.wasm.instance_stats.stable_dirty_pages;
-                let stable_reads = exec_output.wasm.instance_stats.stable_accessed_pages;
-                let heap_writes = exec_output.wasm.instance_stats.wasm_dirty_pages;
-                let heap_reads = exec_output.wasm.instance_stats.wasm_accessed_pages - heap_writes;
-                // we currently charge 1000 for stable and heap writes (plus 3000 for copy overhead, which remains separate), and 0 for everything else.
-                let additional_cost =
-                    (stable_writes + heap_writes) * 4000 + (stable_reads + heap_reads) * 5000;
-                exec_output.wasm.instance_stats.dmt_projected_message_cost =
-                    instructions_used.get() as usize + additional_cost;
-
                 self.metrics
                     .observe_instance_stats(&exec_output.wasm.instance_stats, api_type_label);
                 exec_output

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -923,7 +923,6 @@ pub struct PageAccessResults {
     pub stable_mprotect_count: usize,
     pub stable_copy_page_count: usize,
     pub stable_sigsegv_handler_duration: Duration,
-    pub dmt_projected_message_cost: usize,
 }
 
 /// Encapsulates a Wasmtime instance on the Internet Computer.
@@ -1056,9 +1055,6 @@ impl WasmtimeInstance {
             let stable_sigsegv_handler_duration =
                 stable_tracker.metrics().sigsegv_handler_duration();
 
-            // total cost of the message if the DMT charges for all page accesses. Overwritten later.
-            let dmt_projected_page_cost = 0;
-
             Ok(PageAccessResults {
                 wasm_dirty_pages,
                 wasm_num_accessed_pages: wasm_tracker.num_accessed_pages(),
@@ -1082,7 +1078,6 @@ impl WasmtimeInstance {
                 stable_mprotect_count: stable_tracker.metrics().mprotect_count(),
                 stable_copy_page_count: stable_tracker.metrics().copy_page_count(),
                 stable_sigsegv_handler_duration,
-                dmt_projected_message_cost: dmt_projected_page_cost,
             })
         }
     }
@@ -1126,7 +1121,6 @@ impl WasmtimeInstance {
             stable_mprotect_count: res.stable_mprotect_count,
             stable_copy_page_count: res.stable_copy_page_count,
             stable_sigsegv_handler_duration: res.stable_sigsegv_handler_duration,
-            dmt_projected_message_cost: res.dmt_projected_message_cost,
         };
     }
 

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -104,9 +104,6 @@ pub struct InstanceStats {
 
     /// Total time spent in SIGSEGV handler for stable memory.
     pub stable_sigsegv_handler_duration: Duration,
-
-    /// The cost of the message when the DMT charges for all page accesses.
-    pub dmt_projected_message_cost: usize,
 }
 
 impl InstanceStats {


### PR DESCRIPTION
This metric was introduced to estimate the impact of the DMT uniform page charging, which is now rolled out, so the metric can go. 