### PR TITLE
fix: Only observe consumed ECDSA/Schnorr/VetKD cycles after all checks succeeded 

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3937,7 +3937,7 @@ impl ExecutionEnvironment {
         // If the request isn't from the NNS, then we need to charge for it.
         let source_subnet = state.metadata.network_topology.route(request.sender.get());
         let nns_subnet_id = state.metadata.network_topology.nns_subnet_id;
-        if source_subnet != Some(nns_subnet_id) {
+        let signature_fee = if source_subnet != Some(nns_subnet_id) {
             let signature_fee =
                 self.calculate_signature_fee(&args, state.get_own_subnet_cycles_config());
             let real_signature_fee = signature_fee.real();
@@ -3949,27 +3949,11 @@ impl ExecutionEnvironment {
                         request.method_name, request.payment, real_signature_fee
                     ),
                 ));
-            } else {
-                // Charge for the request.
-                request.payment -= real_signature_fee;
-                let nominal_fee = signature_fee.nominal();
-                let use_case = match args {
-                    ThresholdArguments::Ecdsa(_) => {
-                        state
-                            .metadata
-                            .subnet_metrics
-                            .observe_consumed_cycles_ecdsa_outcalls(nominal_fee);
-                        CyclesUseCase::ECDSAOutcalls
-                    }
-                    ThresholdArguments::Schnorr(_) => CyclesUseCase::SchnorrOutcalls,
-                    ThresholdArguments::VetKd(_) => CyclesUseCase::VetKd,
-                };
-                state
-                    .metadata
-                    .subnet_metrics
-                    .observe_consumed_cycles_with_use_case(use_case, nominal_fee);
             }
-        }
+            Some(signature_fee)
+        } else {
+            None
+        };
 
         let threshold_key = args.key_id();
 
@@ -4009,6 +3993,26 @@ impl ExecutionEnvironment {
                     request.method_name, threshold_key
                 ),
             ));
+        }
+
+        if let Some(signature_fee) = signature_fee {
+            request.payment -= signature_fee.real();
+            let nominal_fee = signature_fee.nominal();
+            let use_case = match args {
+                ThresholdArguments::Ecdsa(_) => {
+                    state
+                        .metadata
+                        .subnet_metrics
+                        .observe_consumed_cycles_ecdsa_outcalls(nominal_fee);
+                    CyclesUseCase::ECDSAOutcalls
+                }
+                ThresholdArguments::Schnorr(_) => CyclesUseCase::SchnorrOutcalls,
+                ThresholdArguments::VetKd(_) => CyclesUseCase::VetKd,
+            };
+            state
+                .metadata
+                .subnet_metrics
+                .observe_consumed_cycles_with_use_case(use_case, nominal_fee);
         }
 
         state.metadata.subnet_call_context_manager.push_context(

--- a/rs/execution_environment/tests/threshold_signatures.rs
+++ b/rs/execution_environment/tests/threshold_signatures.rs
@@ -10,7 +10,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, UserError};
 use ic_test_utilities::universal_canister::{UNIVERSAL_CANISTER_WASM, call_args, wasm};
 use ic_types::{CanisterId, RegistryVersion, SubnetId, ingress::WasmResult};
-use ic_types_cycles::Cycles;
+use ic_types_cycles::{Cycles, NominalCycles};
 use ic_types_test_utils::ids::{node_test_id, subnet_test_id};
 use itertools::Itertools;
 use serde::Deserialize;
@@ -26,6 +26,28 @@ fn create_universal_canister(env: &StateMachine) -> CanisterId {
     )
     .unwrap();
     canister_id
+}
+
+/// The number of `sign_with_threshold` contexts currently queued for `method`.
+fn sign_with_threshold_contexts_len(env: &StateMachine, method: Method) -> usize {
+    match method {
+        Method::SignWithECDSA => env.sign_with_ecdsa_contexts().len(),
+        Method::SignWithSchnorr => env.sign_with_schnorr_contexts().len(),
+        Method::VetKdDeriveKey => env.vetkd_derive_key_contexts().len(),
+        _ => panic!("Unexpected method"),
+    }
+}
+
+/// The subnet-level cycles recorded as consumed by `method`'s use case.
+fn consumed_cycles_for_method(env: &StateMachine, method: Method) -> NominalCycles {
+    let state = env.get_latest_state();
+    let subnet_metrics = &state.metadata.subnet_metrics;
+    match method {
+        Method::SignWithECDSA => subnet_metrics.get_consumed_cycles_ecdsa_outcalls(),
+        Method::SignWithSchnorr => subnet_metrics.get_consumed_cycles_schnorr_outcalls(),
+        Method::VetKdDeriveKey => subnet_metrics.get_consumed_cycles_vetkd(),
+        _ => panic!("Unexpected method"),
+    }
 }
 
 fn make_ecdsa_key(name: &str) -> MasterPublicKeyId {
@@ -894,6 +916,23 @@ fn test_sign_with_threshold_key_queue_fills_up() {
                 payload.clone(),
             );
         }
+        // Tick until all the requests above have been queued. They are never
+        // answered (signing is disabled), so they cannot be awaited.
+        for _ in 0..100 {
+            if sign_with_threshold_contexts_len(&env, method) >= max_queue_size {
+                break;
+            }
+            env.tick();
+        }
+        assert_eq!(
+            sign_with_threshold_contexts_len(&env, method),
+            max_queue_size
+        );
+
+        // Every queued request was charged the fee.
+        let consumed_cycles = consumed_cycles_for_method(&env, method);
+        assert_eq!(consumed_cycles.get(), fee * max_queue_size as u128);
+
         let result = env.execute_ingress(canister_id, "update", payload.clone());
 
         assert_eq!(
@@ -902,5 +941,9 @@ fn test_sign_with_threshold_key_queue_fills_up() {
                 "{method} request failed: request queue for key {key_id} is full.",
             )))
         );
+
+        // The rejected request was refunded its full payment, so it must not
+        // have been recorded as consumed.
+        assert_eq!(consumed_cycles_for_method(&env, method), consumed_cycles);
     }
 }


### PR DESCRIPTION
If the request queue is full or the key is disabled, the caller is refunded.