### PR TITLE
feat(cketh): report the token's minimum deposit amount from deposit_erc20

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -436,6 +436,11 @@ type DepositErc20Response = record {
     // balance scan to detect it. The scan reads the address' whole balance for the token, so
     // several smaller transfers count together; the funds stay undetected only while their
     // total is below this.
+    //
+    // A supported token with no configured minimum reports 2^256 - 1, which no real balance can
+    // reach: a deposit of that token would never be detected. Frontends should treat such a value
+    // as "deposits unavailable for this token" and warn the user, rather than display it as an
+    // amount to send.
     minimum_deposit_amount : nat;
     // Where the deposit stands in the detect-and-sweep pipeline.
     status : DepositStatus;

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -432,6 +432,9 @@ type DepositMode = variant {
 type DepositErc20Response = record {
     // The Ethereum deposit address derived for the caller.
     address : text;
+    // Minimum balance, in the token's own units, that the deposit address must hold for the
+    // balance scan to detect it. A smaller deposit is never detected and never credited.
+    minimum_deposit_amount : nat;
     // Where the deposit stands in the detect-and-sweep pipeline.
     status : DepositStatus;
 };
@@ -873,7 +876,8 @@ service : (MinterArg) -> {
     // Derive and register the ckERC20 deposit address for the caller.
     // The account is derived from the caller's principal and the subaccount in the argument.
     // Returns the EIP-55 checksummed deposit address together with `valid_until`, the timestamp
-    // (nanoseconds since the Unix epoch) until which a deposit to it is guaranteed to be noticed.
+    // (nanoseconds since the Unix epoch) until which a deposit to it is guaranteed to be noticed,
+    // and the minimum amount of the requested token that a deposit must reach to be noticed.
     deposit_erc20 : (DepositErc20Arg) -> (variant { Ok : DepositErc20Response; Err : DepositErc20Error });
 
     // Retrieve the status of a Eth withdrawal request.

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -433,7 +433,9 @@ type DepositErc20Response = record {
     // The Ethereum deposit address derived for the caller.
     address : text;
     // Minimum balance, in the token's own units, that the deposit address must hold for the
-    // balance scan to detect it. A smaller deposit is never detected and never credited.
+    // balance scan to detect it. The scan reads the address' whole balance for the token, so
+    // several smaller transfers count together; the funds stay undetected only while their
+    // total is below this.
     minimum_deposit_amount : nat;
     // Where the deposit stands in the detect-and-sweep pipeline.
     status : DepositStatus;
@@ -877,7 +879,7 @@ service : (MinterArg) -> {
     // The account is derived from the caller's principal and the subaccount in the argument.
     // Returns the EIP-55 checksummed deposit address together with `valid_until`, the timestamp
     // (nanoseconds since the Unix epoch) until which a deposit to it is guaranteed to be noticed,
-    // and the minimum amount of the requested token that a deposit must reach to be noticed.
+    // and the minimum balance of the requested token the address must hold to be noticed.
     deposit_erc20 : (DepositErc20Arg) -> (variant { Ok : DepositErc20Response; Err : DepositErc20Error });
 
     // Retrieve the status of a Eth withdrawal request.

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -253,6 +253,10 @@ pub struct DepositErc20Response {
     /// balance scan to detect it. The scan reads the address' whole balance for the token, so
     /// several smaller transfers count together; the funds stay undetected only while their
     /// total is below this.
+    ///
+    /// A supported token with no configured minimum reports `2^256 - 1`, which no real balance
+    /// can reach: a deposit of that token would never be detected. Treat such a value as
+    /// "deposits unavailable for this token" rather than as an amount to display.
     pub minimum_deposit_amount: Nat,
     /// Where the deposit stands in the detect-and-sweep pipeline.
     pub status: DepositStatus,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -249,6 +249,9 @@ pub enum DepositMode {
 pub struct DepositErc20Response {
     /// The Ethereum deposit address derived for the caller.
     pub address: String,
+    /// Minimum balance, in the token's own units, that the deposit address must hold for the
+    /// balance scan to detect it. A smaller deposit is never detected and never credited.
+    pub minimum_deposit_amount: Nat,
     /// Where the deposit stands in the detect-and-sweep pipeline.
     pub status: DepositStatus,
 }

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -250,7 +250,9 @@ pub struct DepositErc20Response {
     /// The Ethereum deposit address derived for the caller.
     pub address: String,
     /// Minimum balance, in the token's own units, that the deposit address must hold for the
-    /// balance scan to detect it. A smaller deposit is never detected and never credited.
+    /// balance scan to detect it. The scan reads the address' whole balance for the token, so
+    /// several smaller transfers count together; the funds stay undetected only while their
+    /// total is below this.
     pub minimum_deposit_amount: Nat,
     /// Where the deposit stands in the detect-and-sweep pipeline.
     pub status: DepositStatus,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -30,6 +30,7 @@ use ic_cketh_minter::logs::INFO;
 use ic_cketh_minter::memo::{self, BurnMemo};
 use ic_cketh_minter::numeric::{Erc20Value, LedgerBurnIndex, Wei};
 use ic_cketh_minter::state::audit::{Event, EventType, process_event};
+use ic_cketh_minter::state::automatic_deposits::DepositRequest;
 use ic_cketh_minter::state::eth_logs_scraping::{LogScrapingId, LogScrapingInfo};
 use ic_cketh_minter::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
@@ -207,10 +208,14 @@ async fn deposit_erc20(arg: DepositErc20Arg) -> Result<DepositErc20Response, Dep
         owner: caller,
         subaccount,
     };
+    let request = DepositRequest::new(account, token);
+    let minimum_deposit_amount = min_deposit(&token);
     let now = Timestamp::from_nanos(ic_cdk::api::time());
 
-    if let Some(status) = read_state(|s| s.automatic_deposits.deposit_status(now, &account, token))
-    {
+    if let Some(status) = read_state(|s| {
+        s.automatic_deposits
+            .deposit_status(now, &request, minimum_deposit_amount)
+    }) {
         return Ok(status);
     }
 
@@ -223,15 +228,18 @@ async fn deposit_erc20(arg: DepositErc20Arg) -> Result<DepositErc20Response, Dep
     // after an upgrade, before the key is cached). Returning its status here keeps `register_deposit_
     // address` from trying to re-arm an already-swept pair. From here on the call is synchronous, so
     // no further scan can interleave before the registration below.
-    if let Some(status) = read_state(|s| s.automatic_deposits.deposit_status(now, &account, token))
-    {
+    if let Some(status) = read_state(|s| {
+        s.automatic_deposits
+            .deposit_status(now, &request, minimum_deposit_amount)
+    }) {
         return Ok(status);
     }
     mutate_state(|s| s.register_deposit_address(now, account, token))?;
-    Ok(
-        read_state(|s| s.automatic_deposits.deposit_status(now, &account, token))
-            .expect("BUG: a just-registered pair must report a Scanning status"),
-    )
+    Ok(read_state(|s| {
+        s.automatic_deposits
+            .deposit_status(now, &request, minimum_deposit_amount)
+    })
+    .expect("BUG: a just-registered pair must report a Scanning status"))
 }
 
 #[query]

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -286,30 +286,33 @@ impl AutomaticDeposits {
         self.sweep.len()
     }
 
-    /// Where the `(account, token)` pair's deposit currently stands, or `None` if the pair is
-    /// neither armed nor has funds queued for sweeping (so it must be registered). Reports
+    /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
+    /// funds queued for sweeping (so it must be registered). Reports
     /// [`DepositStatus::AwaitingSweep`] once funds have been detected and queued, otherwise
     /// [`DepositStatus::Scanning`] while the address is armed and being scanned as of `now`.
+    /// `minimum_deposit_amount` is the balance the address must hold for the scan to detect it,
+    /// reported back to the caller alongside the status.
     pub fn deposit_status(
         &self,
         now: Timestamp,
-        account: &Account,
-        token: Address,
+        request: &DepositRequest,
+        minimum_deposit_amount: Erc20Value,
     ) -> Option<DepositErc20Response> {
-        let request = DepositRequest::new(*account, token);
-        if let Some(entry) = self.sweep.get(&request) {
+        if let Some(entry) = self.sweep.get(request) {
             return Some(DepositErc20Response {
                 address: entry.address.to_string(),
+                minimum_deposit_amount: minimum_deposit_amount.into(),
                 status: DepositStatus::AwaitingSweep(DetectedDeposit {
-                    erc20_contract_address: token.to_string(),
+                    erc20_contract_address: request.token().to_string(),
                     scanned_balance: entry.scanned_balance.into(),
                     detected_at_block: entry.last_scanned_block.into(),
                 }),
             });
         }
-        self.get_entry(now, &request)
+        self.get_entry(now, request)
             .map(|entry| DepositErc20Response {
                 address: entry.value.address.to_string(),
+                minimum_deposit_amount: minimum_deposit_amount.into(),
                 status: DepositStatus::Scanning {
                     valid_until: entry.expires_at.as_nanos(),
                     last_scanned_block: entry.value.last_scanned_block.map(Into::into),

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -601,19 +601,27 @@ fn record_automatic_deposit_received_inserts_unconditionally_without_a_watchlist
 
 #[test]
 fn deposit_status_reports_none_scanning_then_awaiting_sweep() {
+    const MINIMUM_DEPOSIT_AMOUNT: u128 = 10_000_000;
+
     let mut deposits = AutomaticDeposits::default();
+    let minimum = Erc20Value::new(MINIMUM_DEPOSIT_AMOUNT);
 
     // Unknown pair: neither armed nor funded.
-    assert_eq!(deposits.deposit_status(ts(0), &account(0), usdc()), None);
+    assert_eq!(
+        deposits.deposit_status(ts(0), &request(account(0), usdc()), minimum),
+        None
+    );
 
-    // Armed but not yet funded: Scanning until the window closes.
+    // Armed but not yet funded: Scanning until the window closes, with the token's minimum
+    // reported alongside it.
     deposits
         .watch_deposit(ts(0), account(0), usdc(), deposit_address(&account(0)))
         .unwrap();
     assert_eq!(
-        deposits.deposit_status(ts(0), &account(0), usdc()),
+        deposits.deposit_status(ts(0), &request(account(0), usdc()), minimum),
         Some(DepositErc20Response {
             address: deposit_address(&account(0)).to_string(),
+            minimum_deposit_amount: Nat::from(MINIMUM_DEPOSIT_AMOUNT),
             status: DepositStatus::Scanning {
                 valid_until: window_nanos(),
                 last_scanned_block: None,
@@ -641,9 +649,10 @@ fn deposit_status_reports_none_scanning_then_awaiting_sweep() {
     // Once funds are detected, AwaitingSweep takes precedence over Scanning, carrying the balance
     // and finding block for that one token.
     assert_eq!(
-        deposits.deposit_status(ts(0), &account(0), usdc()),
+        deposits.deposit_status(ts(0), &request(account(0), usdc()), minimum),
         Some(DepositErc20Response {
             address: deposit_address(&account(0)).to_string(),
+            minimum_deposit_amount: Nat::from(MINIMUM_DEPOSIT_AMOUNT),
             status: DepositStatus::AwaitingSweep(DetectedDeposit {
                 erc20_contract_address: usdc().to_string(),
                 scanned_balance: Nat::from(10_u8),
@@ -652,8 +661,14 @@ fn deposit_status_reports_none_scanning_then_awaiting_sweep() {
         })
     );
     // A different token at the same account is still unknown.
-    assert_eq!(deposits.deposit_status(ts(0), &account(0), usdt()), None);
-    assert_eq!(deposits.deposit_status(ts(0), &account(2), usdc()), None);
+    assert_eq!(
+        deposits.deposit_status(ts(0), &request(account(0), usdt()), minimum),
+        None
+    );
+    assert_eq!(
+        deposits.deposit_status(ts(0), &request(account(2), usdc()), minimum),
+        None
+    );
 }
 
 fn ts(nanos: u64) -> Timestamp {

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -146,7 +146,7 @@ fn should_mint_with_ckerc20_setup() {
 
 mod deposit_erc20 {
     use assert_matches::assert_matches;
-    use candid::Principal;
+    use candid::{Nat, Principal};
     use ic_cketh_minter::endpoints::events::EventPayload;
     use ic_cketh_minter::endpoints::{DepositErc20Error, DepositStatus};
     use ic_cketh_minter::state::automatic_deposits::DEPOSIT_ADDRESS_SCAN_WINDOW;
@@ -329,6 +329,36 @@ mod deposit_erc20 {
             .check_minter_metrics()
             .assert_contains_metric_matching(r"cketh_minter_latest_block_height 2000 \d+")
             .assert_does_not_contain_metric_matching(r"cketh_minter_latest_block_height 1500 \d+");
+    }
+
+    #[test]
+    fn should_report_the_minimum_deposit_amount_of_the_requested_token() {
+        // The first supported token is ckUSDC, whose minimum is $10 worth, i.e. 10 USDC.
+        const CKUSDC_MINIMUM_DEPOSIT: u64 = 10_000_000;
+
+        let ckerc20 = CkErc20Setup::default().add_supported_erc20_tokens();
+        let caller = ckerc20.caller();
+        let token = a_supported_token(&ckerc20);
+        let minimum_from_minter_info = ckerc20
+            .cketh
+            .get_minter_info()
+            .minimum_deposit_amounts
+            .expect("BUG: the ckERC20 feature is active")
+            .into_iter()
+            .find(|minimum| minimum.erc20_contract_address == token)
+            .expect("BUG: a supported token must have a minimum deposit amount")
+            .minimum_deposit_amount;
+
+        let (_ckerc20, response) = ckerc20
+            .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
+            .expect_deposit_response();
+
+        assert_eq!(
+            response.minimum_deposit_amount,
+            Nat::from(CKUSDC_MINIMUM_DEPOSIT)
+        );
+        // Both endpoints must quote the same threshold as the one the balance scan enforces.
+        assert_eq!(response.minimum_deposit_amount, minimum_from_minter_info);
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -150,8 +150,9 @@ mod deposit_erc20 {
     use ic_cketh_minter::endpoints::events::EventPayload;
     use ic_cketh_minter::endpoints::{DepositErc20Error, DepositStatus};
     use ic_cketh_minter::state::automatic_deposits::DEPOSIT_ADDRESS_SCAN_WINDOW;
-    use ic_cketh_test_utils::ckerc20::CkErc20Setup;
+    use ic_cketh_test_utils::ckerc20::{CKWBTC_CONTRACT_ADDRESS, CkErc20Setup, ckwbtc};
     use ic_cketh_test_utils::{DEFAULT_USER_SUBACCOUNT, format_ethereum_address_to_eip_55};
+    use std::collections::BTreeMap;
 
     /// Number of `AutomaticDepositReceived` events currently in the minter's audit log.
     fn count_automatic_deposits_received(ckerc20: &CkErc20Setup) -> usize {
@@ -333,32 +334,58 @@ mod deposit_erc20 {
 
     #[test]
     fn should_report_the_minimum_deposit_amount_of_the_requested_token() {
-        // The first supported token is ckUSDC, whose minimum is $10 worth, i.e. 10 USDC.
-        const CKUSDC_MINIMUM_DEPOSIT: u64 = 10_000_000;
+        // The default supported tokens, ckUSDC and ckUSDT, are both $10 worth of a 6-decimal
+        // stablecoin. ckWBTC is added so the set holds a token whose minimum differs, which is what
+        // makes the per-token lookup below observable at all.
+        const STABLECOIN_MINIMUM_DEPOSIT: u64 = 10_000_000;
+        const CKWBTC_MINIMUM_DEPOSIT: u64 = 15_000;
 
-        let ckerc20 = CkErc20Setup::default().add_supported_erc20_tokens();
+        let ckerc20 = CkErc20Setup::default()
+            .add_supported_erc20_tokens()
+            .add_supported_erc20_token(ckwbtc());
         let caller = ckerc20.caller();
-        let token = a_supported_token(&ckerc20);
-        let minimum_from_minter_info = ckerc20
+        let minimums_from_minter_info: BTreeMap<_, _> = ckerc20
             .cketh
             .get_minter_info()
             .minimum_deposit_amounts
             .expect("BUG: the ckERC20 feature is active")
             .into_iter()
-            .find(|minimum| minimum.erc20_contract_address == token)
-            .expect("BUG: a supported token must have a minimum deposit amount")
-            .minimum_deposit_amount;
+            .map(|minimum| {
+                (
+                    minimum.erc20_contract_address,
+                    minimum.minimum_deposit_amount,
+                )
+            })
+            .collect();
+        let tokens: Vec<String> = ckerc20
+            .supported_erc20_tokens
+            .iter()
+            .map(|token| format_ethereum_address_to_eip_55(&token.contract.address))
+            .collect();
+        assert_eq!(tokens.len(), 3, "BUG: expected ckUSDC, ckUSDT and ckWBTC");
 
-        let (_ckerc20, response) = ckerc20
-            .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
-            .expect_deposit_response();
+        let mut ckerc20 = ckerc20;
+        for token in tokens {
+            let expected = match token.as_str() {
+                CKWBTC_CONTRACT_ADDRESS => Nat::from(CKWBTC_MINIMUM_DEPOSIT),
+                _ => Nat::from(STABLECOIN_MINIMUM_DEPOSIT),
+            };
+            let (setup, response) = ckerc20
+                .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token.clone())
+                .expect_deposit_response();
+            ckerc20 = setup;
 
-        assert_eq!(
-            response.minimum_deposit_amount,
-            Nat::from(CKUSDC_MINIMUM_DEPOSIT)
-        );
-        // Both endpoints must quote the same threshold as the one the balance scan enforces.
-        assert_eq!(response.minimum_deposit_amount, minimum_from_minter_info);
+            assert_eq!(
+                response.minimum_deposit_amount, expected,
+                "wrong minimum reported for {token}"
+            );
+            // Both endpoints must quote the same threshold as the one the balance scan enforces.
+            assert_eq!(
+                Some(&response.minimum_deposit_amount),
+                minimums_from_minter_info.get(&token),
+                "deposit_erc20 and get_minter_info disagree for {token}"
+            );
+        }
     }
 
     #[test]

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -33,6 +33,7 @@ use ic_cketh_minter::{
 use ic_ethereum_types::Address;
 pub use ic_ledger_suite_orchestrator::candid::AddErc20Arg as Erc20Token;
 use ic_ledger_suite_orchestrator::candid::InitArg as LedgerSuiteOrchestratorInitArg;
+pub use ic_ledger_suite_orchestrator::candid::{Erc20Contract, LedgerInitArg};
 use ic_ledger_suite_orchestrator_test_utils::pocket_ic::LedgerSuiteOrchestrator;
 use ic_ledger_suite_orchestrator_test_utils::supported_erc20_tokens;
 use icrc_ledger_types::icrc1::account::Account;
@@ -69,6 +70,27 @@ impl Default for CkErc20Setup {
 impl AsRef<CkEthSetup> for CkErc20Setup {
     fn as_ref(&self) -> &CkEthSetup {
         &self.cketh
+    }
+}
+
+/// Mainnet ckWBTC. Its `MIN_DEPOSITS` entry (0.00015 WBTC) differs from the stablecoins', so
+/// registering it gives a test a supported token whose minimum deposit amount is distinguishable
+/// from ckUSDC's and ckUSDT's.
+pub const CKWBTC_CONTRACT_ADDRESS: &str = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+
+pub fn ckwbtc() -> Erc20Token {
+    Erc20Token {
+        contract: Erc20Contract {
+            chain_id: Nat::from(1_u8),
+            address: CKWBTC_CONTRACT_ADDRESS.to_string(),
+        },
+        ledger_init_arg: LedgerInitArg {
+            transfer_fee: 2_000_000_u32.into(),
+            decimals: 8,
+            token_name: "Chain-Key Wrapped Bitcoin".to_string(),
+            token_symbol: "ckWBTC".to_string(),
+            token_logo: "".to_string(),
+        },
     }
 }
 
@@ -116,29 +138,36 @@ impl CkErc20Setup {
     }
 
     pub fn add_supported_erc20_tokens(mut self) -> Self {
-        self.supported_erc20_tokens = supported_erc20_tokens();
-        for token in self.supported_erc20_tokens.iter() {
-            self.orchestrator = self
-                .orchestrator
-                .add_erc20_token(token.clone())
-                .expect_new_ledger_and_index_canisters()
-                .setup;
-            let new_ledger_id = self
-                .orchestrator
-                .call_orchestrator_canister_ids(&token.contract)
-                .unwrap()
-                .ledger
-                .unwrap();
-
-            self.cketh =
-                self.cketh
-                    .assert_has_unique_events_in_order(&[EventPayload::AddedCkErc20Token {
-                        chain_id: token.contract.chain_id.clone(),
-                        address: format_ethereum_address_to_eip_55(&token.contract.address),
-                        ckerc20_token_symbol: token.ledger_init_arg.token_symbol.clone(),
-                        ckerc20_ledger_id: new_ledger_id,
-                    }]);
+        for token in supported_erc20_tokens() {
+            self = self.add_supported_erc20_token(token);
         }
+        self
+    }
+
+    /// Registers one more ckERC20 token with the orchestrator and the minter, on top of whatever
+    /// [`Self::add_supported_erc20_tokens`] already added.
+    pub fn add_supported_erc20_token(mut self, token: Erc20Token) -> Self {
+        self.orchestrator = self
+            .orchestrator
+            .add_erc20_token(token.clone())
+            .expect_new_ledger_and_index_canisters()
+            .setup;
+        let new_ledger_id = self
+            .orchestrator
+            .call_orchestrator_canister_ids(&token.contract)
+            .unwrap()
+            .ledger
+            .unwrap();
+
+        self.cketh =
+            self.cketh
+                .assert_has_unique_events_in_order(&[EventPayload::AddedCkErc20Token {
+                    chain_id: token.contract.chain_id.clone(),
+                    address: format_ethereum_address_to_eip_55(&token.contract.address),
+                    ckerc20_token_symbol: token.ledger_init_arg.token_symbol.clone(),
+                    ckerc20_ledger_id: new_ledger_id,
+                }]);
+        self.supported_erc20_tokens.push(token);
         self
     }
 


### PR DESCRIPTION
A deposit below the balance-scan minimum is never detected and never credited, so a caller that has just registered a deposit address needs to know the threshold that applies to the token it armed.

- `deposit_erc20` now returns `minimum_deposit_amount` next to the deposit address and its status, in the requested token's own units.
- It is the same threshold `get_minter_info` reports and the balance scan enforces, so a frontend can show the minimum right where it shows the deposit address, without a second call.
- Once DEFI-2961's daily exchange-rate refresh lands, this endpoint tracks the live value automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)