### PR TITLE
fix: deflake //rs/ethereum/cketh/minter:deposit_from_cex

### DIFF
--- a/rs/ethereum/cketh/test_utils/src/live_scan.rs
+++ b/rs/ethereum/cketh/test_utils/src/live_scan.rs
@@ -13,12 +13,27 @@
 //! every setup call race a round deadline it did not control, which reproducibly failed under CPU
 //! contention.
 //!
-//! Nothing gets lost in the switch: the minter's startup timers already schedule outcalls during
-//! that non-live phase, but PocketIC's auto-progress dispatch (`ProcessCanisterHttpInternal`)
-//! re-scans every canister's current `canister_http_request_contexts()` each round and sends
-//! whichever of them it has not already handed to the adapter, so outcalls created before
-//! [`auto_progress`](pocket_ic::PocketIc::auto_progress) starts are simply picked up and answered
-//! for real on its first round rather than dropped.
+//! The switch to live mode is made deterministic in two steps. First, every HTTPS outcall still in
+//! flight from the construction phase is answered (with an HTTP 500, exactly as during
+//! construction): those outcalls carry the genesis-era request time, so once the clock jumps >5
+//! years past their 60-second timeout, consensus rejects them all in the first round — before
+//! [`auto_progress`](pocket_ic::PocketIc::auto_progress)'s dispatch could hand them to the adapter,
+//! and past the point where any response (mocked or real) can still be delivered. Worse, the
+//! rejects only reach the minter *after* the same round has already fired its >5-years-overdue
+//! timers, whose tasks then find their `TimerGuard`s still held by the cycles awaiting those
+//! outcalls and are dropped as `AlreadyProcessing` — losing a full timer interval (30s–3min) of
+//! real wall-clock time on the live instance. Draining first delivers the failures while their
+//! request time is still current, so the cycles resume, release their guards, and the first
+//! post-jump timer firing actually runs.
+//!
+//! Second, the instance's certified time is set to the current system time *before* enabling
+//! auto-progress. `auto_progress` returns as soon as its background task is spawned — before that
+//! task applies its own initial time jump — so an ingress message submitted right after
+//! `auto_progress` returns can race the jump and get stamped with an expiry derived from the
+//! genesis clock; the jump then moves past that expiry, leaving the message pooled but permanently
+//! unselectable, and the call fails with
+//! `BadIngressMessage("Failed to answer to ingress … after 100 rounds.")`. With the clock already
+//! current, the task's own time-set is a millisecond-sized step and the race is harmless.
 //!
 //! The EVM RPC canister is installed with an `overrideProvider` that rewrites every provider URL to
 //! the harness' anvil node (reached over HTTP, mirroring the `evm_rpc_local` configuration of the
@@ -34,7 +49,7 @@ use ic_cketh_minter::numeric::Erc20Value;
 use ic_ethereum_types::Address;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use crate::anvil::{
     Anvil, DEV_ACCOUNT, address_from_hex, deploy_mock_erc20, erc20_balance_slot, u256_be,
@@ -72,12 +87,23 @@ impl LiveBalanceScanSetup {
     /// EVM RPC canister, orchestrator, and the ckUSDC/ckUSDT ledger and index canisters it spawns —
     /// on an ordinary (non-live) PocketIC instance, then switches that instance to live outcalls
     /// now that construction is complete, so the EVM RPC canister's outcalls reach anvil for real
-    /// from this point on.
+    /// from this point on. The switch drains the in-flight outcalls and moves the clock to the
+    /// current time before enabling auto-progress, making the transition deterministic (see the
+    /// module documentation).
     pub fn new_live() -> Self {
         let anvil = Arc::new(Anvil::start());
         let cketh = CkEthSetup::new(EthereumBackend::Anvil(Arc::clone(&anvil)));
         let ckerc20 = CkErc20Setup::with_cketh(cketh).add_supported_erc20_tokens();
 
+        // Answer the HTTPS outcalls still in flight from construction while their request time
+        // is still current; the clock jump below would time them all out (see the module doc).
+        ckerc20.cketh.stop_ongoing_https_outcalls();
+        // Jump the clock synchronously, so `auto_progress`'s own (asynchronous) initial time-set
+        // becomes a millisecond-sized step: an ingress message submitted once `auto_progress`
+        // returns can no longer be stamped with a genesis-derived expiry and then be
+        // retroactively expired by a >5-year jump it raced (see the module doc). Certified time,
+        // matching what `auto_progress` sets — `advance_time` would move the uncertified clock.
+        ckerc20.env.set_certified_time(SystemTime::now().into());
         ckerc20.env.auto_progress();
 
         Self { ckerc20, anvil }


### PR DESCRIPTION
## Problem

`//rs/ethereum/cketh/minter:deposit_from_cex` flaked in ~3% of CI runs (25 of 27 flaky invocations in the last week share one signature): the live-PocketIC test `should_flag_only_deposits_at_or_above_the_per_token_minimum` panicked during setup with

```
BadIngressMessage("Failed to answer to ingress 0x651da560… after 100 rounds.")
```

## Root cause

`LiveBalanceScanSetup::new_live` builds the fixture on a non-live PocketIC at the genesis clock (2021-05-06) and then calls `auto_progress()` — which returns as soon as its background task is *spawned*, before that task's `SetCertifiedTime` applies a ~5.3-year jump to the current time. The test's next `update_call` can race that jump: its `ingress_expiry` is stamped from the **instance** clock (`rs/state_machine_tests/src/lib.rs:4655`), i.e. genesis + 5 min if the submit wins. The jump then retroactively expires the message; expired pooled messages sort below the ingress selector's `[now, now + 5 min]` window and are never purged, so the message is never answered and `AwaitIngressMessage` burns its 100-round budget.

Evidence: the failing ingress hash was **constant** across 27 CI runs on 19 branches over 6 days (`ingress_expiry` is a hashed request field — a constant hash means a genesis-derived constant expiry), and forcing the ordering locally (`submit_call` → `advance_time(600s)` → `await_call`) reproduces the failure deterministically.

## Fix (harness-side, two steps in `new_live`)

1. **Drain in-flight outcalls** with the existing `CkEthSetup::stop_ongoing_https_outcalls()`. Construction leaves ~8 HTTPS outcalls pending, stamped with genesis-era `request.time`. Once the clock jumps past their 60-second timeout, the consensus payload builder rejects them *before considering any response shares* (`rs/https_outcalls/consensus/src/payload_builder.rs:220`), so neither a mock nor a real anvil response can be delivered after the jump — and the minter cycles awaiting them keep holding their `TimerGuard`s across the first overdue timer firing, which is then dropped as `AlreadyProcessing`, costing a full timer interval (30 s – 3 min) of real wall-clock time on the live instance. Draining while the request time is still current delivers the responses, resumes the cycles, and releases the guards. This mirrors the in-crate precedent: `CkEthSetup::advance_time` performs the same drain before any >60 s advance, for the same documented reason.
2. **Set the certified time synchronously** (`env.set_certified_time(SystemTime::now().into())`) before `auto_progress()`. With the clock already current, the progress task's own initial time-set is a millisecond-sized step, so an ingress submitted after `auto_progress()` returns can no longer be stamped behind the jump. (`set_certified_time`, not `advance_time` — the latter moves only the uncertified clock.)

Also rewrites the module doc, whose claim that in-flight outcalls are "simply picked up and answered for real" after the switch was factually wrong — they were timed out one operation before the auto-progress dispatch could reach the adapter.

## Validation

- `cargo check -p ic-cketh-test-utils`, `cargo fmt`, `./ci/scripts/rust-lint.sh` — clean.
- Depth-2 bazel rdeps all pass: `deposit_from_cex`, `integration_tests_tests/{ckerc20,cketh}_test`, `minter:lib_tests`, `test_utils:lib_tests`.
- Flake validation on a 32-core host at `--jobs=20 --local_test_jobs=20` (the CPU contention that reproduces the race): **before** 3 failures in 60 runs; **after** 0 failures in 40 runs.
- Passing logs now show **0** `Canister http request timed out` lines at the transition (previously 8 in every run). The `too many concurrent calls for single timer (5)` lines remain: they come from all of the minter's interval timers becoming due at once after any multi-year jump (ic-cdk-timers caps concurrent tasks per firing at 5) — pre-existing, benign, and independent of the outcall drain.

## Relation to #11298

#11298 fixes the same race server-side (making `auto_progress` not return until its initial time-set has been applied), which covers every PocketIC consumer. It is left open as the alternative; this PR is the simpler, harness-local fix and does not depend on it. Either one alone deflakes the test; they are compatible.

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`. Full root-cause analysis in the investigation notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)