### PR TITLE
feat(cketh): check the EIP-7702 encoding against alloy and drop the decoder

### DIFF
--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -21,7 +21,7 @@ use crate::sweeper_contract::SweepItem;
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
     AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
-    SignedAuthorization, SignedEip1559TransactionRequest, SignedEip7702TransactionRequest,
+    Eip7702TransactionRequest, SignedAuthorization, SignedEip1559TransactionRequest,
     SignedSweepTransaction, StorageKey, SweepTransaction, TransactionSignature,
 };
 use candid::Principal;
@@ -233,20 +233,59 @@ impl GetEventsFile {
                 ),
                 amount: CheckedAmountOf::from_be_bytes(transaction.value.to_be_bytes()),
                 data: transaction.input.to_vec(),
-                access_list: AccessList(
-                    transaction
-                        .access_list
-                        .iter()
-                        .map(|item| AccessListItem {
-                            address: map_address(&item.address),
-                            storage_keys: item
-                                .storage_keys
-                                .iter()
-                                .map(|key| StorageKey(key.0))
-                                .collect(),
-                        })
-                        .collect(),
-                ),
+                access_list: map_access_list(&transaction.access_list),
+            }
+        }
+
+        fn map_eip_7702_transaction(
+            transaction: &alloy_consensus::TxEip7702,
+        ) -> Eip7702TransactionRequest {
+            Eip7702TransactionRequest {
+                chain_id: transaction.chain_id,
+                nonce: transaction.nonce.into(),
+                max_priority_fee_per_gas: transaction.max_priority_fee_per_gas.into(),
+                max_fee_per_gas: transaction.max_fee_per_gas.into(),
+                gas_limit: transaction.gas_limit.into(),
+                destination: map_address(&transaction.to),
+                amount: CheckedAmountOf::from_be_bytes(transaction.value.to_be_bytes()),
+                data: transaction.input.to_vec(),
+                access_list: map_access_list(&transaction.access_list),
+                authorization_list: transaction
+                    .authorization_list
+                    .iter()
+                    .map(map_signed_authorization)
+                    .collect(),
+            }
+        }
+
+        fn map_access_list(access_list: &alloy_eips::eip2930::AccessList) -> AccessList {
+            AccessList(
+                access_list
+                    .iter()
+                    .map(|item| AccessListItem {
+                        address: map_address(&item.address),
+                        storage_keys: item
+                            .storage_keys
+                            .iter()
+                            .map(|key| StorageKey(key.0))
+                            .collect(),
+                    })
+                    .collect(),
+            )
+        }
+
+        fn map_signed_authorization(
+            authorization: &alloy_eips::eip7702::SignedAuthorization,
+        ) -> SignedAuthorization {
+            use ethnum::u256;
+
+            SignedAuthorization {
+                chain_id: authorization.chain_id.to::<u64>(),
+                delegate: map_address(&authorization.address),
+                nonce: authorization.nonce.into(),
+                y_parity: authorization.y_parity() == 1,
+                r: u256::from_be_bytes(authorization.r().to_be_bytes()),
+                s: u256::from_be_bytes(authorization.s().to_be_bytes()),
             }
         }
 
@@ -265,23 +304,29 @@ impl GetEventsFile {
             ic_ethereum_types::Address::new(address.into_array())
         }
         fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
-            const EIP_7702_TRANSACTION_TYPE: u8 = 4;
+            use alloy_consensus::TxEnvelope;
+            use alloy_eips::eip2718::Decodable2718;
 
             let raw_bytes = hex::decode(raw_transaction.trim_start_matches("0x"))
                 .expect("BUG: sent sweep transaction is not hex-encoded");
-            if raw_bytes.first() == Some(&EIP_7702_TRANSACTION_TYPE) {
-                let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
-                    .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
-                return SignedSweepTransaction::from((
+            match TxEnvelope::decode_2718(&mut raw_bytes.as_slice())
+                .expect("BUG: failed to deserialize sent sweep transaction")
+            {
+                TxEnvelope::Eip1559(signed) => SignedSweepTransaction::from((
+                    SweepTransaction::Eip1559(map_eip_1559_transaction(signed.tx())),
+                    map_signature(signed.signature()),
+                )),
+                TxEnvelope::Eip7702(signed) => SignedSweepTransaction::from((
                     SweepTransaction::Eip7702(
-                        DelegatingSweep::new(signed.transaction().clone())
+                        DelegatingSweep::new(map_eip_7702_transaction(signed.tx()))
                             .expect("BUG: sent EIP-7702 sweep installs no delegation"),
                     ),
-                    signed.signature().clone(),
-                ));
+                    map_signature(signed.signature()),
+                )),
+                transaction => {
+                    panic!("BUG: unexpected sent sweep transaction type {transaction:?}")
+                }
             }
-            let (transaction, signature) = decode_signed_transaction(raw_transaction);
-            SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
         }
 
         fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTransaction {

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -1,9 +1,7 @@
 use super::{
-    AccessList, AccessListItem, SignableTransaction, Signed, StorageKey, TransactionPrice,
-    TransactionSignature, encode_u256,
+    AccessList, SignableTransaction, Signed, TransactionPrice, TransactionSignature, encode_u256,
 };
 use crate::{
-    checked_amount::CheckedAmountOf,
     deposit_address::{DepositAddressSchema, deposit_derivation_path},
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
@@ -12,7 +10,7 @@ use ethnum::u256;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use minicbor::{Decode, Encode};
-use rlp::{Rlp, RlpStream};
+use rlp::RlpStream;
 use serde_bytes::ByteBuf;
 
 const SET_CODE_TX_ID: u8 = 4;
@@ -250,138 +248,4 @@ impl SignableTransaction for Eip7702TransactionRequest {
             ..self.clone()
         }
     }
-}
-
-// TODO(DEFI-2970): drop this decoder in favour of one from `alloy`, whose `TxEip7702` already
-// implements it. It is hand-written because the only EIP-7702-aware library is not a dependency
-// yet: `ethers-core`, which the replay tests use to decode EIP-1559 transactions, was archived
-// before EIP-7702 and stops at transaction type `0x02`.
-//
-// It also sits in productive code although only tests call it, because no test-only home is
-// reachable from all of its callers: `ic-cketh-test-utils` cannot serve this crate's own unit
-// tests, since those compile this crate a second time under `cfg(test)` and would receive
-// `Eip7702TransactionRequest` values of the other compilation, while the `dump_stable_memory`
-// binary links this library and so cannot see `#[cfg(test)]` items either. Moving to `alloy`
-// removes the decoder from here altogether, which settles both.
-impl SignedEip7702TransactionRequest {
-    /// Decodes the payload a signed EIP-7702 transaction is broadcast as, i.e.
-    /// `0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to,
-    /// value, data, access_list, authorization_list, y_parity, r, s])`. The inverse of
-    /// [`Signed::raw_transaction_bytes`].
-    ///
-    /// # Errors
-    /// * a description of why `raw_transaction` is not such a payload.
-    pub fn decode(raw_transaction: &[u8]) -> Result<Self, String> {
-        let (transaction_type, payload) = raw_transaction
-            .split_first()
-            .ok_or_else(|| "empty transaction".to_string())?;
-        if *transaction_type != SET_CODE_TX_ID {
-            return Err(format!(
-                "expected an EIP-7702 transaction (type {SET_CODE_TX_ID}), got type {transaction_type}"
-            ));
-        }
-        let rlp = Rlp::new(payload);
-        let authorization_list: Vec<SignedAuthorization> = decode_list(&rlp, 9)?
-            .iter()
-            .map(|item| {
-                Ok(SignedAuthorization {
-                    chain_id: decode_val(item, 0)?,
-                    delegate: decode_address(item, 1)?,
-                    nonce: decode_amount(item, 2)?,
-                    y_parity: decode_val(item, 3)?,
-                    r: decode_u256(item, 4)?,
-                    s: decode_u256(item, 5)?,
-                })
-            })
-            .collect::<Result<_, String>>()?;
-        if authorization_list.is_empty() {
-            return Err(format!(
-                "an EIP-7702 transaction (type {SET_CODE_TX_ID}) must have a non-empty authorization list"
-            ));
-        }
-        let transaction = Eip7702TransactionRequest {
-            chain_id: decode_val(&rlp, 0)?,
-            nonce: decode_amount(&rlp, 1)?,
-            max_priority_fee_per_gas: decode_amount(&rlp, 2)?,
-            max_fee_per_gas: decode_amount(&rlp, 3)?,
-            gas_limit: decode_amount(&rlp, 4)?,
-            destination: decode_address(&rlp, 5)?,
-            amount: decode_amount(&rlp, 6)?,
-            data: decode_bytes(&rlp, 7)?.to_vec(),
-            access_list: AccessList(
-                decode_list(&rlp, 8)?
-                    .iter()
-                    .map(|item| {
-                        Ok(AccessListItem {
-                            address: decode_address(item, 0)?,
-                            storage_keys: decode_list(item, 1)?
-                                .iter()
-                                .map(|key| Ok(StorageKey(decode_be_bytes_of(key)?)))
-                                .collect::<Result<_, String>>()?,
-                        })
-                    })
-                    .collect::<Result<_, String>>()?,
-            ),
-            authorization_list,
-        };
-        let signature = TransactionSignature {
-            signature_y_parity: decode_val(&rlp, 10)?,
-            r: decode_u256(&rlp, 11)?,
-            s: decode_u256(&rlp, 12)?,
-        };
-        Ok(Self::from((transaction, signature)))
-    }
-}
-
-fn decode_bytes<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<&'a [u8], String> {
-    decode_be_bytes_slice(&item_at(rlp, index)?)
-}
-
-fn item_at<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<Rlp<'a>, String> {
-    rlp.at(index)
-        .map_err(|e| format!("missing RLP item at index {index}: {e}"))
-}
-
-fn decode_be_bytes_slice<'a>(rlp: &Rlp<'a>) -> Result<&'a [u8], String> {
-    rlp.data()
-        .map_err(|e| format!("expected a byte string: {e}"))
-}
-
-fn decode_be_bytes_of(rlp: &Rlp) -> Result<[u8; 32], String> {
-    let data = decode_be_bytes_slice(rlp)?;
-    if data.len() > 32 {
-        return Err(format!("expected at most 32 bytes, got {}", data.len()));
-    }
-    let mut bytes = [0_u8; 32];
-    bytes[32 - data.len()..].copy_from_slice(data);
-    Ok(bytes)
-}
-
-fn decode_amount<Unit>(rlp: &Rlp, index: usize) -> Result<CheckedAmountOf<Unit>, String> {
-    Ok(CheckedAmountOf::from_be_bytes(decode_be_bytes_of(
-        &item_at(rlp, index)?,
-    )?))
-}
-
-fn decode_u256(rlp: &Rlp, index: usize) -> Result<u256, String> {
-    Ok(u256::from_be_bytes(decode_be_bytes_of(&item_at(
-        rlp, index,
-    )?)?))
-}
-
-fn decode_val<T: rlp::Decodable>(rlp: &Rlp, index: usize) -> Result<T, String> {
-    item_at(rlp, index)?
-        .as_val()
-        .map_err(|e| format!("malformed RLP item at index {index}: {e}"))
-}
-
-fn decode_address(rlp: &Rlp, index: usize) -> Result<Address, String> {
-    let data = decode_bytes(rlp, index)?;
-    Ok(Address::new(data.try_into().map_err(|_| {
-        format!("expected a 20-byte address, got {} bytes", data.len())
-    })?))
-}
-
-fn decode_list<'a>(rlp: &'a Rlp<'a>, index: usize) -> Result<Vec<Rlp<'a>>, String> {
-    Ok(item_at(rlp, index)?.iter().collect())
 }

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -220,14 +220,15 @@ fn should_cbor_encoding_be_stable() {
 }
 
 mod eip7702 {
+    use crate::checked_amount::CheckedAmountOf;
     use crate::numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas};
     use crate::tx::{
         AccessList, AccessListItem, Authorization, Eip7702TransactionRequest, SignedAuthorization,
         SignedEip7702TransactionRequest, StorageKey, TransactionSignature,
     };
-    use assert_matches::assert_matches;
     use ethnum::u256;
     use ic_ethereum_types::Address;
+    use rlp::Encodable;
     use std::str::FromStr;
 
     // Published test vector from the trust-wallet/wallet-core EIP-7702 test suite:
@@ -396,65 +397,105 @@ mod eip7702 {
         assert_eq!(recovered.as_slice(), authority.as_ref());
     }
 
+    /// Cross-checks the minter's hand-rolled EIP-7702 encoding against `alloy`, which encodes the
+    /// same transaction independently: the payload to sign, the broadcast payload of the signed
+    /// transaction, and the hash the transaction is referenced by. `ethers-core` was archived
+    /// before EIP-7702 and could not check any of this.
     #[test]
-    fn should_decode_the_raw_bytes_it_encoded() {
+    fn should_encode_the_same_transaction_as_alloy() {
+        use alloy_consensus::SignableTransaction;
+        use alloy_eips::eip2718::Encodable2718;
+
         for signed_tx in [
             sample_signed_transaction(),
             sample_signed_transaction_with_access_list(),
         ] {
-            let decoded =
-                SignedEip7702TransactionRequest::decode(&signed_tx.raw_transaction_bytes())
-                    .unwrap();
+            let alloy_tx = to_alloy_transaction(signed_tx.transaction());
+            assert_eq!(
+                prefix_with_transaction_type(
+                    crate::tx::SignableTransaction::transaction_type(signed_tx.transaction()),
+                    signed_tx.transaction().rlp_bytes().to_vec()
+                ),
+                alloy_tx.encoded_for_signing()
+            );
 
-            assert_eq!(decoded, signed_tx);
-            assert_eq!(decoded.hash(), signed_tx.hash());
+            let alloy_signed = alloy_tx.into_signed(to_alloy_signature(signed_tx.signature()));
+            assert_eq!(
+                signed_tx.raw_transaction_bytes(),
+                alloy_signed.encoded_2718()
+            );
+            assert_eq!(signed_tx.hash().0, alloy_signed.hash().0);
         }
     }
 
-    #[test]
-    fn should_refuse_to_decode_a_transaction_of_another_type() {
-        let mut raw_transaction = sample_signed_transaction().raw_transaction_bytes();
-        raw_transaction[0] = 2;
-
-        assert_matches!(
-            SignedEip7702TransactionRequest::decode(&raw_transaction),
-            Err(e) if e.contains("got type 2")
-        );
-    }
-
-    #[test]
-    fn should_refuse_to_decode_a_transaction_without_authorizations() {
-        use rlp::{Rlp, RlpStream};
-
-        const AUTHORIZATION_LIST_INDEX: usize = 9;
-        const FIELD_COUNT: usize = 13;
-
-        let raw_transaction = sample_signed_transaction().raw_transaction_bytes();
-        let (transaction_type, payload) = raw_transaction.split_first().unwrap();
-        let fields = Rlp::new(payload);
-        let mut stream = RlpStream::new_list(FIELD_COUNT);
-        for index in 0..FIELD_COUNT {
-            if index == AUTHORIZATION_LIST_INDEX {
-                stream.begin_list(0);
-            } else {
-                stream.append_raw(fields.at(index).unwrap().as_raw(), 1);
-            }
+    fn to_alloy_transaction(transaction: &Eip7702TransactionRequest) -> alloy_consensus::TxEip7702 {
+        alloy_consensus::TxEip7702 {
+            chain_id: transaction.chain_id,
+            nonce: to_u64(transaction.nonce),
+            gas_limit: to_u64(transaction.gas_limit),
+            max_fee_per_gas: to_u128(transaction.max_fee_per_gas),
+            max_priority_fee_per_gas: to_u128(transaction.max_priority_fee_per_gas),
+            to: alloy_primitives::Address::from(transaction.destination.into_bytes()),
+            value: alloy_primitives::U256::from_be_bytes(transaction.amount.to_be_bytes()),
+            access_list: alloy_eips::eip2930::AccessList(
+                transaction
+                    .access_list
+                    .0
+                    .iter()
+                    .map(|item| alloy_eips::eip2930::AccessListItem {
+                        address: alloy_primitives::Address::from(item.address.into_bytes()),
+                        storage_keys: item
+                            .storage_keys
+                            .iter()
+                            .map(|key| alloy_primitives::B256::from(key.0))
+                            .collect(),
+                    })
+                    .collect(),
+            ),
+            authorization_list: transaction
+                .authorization_list
+                .iter()
+                .map(to_alloy_authorization)
+                .collect(),
+            input: alloy_primitives::Bytes::copy_from_slice(&transaction.data),
         }
-        let mut without_authorizations = vec![*transaction_type];
-        without_authorizations.extend(stream.out());
-
-        assert_matches!(
-            SignedEip7702TransactionRequest::decode(&without_authorizations),
-            Err(e) if e.contains("non-empty authorization list")
-        );
     }
 
-    #[test]
-    fn should_refuse_to_decode_an_empty_transaction() {
-        assert_matches!(
-            SignedEip7702TransactionRequest::decode(&[]),
-            Err(e) if e.contains("empty transaction")
-        );
+    fn to_alloy_authorization(
+        authorization: &SignedAuthorization,
+    ) -> alloy_eips::eip7702::SignedAuthorization {
+        alloy_eips::eip7702::SignedAuthorization::new_unchecked(
+            alloy_eips::eip7702::Authorization {
+                chain_id: alloy_primitives::U256::from(authorization.chain_id),
+                address: alloy_primitives::Address::from(authorization.delegate.into_bytes()),
+                nonce: to_u64(authorization.nonce),
+            },
+            u8::from(authorization.y_parity),
+            alloy_primitives::U256::from_be_bytes(authorization.r.to_be_bytes()),
+            alloy_primitives::U256::from_be_bytes(authorization.s.to_be_bytes()),
+        )
+    }
+
+    fn to_alloy_signature(signature: &TransactionSignature) -> alloy_primitives::Signature {
+        alloy_primitives::Signature::new(
+            alloy_primitives::U256::from_be_bytes(signature.r.to_be_bytes()),
+            alloy_primitives::U256::from_be_bytes(signature.s.to_be_bytes()),
+            signature.signature_y_parity,
+        )
+    }
+
+    fn to_u64<Unit>(amount: CheckedAmountOf<Unit>) -> u64 {
+        alloy_primitives::U256::from_be_bytes(amount.to_be_bytes()).to::<u64>()
+    }
+
+    fn to_u128<Unit>(amount: CheckedAmountOf<Unit>) -> u128 {
+        alloy_primitives::U256::from_be_bytes(amount.to_be_bytes()).to::<u128>()
+    }
+
+    fn prefix_with_transaction_type(transaction_type: u8, rlp: Vec<u8>) -> Vec<u8> {
+        let mut prefixed = rlp;
+        prefixed.insert(0, transaction_type);
+        prefixed
     }
 
     /// The sample transaction carries an empty access list, so decoding it exercises neither the

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -30,7 +30,7 @@ use ic_cketh_minter::sweeper_contract::SweepItem;
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
     AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
-    SignedAuthorization, SignedEip1559TransactionRequest, SignedEip7702TransactionRequest,
+    Eip7702TransactionRequest, SignedAuthorization, SignedEip1559TransactionRequest,
     SignedSweepTransaction, SweepTransaction, TransactionSignature,
 };
 use ic_stable_structures::Memory;
@@ -175,20 +175,55 @@ fn map_eip_1559_transaction(transaction: &alloy_consensus::TxEip1559) -> Eip1559
         ),
         amount: CheckedAmountOf::from_be_bytes(transaction.value.to_be_bytes()),
         data: transaction.input.to_vec(),
-        access_list: AccessList(
-            transaction
-                .access_list
-                .iter()
-                .map(|item| AccessListItem {
-                    address: map_address(&item.address),
-                    storage_keys: item
-                        .storage_keys
-                        .iter()
-                        .map(|key| ic_cketh_minter::tx::StorageKey(key.0))
-                        .collect(),
-                })
-                .collect(),
-        ),
+        access_list: map_access_list(&transaction.access_list),
+    }
+}
+
+fn map_eip_7702_transaction(transaction: &alloy_consensus::TxEip7702) -> Eip7702TransactionRequest {
+    Eip7702TransactionRequest {
+        chain_id: transaction.chain_id,
+        nonce: transaction.nonce.into(),
+        max_priority_fee_per_gas: transaction.max_priority_fee_per_gas.into(),
+        max_fee_per_gas: transaction.max_fee_per_gas.into(),
+        gas_limit: transaction.gas_limit.into(),
+        destination: map_address(&transaction.to),
+        amount: CheckedAmountOf::from_be_bytes(transaction.value.to_be_bytes()),
+        data: transaction.input.to_vec(),
+        access_list: map_access_list(&transaction.access_list),
+        authorization_list: transaction
+            .authorization_list
+            .iter()
+            .map(map_signed_authorization)
+            .collect(),
+    }
+}
+
+fn map_access_list(access_list: &alloy_eips::eip2930::AccessList) -> AccessList {
+    AccessList(
+        access_list
+            .iter()
+            .map(|item| AccessListItem {
+                address: map_address(&item.address),
+                storage_keys: item
+                    .storage_keys
+                    .iter()
+                    .map(|key| ic_cketh_minter::tx::StorageKey(key.0))
+                    .collect(),
+            })
+            .collect(),
+    )
+}
+
+fn map_signed_authorization(
+    authorization: &alloy_eips::eip7702::SignedAuthorization,
+) -> SignedAuthorization {
+    SignedAuthorization {
+        chain_id: authorization.chain_id.to::<u64>(),
+        delegate: map_address(&authorization.address),
+        nonce: authorization.nonce.into(),
+        y_parity: authorization.y_parity() == 1,
+        r: ethnum::u256::from_be_bytes(authorization.r().to_be_bytes()),
+        s: ethnum::u256::from_be_bytes(authorization.s().to_be_bytes()),
     }
 }
 
@@ -207,23 +242,27 @@ fn map_address(address: &alloy_primitives::Address) -> ic_ethereum_types::Addres
 }
 
 fn map_signed_sweep_transaction(raw_transaction: &str) -> SignedSweepTransaction {
-    const EIP_7702_TRANSACTION_TYPE: u8 = 4;
+    use alloy_consensus::TxEnvelope;
+    use alloy_eips::eip2718::Decodable2718;
 
     let raw_bytes = hex::decode(raw_transaction.trim_start_matches("0x"))
         .expect("BUG: sent sweep transaction is not hex-encoded");
-    if raw_bytes.first() == Some(&EIP_7702_TRANSACTION_TYPE) {
-        let signed = SignedEip7702TransactionRequest::decode(&raw_bytes)
-            .expect("BUG: failed to deserialize sent EIP-7702 sweep transaction");
-        return SignedSweepTransaction::from((
+    match TxEnvelope::decode_2718(&mut raw_bytes.as_slice())
+        .expect("BUG: failed to deserialize sent sweep transaction")
+    {
+        TxEnvelope::Eip1559(signed) => SignedSweepTransaction::from((
+            SweepTransaction::Eip1559(map_eip_1559_transaction(signed.tx())),
+            map_signature(signed.signature()),
+        )),
+        TxEnvelope::Eip7702(signed) => SignedSweepTransaction::from((
             SweepTransaction::Eip7702(
-                DelegatingSweep::new(signed.transaction().clone())
+                DelegatingSweep::new(map_eip_7702_transaction(signed.tx()))
                     .expect("BUG: sent EIP-7702 sweep installs no delegation"),
             ),
-            signed.signature().clone(),
-        ));
+            map_signature(signed.signature()),
+        )),
+        transaction => panic!("BUG: unexpected sent sweep transaction type {transaction:?}"),
     }
-    let (transaction, signature) = decode_signed_transaction(raw_transaction);
-    SignedSweepTransaction::from((SweepTransaction::Eip1559(transaction), signature))
 }
 
 fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTransaction {


### PR DESCRIPTION
Resolves the `TODO(DEFI-2970)` left by #11250.

## Why

- `SignedEip7702TransactionRequest::decode` sat in productive code although only tests called it, because no test-only home was reachable from both this crate's `cfg(test)` unit tests and the `dump_stable_memory` binary.
- It was hand-written because the only EIP-7702-aware library was not a dependency: ethers was archived before EIP-7702 and stops at transaction type `0x02`.
- `alloy` decodes EIP-7702, so both problems go away together.

## What

- The decoder and its RLP helpers are gone; the replay paths decode both sweep transaction types through `TxEnvelope::decode_2718`, which also retires the transaction-type sniffing they did by hand.
- In exchange the minter's EIP-7702 encoding gains the independent oracle it never had, comparing the payload to sign, the broadcast payload and the transaction hash — the way the EIP-1559 one does.
- Until now only pinned alloy-rs, trust-wallet and viem vectors covered that encoding; those stay.

## Scope

- The decode-time rejection of an empty authorization list goes with the decoder; the invariant itself stays asserted where the list is encoded.

[DEFI-2970]: https://dfinity.atlassian.net/browse/DEFI-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

