### PR TITLE
chore(cketh): drop the deprecated ethers-core dependency

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1919d1279617bf694a811661c4b2a5d4f0eb18a59dfd2424fa3c887daf6f7718",
+  "checksum": "5d175093a4c3bec343f27967cf71d11fb63502018384a14f35b20061c8588fe8",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -12613,12 +12613,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "1.2.2"
       },
@@ -19583,9 +19577,7 @@
         "crate_features": {
           "common": [
             "default",
-            "limit_128",
-            "limit_256",
-            "std"
+            "limit_128"
           ],
           "selects": {}
         },
@@ -23264,10 +23256,6 @@
             {
               "id": "escargot 0.5.7",
               "target": "escargot"
-            },
-            {
-              "id": "ethers-core 2.0.8",
-              "target": "ethers_core"
             },
             {
               "id": "ethnum 1.5.3",
@@ -27172,399 +27160,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "ethabi 18.0.0": {
-      "name": "ethabi",
-      "version": "18.0.0",
-      "package_url": "https://github.com/rust-ethereum/ethabi",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ethabi/18.0.0/download",
-          "sha256": "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ethabi",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ethabi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "full-serde",
-            "once_cell",
-            "regex",
-            "rlp",
-            "serde",
-            "serde_json",
-            "std",
-            "thiserror",
-            "uint"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ethereum-types 0.14.1",
-              "target": "ethereum_types"
-            },
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "regex 1.13.1",
-              "target": "regex"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.145",
-              "target": "serde_json"
-            },
-            {
-              "id": "sha3 0.10.8",
-              "target": "sha3"
-            },
-            {
-              "id": "thiserror 1.0.68",
-              "target": "thiserror"
-            },
-            {
-              "id": "uint 0.9.5",
-              "target": "uint"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "18.0.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "ethbloom 0.13.0": {
-      "name": "ethbloom",
-      "version": "0.13.0",
-      "package_url": "https://github.com/paritytech/parity-common",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ethbloom/0.13.0/download",
-          "sha256": "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ethbloom",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ethbloom",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "codec",
-            "impl-codec",
-            "impl-rlp",
-            "impl-serde",
-            "rlp",
-            "scale-info",
-            "serialize",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "crunchy 0.2.2",
-              "target": "crunchy"
-            },
-            {
-              "id": "fixed-hash 0.8.0",
-              "target": "fixed_hash"
-            },
-            {
-              "id": "impl-codec 0.6.0",
-              "target": "impl_codec"
-            },
-            {
-              "id": "impl-rlp 0.3.0",
-              "target": "impl_rlp"
-            },
-            {
-              "id": "impl-serde 0.4.0",
-              "target": "impl_serde"
-            },
-            {
-              "id": "scale-info 2.9.0",
-              "target": "scale_info"
-            },
-            {
-              "id": "tiny-keccak 2.0.2",
-              "target": "tiny_keccak"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "ethereum-types 0.14.1": {
-      "name": "ethereum-types",
-      "version": "0.14.1",
-      "package_url": "https://github.com/paritytech/parity-common",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ethereum-types/0.14.1/download",
-          "sha256": "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ethereum_types",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ethereum_types",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "codec",
-            "default",
-            "ethbloom",
-            "impl-codec",
-            "impl-rlp",
-            "impl-serde",
-            "rlp",
-            "scale-info",
-            "serialize",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ethbloom 0.13.0",
-              "target": "ethbloom"
-            },
-            {
-              "id": "fixed-hash 0.8.0",
-              "target": "fixed_hash"
-            },
-            {
-              "id": "impl-codec 0.6.0",
-              "target": "impl_codec"
-            },
-            {
-              "id": "impl-rlp 0.3.0",
-              "target": "impl_rlp"
-            },
-            {
-              "id": "impl-serde 0.4.0",
-              "target": "impl_serde"
-            },
-            {
-              "id": "primitive-types 0.12.1",
-              "target": "primitive_types"
-            },
-            {
-              "id": "scale-info 2.9.0",
-              "target": "scale_info"
-            },
-            {
-              "id": "uint 0.9.5",
-              "target": "uint",
-              "alias": "uint_crate"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.14.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "ethers-core 2.0.8": {
-      "name": "ethers-core",
-      "version": "2.0.8",
-      "package_url": "https://github.com/gakonst/ethers-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ethers-core/2.0.8/download",
-          "sha256": "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ethers_core",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ethers_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "arrayvec 0.7.4",
-              "target": "arrayvec"
-            },
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            },
-            {
-              "id": "chrono 0.4.42",
-              "target": "chrono"
-            },
-            {
-              "id": "elliptic-curve 0.13.8",
-              "target": "elliptic_curve"
-            },
-            {
-              "id": "ethabi 18.0.0",
-              "target": "ethabi"
-            },
-            {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
-            },
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "k256 0.13.4",
-              "target": "k256"
-            },
-            {
-              "id": "num_enum 0.6.1",
-              "target": "num_enum"
-            },
-            {
-              "id": "open-fastrlp 0.1.4",
-              "target": "open_fastrlp"
-            },
-            {
-              "id": "rand 0.8.6",
-              "target": "rand"
-            },
-            {
-              "id": "rlp 0.5.2",
-              "target": "rlp"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.145",
-              "target": "serde_json"
-            },
-            {
-              "id": "strum 0.25.0",
-              "target": "strum"
-            },
-            {
-              "id": "thiserror 1.0.68",
-              "target": "thiserror"
-            },
-            {
-              "id": "tiny-keccak 2.0.2",
-              "target": "tiny_keccak"
-            },
-            {
-              "id": "unicode-xid 0.2.4",
-              "target": "unicode_xid"
-            }
-          ],
-          "selects": {
-            "cfg(not(target_arch = \"wasm32\"))": [
-              {
-                "id": "tempfile 3.23.0",
-                "target": "tempfile"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "2.0.8"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "ethnum 1.5.3": {
       "name": "ethnum",
       "version": "1.5.3",
@@ -28892,29 +28487,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "byteorder",
-            "rand",
-            "rustc-hex",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
-            {
-              "id": "byteorder 1.5.0",
-              "target": "byteorder"
-            },
-            {
-              "id": "rand 0.8.6",
-              "target": "rand"
-            },
-            {
-              "id": "rustc-hex 2.1.0",
-              "target": "rustc_hex"
-            },
             {
               "id": "static_assertions 1.1.0",
               "target": "static_assertions"
@@ -40746,12 +40320,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -40809,102 +40377,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "impl-rlp 0.3.0": {
-      "name": "impl-rlp",
-      "version": "0.3.0",
-      "package_url": "https://github.com/paritytech/parity-common",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/impl-rlp/0.3.0/download",
-          "sha256": "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "impl_rlp",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "impl_rlp",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "rlp 0.5.2",
-              "target": "rlp"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "impl-serde 0.4.0": {
-      "name": "impl-serde",
-      "version": "0.4.0",
-      "package_url": "https://github.com/paritytech/parity-common",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/impl-serde/0.4.0/download",
-          "sha256": "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "impl_serde",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "impl_serde",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
     },
     "impl-trait-for-tuples 0.2.2": {
       "name": "impl-trait-for-tuples",
@@ -52549,130 +52021,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "num_enum 0.6.1": {
-      "name": "num_enum",
-      "version": "0.6.1",
-      "package_url": "https://github.com/illicitonion/num_enum",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/num_enum/0.6.1/download",
-          "sha256": "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "num_enum",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_enum",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "num_enum_derive 0.6.1",
-              "target": "num_enum_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.6.1"
-      },
-      "license": "BSD-3-Clause OR MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-3-Clause",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "num_enum_derive 0.6.1": {
-      "name": "num_enum_derive",
-      "version": "0.6.1",
-      "package_url": "https://github.com/illicitonion/num_enum",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/num_enum_derive/0.6.1/download",
-          "sha256": "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "num_enum_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_enum_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "proc-macro-crate",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro-crate 1.3.1",
-              "target": "proc_macro_crate"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.119",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.6.1"
-      },
-      "license": "BSD-3-Clause OR MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-3-Clause",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "num_threads 0.1.6": {
       "name": "num_threads",
       "version": "0.1.6",
@@ -53549,144 +52897,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "open-fastrlp 0.1.4": {
-      "name": "open-fastrlp",
-      "version": "0.1.4",
-      "package_url": "https://github.com/gakonst/open-fastrlp",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/open-fastrlp/0.1.4/download",
-          "sha256": "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "open_fastrlp",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "open_fastrlp",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "derive",
-            "ethereum-types",
-            "rlp-derive",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "arrayvec 0.7.4",
-              "target": "arrayvec"
-            },
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            },
-            {
-              "id": "ethereum-types 0.14.1",
-              "target": "ethereum_types"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "auto_impl 1.3.0",
-              "target": "auto_impl"
-            },
-            {
-              "id": "open-fastrlp-derive 0.1.1",
-              "target": "open_fastrlp_derive",
-              "alias": "rlp_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.1.4"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
-    "open-fastrlp-derive 0.1.1": {
-      "name": "open-fastrlp-derive",
-      "version": "0.1.1",
-      "package_url": "https://github.com/gakonst/open-fastrlp",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/open-fastrlp-derive/0.1.1/download",
-          "sha256": "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "open_fastrlp_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "open_fastrlp_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.1"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
     },
     "openssh-keys 0.5.0": {
       "name": "openssh-keys",
@@ -55052,17 +54262,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "chain-error",
-            "derive",
-            "max-encoded-len",
-            "parity-scale-codec-derive",
-            "serde",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -55072,10 +54271,6 @@
             {
               "id": "byte-slice-cast 1.2.2",
               "target": "byte_slice_cast"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
             }
           ],
           "selects": {}
@@ -55086,10 +54281,6 @@
             {
               "id": "impl-trait-for-tuples 0.2.2",
               "target": "impl_trait_for_tuples"
-            },
-            {
-              "id": "parity-scale-codec-derive 3.6.3",
-              "target": "parity_scale_codec_derive"
             }
           ],
           "selects": {}
@@ -55131,12 +54322,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "max-encoded-len"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -58992,44 +58177,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "byteorder",
-            "codec",
-            "impl-codec",
-            "impl-rlp",
-            "impl-serde",
-            "rlp",
-            "rustc-hex",
-            "scale-info",
-            "scale-info-crate",
-            "serde_no_std",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "fixed-hash 0.8.0",
               "target": "fixed_hash"
-            },
-            {
-              "id": "impl-codec 0.6.0",
-              "target": "impl_codec"
-            },
-            {
-              "id": "impl-rlp 0.3.0",
-              "target": "impl_rlp"
-            },
-            {
-              "id": "impl-serde 0.4.0",
-              "target": "impl_serde"
-            },
-            {
-              "id": "scale-info 2.9.0",
-              "target": "scale_info",
-              "alias": "scale_info_crate"
             },
             {
               "id": "uint 0.9.5",
@@ -65356,8 +64508,6 @@
         "crate_features": {
           "common": [
             "default",
-            "derive",
-            "rlp-derive",
             "std"
           ],
           "selects": {}
@@ -65376,74 +64526,9 @@
           "selects": {}
         },
         "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "rlp-derive 0.1.0",
-              "target": "rlp_derive"
-            }
-          ],
-          "selects": {}
-        },
         "version": "0.5.2"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "rlp-derive 0.1.0": {
-      "name": "rlp-derive",
-      "version": "0.1.0",
-      "package_url": "http://parity.io",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rlp-derive/0.1.0/download",
-          "sha256": "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "rlp_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "rlp_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.0"
-      },
-      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -68307,137 +67392,6 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "scale-info 2.9.0": {
-      "name": "scale-info",
-      "version": "2.9.0",
-      "package_url": "https://github.com/paritytech/scale-info",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/scale-info/2.9.0/download",
-          "sha256": "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "scale_info",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "scale_info",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "derive",
-            "scale-info-derive"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "parity-scale-codec 3.6.3",
-              "target": "parity_scale_codec",
-              "alias": "scale"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
-            },
-            {
-              "id": "scale-info-derive 2.9.0",
-              "target": "scale_info_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "2.9.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "scale-info-derive 2.9.0": {
-      "name": "scale-info-derive",
-      "version": "2.9.0",
-      "package_url": "https://github.com/paritytech/scale-info",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/scale-info-derive/2.9.0/download",
-          "sha256": "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "scale_info_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "scale_info_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro-crate 1.3.1",
-              "target": "proc_macro_crate"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.9.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": null
-    },
     "schannel 0.1.22": {
       "name": "schannel",
       "version": "0.1.22",
@@ -70660,7 +69614,6 @@
         "crate_features": {
           "common": [
             "alloc",
-            "arbitrary_precision",
             "default",
             "raw_value",
             "std",
@@ -75275,62 +74228,6 @@
       ],
       "license_file": null
     },
-    "strum 0.25.0": {
-      "name": "strum",
-      "version": "0.25.0",
-      "package_url": "https://github.com/Peternator7/strum",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/strum/0.25.0/download",
-          "sha256": "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "strum",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "strum",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "derive",
-            "std",
-            "strum_macros"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "strum_macros 0.25.3",
-              "target": "strum_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.25.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "strum 0.26.3": {
       "name": "strum",
       "version": "0.26.3",
@@ -75492,74 +74389,6 @@
           "selects": {}
         },
         "version": "0.28.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "strum_macros 0.25.3": {
-      "name": "strum_macros",
-      "version": "0.25.3",
-      "package_url": "https://github.com/Peternator7/strum",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/strum_macros/0.25.3/download",
-          "sha256": "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "strum_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "strum_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.4.1",
-              "target": "heck"
-            },
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.119",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "rustversion 1.0.14",
-              "target": "rustversion"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.25.3"
       },
       "license": "MIT",
       "license_ids": [
@@ -76098,8 +74927,7 @@
             "printing",
             "proc-macro",
             "quote",
-            "visit",
-            "visit-mut"
+            "visit"
           ],
           "selects": {}
         },
@@ -79031,26 +77859,10 @@
         "crate_features": {
           "common": [
             "default",
-            "keccak"
+            "sha3",
+            "shake"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "sha3",
-              "shake"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "sha3",
-              "shake"
-            ],
-            "x86_64-apple-darwin": [
-              "sha3",
-              "shake"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "sha3",
-              "shake"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -83881,12 +82693,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -96608,7 +95414,6 @@
     "enum-ordinalize-derive 4.4.1",
     "erased-serde 0.3.28",
     "escargot 0.5.7",
-    "ethers-core 2.0.8",
     "ethnum 1.5.3",
     "evm_rpc_client 0.4.0",
     "evm_rpc_types 3.1.1",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3983,7 +3983,6 @@ dependencies = [
  "enum-ordinalize-derive",
  "erased-serde",
  "escargot",
- "ethers-core",
  "ethnum",
  "evm_rpc_client",
  "evm_rpc_types",
@@ -4722,81 +4721,6 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
- "thiserror 1.0.68",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
-dependencies = [
- "arrayvec 0.7.4",
- "bytes",
- "chrono 0.4.42",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "hex",
- "k256",
- "num_enum",
- "open-fastrlp",
- "rand 0.8.6",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.25.0",
- "tempfile",
- "thiserror 1.0.68",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -7148,24 +7072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8995,27 +8901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9134,31 +9019,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec 0.7.4",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openssh-keys"
@@ -10040,9 +9900,6 @@ checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -11078,19 +10935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -11539,30 +11384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
-dependencies = [
- "cfg-if",
- "derive_more 0.99.17",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -12703,15 +12524,6 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -12735,19 +12547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more 2.1.1",
+ "derive_more",
  "encoding_rs",
  "flate2",
  "foldhash 0.1.5",
@@ -150,7 +150,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more 2.1.1",
+ "derive_more",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
@@ -355,7 +355,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.1.1",
+ "derive_more",
  "either",
  "k256",
  "once_cell",
@@ -450,7 +450,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.1.1",
+ "derive_more",
  "either",
  "serde",
  "serde_with",
@@ -492,7 +492,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.1.1",
+ "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
  "hashbrown 0.17.0",
@@ -643,7 +643,7 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.1.1",
+ "derive_more",
  "nybbles",
  "serde",
  "smallvec",
@@ -2238,7 +2238,7 @@ name = "build-info-common"
 version = "0.0.45"
 source = "git+https://github.com/dfinity-lab/build-info?rev=27ba16a68aa312de66f2ebd0f16665f1429eee36#27ba16a68aa312de66f2ebd0f16665f1429eee36"
 dependencies = [
- "derive_more 2.1.1",
+ "derive_more",
  "semver 1.0.27",
  "serde",
 ]
@@ -4220,31 +4220,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.1.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -4905,81 +4885,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec 0.7.6",
- "bytes",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "open-fastrlp",
- "rand 0.8.6",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -8122,7 +8027,6 @@ dependencies = [
  "alloy-sol-types",
  "assert_matches",
  "candid",
- "ethers-core",
  "evm_rpc_types",
  "hex",
  "ic-base-types",
@@ -16989,24 +16893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19276,28 +19162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19413,31 +19277,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec 0.7.6",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "open_rootfs"
@@ -20671,9 +20510,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -21929,19 +21765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -22563,30 +22387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22848,7 +22648,7 @@ checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
  "bitflags",
  "cssparser",
- "derive_more 2.1.1",
+ "derive_more",
  "fxhash",
  "log",
  "new_debug_unreachable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -681,7 +681,6 @@ ed25519-dalek = { version = "2.2.0", features = [
 duration-string = { version = "0.3.0", features = ["serde"] }
 escargot = "0.5.7"
 exitcode = "1.1.2"
-ethers-core = "^2.0.7"
 ethnum = { version = "1.5.3", features = ["serde"] }
 evm_rpc_client = "0.4.0"
 evm_rpc_types = "3.1.0"

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -482,10 +482,6 @@ crate.spec(
     version = "^0.5.7",
 )
 crate.spec(
-    package = "ethers-core",
-    version = "^2.0.7",
-)
-crate.spec(
     features = ["serde"],
     package = "ethnum",
     version = "^1.5.3",

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -399,8 +399,7 @@ mod eip7702 {
 
     /// Cross-checks the minter's hand-rolled EIP-7702 encoding against `alloy`, which encodes the
     /// same transaction independently: the payload to sign, the broadcast payload of the signed
-    /// transaction, and the hash the transaction is referenced by. The deprecated `ethers-rs`
-    /// this replaced was archived before EIP-7702 and could not check any of this.
+    /// transaction, and the hash the transaction is referenced by.
     #[test]
     fn should_encode_the_same_transaction_as_alloy() {
         use alloy_consensus::SignableTransaction;

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -399,8 +399,8 @@ mod eip7702 {
 
     /// Cross-checks the minter's hand-rolled EIP-7702 encoding against `alloy`, which encodes the
     /// same transaction independently: the payload to sign, the broadcast payload of the signed
-    /// transaction, and the hash the transaction is referenced by. `ethers-core` was archived
-    /// before EIP-7702 and could not check any of this.
+    /// transaction, and the hash the transaction is referenced by. The deprecated `ethers-rs`
+    /// this replaced was archived before EIP-7702 and could not check any of this.
     #[test]
     fn should_encode_the_same_transaction_as_alloy() {
         use alloy_consensus::SignableTransaction;

--- a/rs/ethereum/cketh/test_utils/BUILD.bazel
+++ b/rs/ethereum/cketh/test_utils/BUILD.bazel
@@ -34,7 +34,6 @@ rust_library(
         "@crate_index//:alloy-sol-types",
         "@crate_index//:assert_matches",
         "@crate_index//:candid",
-        "@crate_index//:ethers-core",
         "@crate_index//:evm_rpc_types",
         "@crate_index//:hex",
         "@crate_index//:ic-management-canister-types",

--- a/rs/ethereum/cketh/test_utils/Cargo.toml
+++ b/rs/ethereum/cketh/test_utils/Cargo.toml
@@ -14,7 +14,6 @@ alloy-rpc-types-eth = { workspace = true }
 alloy-sol-types = { workspace = true }
 assert_matches = { workspace = true }
 candid = { workspace = true }
-ethers-core = { workspace = true }
 evm_rpc_types = { workspace = true }
 hex = { workspace = true }
 ic-base-types = { path = "../../../types/base_types" }

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -664,7 +664,7 @@ impl DepositCkErc20WithSubaccountParams {
             ),
             format!(
                 "0x000000000000000000000000{}",
-                ethers_core::utils::hex::encode(self.from_address.as_ref())
+                hex::encode(self.from_address.as_ref())
             ),
             encode_principal(self.recipient),
         ];

--- a/rs/ethereum/cketh/test_utils/src/flow.rs
+++ b/rs/ethereum/cketh/test_utils/src/flow.rs
@@ -15,7 +15,6 @@ use crate::{
     format_ethereum_address_to_eip_55,
 };
 use candid::{Decode, Encode, Nat, Principal};
-use ethers_core::utils::hex;
 use ic_base_types::PrincipalId;
 use ic_cketh_minter::endpoints::ckerc20::RetrieveErc20Request;
 use ic_cketh_minter::endpoints::events::{Event, EventPayload, EventSource};


### PR DESCRIPTION
## Why

- Nothing needs `ethers-core` any more except its `hex` re-export in `test_utils`, and the repo already depends on `hex` directly.
- The ticket asks that no ckETH code or manifest reference the archived crate.

## What

- Removed from the `test_utils` manifest, the workspace manifest and `bazel/rust.MODULE.bazel`, and the crate index repinned.
- `ethers-core` and the `ethabi`, `open-fastrlp` and `const-hex` it dragged in are gone from the lockfiles.
- `grep -rn "ethers.core\\|ethers_core"` over `rs/`, `packages/`, the workspace manifest and `bazel/rust.MODULE.bazel` is empty after this PR.

## Scope

- The dependency scanner keeps a captured sample lockfile at `ci/src/dependencies/parser/test_data/real-world-example.toml.lock` that names the crate. That file is input data for that tool's own tests, not a dependency of this repo, so it is left alone.

[DEFI-2970]: https://dfinity.atlassian.net/browse/DEFI-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

