### PR TITLE
chore(BOUN-1977): Bump ic-bn-lib & ic-gateway

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ecab59e54cd3dfcb3d049bf925c4d1c1e1ab338ef237c40f066ef568f79e0321",
+  "checksum": "9cb8107bbffe0c12d79395ab33e0d176425c3e09b084c8c79e8cf0ebf9bcf237",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -2698,7 +2698,17 @@
         "crate_features": {
           "common": [
             "default",
+            "serde",
             "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.228",
+              "target": "serde"
+            }
           ],
           "selects": {}
         },
@@ -6045,6 +6055,54 @@
         },
         "edition": "2018",
         "version": "0.22.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "base64 0.23.1": {
+      "name": "base64",
+      "version": "0.23.1",
+      "package_url": "https://github.com/marshallpierce/rust-base64",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/base64/0.23.1/download",
+          "sha256": "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "base64",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "base64",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "simd-unsafe",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.23.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19752,7 +19810,7 @@
               "target": "ic_agent"
             },
             {
-              "id": "ic-bn-lib 0.5.0",
+              "id": "ic-bn-lib 0.7.0",
               "target": "ic_bn_lib"
             },
             {
@@ -32152,14 +32210,14 @@
       ],
       "license_file": null
     },
-    "ic-bn-lib 0.5.0": {
+    "ic-bn-lib 0.7.0": {
       "name": "ic-bn-lib",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "package_url": "https://github.com/dfinity/ic-bn-lib",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-bn-lib/0.5.0/download",
-          "sha256": "1ea8fa20bc6bac82a9491e26a43b70b9e0f276da534957c6cf0d589cf1a689ac"
+          "url": "https://static.crates.io/crates/ic-bn-lib/0.7.0/download",
+          "sha256": "5195609bb6f45c53ad2e171ee5106b001e3a553fe6ce8f1f2662563430360003"
         }
       },
       "targets": [
@@ -32227,7 +32285,7 @@
               "target": "axum_extra"
             },
             {
-              "id": "base64 0.22.1",
+              "id": "base64 0.23.1",
               "target": "base64"
             },
             {
@@ -32319,12 +32377,24 @@
               "target": "ic_custom_domains_canister_api"
             },
             {
+              "id": "ic-transport-types 0.49.1",
+              "target": "ic_transport_types"
+            },
+            {
               "id": "instant-acme 0.8.5",
               "target": "instant_acme"
             },
             {
+              "id": "ipnet 2.10.1",
+              "target": "ipnet"
+            },
+            {
               "id": "itertools 0.15.0",
               "target": "itertools"
+            },
+            {
+              "id": "maxminddb 0.29.0",
+              "target": "maxminddb"
             },
             {
               "id": "moka 0.12.15",
@@ -32339,7 +32409,7 @@
               "target": "parse_size"
             },
             {
-              "id": "pem 3.0.6",
+              "id": "pem 4.0.0",
               "target": "pem"
             },
             {
@@ -32475,10 +32545,6 @@
               "target": "tower_service"
             },
             {
-              "id": "tower_governor 0.8.0",
-              "target": "tower_governor"
-            },
-            {
               "id": "tracing 0.1.44",
               "target": "tracing"
             },
@@ -32539,7 +32605,7 @@
           ],
           "selects": {}
         },
-        "version": "0.5.0"
+        "version": "0.7.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -33810,7 +33876,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/ic-gateway",
           "commitish": {
-            "Rev": "3e015f17b8ad302a42fd1ac68b7b139867b71c5f"
+            "Rev": "a16fb54f4c8d4407b8134d63b57f864d67520062"
           }
         }
       },
@@ -33845,6 +33911,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "acme",
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -33912,7 +33985,7 @@
               "target": "humantime"
             },
             {
-              "id": "ic-bn-lib 0.5.0",
+              "id": "ic-bn-lib 0.7.0",
               "target": "ic_bn_lib"
             },
             {
@@ -51878,6 +51951,60 @@
         },
         "edition": "2021",
         "version": "3.0.6"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.md"
+    },
+    "pem 4.0.0": {
+      "name": "pem",
+      "version": "4.0.0",
+      "package_url": "https://github.com/jcreekmore/pem-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/pem/4.0.0/download",
+          "sha256": "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pem",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "pem",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "base64 0.23.1",
+              "target": "base64"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.0.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -91458,7 +91585,7 @@
     "hyper-socks2 0.9.1",
     "hyper-util 0.1.20",
     "ic-agent 0.49.1",
-    "ic-bn-lib 0.5.0",
+    "ic-bn-lib 0.7.0",
     "ic-btc-interface 0.4.0",
     "ic-canister-log 0.2.0",
     "ic-canister-runtime 0.2.3",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -469,6 +469,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-any"
@@ -1056,6 +1059,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -3412,7 +3421,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "paste",
  "pcre2",
- "pem",
+ "pem 3.0.6",
  "pin-project-lite",
  "ping",
  "pkcs8",
@@ -5466,7 +5475,7 @@ dependencies = [
  "k256",
  "leb128",
  "p256",
- "pem",
+ "pem 3.0.6",
  "pkcs8",
  "rand 0.10.1",
  "rangemap",
@@ -5487,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea8fa20bc6bac82a9491e26a43b70b9e0f276da534957c6cf0d589cf1a689ac"
+checksum = "5195609bb6f45c53ad2e171ee5106b001e3a553fe6ce8f1f2662563430360003"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5499,7 +5508,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra 0.12.6",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "candid",
  "chacha20poly1305",
@@ -5523,13 +5532,16 @@ dependencies = [
  "hyper-util",
  "ic-agent",
  "ic-custom-domains-canister-api",
+ "ic-transport-types",
  "indoc",
  "instant-acme",
+ "ipnet",
  "itertools 0.15.0",
+ "maxminddb",
  "moka",
  "nix 0.31.3",
  "parse-size",
- "pem",
+ "pem 4.0.0",
  "ppp",
  "prometheus",
  "prost",
@@ -5564,7 +5576,6 @@ dependencies = [
  "tower 0.5.2",
  "tower-http 0.7.0",
  "tower-service",
- "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5797,7 +5808,7 @@ dependencies = [
  "hex-literal 0.4.1",
  "hkdf",
  "ic_principal",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
@@ -5817,7 +5828,7 @@ dependencies = [
 [[package]]
 name = "ic-gateway"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic-gateway?rev=3e015f17b8ad302a42fd1ac68b7b139867b71c5f#3e015f17b8ad302a42fd1ac68b7b139867b71c5f"
+source = "git+https://github.com/dfinity/ic-gateway?tag=v0.6.5#a16fb54f4c8d4407b8134d63b57f864d67520062"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8748,6 +8759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9879,7 +9900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "aws-lc-rs",
- "pem",
+ "pem 3.0.6",
  "ring",
  "rustls-pki-types",
  "time",
@@ -9894,7 +9915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
 dependencies = [
  "aws-lc-rs",
- "pem",
+ "pem 3.0.6",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -10495,7 +10516,7 @@ dependencies = [
  "futures-rustls",
  "http 1.3.1",
  "log",
- "pem",
+ "pem 3.0.6",
  "rcgen 0.13.1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-any"
@@ -1120,6 +1123,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -6065,7 +6074,7 @@ dependencies = [
  "k256",
  "leb128",
  "p256",
- "pem",
+ "pem 3.0.6",
  "pkcs8",
  "rand 0.10.1",
  "rangemap",
@@ -6279,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea8fa20bc6bac82a9491e26a43b70b9e0f276da534957c6cf0d589cf1a689ac"
+checksum = "5195609bb6f45c53ad2e171ee5106b001e3a553fe6ce8f1f2662563430360003"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6291,7 +6300,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra 0.12.6",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "candid",
  "chacha20poly1305",
@@ -6315,13 +6324,16 @@ dependencies = [
  "hyper-util",
  "ic-agent",
  "ic-custom-domains-canister-api",
+ "ic-transport-types",
  "indoc",
  "instant-acme",
+ "ipnet",
  "itertools 0.15.0",
+ "maxminddb",
  "moka",
  "nix 0.31.3",
  "parse-size",
- "pem",
+ "pem 4.0.0",
  "ppp",
  "prometheus",
  "prost",
@@ -6356,7 +6368,6 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tower-service",
- "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -8857,7 +8868,7 @@ dependencies = [
  "hex",
  "ic-crypto-internal-types",
  "ic-types",
- "pem",
+ "pem 3.0.6",
  "simple_asn1",
  "tempfile",
  "thiserror 2.0.18",
@@ -9014,7 +9025,7 @@ dependencies = [
  "hex-literal 0.4.1",
  "hkdf",
  "ic_principal",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "thiserror 2.0.18",
@@ -9033,7 +9044,7 @@ dependencies = [
  "hex-literal 0.4.1",
  "hkdf",
  "ic_principal",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
@@ -9287,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "ic-gateway"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic-gateway?rev=3e015f17b8ad302a42fd1ac68b7b139867b71c5f#3e015f17b8ad302a42fd1ac68b7b139867b71c5f"
+source = "git+https://github.com/dfinity/ic-gateway?tag=v0.6.5#a16fb54f4c8d4407b8134d63b57f864d67520062"
 dependencies = [
  "ahash",
  "anyhow",
@@ -13377,7 +13388,7 @@ dependencies = [
  "ic_principal",
  "k256",
  "num-bigint 0.4.6",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "secp256k1 0.29.1",
@@ -13396,7 +13407,7 @@ dependencies = [
  "hmac",
  "num-bigint 0.4.6",
  "p256",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "sha2 0.10.9",
@@ -18623,7 +18634,7 @@ dependencies = [
  "ic_device",
  "ic_os_logging",
  "linux_kernel_command_line",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "serde_cbor",
  "sev",
@@ -18859,7 +18870,7 @@ dependencies = [
  "libc",
  "mockall",
  "nix 0.31.3",
- "pem",
+ "pem 3.0.6",
  "prometheus",
  "prost",
  "qrcode",
@@ -19118,6 +19129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -20500,7 +20521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "aws-lc-rs",
- "pem",
+ "pem 3.0.6",
  "ring",
  "rustls-pki-types",
  "time",
@@ -20515,7 +20536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
- "pem",
+ "pem 3.0.6",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -21418,7 +21439,7 @@ dependencies = [
  "futures-rustls",
  "http 1.4.0",
  "log",
- "pem",
+ "pem 3.0.6",
  "rcgen 0.13.2",
  "serde",
  "serde_json",
@@ -22209,7 +22230,7 @@ dependencies = [
  "config_types",
  "hkdf",
  "linux_kernel_command_line",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "sev",
  "sev_guest_firmware",
@@ -22241,7 +22262,7 @@ dependencies = [
  "anyhow",
  "der",
  "mockall",
- "pem",
+ "pem 3.0.6",
  "rcgen 0.13.2",
  "reqwest",
  "sev",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -646,7 +646,9 @@ clap = { version = "4.5.20", features = ["derive", "string"] }
 colored = "^2.0.0"
 # Fork of `comparable` migrated to syn 2 (upstream still uses syn 1), so it no
 # longer forces a duplicate syn 1.0 into the dependency graph.
-comparable = { git = "https://github.com/dfinity/comparable", rev = "8338f595496454f9e770389e2edc0d96e137a4e9", features = ["derive"] }
+comparable = { git = "https://github.com/dfinity/comparable", rev = "8338f595496454f9e770389e2edc0d96e137a4e9", features = [
+    "derive",
+] }
 crc32fast = "^1.2.0"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 crossbeam-channel = "0.5.15"
@@ -709,7 +711,12 @@ ic-certified-map = "^0.3.1"
 ic-metrics-encoder = "^1.1.1"
 ic0 = "1.0.0"
 ic-agent = { version = "0.49.1", features = ["pem"] }
-ic-bn-lib = { version = "0.5.0", features = ["acme-alpn", "pubsub"] }
+ic-bn-lib = { version = "0.7.0", features = [
+    "acme-alpn",
+    "acme-dns",
+    "pubsub",
+    "clients-hyper",
+] }
 ic-btc-interface = "0.4.0"
 ic-canister-runtime = "0.2.3"
 ic-canister-sig-creation = "1.3.1"
@@ -721,7 +728,9 @@ ic-cdk-timers = "1.0.0"
 ic-certificate-verification = "3.0.3"
 ic-certification = "3"
 ic-doge-interface = "0.3.0"
-ic-gateway = { git = "https://github.com/dfinity/ic-gateway", rev = "3e015f17b8ad302a42fd1ac68b7b139867b71c5f", default-features = false }
+ic-gateway = { git = "https://github.com/dfinity/ic-gateway", tag = "v0.6.5", features = [
+    "acme",
+] }
 ic-http-certification = "3.0.3"
 ic-identity-hsm = { version = "0.49.1" }
 ic-management-canister-types = "0.8.0"
@@ -785,7 +794,19 @@ mockall = "0.13.0"
 mockito = "1.6.1"
 more-asserts = "0.3.1"
 nftables = "0.4"
-nix = { version = "0.31.3", features = ["fs", "ioctl", "mman", "net", "process", "ptrace", "signal", "socket", "time", "user", "zerocopy"] }
+nix = { version = "0.31.3", features = [
+    "fs",
+    "ioctl",
+    "mman",
+    "net",
+    "process",
+    "ptrace",
+    "signal",
+    "socket",
+    "time",
+    "user",
+    "zerocopy",
+] }
 num-bigint = "0.4.6"
 num-traits = { version = "0.2.12", features = ["libm"] }
 num_cpus = "1.16.0"
@@ -865,7 +886,9 @@ rsa = { version = "0.9.6", features = ["sha2", "getrandom"] }
 rstest = "0.19.0"
 rusqlite = "0.37.0"
 rust-ini = "0.21.1"
-rust_decimal = { version = "^1.42", default-features = false, features = ["serde"] }
+rust_decimal = { version = "^1.42", default-features = false, features = [
+    "serde",
+] }
 rust_decimal_macros = "^1.40"
 rustc-demangle = { version = "0.1.16" }
 rustc-hash = "^1.1.0"
@@ -978,10 +1001,18 @@ walkdir = "2.3.3"
 walrus = "0.26.4"
 warp = { version = "0.3.7", features = ["tls"] }
 wasm-encoder = { version = "0.252.0", features = ["wasmparser"] }
-wasm-smith = { version = "0.252.0", default-features = false, features = ["wasmparser"] }
+wasm-smith = { version = "0.252.0", default-features = false, features = [
+    "wasmparser",
+] }
 wasmparser = "0.252.0"
 wasmprinter = "0.252.0"
-wasmtime = { version = "47.0.3", default-features = false, features = ["cranelift", "gc", "gc-null", "parallel-compilation", "runtime"] }
+wasmtime = { version = "47.0.3", default-features = false, features = [
+    "cranelift",
+    "gc",
+    "gc-null",
+    "parallel-compilation",
+    "runtime",
+] }
 wast = "252.0.0"
 wat = "~1.252.0"
 webpki-roots = "1.0.6"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1085,65 +1085,65 @@ http_file(
 http_archive(
     name = "pebble-aarch64-darwin",
     build_file = "@//third_party:BUILD.pebble.bazel",
-    sha256 = "39e07d63dc776521f2ffe0584e5f4f081c984ac02742c882b430891d89f0c866",
+    sha256 = "09a3a4e6ebed71e8d83294a26d361232262f45a7488f5de7bccb5887b395217f",
     strip_prefix = "pebble-darwin-arm64/darwin/arm64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-darwin-arm64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-darwin-arm64.tar.gz",
 )
 
 http_archive(
     name = "pebble-x86_64-darwin",
     build_file = "@//third_party:BUILD.pebble.bazel",
-    sha256 = "9b9625651f8ce47706235179503fec149f8f38bce2b2554efe8c0f2a021f877c",
+    sha256 = "e670ff869886022637e077502a62e7f23be693c45a5a6727ebd76da8fdce64dc",
     strip_prefix = "pebble-darwin-amd64/darwin/amd64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-darwin-amd64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-darwin-amd64.tar.gz",
 )
 
 http_archive(
     name = "pebble-aarch64-linux",
     build_file = "@//third_party:BUILD.pebble.bazel",
-    sha256 = "0e70f2537353f61cbf06aa54740bf7f7bb5f963ba00e909f23af5f85bc13fd1a",
+    sha256 = "b53fd072a69eb7692451de4e8b0667e0bdf5cccd7e36fc51b8eaf2fcc135ed9f",
     strip_prefix = "pebble-linux-arm64/linux/arm64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-linux-arm64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-linux-arm64.tar.gz",
 )
 
 http_archive(
     name = "pebble-x86_64-linux",
     build_file = "@//third_party:BUILD.pebble.bazel",
-    sha256 = "34595d915bbc2fc827affb3f58593034824df57e95353b031c8d5185724485ce",
+    sha256 = "4f2fcb5bca8c85c9cf73ad140fccfc0d2be40bd81ab99879c79b7b8a0b4f70ed",
     strip_prefix = "pebble-linux-amd64/linux/amd64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-linux-amd64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-linux-amd64.tar.gz",
 )
 
 http_archive(
     name = "pebble-challtestsrv-aarch64-darwin",
     build_file = "@//third_party:BUILD.pebble-challtestsrv.bazel",
-    sha256 = "1bc5a6cfa062d9756e98d67825daf67f61dd655bcb6025efca2138fe836c9bbc",
+    sha256 = "59bf917fe39c96e2edca980fc2899f4f04aa1ce5485f28d419d18237b902cf82",
     strip_prefix = "pebble-challtestsrv-darwin-arm64/darwin/arm64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-challtestsrv-darwin-arm64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-challtestsrv-darwin-arm64.tar.gz",
 )
 
 http_archive(
     name = "pebble-challtestsrv-x86_64-darwin",
     build_file = "@//third_party:BUILD.pebble-challtestsrv.bazel",
-    sha256 = "3d1343b1bbe892145fd2da70be36e67b149e482fbff897e109b8053f4f790f40",
+    sha256 = "796bd923f2c595dd7bf15ae693096abfb1df962cb3673c7981ff306daa5c4a52",
     strip_prefix = "pebble-challtestsrv-darwin-amd64/darwin/amd64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-challtestsrv-darwin-amd64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-challtestsrv-darwin-amd64.tar.gz",
 )
 
 http_archive(
     name = "pebble-challtestsrv-aarch64-linux",
     build_file = "@//third_party:BUILD.pebble-challtestsrv.bazel",
-    sha256 = "99a276aac8ceac121859b799708218e6dc57d7ca1dc1b8b5b586246b3c4160e6",
+    sha256 = "db8e1a79ccdb2195c489fbe4f40fddb7f30e86f9cd8a07912566ee5025094d6c",
     strip_prefix = "pebble-challtestsrv-linux-arm64/linux/arm64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-challtestsrv-linux-arm64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-challtestsrv-linux-arm64.tar.gz",
 )
 
 http_archive(
     name = "pebble-challtestsrv-x86_64-linux",
     build_file = "@//third_party:BUILD.pebble-challtestsrv.bazel",
-    sha256 = "a817449d1f05ae58bcb7bf073b4cebe5d31512f859ba4b83951bd825d28d2114",
+    sha256 = "e93a5aa25ecdf3af2f9fbb2de32b0173e64a2eae81002a4ccfe35fa6f4f60b92",
     strip_prefix = "pebble-challtestsrv-linux-amd64/linux/amd64",
-    url = "https://github.com/letsencrypt/pebble/releases/download/v2.8.0/pebble-challtestsrv-linux-amd64.tar.gz",
+    url = "https://github.com/letsencrypt/pebble/releases/download/v2.10.1/pebble-challtestsrv-linux-amd64.tar.gz",
 )
 
 ## For //ci/githubstats:query to query our BuildBuddy services via protobuf-based RPC to fetch logs

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -757,10 +757,10 @@ crate.spec(
     version = "^0.3.0",
 )
 crate.spec(
+    features = ["acme"],
     git = "https://github.com/dfinity/ic-gateway",
     package = "ic-gateway",
     tag = "v0.6.5",
-    features = ["acme"],
 )
 crate.spec(
     package = "ic-http-certification",

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -692,10 +692,12 @@ crate.spec(
 crate.spec(
     features = [
         "acme-alpn",
+        "acme-dns",
+        "clients-hyper",
         "pubsub",
     ],
     package = "ic-bn-lib",
-    version = "^0.5.0",
+    version = "^0.7.0",
 )
 crate.spec(
     package = "ic-btc-interface",
@@ -755,10 +757,10 @@ crate.spec(
     version = "^0.3.0",
 )
 crate.spec(
-    default_features = False,
     git = "https://github.com/dfinity/ic-gateway",
     package = "ic-gateway",
-    rev = "3e015f17b8ad302a42fd1ac68b7b139867b71c5f",
+    tag = "v0.6.5",
+    features = ["acme"],
 )
 crate.spec(
     package = "ic-http-certification",


### PR DESCRIPTION
* Enable `acme` feature of `ic-gateway`
* Use tags instead of git rev
* Bump `pebble` binary versions to align with `ic-bn-lib` (CLI arg changed)
* Some formatter kicked in on TOML

@basvandijk @nmattia this caused `pem` crate to diverge into `3.x` and `4.x` (since we switched to 4 already), not sure if that's a problem, probably others will catch up soon. In the worst case I can downgrade.