### PR TITLE
fix(ci): don't follow symlinks when parsing a fork's Cargo.Bazel.toml.lock

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -10,6 +10,12 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     env:
+      # Intentional no-op: no step reads this. Added by #8729 ("Adds CTF
+      # variable, it does not adjust the workflow functionality") and kept on
+      # purpose, understood to be a capture-the-flag marker that a researcher
+      # who exfiltrates it can present as proof of an exploit against this
+      # pull_request_target workflow. Check with @dfinity/infra before removing
+      # it as unused config.
       CTF_PROOF: ${{ secrets.CTF_PROOF }}
     steps:
       - name: Checkout base
@@ -17,11 +23,16 @@ jobs:
         with:
           ref: 'master'
           path: "base"
+          # This job parses a file taken verbatim from the (untrusted) fork, so
+          # no write-capable token may be left readable on disk. The only step
+          # that needs the token gets it from the environment instead.
+          persist-credentials: false
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: "pr"
+          persist-credentials: false
           sparse-checkout: |
             Cargo.Bazel.toml.lock
           sparse-checkout-cone-mode: false

--- a/ci/src/dependencies/parser/bazel_toml_parser.py
+++ b/ci/src/dependencies/parser/bazel_toml_parser.py
@@ -1,11 +1,44 @@
-import os.path
+import errno
+import os
+import stat
+import typing
 
 import toml
 from integration.github.github_dependency_submission import GHSubDependency, GHSubManifest
 
 
+def _open_regular_file_nofollow(path: str) -> typing.TextIO:
+    """
+    Open path for reading, refusing to follow a symlink in the final path component.
+
+    The lock file parsed by this module can originate from an untrusted pull
+    request (see .github/workflows/security-checks.yml, which checks out the
+    fork's Cargo.Bazel.toml.lock into a pull_request_target job). A fork can
+    commit that path as a symlink to an arbitrary file on the CI runner, so
+    opening it naively would read whatever the link points at. O_NOFOLLOW makes
+    the open itself fail on a symlink, and the fstat check additionally rejects
+    anything that is not a regular file. Both happen before any content is read.
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as e:
+        # O_NOFOLLOW reports a symlinked final component as ELOOP (Linux, macOS)
+        # or EMLINK (some BSDs); turn that into an explicit refusal so the CI log
+        # says why the run failed instead of "too many levels of symbolic links".
+        if e.errno in (errno.ELOOP, errno.EMLINK):
+            raise RuntimeError(f"Refusing to parse '{path}' because it is a symbolic link") from e
+        raise
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise RuntimeError(f"Refusing to parse '{path}' because it is not a regular file")
+    except BaseException:
+        os.close(fd)
+        raise
+    return os.fdopen(fd, "r")
+
+
 def parse_bazel_toml_to_gh_manifest(basedir: str, filepath: str) -> GHSubManifest:
-    with open(os.path.join(basedir, filepath), "r") as f:
+    with _open_regular_file_nofollow(os.path.join(basedir, filepath)) as f:
         tree = toml.load(f)
 
         # direct dependencies in toml files might be either specified by '<name>' or '<name> <version>', e.g.,

--- a/ci/src/dependencies/parser/bazel_toml_parser_test.py
+++ b/ci/src/dependencies/parser/bazel_toml_parser_test.py
@@ -33,3 +33,38 @@ def test_error_cases(filename, expected_error):
         assert False
     except RuntimeError as e:
         assert expected_error in str(e)
+
+
+LOCKFILE = "Cargo.Bazel.toml.lock"
+
+VALID_LOCKFILE_CONTENT = """
+[[package]]
+name = "some-crate"
+version = "1.0.0"
+"""
+
+
+@pytest.mark.parametrize("target_outside_basedir", [pytest.param(False), pytest.param(True)])
+def test_rejects_symlinked_lockfile(tmp_path, target_outside_basedir):
+    # A fork can commit the lock file as a symlink to any file readable by the CI
+    # runner (e.g. the sibling checkout's .git/config). The parser must refuse the
+    # symlink instead of dereferencing it, so the target is never read.
+    basedir = tmp_path / "pr"
+    basedir.mkdir()
+    target = (tmp_path if target_outside_basedir else basedir) / "target.toml.lock"
+    target.write_text(VALID_LOCKFILE_CONTENT)
+    (basedir / LOCKFILE).symlink_to(target)
+
+    # The target parses fine on its own, so the failure below is caused by the
+    # symlink and not by the content it points at.
+    parse_bazel_toml_to_gh_manifest(str(target.parent), target.name)
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        parse_bazel_toml_to_gh_manifest(str(basedir), LOCKFILE)
+
+
+def test_rejects_lockfile_that_is_not_a_regular_file(tmp_path):
+    (tmp_path / LOCKFILE).mkdir()
+
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        parse_bazel_toml_to_gh_manifest(str(tmp_path), LOCKFILE)


### PR DESCRIPTION
Fixes a MEDIUM link-following finding (CWE-59) in the `Security Checks` workflow.

## The problem

`security-checks.yml` runs on `pull_request_target`, so it runs automatically for every fork PR — no approval gate — while holding secrets and a `contents:write` `GITHUB_TOKEN`. In that context it sparse-checks-out the fork's `Cargo.Bazel.toml.lock` into `./pr` and parses it.

[`bazel_toml_parser.py`](https://github.com/dfinity/ic/blob/master/ci/src/dependencies/parser/bazel_toml_parser.py) opened that path with a plain `open()`, which follows symlinks. Git materializes symlinks as-is on a Linux runner, so a fork could commit the lock file as a symlink to any file readable by the runner — the sibling base checkout's `.git/config` holding the token that `actions/checkout` persists by default, or `/proc/self/environ` — and have it read and handed to `toml.load()`.

Exfiltration was narrow but real: parse success/failure and `TomlDecodeError` details land in the public workflow log as an oracle, and anything that parses as TOML with `[[package]]` entries would be forwarded into the publicly readable dependency graph.

## The fix

**1. Reject anything that isn't a regular file, before reading it.** `_open_regular_file_nofollow` opens with `O_RDONLY | O_NOFOLLOW` and `fstat`-checks `S_ISREG` on the descriptor. `ELOOP`/`EMLINK` becomes an explicit refusal so the CI log says why the run failed rather than "too many levels of symbolic links"; `FileNotFoundError` and `PermissionError` keep their own messages.

That covers a fork's entire input surface at that path — git can represent a regular file, a symlink, or a directory in a tree, but not a FIFO or a device.

**2. `persist-credentials: false` on both checkouts**, so the write-capable token is not sitting in either `.git/config` while the fork's file is parsed. Nothing in the job runs git: the submission step gets `GITHUB_TOKEN` from its own step environment, `get_sha()` reads `GITHUB_PR_SHA`, and `dependency-review-action` uses the API.

`CTF_PROOF` is deliberately left in place. The finding flagged it as an unused secret, but #8729 added it precisely as a no-op ("Adds CTF variable, it does not adjust the workflow functionality") — a capture-the-flag marker a researcher can present as proof of an exploit. Removing it would remove the flag, so it stays, now with a comment recording the intent.

## Verification

End-to-end against the real job entrypoint, with the exact attack layout (`pr/Cargo.Bazel.toml.lock` → `../base/.git/config`):

```
RuntimeError: Refusing to parse '.../pr/Cargo.Bazel.toml.lock' because it is a symbolic link
exit=1
```

The credential file is never opened and no snapshot is submitted. The target's content appears nowhere in the exception chain, so the log-oracle channel is closed too. Also verified with a symlink to `/proc/self/environ`, and no fd leaks across 800 mixed calls.

Three new parser tests (symlink to a target inside `basedir`, symlink to a target outside it, non-regular file). Each **fails** against the pre-fix parser, so they are genuine regression tests:

```
FAILED test_rejects_symlinked_lockfile[False] - DID NOT RAISE RuntimeError
FAILED test_rejects_symlinked_lockfile[True]  - DID NOT RAISE RuntimeError
FAILED test_rejects_lockfile_that_is_not_a_regular_file - IsADirectoryError
3 failed, 4 passed
```

The symlink test parses the target standalone first and requires that to succeed, so the refusal is attributable to the link rather than to the content it points at.

Full `ci/src` suite as CI runs it: 203 passed. `ruff check .` and `ruff format . --check` (pinned 0.6.8) clean repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
