### PR TITLE
fix(bazel): validate the mainnet-revision JSON fields that reach download URLs

### DIFF
--- a/bazel/mainnet-artifact-refs.bzl
+++ b/bazel/mainnet-artifact-refs.bzl
@@ -1,0 +1,343 @@
+"""Validation of the mainnet-revision JSON fields that end up in download URLs.
+
+`mainnet-canister-revisions.json` and `mainnet-icos-revisions.json` are written by
+the mainnet-revisions bot, whose PRs are auto-approved and auto-merged (see
+`.github/workflows/auto-approve.yml`), from data that is not independently
+authenticated: the public dashboard REST API, CDN-served `SHA256SUMS` files and the
+hash of whatever the CDN currently serves. The repository rules that read those files
+must therefore not treat their contents as trusted input.
+
+Every field validated here reaches at least one of:
+
+  * a download URL -- an unexpected value can escape the pinned CDN prefix or the
+    hard-coded GitHub repository through dot-segment normalization
+    (`../../../org/repo/releases/download/x`), or simply select a different artifact
+    on the pinned host,
+  * the `output` path of `repository_ctx.download`, which `..` can walk out of,
+  * the text of a generated `BUILD.bazel` file (the ICOS binary names), where
+    quotes/newlines would inject Starlark,
+  * the `sha256` of `repository_ctx.download`, where the empty string silently
+    *disables* verification.
+
+The `*_error` functions return a message describing the problem, or `None` when the
+value is acceptable. They deliberately do not call `fail()` themselves: `fail()`
+cannot be caught in Starlark, so error-returning predicates are what makes the
+rejecting path unit-testable (see `//bazel/mainnet_artifact_refs_tests`). Use
+`check()`, or the `checked_*` wrappers, to turn an error into a `fail()`.
+
+Starlark has no regular expressions, hence the explicit length, charset and substring
+checks. `ci/src/mainnet_revisions/mainnet_revisions.py` mirrors them so that a
+poisoned upstream value fails when the JSON is written, not just when it is fetched.
+"""
+
+_HEX = "0123456789abcdef"
+
+_NAME_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+
+_TAG_CHARS = _NAME_CHARS + "/"
+
+# Comfortably above every value that legitimately occurs (the longest tag in
+# mainnet-canister-revisions.json is ~20 characters), while keeping a poisoned value
+# from smuggling in a long path.
+_MAX_LEN = 128
+
+# The ICOS variants that appear in a CDN artifact path.
+_VARIANTS = ["guest-os", "host-os", "setup-os"]
+
+# Hash fields of a mainnet-icos-revisions.json record. Optional: absent fields are
+# skipped so that the rules keep reporting their own, more helpful errors (e.g. the
+# "regenerate it" hint of //bazel:mainnet-icos-binaries.bzl) instead of a validation
+# failure.
+_ICOS_HASH_FIELDS = [
+    "setupos_disk_img_hash",
+    "setupos_disk_img_hash_dev",
+    "update_img_hash",
+    "update_img_hash_dev",
+]
+
+def _first_disallowed(value, allowed):
+    """The first character of `value` that is not in `allowed`.
+
+    Args:
+      value: the string to inspect.
+      allowed: a string holding every allowed character.
+
+    Returns:
+      The offending character, or None if all characters are allowed.
+    """
+    for c in value.elems():
+        if c not in allowed:
+            return c
+    return None
+
+def _hex_error(value, length, what):
+    """Checks that `value` is exactly `length` lowercase hex characters.
+
+    Args:
+      value: the value to check; need not be a string.
+      length: the exact number of characters required.
+      what: what the value is, for the error message.
+
+    Returns:
+      An error message, or None if `value` is acceptable.
+    """
+    if type(value) != "string":
+        return "%s must be a string, got %r" % (what, value)
+    if len(value) != length:
+        return "%s must be exactly %d lowercase hex characters, got %d: %r" % (what, length, len(value), value)
+    bad = _first_disallowed(value, _HEX)
+    if bad != None:
+        return "%s must be lowercase hex, got the character %r in %r" % (what, bad, value)
+    return None
+
+def commit_id_error(value):
+    """Checks a git commit id, i.e. the `rev` / `version` fields.
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a 40-character lowercase hex string.
+    """
+    return _hex_error(value, 40, "a git commit id")
+
+def sha256_error(value):
+    """Checks a sha256, i.e. the `sha256` / `*_hash` / `binaries` value fields.
+
+    Rejects the empty string, which `repository_ctx.download` accepts as "do not
+    verify this download".
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a 64-character lowercase hex string.
+    """
+    return _hex_error(value, 64, "a sha256")
+
+def tag_error(value):
+    """Checks a GitHub release tag, which becomes a path segment of a download URL.
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a plausible tag.
+    """
+    if type(value) != "string":
+        return "a tag must be a string, got %r" % (value,)
+    if not value:
+        return "a tag must not be empty"
+    if len(value) > _MAX_LEN:
+        return "a tag must be at most %d characters, got %d: %r" % (_MAX_LEN, len(value), value)
+    bad = _first_disallowed(value, _TAG_CHARS)
+    if bad != None:
+        return "a tag must only contain [A-Za-z0-9._-] and '/', got the character %r in %r" % (bad, value)
+    if ".." in value:
+        return "a tag must not contain '..': %r" % (value,)
+    if "//" in value:
+        return "a tag must not contain '//': %r" % (value,)
+    if value.startswith("/") or value.endswith("/"):
+        return "a tag must not start or end with '/': %r" % (value,)
+    if value.startswith(".") or value.startswith("-"):
+        return "a tag must not start with '.' or '-': %r" % (value,)
+    return None
+
+def artifact_name_error(value):
+    """Checks a single-segment name: a canister key, a binary name, a filename.
+
+    Besides being interpolated into download URLs and into the `output` path of
+    `repository_ctx.download`, the ICOS binary names are interpolated into a
+    generated BUILD file, so quotes, brackets and newlines must not get through.
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a plausible name.
+    """
+    if type(value) != "string":
+        return "a name must be a string, got %r" % (value,)
+    if not value:
+        return "a name must not be empty"
+    if len(value) > _MAX_LEN:
+        return "a name must be at most %d characters, got %d: %r" % (_MAX_LEN, len(value), value)
+    bad = _first_disallowed(value, _NAME_CHARS)
+    if bad != None:
+        return "a name must only contain [A-Za-z0-9._-], got the character %r in %r" % (bad, value)
+    if ".." in value:
+        return "a name must not contain '..': %r" % (value,)
+    if value.startswith(".") or value.startswith("-"):
+        return "a name must not start with '.' or '-': %r" % (value,)
+    return None
+
+def github_repository_error(value):
+    """Checks an `owner/repo` GitHub repository name.
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a plausible repository name.
+    """
+    if type(value) != "string":
+        return "a GitHub repository must be a string, got %r" % (value,)
+    parts = value.split("/")
+    if len(parts) != 2:
+        return "a GitHub repository must be of the form 'owner/repo', got %r" % (value,)
+    for part in parts:
+        error = artifact_name_error(part)
+        if error != None:
+            return "%s (in the GitHub repository %r)" % (error, value)
+    return None
+
+def variant_error(value):
+    """Checks an ICOS variant, i.e. a path segment of an image/binary download URL.
+
+    Args:
+      value: the value to check; need not be a string.
+
+    Returns:
+      An error message, or None if `value` is a known variant.
+    """
+    if value not in _VARIANTS:
+        return "an ICOS variant must be one of %s, got %r" % (_VARIANTS, value)
+    return None
+
+def icos_record_error(record):
+    """Checks one record of mainnet-icos-revisions.json.
+
+    Validates `version` (required) and, when present, the image hashes and the
+    `binaries` names and hashes. Fields that are absent are not reported as errors:
+    the rules that require them say so themselves, with a more helpful message.
+
+    Args:
+      record: the decoded JSON object of a single record.
+
+    Returns:
+      An error message, or None if every validated field is acceptable.
+    """
+    if type(record) != "dict":
+        return "expected a JSON object, got %r" % (record,)
+
+    error = commit_id_error(record.get("version", None))
+    if error != None:
+        return "'version': %s" % error
+
+    for field in _ICOS_HASH_FIELDS:
+        if field in record:
+            error = sha256_error(record[field])
+            if error != None:
+                return "'%s': %s" % (field, error)
+
+    binaries = record.get("binaries", None)
+    if binaries != None:
+        if type(binaries) != "dict":
+            return "'binaries': expected a JSON object, got %r" % (binaries,)
+        for name in sorted(binaries.keys()):
+            error = artifact_name_error(name)
+            if error != None:
+                return "'binaries' key: %s" % error
+            error = sha256_error(binaries[name])
+            if error != None:
+                return "'binaries' entry %r: %s" % (name, error)
+
+    return None
+
+def check(error, context):
+    """Fails with `context` prepended when `error` is not None.
+
+    Args:
+      error: the return value of one of the `*_error` functions above.
+      context: what was being validated, e.g. the JSON file and key.
+    """
+    if error != None:
+        fail("%s: %s" % (context, error))
+
+def checked_commit_id(value, context):
+    """`value` if it is a valid git commit id, otherwise fails.
+
+    Args:
+      value: the value to check.
+      context: what was being validated, for the error message.
+
+    Returns:
+      `value`.
+    """
+    check(commit_id_error(value), context)
+    return value
+
+def checked_tag(value, context):
+    """`value` if it is a valid release tag, otherwise fails.
+
+    Args:
+      value: the value to check.
+      context: what was being validated, for the error message.
+
+    Returns:
+      `value`.
+    """
+    check(tag_error(value), context)
+    return value
+
+def checked_artifact_name(value, context):
+    """`value` if it is a valid single-segment name, otherwise fails.
+
+    Args:
+      value: the value to check.
+      context: what was being validated, for the error message.
+
+    Returns:
+      `value`.
+    """
+    check(artifact_name_error(value), context)
+    return value
+
+def checked_github_repository(value, context):
+    """`value` if it is a valid `owner/repo` name, otherwise fails.
+
+    Args:
+      value: the value to check.
+      context: what was being validated, for the error message.
+
+    Returns:
+      `value`.
+    """
+    check(github_repository_error(value), context)
+    return value
+
+def checked_variant(value, context):
+    """`value` if it is a known ICOS variant, otherwise fails.
+
+    Args:
+      value: the value to check.
+      context: what was being validated, for the error message.
+
+    Returns:
+      `value`.
+    """
+    check(variant_error(value), context)
+    return value
+
+def checked_url(url, prefix):
+    """`url` if it stayed within `prefix` and looks like a single plain URL.
+
+    A postcondition on top of the per-field checks above: it also catches a component
+    that a future change forgets to validate.
+
+    Args:
+      url: the assembled download URL.
+      prefix: the literal prefix the URL must not have escaped.
+
+    Returns:
+      `url`.
+    """
+    if not url.startswith(prefix):
+        fail("refusing to fetch %r: expected it to start with %r" % (url, prefix))
+    if ".." in url:
+        fail("refusing to fetch %r: contains '..'" % (url,))
+    if url.count("://") != 1:
+        fail("refusing to fetch %r: contains more than one '://'" % (url,))
+    if _first_disallowed(url, _TAG_CHARS + ":") != None:
+        fail("refusing to fetch %r: contains an unexpected character" % (url,))
+    return url

--- a/bazel/mainnet-canisters.bzl
+++ b/bazel/mainnet-canisters.bzl
@@ -3,6 +3,53 @@
 This creates a Bazel repository which exports mainnet canisters.
 """
 
+load(
+    "//bazel:mainnet-artifact-refs.bzl",
+    "artifact_name_error",
+    "check",
+    "checked_artifact_name",
+    "checked_commit_id",
+    "checked_github_repository",
+    "checked_tag",
+    "checked_url",
+    "sha256_error",
+)
+
+_CDN_PREFIX = "https://download.dfinity.systems/ic/"
+
+_GITHUB_PREFIX = "https://github.com/"
+
+def canister_download_url(rev, repository, tag, filename, context):
+    """URL of the canister WASM `filename`, either on the CDN or on a GitHub release.
+
+    Every interpolated component is validated: `rev` and `tag` come from the
+    auto-merged mainnet-canister-revisions.json, so an unvalidated value could escape
+    the pinned CDN prefix or GitHub repository (see //bazel:mainnet-artifact-refs.bzl).
+
+    Args:
+      rev: the CDN revision to fetch from, or None to fetch from a GitHub release.
+      repository: the `owner/repo` GitHub repository; only used when `rev` is None.
+      tag: the GitHub release tag; only used when `rev` is None.
+      filename: the name of the artifact, as published.
+      context: what is being fetched, for error messages.
+
+    Returns:
+      The download URL.
+    """
+    filename = checked_artifact_name(filename, context + ": filename")
+
+    if rev == None:
+        return checked_url("https://github.com/{repository}/releases/download/{tag}/{filename}".format(
+            repository = checked_github_repository(repository, context + ": repository"),
+            tag = checked_tag(tag, context + ": tag"),
+            filename = filename,
+        ), _GITHUB_PREFIX)
+
+    return checked_url("https://download.dfinity.systems/ic/{rev}/canisters/{filename}".format(
+        rev = checked_commit_id(rev, context + ": rev"),
+        filename = filename,
+    ), _CDN_PREFIX)
+
 def _canisters_impl(repository_ctx):
     repositories = dict(repository_ctx.attr.repositories)
     filenames = dict(repository_ctx.attr.filenames)
@@ -20,6 +67,12 @@ def _canisters_impl(repository_ctx):
     for canister_key in canister_keys:
         canisterinfo = cans.pop(canister_key, None)
 
+        context = "%s: canister %r" % (json_path, canister_key)
+
+        # The canister key is used as the name of the downloaded file below, so it
+        # must not be able to walk out of the repository directory.
+        check(artifact_name_error(canister_key), "%s: canister key" % json_path)
+
         rev = canisterinfo.get("rev", None)
         if rev == None:
             repository = repositories.pop(canister_key, None)
@@ -36,17 +89,16 @@ def _canisters_impl(repository_ctx):
         if sha256 == None:
             fail("no sha256 for canister: " + canister_key)
 
+        # Not merely a sanity check: repository_ctx.download treats the empty string
+        # as "do not verify this download".
+        check(sha256_error(sha256), context + ": sha256")
+
         filename = filenames.pop(canister_key, None)
         if filename == None:
             fail("no filename for canister: " + canister_key)
 
-        if rev == None:
-            url = "https://github.com/{repository}/releases/download/{tag}/{filename}".format(repository = repository, tag = tag, filename = filename)
-        else:
-            url = "https://download.dfinity.systems/ic/{rev}/canisters/{filename}".format(rev = rev, filename = filename)
-
         repository_ctx.download(
-            url = url,
+            url = canister_download_url(rev, repository, tag, filename, context),
             sha256 = sha256,
             output = "{canister_key}.wasm.gz".format(canister_key = canister_key),
         )

--- a/bazel/mainnet-icos-binaries.bzl
+++ b/bazel/mainnet-icos-binaries.bzl
@@ -9,6 +9,17 @@ network-isolated sandbox. Declaring the binaries as Bazel dependencies instead
 makes them available offline, so the `_local` variants can run too.
 """
 
+load(
+    "//bazel:mainnet-artifact-refs.bzl",
+    "check",
+    "checked_artifact_name",
+    "checked_commit_id",
+    "checked_url",
+    "icos_record_error",
+)
+
+_CDN_PREFIX = "https://download.dfinity.systems/ic/"
+
 def binary_download_url(git_commit_id, name):
     """URL of the gzipped release binary `name` published for `git_commit_id`.
 
@@ -18,6 +29,10 @@ def binary_download_url(git_commit_id, name):
     the directory whose SHA256SUMS ci/src/mainnet_revisions/mainnet_revisions.py
     reads to record the hashes verified below -- the two must agree.
 
+    Both components come from the auto-merged mainnet-icos-revisions.json and are
+    validated here, so that no caller can assemble a URL that leaves the pinned CDN
+    prefix (see //bazel:mainnet-artifact-refs.bzl).
+
     Args:
       git_commit_id: the revision the binary was published for.
       name: the name of the binary, e.g. "ic-replay".
@@ -25,10 +40,10 @@ def binary_download_url(git_commit_id, name):
     Returns:
       The download URL.
     """
-    return "https://download.dfinity.systems/ic/{git_commit_id}/binaries/x86_64-linux/{name}.gz".format(
-        git_commit_id = git_commit_id,
-        name = name,
-    )
+    return checked_url("https://download.dfinity.systems/ic/{git_commit_id}/binaries/x86_64-linux/{name}.gz".format(
+        git_commit_id = checked_commit_id(git_commit_id, "the mainnet ICOS version"),
+        name = checked_artifact_name(name, "a mainnet ICOS binary name"),
+    ), _CDN_PREFIX)
 
 # One genrule per binary, decompressing the downloaded artifact and making it
 # executable.
@@ -42,6 +57,9 @@ def binary_download_url(git_commit_id, name):
 #
 # `gunzip -c > $@` creates a non-executable file and genrules don't mark their
 # outputs executable, hence the explicit `chmod +x`.
+#
+# `{name}` is interpolated verbatim into this Starlark, so it must have been
+# validated (see the icos_record_error() call below) before it gets here.
 _GUNZIP_GENRULE = """
 genrule(
     name = "gunzip_{name}",
@@ -78,6 +96,11 @@ def _mainnet_icos_binaries_impl(repository_ctx):
             parts = "/".join(parts),
             path = json_path,
         ))
+
+    # The JSON is not reviewed by a human before it is merged, so validate it before
+    # any of it is used: the binary names end up in download URLs, in the names of
+    # the downloaded files and -- verbatim -- in the BUILD file generated below.
+    check(icos_record_error(info), "%s: %s" % (json_path, "/".join(parts)))
 
     git_commit_id = info["version"]
     binaries = info["binaries"]

--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -2,19 +2,57 @@
 This module defines Bazel targets for the mainnet versions of ICOS images
 """
 
+load(
+    "//bazel:mainnet-artifact-refs.bzl",
+    "check",
+    "checked_commit_id",
+    "checked_url",
+    "checked_variant",
+    "icos_record_error",
+)
+
+_CDN_PREFIX = "https://download.dfinity.systems/ic/"
+
 def icos_image_download_url(git_commit_id, variant, update):
-    return "https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}/{component}.tar.zst".format(
-        git_commit_id = git_commit_id,
-        variant = variant,
+    """URL of the `variant` disk or update image published for `git_commit_id`.
+
+    `git_commit_id` comes from the auto-merged mainnet-icos-revisions.json (directly,
+    or through @mainnet_icos_versions for the system-test `*_IMG_URL` env vars), so it
+    is validated here -- for every caller -- against escaping the pinned CDN prefix
+    (see //bazel:mainnet-artifact-refs.bzl).
+
+    Args:
+      git_commit_id: the revision the image was published for.
+      variant: the ICOS variant, e.g. "guest-os".
+      update: whether to return the update image instead of the disk image.
+
+    Returns:
+      The download URL.
+    """
+    return checked_url("https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}/{component}.tar.zst".format(
+        git_commit_id = checked_commit_id(git_commit_id, "the mainnet ICOS version"),
+        variant = checked_variant(variant, "the ICOS image variant"),
         component = "update-img" if update else "disk-img",
-    )
+    ), _CDN_PREFIX)
 
 def icos_dev_image_download_url(git_commit_id, variant, update):
-    return "https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}-dev/{component}.tar.zst".format(
-        git_commit_id = git_commit_id,
-        variant = variant,
+    """URL of the `variant` dev disk or update image published for `git_commit_id`.
+
+    Like `icos_image_download_url`, but for the dev channel of the same revision.
+
+    Args:
+      git_commit_id: the revision the image was published for.
+      variant: the ICOS variant, e.g. "guest-os".
+      update: whether to return the update image instead of the disk image.
+
+    Returns:
+      The download URL.
+    """
+    return checked_url("https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}-dev/{component}.tar.zst".format(
+        git_commit_id = checked_commit_id(git_commit_id, "the mainnet ICOS version"),
+        variant = checked_variant(variant, "the ICOS image variant"),
         component = "update-img" if update else "disk-img",
-    )
+    ), _CDN_PREFIX)
 
 def _mainnet_icos_images_impl(repository_ctx):
     """Repository rule for ic-os images.
@@ -39,6 +77,11 @@ def _mainnet_icos_images_impl(repository_ctx):
     info = json.decode(repository_ctx.read(json_path))
     for part in parts:
         info = info[part]
+
+    # The JSON is not reviewed by a human before it is merged, so validate the
+    # version and the image hashes before they are used to locate and to verify
+    # these multi-GB downloads.
+    check(icos_record_error(info), "%s: %s" % (json_path, "/".join(parts)))
 
     git_commit_id = info["version"]
 

--- a/bazel/mainnet-icos-versions.bzl
+++ b/bazel/mainnet-icos-versions.bzl
@@ -4,6 +4,41 @@ This creates a Bazel repository which exports 'mainnet_icos_versions'. This macr
 called to create one Bazel repository for the entire mainnet ICOS versions list.
 """
 
+load("//bazel:mainnet-artifact-refs.bzl", "check", "icos_record_error")
+
+def _validate(json_path, versions):
+    """Validates every record of the mainnet ICOS revisions JSON.
+
+    This is the choke point for the MAINNET_* dicts generated below: besides the
+    download URLs built from them by //bazel:mainnet-icos-images.bzl, they end up in
+    the `ENV_DEPS__*_IMG_URL` and `ENV_DEPS__*_IMG_HASH` env vars of system tests (see
+    rs/tests/configure_icos.bzl), which the Farm backend uses to fetch and verify
+    images itself -- a path that never passes through repository_ctx.download. The
+    JSON reaches master without human review, so none of it is trusted input.
+
+    Args:
+      json_path: the label of the JSON file, for error messages.
+      versions: the decoded JSON.
+    """
+    if type(versions) != "dict":
+        fail("%s: expected a JSON object, got %r" % (json_path, versions))
+    for variant in sorted(versions.keys()):
+        records = versions[variant]
+        if type(records) != "dict":
+            fail("%s: %s: expected a JSON object, got %r" % (json_path, variant, records))
+        for key in sorted(records.keys()):
+            record = records[key]
+
+            # "subnets" holds one record per subnet id, everything else (e.g.
+            # "latest_release") is a record itself.
+            if key == "subnets":
+                if type(record) != "dict":
+                    fail("%s: %s/subnets: expected a JSON object, got %r" % (json_path, variant, record))
+                for subnet in sorted(record.keys()):
+                    check(icos_record_error(record[subnet]), "%s: %s/subnets/%s" % (json_path, variant, subnet))
+            else:
+                check(icos_record_error(record), "%s: %s/%s" % (json_path, variant, key))
+
 def _mainnet_icos_versions_impl(repository_ctx):
     # The path to the mainnet icos info
     json_path = repository_ctx.attr.path
@@ -11,6 +46,8 @@ def _mainnet_icos_versions_impl(repository_ctx):
 
     # Read and decode mainnet version data
     versions = json.decode(repository_ctx.read(json_path))
+
+    _validate(json_path, versions)
 
     # Create a minimal BUILD.bazel file (Bazel requires it)
     repository_ctx.file("BUILD.bazel", content = "\n")

--- a/bazel/mainnet_artifact_refs_tests/BUILD.bazel
+++ b/bazel/mainnet_artifact_refs_tests/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":mainnet_artifact_refs_test.bzl", "mainnet_artifact_refs_test_suite")
+
+mainnet_artifact_refs_test_suite(name = "mainnet_artifact_refs_test")

--- a/bazel/mainnet_artifact_refs_tests/mainnet_artifact_refs_test.bzl
+++ b/bazel/mainnet_artifact_refs_tests/mainnet_artifact_refs_test.bzl
@@ -1,0 +1,433 @@
+"""Unit tests for //bazel:mainnet-artifact-refs.bzl and the download URL builders.
+
+The values that mainnet-canister-revisions.json and mainnet-icos-revisions.json
+contribute to a download URL are not reviewed by a human before they reach master, so
+the repository rules validate them (F-051). These tests pin down what is accepted and
+what is rejected, including the fields of poisoned copies of the real JSON records.
+
+The rejecting path of the URL builders themselves cannot be asserted -- `fail()` is
+uncatchable in Starlark -- which is exactly why the validators return an error message
+instead of failing: the builders are the only path from JSON to URL and they call
+these very functions.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "//bazel:mainnet-artifact-refs.bzl",
+    "artifact_name_error",
+    "commit_id_error",
+    "github_repository_error",
+    "icos_record_error",
+    "sha256_error",
+    "tag_error",
+    "variant_error",
+)
+load("//bazel:mainnet-canisters.bzl", "canister_download_url")
+load("//bazel:mainnet-icos-binaries.bzl", "binary_download_url")
+load("//bazel:mainnet-icos-images.bzl", "icos_dev_image_download_url", "icos_image_download_url")
+
+# Values taken from the committed JSON files: these must never start failing.
+_REAL_COMMIT_IDS = [
+    "3ae3649a2366aaca83404b692fc58e4c6e604a25",
+    "512cf412f33d430b79f42330518166d14fc6884e",
+    "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "79c01052b5f7f49d3cf53d04d696cb2893294cd3",
+    "d4ee25b0865e89d3eaac13a60f0016d5e3296b31",
+]
+
+_REAL_TAGS = [
+    "0.7.0",
+    "cycles-ledger-v1.0.6",
+    "proposal-138924-agg",
+    "proposal-143661",
+    "release-2026-08-19",
+    "release-2026-08-21",
+    "release/2026-04-15",
+    "release/2026-05-27",
+]
+
+_REAL_NAMES = [
+    "canister_sandbox",
+    "ic-icrc1-index-ng-u256.wasm.gz",
+    "ic-replay",
+    "internet_identity_production.wasm.gz",
+    "ledger-canister_notify-method.wasm.gz",
+    "sns_aggregator_dev.wasm.gz",
+]
+
+_REAL_SHA256S = [
+    "5bf34cb029e437c4ccb990b1595876d4c869566d66b8b58059d0ee742891c219",
+    "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2",
+]
+
+# The escape described by F-051: with standard RFC 3986 dot-segment normalization by
+# the HTTP client or server this leaves the hard-coded GitHub repository.
+_EXPLOIT_TAG = "../../../evil-org/evil-repo/releases/download/x"
+
+# A poisoned field can be of any JSON type, so every validator has to survive one.
+_NON_STRINGS = [None, 0, 42, True, ["x"], {"x": 1}]
+
+def _accepts(env, error_fn, values, what):
+    for value in values:
+        asserts.equals(env, None, error_fn(value), "%s should accept %r" % (what, value))
+
+def _rejects(env, error_fn, values, what):
+    for value in values:
+        asserts.true(env, error_fn(value) != None, "%s should reject %r" % (what, value))
+
+def _commit_id_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, commit_id_error, _REAL_COMMIT_IDS, "commit_id_error")
+    _rejects(env, commit_id_error, [
+        "",
+        "3ae3649a2366aaca83404b692fc58e4c6e604a2",  # 39 characters
+        "3ae3649a2366aaca83404b692fc58e4c6e604a255",  # 41 characters
+        "3AE3649A2366AACA83404B692FC58E4C6E604A25",  # uppercase
+        ".." + "0" * 38,  # exactly 40 characters, but a traversal
+        "../../../../evil/guest-os/update-img",
+        "..",
+        "release-2026-08-19",  # a tag is not a commit id
+        _REAL_SHA256S[0],  # a sha256 is not a commit id
+    ] + _NON_STRINGS, "commit_id_error")
+
+    return unittest.end(env)
+
+commit_id_test = unittest.make(_commit_id_test_impl)
+
+def _tag_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, tag_error, _REAL_TAGS, "tag_error")
+    _rejects(env, tag_error, [
+        _EXPLOIT_TAG,
+        "..",
+        "release/../../evil",
+        "release/..",
+        "../release",
+        "/release-2026-08-19",
+        "release-2026-08-19/",
+        "release//2026-08-19",
+        ".release",
+        "-release",
+        "release 2026-08-19",
+        "release\n2026-08-19",
+        "release\t2026",
+        "%2e%2e/x",
+        "https://evil.example/x",
+        "release?ref=evil",
+        "release#evil",
+        "release@evil.example",
+        "",
+        "a" * 129,
+    ] + _NON_STRINGS, "tag_error")
+
+    return unittest.end(env)
+
+tag_test = unittest.make(_tag_test_impl)
+
+def _sha256_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, sha256_error, _REAL_SHA256S, "sha256_error")
+    _rejects(env, sha256_error, [
+        # Not merely malformed: repository_ctx.download reads the empty string as
+        # "do not verify this download".
+        "",
+        "0" * 63,
+        "0" * 65,
+        _REAL_SHA256S[0].upper(),
+        ".." + "0" * 62,  # exactly 64 characters, but a traversal
+        _REAL_COMMIT_IDS[0],  # a commit id is not a sha256
+    ] + _NON_STRINGS, "sha256_error")
+
+    return unittest.end(env)
+
+sha256_test = unittest.make(_sha256_test_impl)
+
+def _artifact_name_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, artifact_name_error, _REAL_NAMES, "artifact_name_error")
+    _rejects(env, artifact_name_error, [
+        "",
+        "..",
+        "../../x",
+        "a/b",
+        "canister..sandbox",
+        ".hidden",
+        "-dash",
+        # An ICOS binary name is interpolated verbatim into a generated BUILD file.
+        'ic-replay"]) load("@evil//:evil.bzl", "evil")',
+        "ic-replay\n)",
+        "ic replay",
+        "a" * 129,
+    ] + _NON_STRINGS, "artifact_name_error")
+
+    return unittest.end(env)
+
+artifact_name_test = unittest.make(_artifact_name_test_impl)
+
+def _github_repository_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, github_repository_error, [
+        "dfinity/ic",
+        "dfinity/internet-identity",
+        "dfinity/cycles-ledger",
+        "dfinity/subnet-rental-canister",
+    ], "github_repository_error")
+    _rejects(env, github_repository_error, [
+        "",
+        "dfinity",
+        "dfinity/ic/extra",
+        "dfinity/..",
+        "dfinity/../evil",
+        "../dfinity/ic",
+        "/ic",
+        "dfinity/",
+        "dfinity/i c",
+        "evil.example/dfinity/ic",
+    ] + _NON_STRINGS, "github_repository_error")
+
+    return unittest.end(env)
+
+github_repository_test = unittest.make(_github_repository_test_impl)
+
+def _variant_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    _accepts(env, variant_error, ["guest-os", "host-os", "setup-os"], "variant_error")
+    _rejects(env, variant_error, [
+        "",
+        "guestos",
+        "GUEST-OS",
+        "../guest-os",
+        "guest-os/..",
+    ] + _NON_STRINGS, "variant_error")
+
+    return unittest.end(env)
+
+variant_test = unittest.make(_variant_test_impl)
+
+# A copy of real mainnet-canister-revisions.json entries with one poisoned field
+# each: a tag that escapes the pinned GitHub repository, a rev that escapes the
+# pinned CDN prefix, and a sha256 that disables verification.
+_POISONED_CANISTERS_JSON = """{
+  "internet_identity_backend": {
+    "sha256": "5bf34cb029e437c4ccb990b1595876d4c869566d66b8b58059d0ee742891c219",
+    "tag": "../../../evil-org/evil-repo/releases/download/x"
+  },
+  "registry": {
+    "rev": "../../../../evil/release/canisters",
+    "sha256": "5bf34cb029e437c4ccb990b1595876d4c869566d66b8b58059d0ee742891c219"
+  },
+  "governance": {
+    "rev": "3ae3649a2366aaca83404b692fc58e4c6e604a25",
+    "sha256": ""
+  }
+}"""
+
+_CLEAN_CANISTERS_JSON = """{
+  "internet_identity_backend": {
+    "sha256": "5bf34cb029e437c4ccb990b1595876d4c869566d66b8b58059d0ee742891c219",
+    "tag": "release-2026-08-21"
+  },
+  "registry": {
+    "rev": "3ae3649a2366aaca83404b692fc58e4c6e604a25",
+    "sha256": "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2"
+  }
+}"""
+
+def _poisoned_canisters_json_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    poisoned = json.decode(_POISONED_CANISTERS_JSON)
+    asserts.true(
+        env,
+        tag_error(poisoned["internet_identity_backend"]["tag"]) != None,
+        "the crafted tag must be rejected",
+    )
+    asserts.true(
+        env,
+        commit_id_error(poisoned["registry"]["rev"]) != None,
+        "the crafted rev must be rejected",
+    )
+    asserts.true(
+        env,
+        sha256_error(poisoned["governance"]["sha256"]) != None,
+        "the empty sha256 must be rejected",
+    )
+
+    clean = json.decode(_CLEAN_CANISTERS_JSON)
+    asserts.equals(env, None, tag_error(clean["internet_identity_backend"]["tag"]))
+    asserts.equals(env, None, sha256_error(clean["internet_identity_backend"]["sha256"]))
+    asserts.equals(env, None, commit_id_error(clean["registry"]["rev"]))
+    asserts.equals(env, None, sha256_error(clean["registry"]["sha256"]))
+
+    return unittest.end(env)
+
+poisoned_canisters_json_test = unittest.make(_poisoned_canisters_json_test_impl)
+
+# Records shaped like mainnet-icos-revisions.json: "clean" is a (trimmed) copy of a
+# real one, every other record poisons exactly one field.
+_ICOS_JSON = """{
+  "clean": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "update_img_hash": "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2",
+    "update_img_hash_dev": "3924d5e9c86822b367cbfdbaab48c667f2a32bee3ab65e5772d54c32e6a829ed",
+    "setupos_disk_img_hash": "5c488a88730dd52c2cf3186d10517b8e86cfbc445f47e850a07479632d466390",
+    "setupos_disk_img_hash_dev": "18330bb4c6fcf94977fb7e8576e0d781864777406a8b33b47153f15fbef4e454",
+    "binaries": {
+      "canister_sandbox": "2a2e8891dc8837b02b1bf00972b71e5e8393fc5334ac611638071bc151b37cfc",
+      "ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5"
+    }
+  },
+  "no_version": {
+    "update_img_hash": "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2"
+  },
+  "poisoned_version": {
+    "version": "../../../../evil/guest-os/update-img",
+    "update_img_hash": "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2"
+  },
+  "downgraded_version": {
+    "version": 79,
+    "update_img_hash": "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2"
+  },
+  "poisoned_update_img_hash": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "update_img_hash": ""
+  },
+  "poisoned_setupos_hash": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "setupos_disk_img_hash_dev": "not-a-hash"
+  },
+  "poisoned_binary_name": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "binaries": {
+      "../../../../evil/binaries/x86_64-linux/ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5"
+    }
+  },
+  "poisoned_binary_hash": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "binaries": {
+      "ic-replay": ""
+    }
+  },
+  "poisoned_binaries": {
+    "version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da",
+    "binaries": ["ic-replay"]
+  }
+}"""
+
+def _icos_record_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    records = json.decode(_ICOS_JSON)
+
+    asserts.equals(env, None, icos_record_error(records["clean"]), "the real record must be accepted")
+
+    # A record with no "binaries" is left to the rule that requires them, which
+    # reports a more helpful error (how to regenerate the JSON).
+    asserts.equals(
+        env,
+        None,
+        icos_record_error({"version": "59c42492cd6ee3ef5e60cd35d7b766e7bfd085da"}),
+        "a record without optional fields must be accepted",
+    )
+
+    for key in sorted(records.keys()):
+        if key != "clean":
+            asserts.true(env, icos_record_error(records[key]) != None, "%s must be rejected" % key)
+
+    _rejects(env, icos_record_error, _NON_STRINGS, "icos_record_error")
+
+    return unittest.end(env)
+
+icos_record_test = unittest.make(_icos_record_test_impl)
+
+def _download_url_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Adding the validation must not have changed any URL that is fetched today.
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/3ae3649a2366aaca83404b692fc58e4c6e604a25/canisters/ledger-archive-node-canister.wasm.gz",
+        canister_download_url(
+            "3ae3649a2366aaca83404b692fc58e4c6e604a25",
+            None,
+            None,
+            "ledger-archive-node-canister.wasm.gz",
+            "test",
+        ),
+    )
+    asserts.equals(
+        env,
+        "https://github.com/dfinity/internet-identity/releases/download/release-2026-08-21/internet_identity_production.wasm.gz",
+        canister_download_url(
+            None,
+            "dfinity/internet-identity",
+            "release-2026-08-21",
+            "internet_identity_production.wasm.gz",
+            "test",
+        ),
+    )
+    asserts.equals(
+        env,
+        "https://github.com/dfinity/bitcoin-canister/releases/download/release/2026-04-15/ic-btc-canister.wasm.gz",
+        canister_download_url(
+            None,
+            "dfinity/bitcoin-canister",
+            "release/2026-04-15",
+            "ic-btc-canister.wasm.gz",
+            "test",
+        ),
+    )
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/79c01052b5f7f49d3cf53d04d696cb2893294cd3/binaries/x86_64-linux/ic-replay.gz",
+        binary_download_url("79c01052b5f7f49d3cf53d04d696cb2893294cd3", "ic-replay"),
+    )
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/79c01052b5f7f49d3cf53d04d696cb2893294cd3/guest-os/update-img/update-img.tar.zst",
+        icos_image_download_url("79c01052b5f7f49d3cf53d04d696cb2893294cd3", "guest-os", True),
+    )
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/79c01052b5f7f49d3cf53d04d696cb2893294cd3/setup-os/disk-img/disk-img.tar.zst",
+        icos_image_download_url("79c01052b5f7f49d3cf53d04d696cb2893294cd3", "setup-os", False),
+    )
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/79c01052b5f7f49d3cf53d04d696cb2893294cd3/setup-os/disk-img-dev/disk-img.tar.zst",
+        icos_dev_image_download_url("79c01052b5f7f49d3cf53d04d696cb2893294cd3", "setup-os", False),
+    )
+    asserts.equals(
+        env,
+        "https://download.dfinity.systems/ic/79c01052b5f7f49d3cf53d04d696cb2893294cd3/host-os/update-img-dev/update-img.tar.zst",
+        icos_dev_image_download_url("79c01052b5f7f49d3cf53d04d696cb2893294cd3", "host-os", True),
+    )
+
+    return unittest.end(env)
+
+download_url_test = unittest.make(_download_url_test_impl)
+
+def mainnet_artifact_refs_test_suite(name):
+    """Registers every test in this file under a test_suite called `name`.
+
+    Args:
+      name: the name of the generated test_suite.
+    """
+    unittest.suite(
+        name,
+        artifact_name_test,
+        commit_id_test,
+        download_url_test,
+        github_repository_test,
+        icos_record_test,
+        poisoned_canisters_json_test,
+        sha256_test,
+        tag_test,
+        variant_test,
+    )

--- a/bazel/mainnet_artifact_refs_tests/mainnet_artifact_refs_test.bzl
+++ b/bazel/mainnet_artifact_refs_tests/mainnet_artifact_refs_test.bzl
@@ -2,7 +2,7 @@
 
 The values that mainnet-canister-revisions.json and mainnet-icos-revisions.json
 contribute to a download URL are not reviewed by a human before they reach master, so
-the repository rules validate them (F-051). These tests pin down what is accepted and
+the repository rules validate them. These tests pin down what is accepted and
 what is rejected, including the fields of poisoned copies of the real JSON records.
 
 The rejecting path of the URL builders themselves cannot be asserted -- `fail()` is

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -34,6 +34,37 @@ MAINNET_BINARIES = [
 ]
 
 
+# The fields below end up interpolated into download URLs, into the names of
+# downloaded files and (for the binary names) verbatim into a generated BUILD file by
+# //bazel:mainnet-icos-{images,binaries,versions}.bzl. They are read from the public
+# dashboard API and from CDN-served SHA256SUMS files -- neither of which is
+# authenticated -- and the resulting PR is auto-approved and auto-merged, so a value
+# that is not exactly a commit id / sha256 / plain name must never be written to
+# mainnet-icos-revisions.json in the first place. The repository rules reject such
+# values as well (see bazel/mainnet-artifact-refs.bzl, which these patterns mirror);
+# failing here means a poisoned upstream value never reaches a PR.
+COMMIT_ID_PATTERN = re.compile(r"\A[0-9a-f]{40}\Z")
+SHA256_PATTERN = re.compile(r"\A[0-9a-f]{64}\Z")
+ARTIFACT_NAME_PATTERN = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+
+
+def check_commit_id(value, what: str):
+    if not isinstance(value, str) or not COMMIT_ID_PATTERN.match(value):
+        raise ValueError(f"{what} must be a 40-character lowercase hex git commit id, got {value!r}")
+
+
+def check_sha256(value, what: str):
+    # The empty string is not merely malformed: repository_ctx.download reads it as
+    # "do not verify this download".
+    if not isinstance(value, str) or not SHA256_PATTERN.match(value):
+        raise ValueError(f"{what} must be a 64-character lowercase hex sha256, got {value!r}")
+
+
+def check_artifact_name(value, what: str):
+    if not isinstance(value, str) or not ARTIFACT_NAME_PATTERN.match(value) or ".." in value:
+        raise ValueError(f"{what} must only contain [A-Za-z0-9._-] and no '..', got {value!r}")
+
+
 class Command(Enum):
     ICOS = 1
     CANISTERS = 2
@@ -55,6 +86,23 @@ class VersionInfo:
     # `binaries/x86_64-linux/`, read from that directory's SHA256SUMS. Consumed by
     # //bazel:mainnet-icos-binaries.bzl.
     binaries: dict
+
+    def __post_init__(self):
+        """Rejects values that must never reach mainnet-icos-revisions.json.
+
+        Every path that records a version constructs a VersionInfo, so this is the
+        single choke point between the unauthenticated upstreams and the JSON file.
+        `launch_measurements` is deliberately not checked here: it is arbitrary JSON
+        by design and is not interpolated into a URL or a file name.
+        """
+        check_commit_id(self.version, "version")
+        for field in ("hash", "dev_hash", "setupos_hash", "setupos_dev_hash"):
+            check_sha256(getattr(self, field), field)
+        if not isinstance(self.binaries, dict):
+            raise ValueError(f"binaries must be a dict, got {self.binaries!r}")
+        for name, digest in self.binaries.items():
+            check_artifact_name(name, "binaries key")
+            check_sha256(digest, f"binaries[{name!r}]")
 
 
 def sync_main_branch_and_checkout_branch(

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -88,7 +88,8 @@ class VersionInfo:
     binaries: dict
 
     def __post_init__(self):
-        """Rejects values that must never reach mainnet-icos-revisions.json.
+        """
+        Rejects values that must never reach mainnet-icos-revisions.json.
 
         Every path that records a version constructs a VersionInfo, so this is the
         single choke point between the unauthenticated upstreams and the JSON file.

--- a/ci/src/mainnet_revisions/mainnet_revisions_test.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions_test.py
@@ -1,4 +1,5 @@
-"""Tests for the validation of the values written to mainnet-icos-revisions.json.
+"""
+Tests for the validation of the values written to mainnet-icos-revisions.json.
 
 The version and the hashes come from the public dashboard API and from CDN-served
 SHA256SUMS files, and the PR that records them is auto-approved and auto-merged. They

--- a/ci/src/mainnet_revisions/mainnet_revisions_test.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions_test.py
@@ -1,0 +1,68 @@
+"""Tests for the validation of the values written to mainnet-icos-revisions.json.
+
+The version and the hashes come from the public dashboard API and from CDN-served
+SHA256SUMS files, and the PR that records them is auto-approved and auto-merged. They
+are interpolated into download URLs by //bazel:mainnet-icos-*.bzl, so a value that is
+not exactly a commit id / sha256 / plain name must be rejected here, before it can
+reach a PR (F-051).
+"""
+
+import pytest
+from mainnet_revisions import VersionInfo
+
+VERSION = "79c01052b5f7f49d3cf53d04d696cb2893294cd3"
+HASH = "5e67e60caf8b71d79f6f2300ceb2461086d9d763cabc5656175307c13a4410e2"
+BINARIES = {
+    "canister_sandbox": "2a2e8891dc8837b02b1bf00972b71e5e8393fc5334ac611638071bc151b37cfc",
+    "ic-replay": "6fc9e9b24e74690964357ac1681d4dcfac1c7907af6fbdd4d24a45e986d56ee5",
+}
+
+
+def version_info(**overrides) -> VersionInfo:
+    fields = dict(
+        version=VERSION,
+        hash=HASH,
+        dev_hash=HASH,
+        launch_measurements={"guest_launch_measurements": []},
+        dev_measurements={"guest_launch_measurements": []},
+        setupos_hash=HASH,
+        setupos_dev_hash=HASH,
+        binaries=dict(BINARIES),
+    )
+    fields.update(overrides)
+    return VersionInfo(**fields)
+
+
+def test_accepts_real_values():
+    assert version_info().version == VERSION
+
+
+def test_accepts_arbitrary_launch_measurements():
+    # Not validated on purpose: arbitrary JSON by design, and not interpolated into a
+    # URL or a file name.
+    assert version_info(launch_measurements={"whatever": [1, 2, 3]}).version == VERSION
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # A version that escapes the pinned CDN prefix, or selects another artifact.
+        pytest.param({"version": "../../../../evil/guest-os/update-img"}, id="traversing version"),
+        pytest.param({"version": VERSION.upper()}, id="uppercase version"),
+        pytest.param({"version": VERSION[:-1]}, id="short version"),
+        pytest.param({"version": None}, id="missing version"),
+        pytest.param({"version": 79}, id="non-string version"),
+        # The empty string makes repository_ctx.download skip verification.
+        pytest.param({"hash": ""}, id="empty hash"),
+        pytest.param({"dev_hash": "not-a-hash"}, id="malformed dev_hash"),
+        pytest.param({"setupos_hash": None}, id="missing setupos_hash"),
+        pytest.param({"setupos_dev_hash": HASH.upper()}, id="uppercase setupos_dev_hash"),
+        pytest.param({"binaries": {"../../../evil/ic-replay": HASH}}, id="traversing binary name"),
+        pytest.param({"binaries": {'ic-replay"]) load("@evil//:evil.bzl", "evil")': HASH}}, id="injecting binary name"),
+        pytest.param({"binaries": {"ic-replay": ""}}, id="empty binary hash"),
+        pytest.param({"binaries": ["ic-replay"]}, id="non-dict binaries"),
+    ],
+)
+def test_rejects_poisoned_values(overrides):
+    with pytest.raises(ValueError):
+        version_info(**overrides)


### PR DESCRIPTION
Addresses the **first recommended fix of security finding F-051**: URL components taken from an unreviewed, externally-derived JSON file were interpolated into download URLs without validation.

## Why

`mainnet-canister-revisions.json` and `mainnet-icos-revisions.json` are written by the mainnet-revisions bot, whose PRs are auto-approved and auto-merged, from data that is not independently authenticated (the public dashboard REST API, CDN-served `SHA256SUMS` files, and the hash of whatever the CDN currently serves). The repository rules that read them treated every field as trusted, interpolating it into:

- download URLs — a `tag` such as `../../../org/repo/releases/download/x` escapes the hard-coded GitHub repository under standard RFC 3986 dot-segment normalization; a `rev`/`version` selects any other artifact on the CDN,
- the `output` path of `repository_ctx.download`, which `..` can walk out of,
- the text of a generated `BUILD.bazel` file (the ICOS binary names), where quotes and newlines inject Starlark.

Two things this also closes, found while implementing:

- **An empty hash silently disables verification.** `repository_ctx.download(sha256 = "")` skips the integrity check, and `""` passed the existing `== None` guard.
- **`binaries` keys are interpolated raw into generated Starlark.** Unlike canister keys (which must match a reviewed `filenames` entry in `MODULE.bazel`), they are constrained by nothing.

## What

New `bazel/mainnet-artifact-refs.bzl` holds the validators; every choke point uses them:

| File | Checks added |
| --- | --- |
| `mainnet-canisters.bzl` | URL construction extracted into `canister_download_url` (validates rev/tag/repository/filename); impl validates the canister key and sha256 |
| `mainnet-icos-binaries.bzl` | `binary_download_url` validates; whole record validated before any download and before the BUILD text is generated |
| `mainnet-icos-images.bzl` | both URL builders validate, `variant` gated on a fixed set, record validated before the multi-GB fetches |
| `mainnet-icos-versions.bzl` | every record validated before `defs.bzl` is generated |
| `mainnet_revisions.py` | `VersionInfo.__post_init__` mirrors the checks so a poisoned upstream value fails when the JSON is written, not only when it is fetched |

Because the URL builders themselves validate, every call site is covered by construction — including the `ENV_DEPS__*_IMG_URL` env vars built by `rs/tests/configure_icos.bzl`. Validating in `mainnet-icos-versions.bzl` covers the matching `*_IMG_HASH` values, which the Farm backend uses to fetch and verify images itself, never through `repository_ctx.download`.

The validators return an error message rather than calling `fail()` (uncatchable in Starlark) — that is what makes the rejecting path unit-testable. `//bazel/mainnet_artifact_refs_tests` is the first Starlark unit test in the repo (bazel_skylib `unittest`, already a `bazel_dep`).

## Verification

- **The F-051 criterion, end to end**: with the exploit tag planted in the JSON, `bazel fetch --repo=@mainnet_canisters` fails with `canister "internet_identity_backend": tag: a tag must not contain '..'`.
- `bazel test //bazel/mainnet_artifact_refs_tests/...` — 9/9 pass; I also confirmed the suite fails on a deliberately bad assertion, so the passes are not vacuous.
- `bazel build //... --nobuild` clean; `bazel fetch` of `@mainnet_canisters` and `@mainnet_nns_binaries` succeed; all four committed ICOS records are accepted by both the Starlark and the Python validators. Accept-path tests pin the exact URLs fetched today, so validation cannot silently move a fetch.

## Not in this PR

- F-051's **second** recommended fix (anchoring hashes to an independent trust source; removing auto-approve for values the updater did not cross-verify on-chain).
- Mirroring the checks in `rs/nervous_system/tools/sync-with-released-nervous-system-wasms`, which writes the canister-side `rev`/`tag`/`sha256`. Same few lines, easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
