### PR TITLE
fix(ci): verify the crane download against a pinned sha256

### DIFF
--- a/.github/workflows/container-mirror.yml
+++ b/.github/workflows/container-mirror.yml
@@ -16,9 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
+  contents: read
   packages: write
-  contents: write
 
 jobs:
   get-images:
@@ -57,10 +56,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Crane
+        env:
+          # Keep CRANE_SHA256 in sync with CRANE_VERSION. It is the sha256 of
+          # go-containerregistry_Linux_x86_64.tar.gz listed in the release's
+          # checksums.txt, e.g.:
+          #   curl -fsSL https://github.com/google/go-containerregistry/releases/download/$CRANE_VERSION/checksums.txt
+          CRANE_VERSION: v0.21.9
+          CRANE_SHA256: 5c16d8ddb971cb1d5e6ed8b1e743da8224414eeba2c2762d8f1a61b2f095699e
         run: |
-          curl -fsL https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz | tar xz crane
+          set -euo pipefail
+          curl -fsSL -o crane.tar.gz \
+            "https://github.com/google/go-containerregistry/releases/download/$CRANE_VERSION/go-containerregistry_Linux_x86_64.tar.gz"
+          echo "$CRANE_SHA256  crane.tar.gz" | sha256sum --check --strict -
+          tar xzf crane.tar.gz crane
+          rm crane.tar.gz
           chmod +x crane
           sudo mv crane /usr/local/bin/crane
+          crane version
 
       - name: Mirror Container
         run: |


### PR DESCRIPTION
Addresses evidence item 5 of security finding **F-012** (HIGH, CWE-494, `@dfinity/infra`): *"Unverified download-and-execute of external binaries in secret-bearing CI jobs"*.

## The problem

`.github/workflows/container-mirror.yml` installed crane with:

```yaml
curl -fsL https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz | tar xz crane
chmod +x crane
sudo mv crane /usr/local/bin/crane
```

The binary was trusted on its URL alone. GitHub release assets are mutable under an existing tag — the API reports `"immutable": false` for v0.20.2 — so release access to `google/go-containerregistry` meant arbitrary code execution in a job already logged into `ghcr.io/dfinity` with a `packages: write` + `contents: write` `GITHUB_TOKEN`. A trojaned crane could push images into the mirror namespace and use the token against this repo.

The `curl | tar` pipe also made verification structurally impossible: the archive was extracted as it streamed, so there was never an artifact to hash.

## The fix

Download to a file, verify it against a sha256 pinned **in this repo**, and only then unpack and install — the pattern already used for bazelisk in `ci/container/Dockerfile`. The hash comes from the release's `checksums.txt`; verifying against that asset at runtime would be worthless, since whoever can swap the tarball can swap the sums file alongside it.

Two smaller changes ride along:

- **Bump 0.20.2 → 0.21.9** (current upstream release). `crane copy` is unchanged across the range — v0.21.0 was a Go-version floor bump plus dependency updates — and this workflow passes only positional arguments.
- **Narrow the permissions block** to `contents: read` + `packages: write`, dropping the unused `pull-requests: write` and the `contents: write` the finding calls out. Neither job needs them: `get-images` checks out and runs `jq`; `mirror` checks out, logs into GHCR and pushes. This matches `container-api-bn-recovery.yml`, which already uses exactly that pair for the same shape of job.

## Verification

The hash was taken from `checksums.txt` and independently confirmed by downloading the asset and hashing it.

The step's `env:` and `run:` blocks were then extracted back out of the YAML and executed, so these results are against what CI will actually run:

- **Positive** — `crane.tar.gz: OK`, then `crane version` prints `0.21.9`, exit 0.
- **Negative** — flipping one character of `CRANE_SHA256` gives `crane.tar.gz: FAILED` / `1 computed checksum did NOT match`, exit 1, with the binary never reaching the install path.

That negative case is the check the finding asks for: replacing the upstream release asset now fails the job instead of executing the new binary.

This PR is also self-testing. The workflow triggers on `pull_request` for edits to itself, so opening it runs the full mirror matrix over all 11 images in `container-mirror-images.json` using the new step. Every image is pinned by digest and already mirrored, so the copies are idempotent.

## Out of scope

F-012 lists six other unverified downloads. Two are already in flight — #11310 (execlog2csv) and #11311 (gh CLI). The rest (motoko in `ci/container/Dockerfile`, the dfx install script, the unpinned namespacelabs actions) are left for separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
