### PR TITLE
feat(ci): attest CDN artifact uploads with build provenance

### DIFF
--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -6,7 +6,7 @@ description: |
 
   The attestation is the integrity anchor that lets release workflows and the
   mainnet-revisions updater verify CDN downloads against something independent
-  of the CDN (security finding 3618194): they fetch a directory's SHA256SUMS
+  of the CDN: they fetch a directory's SHA256SUMS
   from the CDN, check it with
   `gh attestation verify --repo dfinity/ic --signer-workflow <this pipeline>
   --source-digest <commit>` and then verify each artifact against the now

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -1,13 +1,12 @@
 name: Attest Uploaded Artifacts
 description: |
   Generate a build-provenance attestation covering every file that this run's
-  ci-main.yml uploaded to the CDN (see ci-main's merge-upload-manifests job,
+  ci-main.yml uploaded to the CDN (see ci-main's upload-manifests job,
   which produces the upload manifest consumed here).
 
   The attestation is the integrity anchor that lets release workflows and the
   mainnet-revisions updater verify CDN downloads against something independent
-  of the CDN: they fetch a directory's SHA256SUMS
-  from the CDN, check it with
+  of the CDN: they fetch a directory's SHA256SUMS from the CDN, check it with
   `gh attestation verify --repo dfinity/ic --signer-workflow <this pipeline>
   --source-digest <commit>` and then verify each artifact against the now
   trusted sums.
@@ -16,7 +15,7 @@ description: |
   `manifest-sha256` output: an Actions artifact can be replaced mid-run by
   anything holding an `actions: write` token, but job outputs cannot be
   tampered with by other jobs. The same check anchors the merge that produced
-  the artifact: ci-main's merge-upload-manifests job verified each upload
+  the artifact: ci-main's upload-manifests job verified each upload
   job's manifest against that job's output before merging.
 
   The calling job needs `attestations: write` and `id-token: write` and must
@@ -49,11 +48,8 @@ runs:
         # empty output also fails here: sha256sum rejects the malformed line.
         echo "$MANIFEST_SHA256  upload-manifest.sha256sums" | sha256sum --check
 
-    # No continue-on-error: an unattested release upload is exactly the gap
-    # this anchor exists to close, so a failure here must fail the run.
     # With no predicate input, actions/attest emits a SLSA build-provenance
-    # attestation — the predicate type `gh attestation verify` expects by
-    # default.
+    # attestation — the predicate type `gh attestation verify` expects by default.
     - name: Attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -1,8 +1,8 @@
 name: Attest Uploaded Artifacts
 description: |
   Generate a build-provenance attestation covering every file that this run's
-  ci-main.yml uploaded to the CDN (see the upload-artifacts action, which
-  produces the upload manifests consumed here).
+  ci-main.yml uploaded to the CDN (see ci-main's merge-upload-manifests job,
+  which produces the upload manifest consumed here).
 
   The attestation is the integrity anchor that lets release workflows and the
   mainnet-revisions updater verify CDN downloads against something independent
@@ -12,60 +12,46 @@ description: |
   --source-digest <commit>` and then verify each artifact against the now
   trusted sums.
 
-  The manifest artifacts are re-checked against the sha256s carried by
-  ci-main's job outputs: an Actions artifact can be replaced mid-run by
+  The manifest artifact is re-checked against the sha256 carried by ci-main's
+  `manifest-sha256` output: an Actions artifact can be replaced mid-run by
   anything holding an `actions: write` token, but job outputs cannot be
-  tampered with by other jobs.
+  tampered with by other jobs. The same check anchors the merge that produced
+  the artifact: ci-main's merge-upload-manifests job verified each upload
+  job's manifest against that job's output before merging.
 
   The calling job needs `attestations: write` and `id-token: write` and must
-  therefore never execute build or test code — it may consume only these
-  manifests and 64-hex job outputs.
+  therefore never execute build or test code — it may consume only this
+  manifest and 64-hex job outputs.
 inputs:
-  manifest-sha256-main:
+  manifest-sha256:
     required: true
-    description: sha256 of the upload-manifest-main artifact, from ci-main's outputs.
-  manifest-sha256-external:
-    required: true
-    description: sha256 of the upload-manifest-external artifact, from ci-main's outputs.
+    description: sha256 of the upload-manifest artifact, from ci-main's outputs.
 
 runs:
   using: "composite"
   steps:
-    - name: Download main upload manifest
+    - name: Download upload manifest
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: upload-manifest-main
-        path: ${{ runner.temp }}/upload-manifests/main
+        name: upload-manifest
+        path: ${{ runner.temp }}/upload-manifest
 
-    - name: Download external upload manifest
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: upload-manifest-external
-        path: ${{ runner.temp }}/upload-manifests/external
-
-    - name: Verify and merge manifests
+    - name: Verify manifest
       shell: bash
       env:
-        MANIFEST_SHA256_MAIN: ${{ inputs.manifest-sha256-main }}
-        MANIFEST_SHA256_EXTERNAL: ${{ inputs.manifest-sha256-external }}
+        MANIFEST_SHA256: ${{ inputs.manifest-sha256 }}
       run: |
         set -euo pipefail
-        cd "$RUNNER_TEMP/upload-manifests"
+        cd "$RUNNER_TEMP/upload-manifest"
 
-        # Verify the downloaded artifacts against the hashes recorded in the
-        # producing jobs' outputs before attesting anything. A missing or
+        # Verify the downloaded artifact against the hash recorded in
+        # ci-main's job outputs before attesting anything. A missing or
         # empty output also fails here: sha256sum rejects the malformed line.
-        echo "$MANIFEST_SHA256_MAIN  main/upload-manifest.sha256sums" | sha256sum --check
-        echo "$MANIFEST_SHA256_EXTERNAL  external/upload-manifest.sha256sums" | sha256sum --check
-
-        LC_ALL=C sort -k2 \
-          main/upload-manifest.sha256sums \
-          external/upload-manifest.sha256sums \
-          >merged.sha256sums
+        echo "$MANIFEST_SHA256  upload-manifest.sha256sums" | sha256sum --check
 
     # No continue-on-error: an unattested release upload is exactly the gap
     # this anchor exists to close, so a failure here must fail the run.
     - name: Attest
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
-        subject-checksums: ${{ runner.temp }}/upload-manifests/merged.sha256sums
+        subject-checksums: ${{ runner.temp }}/upload-manifest/upload-manifest.sha256sums

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -51,7 +51,10 @@ runs:
 
     # No continue-on-error: an unattested release upload is exactly the gap
     # this anchor exists to close, so a failure here must fail the run.
+    # With no predicate input, actions/attest emits a SLSA build-provenance
+    # attestation — the predicate type `gh attestation verify` expects by
+    # default.
     - name: Attest
-      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-checksums: ${{ runner.temp }}/upload-manifest/upload-manifest.sha256sums

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -1,35 +1,11 @@
 name: Attest Uploaded Artifacts
 description: |
-  Generate a build-provenance attestation covering every file that this run's
-  ci-main.yml uploaded to the CDN (see ci-main's upload-manifests job,
-  which produces the upload manifest consumed here).
+  Generate a build-provenance attestation from a `upload-manifest` artifact.
 
-  The attestation is the integrity anchor that lets release workflows and the
-  mainnet-revisions updater verify CDN downloads against something independent
-  of the CDN: they fetch a directory's SHA256SUMS from the CDN, check it with
-  `gh attestation verify --repo dfinity/ic --signer-workflow <this pipeline>
-  --source-digest <commit> --format json`, require the verified attestation to
-  record the file's digest under the exact subject name
-  ic/<commit>/<directory>/SHA256SUMS — gh authenticates the digest only, and
-  this attestation covers every uploaded directory, so without the name check
-  a compromised CDN could serve another same-commit directory's attested
-  SHA256SUMS here — and then verify each artifact against the now trusted
-  sums.
-
-  The manifest artifact is re-checked against the sha256 carried by ci-main's
-  `manifest-sha256` output: an Actions artifact can be replaced mid-run by
-  anything holding an `actions: write` token, but job outputs cannot be
-  tampered with by other jobs. The same check anchors the merge that produced
-  the artifact: ci-main's upload-manifests job verified each upload
-  job's manifest against that job's output before merging.
-
-  The calling job needs `attestations: write` and `id-token: write` and must
-  therefore never execute build or test code — it may consume only this
-  manifest and 64-hex job outputs.
 inputs:
   manifest-sha256:
     required: true
-    description: sha256 of the upload-manifest artifact, from ci-main's outputs.
+    description: sha256 of the upload-manifest artifact.
 
 runs:
   using: "composite"
@@ -47,14 +23,8 @@ runs:
       run: |
         set -euo pipefail
         cd "$RUNNER_TEMP/upload-manifest"
-
-        # Verify the downloaded artifact against the hash recorded in
-        # ci-main's job outputs before attesting anything. A missing or
-        # empty output also fails here: sha256sum rejects the malformed line.
         echo "$MANIFEST_SHA256  upload-manifest.sha256sums" | sha256sum --check
 
-    # With no predicate input, actions/attest emits a SLSA build-provenance
-    # attestation — the predicate type `gh attestation verify` expects by default.
     - name: Attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -1,0 +1,71 @@
+name: Attest Uploaded Artifacts
+description: |
+  Generate a build-provenance attestation covering every file that this run's
+  ci-main.yml uploaded to the CDN (see the upload-artifacts action, which
+  produces the upload manifests consumed here).
+
+  The attestation is the integrity anchor that lets release workflows and the
+  mainnet-revisions updater verify CDN downloads against something independent
+  of the CDN (security finding 3618194): they fetch a directory's SHA256SUMS
+  from the CDN, check it with
+  `gh attestation verify --repo dfinity/ic --signer-workflow <this pipeline>
+  --source-digest <commit>` and then verify each artifact against the now
+  trusted sums.
+
+  The manifest artifacts are re-checked against the sha256s carried by
+  ci-main's job outputs: an Actions artifact can be replaced mid-run by
+  anything holding an `actions: write` token, but job outputs cannot be
+  tampered with by other jobs.
+
+  The calling job needs `attestations: write` and `id-token: write` and must
+  therefore never execute build or test code — it may consume only these
+  manifests and 64-hex job outputs.
+inputs:
+  manifest-sha256-main:
+    required: true
+    description: sha256 of the upload-manifest-main artifact, from ci-main's outputs.
+  manifest-sha256-external:
+    required: true
+    description: sha256 of the upload-manifest-external artifact, from ci-main's outputs.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download main upload manifest
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: upload-manifest-main
+        path: ${{ runner.temp }}/upload-manifests/main
+
+    - name: Download external upload manifest
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: upload-manifest-external
+        path: ${{ runner.temp }}/upload-manifests/external
+
+    - name: Verify and merge manifests
+      shell: bash
+      env:
+        MANIFEST_SHA256_MAIN: ${{ inputs.manifest-sha256-main }}
+        MANIFEST_SHA256_EXTERNAL: ${{ inputs.manifest-sha256-external }}
+      run: |
+        set -euo pipefail
+        cd "$RUNNER_TEMP/upload-manifests"
+
+        # Verify the downloaded artifacts against the hashes recorded in the
+        # producing jobs' outputs before attesting anything. A missing or
+        # empty output also fails here: sha256sum rejects the malformed line.
+        echo "$MANIFEST_SHA256_MAIN  main/upload-manifest.sha256sums" | sha256sum --check
+        echo "$MANIFEST_SHA256_EXTERNAL  external/upload-manifest.sha256sums" | sha256sum --check
+
+        LC_ALL=C sort -k2 \
+          main/upload-manifest.sha256sums \
+          external/upload-manifest.sha256sums \
+          >merged.sha256sums
+
+    # No continue-on-error: an unattested release upload is exactly the gap
+    # this anchor exists to close, so a failure here must fail the run.
+    - name: Attest
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-checksums: ${{ runner.temp }}/upload-manifests/merged.sha256sums

--- a/.github/actions/attest-uploads/action.yaml
+++ b/.github/actions/attest-uploads/action.yaml
@@ -8,8 +8,13 @@ description: |
   mainnet-revisions updater verify CDN downloads against something independent
   of the CDN: they fetch a directory's SHA256SUMS from the CDN, check it with
   `gh attestation verify --repo dfinity/ic --signer-workflow <this pipeline>
-  --source-digest <commit>` and then verify each artifact against the now
-  trusted sums.
+  --source-digest <commit> --format json`, require the verified attestation to
+  record the file's digest under the exact subject name
+  ic/<commit>/<directory>/SHA256SUMS — gh authenticates the digest only, and
+  this attestation covers every uploaded directory, so without the name check
+  a compromised CDN could serve another same-commit directory's attested
+  SHA256SUMS here — and then verify each artifact against the now trusted
+  sums.
 
   The manifest artifact is re-checked against the sha256 carried by ci-main's
   `manifest-sha256` output: an Actions artifact can be replaced mid-run by

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -14,9 +14,11 @@ inputs:
       converted to sha256sum format and uploaded as a GitHub Actions artifact
       with this name, and the manifest's own sha256 is exposed as the
       `manifest-sha256` output. The manifest is the build-time integrity
-      record that the `attest-uploads` jobs (see ci-kickoff.yml and
-      release-testing.yml) attest, so that release workflows can verify CDN
-      downloads against an anchor independent of the CDN itself.
+      record that ci-main's merge-upload-manifests job merges into the single
+      upload-manifest artifact, which the `attest-uploads` jobs (see
+      ci-kickoff.yml and release-testing.yml) attest, so that release
+      workflows can verify CDN downloads against an anchor independent of the
+      CDN itself.
 outputs:
   manifest-sha256:
     description: sha256 of the uploaded manifest ('' when manifest-name is unset)

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -6,6 +6,21 @@ inputs:
     required: true
   name:
     required: true
+  manifest-name:
+    required: false
+    default: ''
+    description: |
+      When set, the "<sha256>,<url>" lines emitted by the upload command are
+      converted to sha256sum format and uploaded as a GitHub Actions artifact
+      with this name, and the manifest's own sha256 is exposed as the
+      `manifest-sha256` output. The manifest is the build-time integrity
+      record that the `attest-uploads` jobs (see ci-kickoff.yml and
+      release-testing.yml) attest, so that release workflows can verify CDN
+      downloads against an anchor independent of the CDN itself.
+outputs:
+  manifest-sha256:
+    description: sha256 of the uploaded manifest ('' when manifest-name is unset)
+    value: ${{ steps.manifest.outputs.sha256 }}
 
 runs:
   using: "composite"
@@ -33,4 +48,43 @@ runs:
             echo '</details>';
           } >>"$GITHUB_STEP_SUMMARY"
 
+          # Persist the upload manifest in sha256sum format ("<hex>  <path>",
+          # path relative to https://download.dfinity.systems/). The hashes
+          # were computed by the uploader from the local files before upload,
+          # so this is a build-time record of what was published, not a
+          # restatement of what the CDN serves. The steps below (gated on
+          # `manifest-name`) upload it for the attest-uploads jobs.
+          sed 's|,https://download.dfinity.systems/|  |' "$upload_output" >"$RUNNER_TEMP/upload-manifest.sha256sums"
+
           rm "$upload_output"
+
+    - name: Check manifest
+      id: manifest
+      if: inputs.manifest-name != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        manifest="$RUNNER_TEMP/upload-manifest.sha256sums"
+
+        # Fail closed rather than attest garbage: the manifest must be
+        # non-empty and every line must be "<64-hex>  ic/<path>". A new
+        # artifact whose name falls outside this character set should extend
+        # the pattern here deliberately, not slip through.
+        if ! [ -s "$manifest" ]; then
+          echo "upload manifest is missing or empty: $manifest" >&2
+          exit 1
+        fi
+        if grep -Ev '^[0-9a-f]{64}  ic/[A-Za-z0-9._/-]+$' "$manifest"; then
+          echo "upload manifest contains malformed lines (printed above)" >&2
+          exit 1
+        fi
+
+        echo "sha256=$(sha256sum "$manifest" | cut -d' ' -f1)" >>"$GITHUB_OUTPUT"
+
+    - name: Upload manifest
+      if: inputs.manifest-name != ''
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ inputs.manifest-name }}
+        path: ${{ runner.temp }}/upload-manifest.sha256sums
+        if-no-files-found: error

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -31,7 +31,14 @@ runs:
       with:
         run: |
           echo uploading artifacts to remote storage
-          upload_output=$(mktemp) # used in summary
+
+          # The upload manifest the uploader prints to stdout: sha256sum
+          # lines ("<hex>  <path>", path relative to
+          # https://download.dfinity.systems/), hashed by the uploader from
+          # its local copy of each file — never from anything served back by
+          # the CDN (see ci/src/artifacts/upload.sh). The steps below (gated
+          # on `manifest-name`) upload it for the attest-uploads jobs.
+          upload_output="$RUNNER_TEMP/upload-manifest.sha256sums"
 
           ${{ inputs.upload-command }} >"$upload_output"
 
@@ -48,16 +55,6 @@ runs:
             echo
             echo '</details>';
           } >>"$GITHUB_STEP_SUMMARY"
-
-          # Persist the upload manifest the uploader printed to stdout:
-          # sha256sum lines ("<hex>  <path>", path relative to
-          # https://download.dfinity.systems/), hashed by the uploader from
-          # its local copy of each file — never from anything served back by
-          # the CDN (see ci/src/artifacts/upload.sh). The steps below (gated
-          # on `manifest-name`) upload it for the attest-uploads jobs.
-          cp "$upload_output" "$RUNNER_TEMP/upload-manifest.sha256sums"
-
-          rm "$upload_output"
 
     - name: Check manifest
       id: manifest

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -7,20 +7,10 @@ inputs:
   name:
     required: true
   manifest-name:
-    required: false
-    default: ''
-    description: |
-      When set, the sha256sum-format manifest the upload command emits on
-      stdout is uploaded as a GitHub Actions artifact with this name, and the
-      manifest's own sha256 is exposed as the `manifest-sha256` output. The manifest is the build-time integrity
-      record that ci-main's upload-manifests job merges into the single
-      upload-manifest artifact, which the `attest-uploads` jobs (see
-      ci-kickoff.yml and release-testing.yml) attest, so that release
-      workflows can verify CDN downloads against an anchor independent of the
-      CDN itself.
+    required: true
 outputs:
   manifest-sha256:
-    description: sha256 of the uploaded manifest ('' when manifest-name is unset)
+    description: sha256 of the uploaded manifest
     value: ${{ steps.manifest.outputs.sha256 }}
 
 runs:
@@ -51,7 +41,6 @@ runs:
 
     - name: Check manifest
       id: manifest
-      if: inputs.manifest-name != ''
       shell: bash
       run: |
         set -euo pipefail
@@ -71,7 +60,6 @@ runs:
         echo "sha256=$(sha256sum "$manifest" | cut -d' ' -f1)" >>"$GITHUB_OUTPUT"
 
     - name: Upload manifest
-      if: inputs.manifest-name != ''
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.manifest-name }}

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -10,10 +10,9 @@ inputs:
     required: false
     default: ''
     description: |
-      When set, the "<sha256>,<url>" lines emitted by the upload command are
-      converted to sha256sum format and uploaded as a GitHub Actions artifact
-      with this name, and the manifest's own sha256 is exposed as the
-      `manifest-sha256` output. The manifest is the build-time integrity
+      When set, the sha256sum-format manifest the upload command emits on
+      stdout is uploaded as a GitHub Actions artifact with this name, and the
+      manifest's own sha256 is exposed as the `manifest-sha256` output. The manifest is the build-time integrity
       record that ci-main's merge-upload-manifests job merges into the single
       upload-manifest artifact, which the `attest-uploads` jobs (see
       ci-kickoff.yml and release-testing.yml) attest, so that release
@@ -50,14 +49,13 @@ runs:
             echo '</details>';
           } >>"$GITHUB_STEP_SUMMARY"
 
-          # Persist the upload manifest in sha256sum format ("<hex>  <path>",
-          # path relative to https://download.dfinity.systems/). The uploader
-          # computes each hash from its local copy of the file — never from
-          # anything served back by the CDN — so this is a build-time record
-          # of what was published, not a restatement of what the CDN serves.
-          # The steps below (gated on `manifest-name`) upload it for the
-          # attest-uploads jobs.
-          sed 's|,https://download.dfinity.systems/|  |' "$upload_output" >"$RUNNER_TEMP/upload-manifest.sha256sums"
+          # Persist the upload manifest the uploader printed to stdout:
+          # sha256sum lines ("<hex>  <path>", path relative to
+          # https://download.dfinity.systems/), hashed by the uploader from
+          # its local copy of each file — never from anything served back by
+          # the CDN (see ci/src/artifacts/upload.sh). The steps below (gated
+          # on `manifest-name`) upload it for the attest-uploads jobs.
+          cp "$upload_output" "$RUNNER_TEMP/upload-manifest.sha256sums"
 
           rm "$upload_output"
 

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -13,7 +13,7 @@ inputs:
       When set, the sha256sum-format manifest the upload command emits on
       stdout is uploaded as a GitHub Actions artifact with this name, and the
       manifest's own sha256 is exposed as the `manifest-sha256` output. The manifest is the build-time integrity
-      record that ci-main's merge-upload-manifests job merges into the single
+      record that ci-main's upload-manifests job merges into the single
       upload-manifest artifact, which the `attest-uploads` jobs (see
       ci-kickoff.yml and release-testing.yml) attest, so that release
       workflows can verify CDN downloads against an anchor independent of the
@@ -31,13 +31,6 @@ runs:
       with:
         run: |
           echo uploading artifacts to remote storage
-
-          # The upload manifest the uploader prints to stdout: sha256sum
-          # lines ("<hex>  <path>", path relative to
-          # https://download.dfinity.systems/), hashed by the uploader from
-          # its local copy of each file — never from anything served back by
-          # the CDN (see ci/src/artifacts/upload.sh). The steps below (gated
-          # on `manifest-name`) upload it for the attest-uploads jobs.
           upload_output="$RUNNER_TEMP/upload-manifest.sha256sums"
 
           ${{ inputs.upload-command }} >"$upload_output"
@@ -65,9 +58,7 @@ runs:
         manifest="$RUNNER_TEMP/upload-manifest.sha256sums"
 
         # Fail closed rather than attest garbage: the manifest must be
-        # non-empty and every line must be "<64-hex>  ic/<path>". A new
-        # artifact whose name falls outside this character set should extend
-        # the pattern here deliberately, not slip through.
+        # non-empty and every line must be "<64-hex>  ic/<path>".
         if ! [ -s "$manifest" ]; then
           echo "upload manifest is missing or empty: $manifest" >&2
           exit 1

--- a/.github/actions/upload-artifacts/action.yaml
+++ b/.github/actions/upload-artifacts/action.yaml
@@ -49,11 +49,12 @@ runs:
           } >>"$GITHUB_STEP_SUMMARY"
 
           # Persist the upload manifest in sha256sum format ("<hex>  <path>",
-          # path relative to https://download.dfinity.systems/). The hashes
-          # were computed by the uploader from the local files before upload,
-          # so this is a build-time record of what was published, not a
-          # restatement of what the CDN serves. The steps below (gated on
-          # `manifest-name`) upload it for the attest-uploads jobs.
+          # path relative to https://download.dfinity.systems/). The uploader
+          # computes each hash from its local copy of the file — never from
+          # anything served back by the CDN — so this is a build-time record
+          # of what was published, not a restatement of what the CDN serves.
+          # The steps below (gated on `manifest-name`) upload it for the
+          # attest-uploads jobs.
           sed 's|,https://download.dfinity.systems/|  |' "$upload_output" >"$RUNNER_TEMP/upload-manifest.sha256sums"
 
           rm "$upload_output"

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -40,6 +40,35 @@ jobs:
       id-token: write
       pull-requests: read
 
+  # Attest what ci-main uploaded to the CDN so that release workflows and the
+  # mainnet-revisions updater can verify their CDN downloads against an anchor
+  # independent of the CDN (security finding 3618194). This job lives here in
+  # the caller rather than in ci-main.yml because GitHub validates a called
+  # workflow's permission requests against the caller's grant statically (even
+  # for jobs whose `if:` would skip them), and ci-kickoff-manual.yml — which
+  # runs CI on fork PRs — must never be granted `attestations: write`.
+  attest-uploads:
+    name: Attest Uploaded Artifacts
+    runs-on: ubuntu-latest
+    needs: [ci-main]
+    # Only release builds upload artifacts, and only the public repo has
+    # attestations (they are the public integrity anchor: a build from
+    # ic-private gets attested when its branch is pushed to dfinity/ic and is
+    # re-built and re-uploaded byte-identically there).
+    if: needs.ci-main.outputs.release-build == 'true' && github.repository == 'dfinity/ic'
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+      - uses: ./.github/actions/attest-uploads
+        with:
+          manifest-sha256-main: ${{ needs.ci-main.outputs.manifest-sha256-main }}
+          manifest-sha256-external: ${{ needs.ci-main.outputs.manifest-sha256-external }}
+
   ci-pr-only:
     name: CI PR Only
     # only run on PRs and not forked PRs

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -104,17 +104,9 @@ jobs:
   post-required-check-status-ci-main:
     name: CI Main Required Check Status
     runs-on: ubuntu-latest
-    needs: [ci-main, attest-uploads]
-    # Only run this job on pull requests or merge queues, but run it
-    # regardless of the previous result. attest-uploads is normally skipped
-    # on those events (it only runs on release builds), so the gate checks
-    # ci-main's result explicitly rather than using success() || failure(),
-    # which are both false when any needed job was skipped and would leave
-    # the required status unposted. !cancelled() suppresses the implicit
-    # success() that GitHub applies to conditions without a status function.
-    if: |
-      !cancelled() && (needs.ci-main.result == 'success' || needs.ci-main.result == 'failure') &&
-      ( github.event_name == 'pull_request' || github.event_name == 'merge_group' )
+    needs: [ci-main]
+    # only run this job on pull requests or merge queues, but run it regardless of the previous result
+    if: (success() || failure()) && ( github.event_name == 'pull_request' || github.event_name == 'merge_group' )
     permissions:
       contents: read
       pull-requests: write
@@ -127,11 +119,7 @@ jobs:
         with:
           # on pull requests the github.sha is the merge commit - here we use the head commit so that it will show up on PRs
           commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-          # A failed attestation must fail the required check: an unattested
-          # release upload is exactly the gap the attest job closes. A
-          # skipped attest-uploads (non-release build) passes ci-main's
-          # result through unchanged.
-          run-result: ${{ case(needs.attest-uploads.result == 'failure', 'failure', needs.ci-main.result) }}
+          run-result: ${{ needs.ci-main.result }}
           name: ci-main-status
 
   post-required-check-status-ci-pr-only:

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -53,8 +53,8 @@ jobs:
     needs: [ci-main]
     # Only release builds upload artifacts, and only the public repo has
     # attestations (they are the public integrity anchor: a build from
-    # ic-private gets attested when its branch is pushed to dfinity/ic and is
-    # re-built and re-uploaded byte-identically there).
+    # ic-private gets attested when its branch is pushed to dfinity/ic as a
+    # hotfix-* branch and is re-built and re-uploaded byte-identically there).
     if: needs.ci-main.outputs.release-build == 'true' && github.repository == 'dfinity/ic'
     permissions:
       attestations: write

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -66,8 +66,7 @@ jobs:
           ref: ${{ github.sha }}
       - uses: ./.github/actions/attest-uploads
         with:
-          manifest-sha256-main: ${{ needs.ci-main.outputs.manifest-sha256-main }}
-          manifest-sha256-external: ${{ needs.ci-main.outputs.manifest-sha256-external }}
+          manifest-sha256: ${{ needs.ci-main.outputs.manifest-sha256 }}
 
   ci-pr-only:
     name: CI PR Only

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -42,7 +42,7 @@ jobs:
 
   # Attest what ci-main uploaded to the CDN so that release workflows and the
   # mainnet-revisions updater can verify their CDN downloads against an anchor
-  # independent of the CDN (security finding 3618194). This job lives here in
+  # independent of the CDN. This job lives here in
   # the caller rather than in ci-main.yml because GitHub validates a called
   # workflow's permission requests against the caller's grant statically (even
   # for jobs whose `if:` would skip them), and ci-kickoff-manual.yml — which

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -104,9 +104,17 @@ jobs:
   post-required-check-status-ci-main:
     name: CI Main Required Check Status
     runs-on: ubuntu-latest
-    needs: [ci-main]
-    # only run this job on pull requests or merge queues, but run it regardless of the previous result
-    if: (success() || failure()) && ( github.event_name == 'pull_request' || github.event_name == 'merge_group' )
+    needs: [ci-main, attest-uploads]
+    # Only run this job on pull requests or merge queues, but run it
+    # regardless of the previous result. attest-uploads is normally skipped
+    # on those events (it only runs on release builds), so the gate checks
+    # ci-main's result explicitly rather than using success() || failure(),
+    # which are both false when any needed job was skipped and would leave
+    # the required status unposted. !cancelled() suppresses the implicit
+    # success() that GitHub applies to conditions without a status function.
+    if: |
+      !cancelled() && (needs.ci-main.result == 'success' || needs.ci-main.result == 'failure') &&
+      ( github.event_name == 'pull_request' || github.event_name == 'merge_group' )
     permissions:
       contents: read
       pull-requests: write
@@ -119,7 +127,11 @@ jobs:
         with:
           # on pull requests the github.sha is the merge commit - here we use the head commit so that it will show up on PRs
           commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-          run-result: ${{ needs.ci-main.result }}
+          # A failed attestation must fail the required check: an unattested
+          # release upload is exactly the gap the attest job closes. A
+          # skipped attest-uploads (non-release build) passes ci-main's
+          # result through unchanged.
+          run-result: ${{ case(needs.attest-uploads.result == 'failure', 'failure', needs.ci-main.result) }}
           name: ci-main-status
 
   post-required-check-status-ci-pr-only:

--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -40,13 +40,6 @@ jobs:
       id-token: write
       pull-requests: read
 
-  # Attest what ci-main uploaded to the CDN so that release workflows and the
-  # mainnet-revisions updater can verify their CDN downloads against an anchor
-  # independent of the CDN. This job lives here in
-  # the caller rather than in ci-main.yml because GitHub validates a called
-  # workflow's permission requests against the caller's grant statically (even
-  # for jobs whose `if:` would skip them), and ci-kickoff-manual.yml — which
-  # runs CI on fork PRs — must never be granted `attestations: write`.
   attest-uploads:
     name: Attest Uploaded Artifacts
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -544,10 +544,13 @@ jobs:
           # sha256sum rejects input without valid checksum lines.
           check() { # <download-dir> <recorded sha256sum lines>
             echo "$2" | (cd "$1" && sha256sum --check --strict)
-            # Also reject artifacts carrying files beyond the recorded ones,
-            # so a future edit that globs from these directories cannot pick
-            # up unrecorded extras that the check above never covered.
-            diff <(echo "$2" | awk '{print $2}' | LC_ALL=C sort) <(ls "$1" | LC_ALL=C sort)
+            # Also reject artifacts carrying anything beyond the recorded
+            # files — enumerated with find so hidden entries and
+            # subdirectories count too — so a future edit that globs from
+            # these directories cannot pick up unrecorded extras that the
+            # check above never covered.
+            diff <(echo "$2" | awk '{print $2}' | LC_ALL=C sort) \
+              <(cd "$1" && find . -mindepth 1 | sed 's|^\./||' | LC_ALL=C sort)
           }
           check ~/.cache/arm64-binaries-linux "$ARM64_LINUX_SUMS"
           check ~/.cache/arm64-binaries-darwin "$ARM64_DARWIN_SUMS"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -12,6 +12,21 @@ on:
         required: false
         default: ''
         type: string
+    outputs:
+      release-build:
+        description: Whether this run was a release build, i.e. uploaded artifacts to the CDN.
+        value: ${{ jobs.config.outputs.release-build }}
+      # sha256s of the upload-manifest-{main,external} Actions artifacts
+      # ('' on non-release builds). Callers pass them to the attest-uploads
+      # action, which re-checks the downloaded artifacts against them: job
+      # outputs, unlike the artifacts themselves, cannot be tampered with by
+      # other jobs holding an `actions: write` token.
+      manifest-sha256-main:
+        description: sha256 of the upload-manifest-main artifact.
+        value: ${{ jobs.bazel-test-all.outputs.manifest-sha256 }}
+      manifest-sha256-external:
+        description: sha256 of the upload-manifest-external artifact.
+        value: ${{ jobs.upload-external-artifacts.outputs.manifest-sha256 }}
 
 permissions:
   actions: write # needed for uploading artifacts to github
@@ -211,6 +226,8 @@ jobs:
   bazel-test-all:
     name: Bazel Test All
     needs: [config, infer-bazel-targets]
+    outputs:
+      manifest-sha256: ${{ steps.upload-artifacts.outputs.manifest-sha256 }}
     environment:
       # The `Upload artifacts` step below only executes if `release-build == 'true'` which is the case on protected branches.
       # It also requires the AWS and CF secrets which are only available in the `upload-artifacts` environment.
@@ -278,6 +295,7 @@ jobs:
           aws-region: eu-central-1
 
       - name: Upload artifacts
+        id: upload-artifacts
         uses: ./.github/actions/upload-artifacts
         if: needs.config.outputs.release-build == 'true'
         env:
@@ -285,6 +303,7 @@ jobs:
           CF_AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_AWS_SECRET_ACCESS_KEY }}
         with:
           name: Bazel Test All
+          manifest-name: upload-manifest-main
           # with --check_up_to_date Bazel will error out if the artifacts
           # to be uploaded were not built in the build step above
           # (this ensures that the exact artifacts built above are uploaded)
@@ -422,6 +441,8 @@ jobs:
     name: Upload external artifacts
     needs: [bazel-test-arm64, config]
     if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string
+    outputs:
+      manifest-sha256: ${{ steps.upload-artifacts.outputs.manifest-sha256 }}
     # The `Upload artifacts` step below requires the AWS & CF secrets
     # which are only available in the `upload-artifacts` environment.
     environment: upload-artifacts
@@ -470,6 +491,15 @@ jobs:
           mkdir -p "$bundledir/binaries/x86_64-darwin/"
           cp ~/.cache/pocket-ic-server-x86_64-darwin/pocket-ic-server-x86_64-darwin.gz "$bundledir/binaries/x86_64-darwin/pocket-ic.gz"
 
+          # Give these hand-assembled directories the same SHA256SUMS file
+          # that the bazel-built bundles get from the artifact_bundle rule
+          # (publish/defs.bzl), so every binaries/<platform>/ directory on the
+          # CDN carries a checksum manifest that release workflows can verify
+          # against its attestation.
+          for d in arm64-linux arm64-darwin x86_64-darwin; do
+            (cd "$bundledir/binaries/$d" && sha256sum *.gz | LC_ALL=C sort -k2 >SHA256SUMS)
+          done
+
           echo bundledir="$bundledir" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
@@ -480,12 +510,14 @@ jobs:
           aws-region: eu-central-1
 
       - name: Upload artifacts
+        id: upload-artifacts
         uses: ./.github/actions/upload-artifacts
         env:
           CF_AWS_ACCESS_KEY_ID: ${{ secrets.CF_AWS_ACCESS_KEY_ID }}
           CF_AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_AWS_SECRET_ACCESS_KEY }}
         with:
           name: arm64 artifacts
+          manifest-name: upload-manifest-external
           upload-command: bazel run --config=stamped //:artifact-uploader -- ${{ steps.prepare-bundle.outputs.bundledir }}
 
   python-ci-tests:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -342,6 +342,16 @@ jobs:
     timeout-minutes: 120
     needs: [config]
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
+    # sha256sum lines for the files inside each uploaded Actions artifact
+    # ('' unless release-build), recorded by the "Record artifact checksums"
+    # step. Each matrix leg sets only its own keys; the runner drops empty
+    # outputs when merging matrix legs, so the legs do not overwrite each
+    # other. upload-external-artifacts re-checks its downloads against these
+    # before re-uploading anything to the CDN.
+    outputs:
+      arm64-linux-sums: ${{ steps.sums.outputs.arm64-linux-sums }}
+      arm64-darwin-sums: ${{ steps.sums.outputs.arm64-darwin-sums }}
+      x86_64-darwin-sums: ${{ steps.sums.outputs.x86_64-darwin-sums }}
     steps:
       - name: Set up Bazel cache
         run: |
@@ -383,6 +393,53 @@ jobs:
           cp \
             ./bazel-bin/publish/binaries/pocket-ic.gz \
             ./build/pocket-ic-server-x86_64-darwin.gz
+
+      - name: Record artifact checksums
+        id: sums
+        if: ${{ needs.config.outputs.release-build == 'true' }}
+        env:
+          OS: ${{ matrix.os }}
+        run: |
+          set -euo pipefail
+          cd build
+
+          # macOS runners may only have perl's shasum, not GNU coreutils
+          # (same fallback as in .github/actions/bazel).
+          if command -v sha256sum >/dev/null; then
+            sha256() { sha256sum "$@"; }
+          else
+            sha256() { shasum -a 256 "$@"; }
+          fi
+
+          # Record the sha256sum lines of every file uploaded as an Actions
+          # artifact below in this job's outputs. The
+          # upload-external-artifacts job re-checks the downloaded artifacts
+          # against them before re-uploading anything to the CDN: an Actions
+          # artifact can be replaced mid-run by anything holding an
+          # `actions: write` token, but job outputs cannot be tampered with
+          # by other jobs. Recording happens right after the builds so the
+          # whole-codebase build and test steps below stay outside this
+          # trust chain: should any of them overwrite these files, the
+          # uploaded artifact no longer matches its recorded sums and
+          # verification fails loudly.
+          sha256 \
+            "pocket-ic-server-arm64-$OS.gz" \
+            "ic-admin-arm64-$OS.gz" \
+            "sns-arm64-$OS.gz" \
+            | LC_ALL=C sort -k2 >"$RUNNER_TEMP/arm64-sums"
+          {
+            echo "arm64-$OS-sums<<SUMS"
+            cat "$RUNNER_TEMP/arm64-sums"
+            echo "SUMS"
+          } >>"$GITHUB_OUTPUT"
+
+          if [[ "$OS" == darwin ]]; then
+            {
+              echo "x86_64-darwin-sums<<SUMS"
+              sha256 pocket-ic-server-x86_64-darwin.gz
+              echo "SUMS"
+            } >>"$GITHUB_OUTPUT"
+          fi
 
       # Ensures that local development works on arm64-darwin.
       - name: Build the entire codebase on darwin
@@ -469,6 +526,32 @@ jobs:
           name: pocket-ic-server-x86_64-darwin.gz
           # avoid downloading to workspace to avoid version being marked as dirty
           path: ~/.cache/pocket-ic-server-x86_64-darwin
+
+      - name: Verify downloaded artifacts
+        env:
+          ARM64_LINUX_SUMS: ${{ needs.bazel-test-arm64.outputs.arm64-linux-sums }}
+          ARM64_DARWIN_SUMS: ${{ needs.bazel-test-arm64.outputs.arm64-darwin-sums }}
+          X86_64_DARWIN_SUMS: ${{ needs.bazel-test-arm64.outputs.x86_64-darwin-sums }}
+        run: |
+          set -euo pipefail
+
+          # Re-check every file downloaded above against the sha256sum lines
+          # the producing bazel-test-arm64 legs recorded in their job
+          # outputs, before anything is bundled and re-uploaded to the CDN:
+          # an Actions artifact can be replaced mid-run by anything holding
+          # an `actions: write` token, but job outputs cannot be tampered
+          # with by other jobs. A missing or empty output also fails here:
+          # sha256sum rejects input without valid checksum lines.
+          check() { # <download-dir> <recorded sha256sum lines>
+            echo "$2" | (cd "$1" && sha256sum --check --strict)
+            # Also reject artifacts carrying files beyond the recorded ones,
+            # so a future edit that globs from these directories cannot pick
+            # up unrecorded extras that the check above never covered.
+            diff <(echo "$2" | awk '{print $2}' | LC_ALL=C sort) <(ls "$1" | LC_ALL=C sort)
+          }
+          check ~/.cache/arm64-binaries-linux "$ARM64_LINUX_SUMS"
+          check ~/.cache/arm64-binaries-darwin "$ARM64_DARWIN_SUMS"
+          check ~/.cache/pocket-ic-server-x86_64-darwin "$X86_64_DARWIN_SUMS"
 
       - name: Prepare bundle
         id: prepare-bundle

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,17 +16,15 @@ on:
       release-build:
         description: Whether this run was a release build, i.e. uploaded artifacts to the CDN.
         value: ${{ jobs.config.outputs.release-build }}
-      # sha256s of the upload-manifest-{main,external} Actions artifacts
-      # ('' on non-release builds). Callers pass them to the attest-uploads
-      # action, which re-checks the downloaded artifacts against them: job
+      # sha256 of the upload-manifest Actions artifact ('' on non-release
+      # builds), which lists every file this run uploaded to the CDN (see the
+      # merge-upload-manifests job). Callers pass it to the attest-uploads
+      # action, which re-checks the downloaded artifact against it: job
       # outputs, unlike the artifacts themselves, cannot be tampered with by
       # other jobs holding an `actions: write` token.
-      manifest-sha256-main:
-        description: sha256 of the upload-manifest-main artifact.
-        value: ${{ jobs.bazel-test-all.outputs.manifest-sha256 }}
-      manifest-sha256-external:
-        description: sha256 of the upload-manifest-external artifact.
-        value: ${{ jobs.upload-external-artifacts.outputs.manifest-sha256 }}
+      manifest-sha256:
+        description: sha256 of the upload-manifest artifact.
+        value: ${{ jobs.merge-upload-manifests.outputs.manifest-sha256 }}
 
 permissions:
   actions: write # needed for uploading artifacts to github
@@ -519,6 +517,75 @@ jobs:
           name: arm64 artifacts
           manifest-name: upload-manifest-external
           upload-command: bazel run --config=stamped //:artifact-uploader -- ${{ steps.prepare-bundle.outputs.bundledir }}
+
+  # Merge the per-job upload manifests into the single upload-manifest
+  # artifact exposed through this workflow's `manifest-sha256` output. That
+  # the CDN uploads happen in two jobs (bazel-test-all and
+  # upload-external-artifacts) is an implementation detail of this workflow:
+  # callers and the attest-uploads action only ever see one manifest, so a
+  # change to the set of upload jobs stays confined to this file.
+  #
+  # This job is part of the attestation trust chain (see the attest-uploads
+  # action): it verifies each downloaded manifest against the producing job's
+  # output before merging, and anchors the merged artifact in its own job
+  # output. It must never execute build or test code.
+  merge-upload-manifests:
+    name: Merge upload manifests
+    needs: [config, bazel-test-all, upload-external-artifacts]
+    if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string
+    runs-on: ubuntu-latest
+    # Reduced from the workflow-level grants: same-run artifact transfer uses
+    # the runner's runtime token, so this job needs neither `actions: write`
+    # nor `id-token: write`; `contents: read` is kept as the read-only floor.
+    permissions:
+      contents: read
+    outputs:
+      manifest-sha256: ${{ steps.merge.outputs.sha256 }}
+    steps:
+      - name: Download main upload manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: upload-manifest-main
+          path: ${{ runner.temp }}/upload-manifests/main
+
+      - name: Download external upload manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: upload-manifest-external
+          path: ${{ runner.temp }}/upload-manifests/external
+
+      - name: Verify and merge manifests
+        id: merge
+        shell: bash
+        env:
+          MANIFEST_SHA256_MAIN: ${{ needs.bazel-test-all.outputs.manifest-sha256 }}
+          MANIFEST_SHA256_EXTERNAL: ${{ needs.upload-external-artifacts.outputs.manifest-sha256 }}
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/upload-manifests"
+
+          # Verify the downloaded artifacts against the hashes recorded in
+          # the producing jobs' outputs before merging anything: an Actions
+          # artifact can be replaced mid-run by anything holding an
+          # `actions: write` token, but job outputs cannot be tampered with
+          # by other jobs. A missing or empty output also fails here:
+          # sha256sum rejects the malformed line.
+          echo "$MANIFEST_SHA256_MAIN  main/upload-manifest.sha256sums" | sha256sum --check
+          echo "$MANIFEST_SHA256_EXTERNAL  external/upload-manifest.sha256sums" | sha256sum --check
+
+          LC_ALL=C sort -k2 \
+            main/upload-manifest.sha256sums \
+            external/upload-manifest.sha256sums \
+            >upload-manifest.sha256sums
+
+          echo "sha256=$(sha256sum upload-manifest.sha256sums | cut -d' ' -f1)" >>"$GITHUB_OUTPUT"
+
+      - name: Upload merged manifest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: upload-manifest
+          path: ${{ runner.temp }}/upload-manifests/upload-manifest.sha256sums
+          if-no-files-found: error
 
   python-ci-tests:
     name: Python CI Tests

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -336,12 +336,6 @@ jobs:
     timeout-minutes: 120
     needs: [config]
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
-    # sha256sum lines for the files inside each uploaded Actions artifact
-    # ('' unless release-build), recorded by the "Record artifact checksums"
-    # step. Each matrix leg sets only its own keys; the runner drops empty
-    # outputs when merging matrix legs, so the legs do not overwrite each
-    # other. upload-external-artifacts re-checks its downloads against these
-    # before re-uploading anything to the CDN.
     outputs:
       arm64-linux-sums: ${{ steps.sums.outputs.arm64-linux-sums }}
       arm64-darwin-sums: ${{ steps.sums.outputs.arm64-darwin-sums }}
@@ -391,8 +385,6 @@ jobs:
       - name: Record artifact checksums
         id: sums
         if: ${{ needs.config.outputs.release-build == 'true' }}
-        # Explicit bash: without `shell:` the runner may resolve the default
-        # to plain sh, which cannot parse this script.
         shell: bash
         env:
           OS: ${{ matrix.os }}
@@ -525,8 +517,6 @@ jobs:
           path: ~/.cache/pocket-ic-server-x86_64-darwin
 
       - name: Verify downloaded artifacts
-        # Explicit bash: in this container job the default shell resolves to
-        # plain sh, which cannot parse the process substitutions below.
         shell: bash
         env:
           ARM64_LINUX_SUMS: ${{ needs.bazel-test-arm64.outputs.arm64-linux-sums }}
@@ -544,11 +534,7 @@ jobs:
           # sha256sum rejects input without valid checksum lines.
           check() { # <download-dir> <recorded sha256sum lines>
             echo "$2" | (cd "$1" && sha256sum --check --strict)
-            # Also reject artifacts carrying anything beyond the recorded
-            # files — enumerated with find so hidden entries and
-            # subdirectories count too — so a future edit that globs from
-            # these directories cannot pick up unrecorded extras that the
-            # check above never covered.
+            # Also reject artifacts carrying anything beyond the recorded files
             diff <(echo "$2" | awk '{print $2}' | LC_ALL=C sort) \
               <(cd "$1" && find . -mindepth 1 | sed 's|^\./||' | LC_ALL=C sort)
           }
@@ -577,8 +563,8 @@ jobs:
 
           # Give these hand-assembled directories the same SHA256SUMS file
           # that the bazel-built bundles get from the artifact_bundle rule
-          # (publish/defs.bzl), so every binaries/<platform>/ directory on the
-          # CDN carries a checksum manifest that release workflows can verify
+          # so every binaries/<platform>/ directory on the CDN carries
+          # a checksum manifest that release workflows can verify
           # against its attestation.
           for d in arm64-linux arm64-darwin x86_64-darwin; do
             (cd "$bundledir/binaries/$d" && sha256sum *.gz | LC_ALL=C sort -k2 >SHA256SUMS)
@@ -605,24 +591,12 @@ jobs:
           upload-command: bazel run --config=stamped //:artifact-uploader -- ${{ steps.prepare-bundle.outputs.bundledir }}
 
   # Merge the per-job upload manifests into the single upload-manifest
-  # artifact exposed through this workflow's `manifest-sha256` output. That
-  # the CDN uploads happen in two jobs (bazel-test-all and
-  # upload-external-artifacts) is an implementation detail of this workflow:
-  # callers and the attest-uploads action only ever see one manifest, so a
-  # change to the set of upload jobs stays confined to this file.
-  #
-  # This job is part of the attestation trust chain (see the attest-uploads
-  # action): it verifies each downloaded manifest against the producing job's
-  # output before merging, and anchors the merged artifact in its own job
-  # output. It must never execute build or test code.
+  # artifact exposed through this workflow's `manifest-sha256` output.
   upload-manifests:
     name: Merge upload manifests
     needs: [config, bazel-test-all, upload-external-artifacts]
     if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string
     runs-on: ubuntu-latest
-    # Reduced from the workflow-level grants: same-run artifact transfer uses
-    # the runner's runtime token, so this job needs neither `actions: write`
-    # nor `id-token: write`; `contents: read` is kept as the read-only floor.
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -397,6 +397,9 @@ jobs:
       - name: Record artifact checksums
         id: sums
         if: ${{ needs.config.outputs.release-build == 'true' }}
+        # Explicit bash: without `shell:` the runner may resolve the default
+        # to plain sh, which cannot parse this script.
+        shell: bash
         env:
           OS: ${{ matrix.os }}
         run: |
@@ -528,6 +531,9 @@ jobs:
           path: ~/.cache/pocket-ic-server-x86_64-darwin
 
       - name: Verify downloaded artifacts
+        # Explicit bash: in this container job the default shell resolves to
+        # plain sh, which cannot parse the process substitutions below.
+        shell: bash
         env:
           ARM64_LINUX_SUMS: ${{ needs.bazel-test-arm64.outputs.arm64-linux-sums }}
           ARM64_DARWIN_SUMS: ${{ needs.bazel-test-arm64.outputs.arm64-darwin-sums }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,15 +16,9 @@ on:
       release-build:
         description: Whether this run was a release build, i.e. uploaded artifacts to the CDN.
         value: ${{ jobs.config.outputs.release-build }}
-      # sha256 of the upload-manifest Actions artifact ('' on non-release
-      # builds), which lists every file this run uploaded to the CDN (see the
-      # merge-upload-manifests job). Callers pass it to the attest-uploads
-      # action, which re-checks the downloaded artifact against it: job
-      # outputs, unlike the artifacts themselves, cannot be tampered with by
-      # other jobs holding an `actions: write` token.
       manifest-sha256:
-        description: sha256 of the upload-manifest artifact.
-        value: ${{ jobs.merge-upload-manifests.outputs.manifest-sha256 }}
+        description: sha256 of the upload-manifest.
+        value: ${{ jobs.upload-manifests.outputs.manifest-sha256 }}
 
 permissions:
   actions: write # needed for uploading artifacts to github
@@ -621,7 +615,7 @@ jobs:
   # action): it verifies each downloaded manifest against the producing job's
   # output before merging, and anchors the merged artifact in its own job
   # output. It must never execute build or test code.
-  merge-upload-manifests:
+  upload-manifests:
     name: Merge upload manifests
     needs: [config, bazel-test-all, upload-external-artifacts]
     if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -66,13 +66,6 @@ jobs:
       commit-sha: ${{ github.sha }}
       release-build: 'true'
 
-  # Attest what ci-main uploaded to the CDN so that tag-release.yml and the
-  # mainnet-revisions updater can verify their CDN downloads against an anchor
-  # independent of the CDN. Job-level permissions
-  # only: this job must stay isolated — it consumes nothing but ci-main's
-  # 64-hex manifest-sha256 output and the run-local upload-manifest artifact,
-  # never data derived from external dashboards, and no other job in this
-  # workflow may hold `attestations: write`.
   attest-uploads:
     name: Attest Uploaded Artifacts
     runs-on: ubuntu-latest

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -66,6 +66,34 @@ jobs:
       commit-sha: ${{ github.sha }}
       release-build: 'true'
 
+  # Attest what ci-main uploaded to the CDN so that tag-release.yml and the
+  # mainnet-revisions updater can verify their CDN downloads against an anchor
+  # independent of the CDN (security finding 3618194). Job-level permissions
+  # only: this job must stay isolated — it consumes nothing but 64-hex job
+  # outputs and run-local manifest artifacts, never data derived from external
+  # dashboards, and no other job in this workflow may hold
+  # `attestations: write`.
+  attest-uploads:
+    name: Attest Uploaded Artifacts
+    runs-on: ubuntu-latest
+    needs: [ci-main]
+    # Attestations exist only for the public repo: a build from ic-private
+    # gets attested when its branch is pushed to dfinity/ic and is re-built
+    # and re-uploaded byte-identically there.
+    if: needs.ci-main.outputs.release-build == 'true' && github.repository == 'dfinity/ic'
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+      - uses: ./.github/actions/attest-uploads
+        with:
+          manifest-sha256-main: ${{ needs.ci-main.outputs.manifest-sha256-main }}
+          manifest-sha256-external: ${{ needs.ci-main.outputs.manifest-sha256-external }}
+
   setup-guest-os-qualification:
     name: Setting up guest os qualification pipeline
     runs-on: &dind-large-setup

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -78,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci-main]
     # Attestations exist only for the public repo: a build from ic-private
-    # gets attested when its branch is pushed to dfinity/ic and is re-built
-    # and re-uploaded byte-identically there.
+    # gets attested when its branch is pushed to dfinity/ic as a hotfix-*
+    # branch and is re-built and re-uploaded byte-identically there.
     if: needs.ci-main.outputs.release-build == 'true' && github.repository == 'dfinity/ic'
     permissions:
       attestations: write

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -68,7 +68,7 @@ jobs:
 
   # Attest what ci-main uploaded to the CDN so that tag-release.yml and the
   # mainnet-revisions updater can verify their CDN downloads against an anchor
-  # independent of the CDN (security finding 3618194). Job-level permissions
+  # independent of the CDN. Job-level permissions
   # only: this job must stay isolated — it consumes nothing but ci-main's
   # 64-hex manifest-sha256 output and the run-local upload-manifest artifact,
   # never data derived from external dashboards, and no other job in this

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -69,10 +69,10 @@ jobs:
   # Attest what ci-main uploaded to the CDN so that tag-release.yml and the
   # mainnet-revisions updater can verify their CDN downloads against an anchor
   # independent of the CDN (security finding 3618194). Job-level permissions
-  # only: this job must stay isolated — it consumes nothing but 64-hex job
-  # outputs and run-local manifest artifacts, never data derived from external
-  # dashboards, and no other job in this workflow may hold
-  # `attestations: write`.
+  # only: this job must stay isolated — it consumes nothing but ci-main's
+  # 64-hex manifest-sha256 output and the run-local upload-manifest artifact,
+  # never data derived from external dashboards, and no other job in this
+  # workflow may hold `attestations: write`.
   attest-uploads:
     name: Attest Uploaded Artifacts
     runs-on: ubuntu-latest
@@ -91,8 +91,7 @@ jobs:
           ref: ${{ github.sha }}
       - uses: ./.github/actions/attest-uploads
         with:
-          manifest-sha256-main: ${{ needs.ci-main.outputs.manifest-sha256-main }}
-          manifest-sha256-external: ${{ needs.ci-main.outputs.manifest-sha256-external }}
+          manifest-sha256: ${{ needs.ci-main.outputs.manifest-sha256 }}
 
   setup-guest-os-qualification:
     name: Setting up guest os qualification pipeline

--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - rc--*
+      - hotfix-*
       - ic-mainnet-revisions
       - ic-nervous-system-wasms
     workflows:

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -102,6 +102,10 @@ for fullrelpath in $(find -L "$BUNDLE" -type f); do
 
     upload "$fullrelpath" "$bucket_path"
 
+    # One sha256sum-format line ("<hex>  <bucket path>") per uploaded file on
+    # stdout, hashed from the local copy of the file — never from anything
+    # served back by the CDN. The upload-artifacts action persists this
+    # output as the upload manifest that gets attested.
     artifact_checksum="$(sha256sum "$fullrelpath" | cut -d' ' -f1)"
-    echo "$artifact_checksum,https://download.dfinity.systems/$bucket_path"
+    echo "$artifact_checksum  $bucket_path"
 done

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -102,10 +102,8 @@ for fullrelpath in $(find -L "$BUNDLE" -type f); do
 
     upload "$fullrelpath" "$bucket_path"
 
-    # One sha256sum-format line ("<hex>  <bucket path>") per uploaded file on
-    # stdout, hashed from the local copy of the file — never from anything
-    # served back by the CDN. The upload-artifacts action persists this
-    # output as the upload manifest that gets attested.
+    # One sha256sum-format line ("<hex>  <bucket path>") per uploaded file on stdout.
+    # The upload-artifacts action persists this output as the upload manifest that gets attested.
     artifact_checksum="$(sha256sum "$fullrelpath" | cut -d' ' -f1)"
     echo "$artifact_checksum  $bucket_path"
 done


### PR DESCRIPTION
First producer-side step for **security finding 3618194** (MEDIUM, CWE-494): the release pipeline has no integrity anchor independent of the serving CDN — `tag-release.yml` and `ledger-suite-release.yml` publish checksums computed *from their own CDN downloads*, and `mainnet_revisions.py` records CDN-served hashes into `mainnet-icos-revisions.json`.

`ci/src/artifacts/upload.sh` already hashes every file it uploads (from the **local** bytes, never from anything served back by the CDN) and prints one manifest line per file — but the `upload-artifacts` action discarded that output into the step summary. This PR switches the output to sha256sum format (`<hex>  <path>`, path relative to the CDN root) and turns it into a durable, attested anchor.

### Changes

* **`.github/actions/upload-artifacts`**: converts the upload manifest to `sha256sum` format, validates its shape (fail closed on empty/malformed lines), exposes its own sha256 as an output, and uploads it as an Actions artifact (`manifest-name` input).
* **`ci-main.yml`**: both upload jobs (`bazel-test-all`, `upload-external-artifacts`) produce named manifests; a new unprivileged `upload-manifests` job re-checks each one against the producing job's output sha256, merges them into a single `upload-manifest` artifact, and anchors it in its own job output. That the uploads happen in two jobs stays an implementation detail of `ci-main.yml`: callers see only the `release-build` and `manifest-sha256` `workflow_call` outputs. The hand-assembled `binaries/{arm64-linux,arm64-darwin,x86_64-darwin}/` directories now also get the `SHA256SUMS` file every other CDN directory already gets from the `artifact_bundle` rule. **No permission changes** (the merge job runs no build or test code, and same-run artifact transfer uses the runtime token, so it drops the workflow-level `actions`/`id-token` grants).
* **`bazel-test-arm64` → `upload-external-artifacts` binding**: the arm64/macOS binaries transit Actions artifacts between the Namespace builders and the CDN-upload job; each `bazel-test-arm64` leg now records the `sha256sum` lines of every file it uploads in its job outputs — immediately after the builds, keeping the whole-codebase build and test steps outside the trust chain — and `upload-external-artifacts` re-checks each downloaded artifact against them (rejecting mismatches, empty outputs, and files beyond the recorded set) before bundling. Closes the same artifact-swap hole for the binaries that the manifest checks close for the manifests.
* **New `attest-uploads` job** in `ci-kickoff.yml` (master builds) and `release-testing.yml` (`rc--*`/`hotfix-*` builds): re-checks the merged manifest artifact against ci-main's `manifest-sha256` output (an Actions artifact can be replaced mid-run by anything holding an `actions: write` token; job outputs cannot — the same check anchors every hop of the merge) and runs `actions/attest` (pinned, v4.2.2; the `attest-build-provenance` wrapper's README directs new implementations to it — same SLSA provenance predicate) with `subject-checksums` — one attestation covering every uploaded file **including each directory's `SHA256SUMS`**.

### Why the attest job lives in the callers, not in ci-main.yml

GitHub validates a called workflow's permission requests against the caller's grant **statically, even for jobs whose `if:` would skip them** ([community discussion #155062](https://github.com/orgs/community/discussions/155062)). An attest job inside `ci-main.yml` would therefore force `attestations: write` into `ci-kickoff-manual.yml`, which runs CI on fork PRs. With this layout no job that executes build or test code ever holds `attestations: write`, and `ci-kickoff-manual.yml` is untouched.

### How consumers will verify (follow-up PRs)

```
gh attestation verify SHA256SUMS --repo dfinity/ic \
  --signer-workflow dfinity/ic/.github/workflows/<ci-kickoff|release-testing>.yml \
  --source-digest <commit>
```
then `sha256sum --check` each downloaded artifact against the verified sums. The `--source-digest` binding prevents replaying another commit's legitimately-attested objects. Follow-ups: `ledger-suite-release.yml`, `tag-release.yml`, `mainnet_revisions.py`.

### Validation

Tested **end-to-end pre-merge** via a `workflow_dispatch` of `ci-kickoff.yml` on this branch with `release-build=true` (the `upload-artifacts` environment temporarily allowed this branch via a custom deployment-branch policy, removed after the test): [run 33004648043](https://github.com/dfinity/ic/actions/runs/33004648043) on `fa328bb033` — all jobs green, including both `bazel-test-arm64` legs (checksum recording), `upload-external-artifacts` (download verification + extras guard), `upload-manifests`, and `Attest Uploaded Artifacts` (one attestation, 180 subjects, `predicateType: https://slsa.dev/provenance/v1`, see: https://github.com/dfinity/ic/attestations/43234804).

Workstation verification against that run's artifacts:

* Positive: `curl -fsSLO https://download.dfinity.systems/ic/fa328bb033…/binaries/x86_64-linux/SHA256SUMS && gh attestation verify SHA256SUMS --repo dfinity/ic --signer-workflow dfinity/ic/.github/workflows/ci-kickoff.yml --source-digest fa328bb033…` → exit 0. The follow-up PR's `ci/scripts/fetch-attested-sums.sh` also ran end-to-end against this attestation (exit 0, fetched file byte-identical), confirming the `--format json` subject structure (`.[].verificationResult.statement.subject[]`) and the per-directory subject-name binding on a live attestation.
* Negative tests (per F-012 house style), all correctly failing: one flipped hex char in the file → exit 1; `--source-digest` of a different commit → exit 1; `--signer-workflow …/release-testing.yml` (wrong pipeline) → exit 1.
* All changed workflow/action files parse as YAML; the manifest-shape check and the sha256 cross-checks fail closed by construction.

### Scope / residual risk

The attestation certifies *what this CI built and uploaded*, not that the build is reproducible — `build-determinism` and `repro-check` remain the complementary controls. A run that uploads but dies before attesting leaves that commit unattested until re-run (the re-upload is checked byte-for-byte by `rclone --immutable --checksum`). Builds in ic-private are not attested; their commits gain attestations when the branch is pushed to dfinity/ic and rebuilt there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





