### PR TITLE
feat(cketh): record the deposits a sweep moves and size its gas to the delegate's work

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -596,8 +596,6 @@ type SweptDeposit = record {
     subaccount : opt blob;
     erc20_contract_address : text;
     address : text;
-    // Whether this sweep is the one that installs the address' delegation.
-    delegating : bool;
 };
 
 // A sweep transaction the minter has created but not yet signed: a transaction,
@@ -679,8 +677,8 @@ type Event = record {
             data : blob;
             max_transaction_fee : nat;
             created_at : nat64;
-            // Delegations the sweep installs on the way, empty if every address
-            // it touches is already delegated.
+            // Delegations the sweep installs on the way, one per deposit address
+            // it touches. Empty only for a sweep that delegates nothing at all.
             authorizations : vec SignedAuthorization;
             // The deposits the sweep moves, one per (account, token) pair. Its call
             // data instead names one item per deposit address, so the two differ

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -590,6 +590,16 @@ type SignedAuthorization = record {
     s : blob;
 };
 
+// One (account, token) deposit a sweep moves, and the address it moves it from.
+type SweptDeposit = record {
+    owner : principal;
+    subaccount : opt blob;
+    erc20_contract_address : text;
+    address : text;
+    // Whether this sweep is the one that installs the address' delegation.
+    delegating : bool;
+};
+
 // A sweep transaction the minter has created but not yet signed: a transaction,
 // plus the delegations it installs on the way. With none it is sent as a plain
 // EIP-1559 (0x02) transaction, and otherwise as an EIP-7702 (0x04) one.
@@ -672,6 +682,10 @@ type Event = record {
             // Delegations the sweep installs on the way, empty if every address
             // it touches is already delegated.
             authorizations : vec SignedAuthorization;
+            // The deposits the sweep moves, one per (account, token) pair. Its call
+            // data instead names one item per deposit address, so the two differ
+            // in length whenever an account has several tokens queued.
+            deposits : vec SweptDeposit;
         };
         CreatedSweeperTransaction : record {
             sweep_id : nat;

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -464,6 +464,17 @@ pub mod events {
         pub s: ByteBuf,
     }
 
+    /// One `(account, token)` deposit a sweep moves, and the address it moves it from.
+    #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+    pub struct SweptDeposit {
+        pub owner: Principal,
+        pub subaccount: Option<[u8; 32]>,
+        pub erc20_contract_address: String,
+        pub address: String,
+        /// Whether this sweep is the one that installs the address' delegation.
+        pub delegating: bool,
+    }
+
     /// A sweep transaction the minter has created but not yet signed: a transaction, plus the
     /// delegations it installs on the way. With none it is sent as a plain EIP-1559 (`0x02`)
     /// transaction, and otherwise as an EIP-7702 (`0x04`) one.
@@ -584,6 +595,10 @@ pub mod events {
             /// Delegations the sweep installs on the way, empty if every address it touches is
             /// already delegated.
             authorizations: Vec<SignedAuthorization>,
+            /// The deposits the sweep moves, one per `(account, token)` pair. Its call data instead
+            /// names one item per deposit address, so the two differ in length whenever an account
+            /// has several tokens queued.
+            deposits: Vec<SweptDeposit>,
         },
         CreatedSweeperTransaction {
             sweep_id: Nat,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -471,8 +471,6 @@ pub mod events {
         pub subaccount: Option<[u8; 32]>,
         pub erc20_contract_address: String,
         pub address: String,
-        /// Whether this sweep is the one that installs the address' delegation.
-        pub delegating: bool,
     }
 
     /// A sweep transaction the minter has created but not yet signed: a transaction, plus the
@@ -592,8 +590,8 @@ pub mod events {
             data: ByteBuf,
             max_transaction_fee: Nat,
             created_at: u64,
-            /// Delegations the sweep installs on the way, empty if every address it touches is
-            /// already delegated.
+            /// Delegations the sweep installs on the way, one per deposit address it touches.
+            /// Empty only for a sweep that delegates nothing at all.
             authorizations: Vec<SignedAuthorization>,
             /// The deposits the sweep moves, one per `(account, token)` pair. Its call data instead
             /// names one item per deposit address, so the two differ in length whenever an account

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1003,7 +1003,6 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                             subaccount: deposit.account.subaccount,
                             erc20_contract_address: deposit.erc20_contract_address.to_string(),
                             address: deposit.address.to_string(),
-                            delegating: deposit.delegating,
                         })
                         .collect(),
                 },

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -815,6 +815,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
     fn map_event(Event { timestamp, payload }: Event) -> CandidEvent {
         use ic_cketh_minter::endpoints::events::{
             DepositAddressRegistration as CandidDepositAddressRegistration, EventPayload as EP,
+            SweptDeposit as CandidSweptDeposit,
         };
         CandidEvent {
             timestamp,
@@ -986,6 +987,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     max_transaction_fee,
                     created_at,
                     authorizations,
+                    deposits,
                 }) => EP::AcceptedSweepRequest {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
@@ -994,6 +996,16 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,
                     authorizations: map_authorizations(&authorizations),
+                    deposits: deposits
+                        .into_iter()
+                        .map(|deposit| CandidSweptDeposit {
+                            owner: deposit.account.owner,
+                            subaccount: deposit.account.subaccount,
+                            erc20_contract_address: deposit.erc20_contract_address.to_string(),
+                            address: deposit.address.to_string(),
+                            delegating: deposit.delegating,
+                        })
+                        .collect(),
                 },
                 EventType::CreatedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -98,7 +98,7 @@ impl GetEventsFile {
     fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
         use crate::endpoints::events::{
             AccessListItem as CandidAccessListItem, EventSource as CandidEventSource,
-            ReimbursementIndex as CandidReimbursementIndex,
+            ReimbursementIndex as CandidReimbursementIndex, SweptDeposit as CandidSweptDeposit,
             TransactionReceipt as CandidTransactionReceipt,
             TransactionStatus as CandidTransactionStatus,
         };
@@ -289,6 +289,20 @@ impl GetEventsFile {
             )
         }
 
+        fn map_swept_deposit(
+            deposit: CandidSweptDeposit,
+        ) -> crate::state::transactions::SweptDeposit {
+            crate::state::transactions::SweptDeposit {
+                account: Account {
+                    owner: deposit.owner,
+                    subaccount: deposit.subaccount,
+                },
+                erc20_contract_address: deposit.erc20_contract_address.parse().unwrap(),
+                address: deposit.address.parse().unwrap(),
+                delegating: deposit.delegating,
+            }
+        }
+
         fn map_authorizations(
             authorizations: Vec<CandidSignedAuthorization>,
         ) -> Vec<SignedAuthorization> {
@@ -463,6 +477,7 @@ impl GetEventsFile {
                     max_transaction_fee,
                     created_at,
                     authorizations,
+                    deposits,
                 } => ET::AcceptedSweepRequest(SweepRequest {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
@@ -471,6 +486,7 @@ impl GetEventsFile {
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,
                     authorizations: map_authorizations(authorizations),
+                    deposits: deposits.into_iter().map(map_swept_deposit).collect(),
                 }),
                 EventPayload::CreatedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -299,7 +299,6 @@ impl GetEventsFile {
                 },
                 erc20_contract_address: deposit.erc20_contract_address.parse().unwrap(),
                 address: deposit.address.parse().unwrap(),
-                delegating: deposit.delegating,
             }
         }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -244,6 +244,11 @@ const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 
 /// Gas one EIP-7702 authorization costs: 12'500 (`PER_AUTH_BASE_COST`) plus the 25'000
 /// (`PER_EMPTY_ACCOUNT_COST`) a deposit EOA pays, its account holding no ETH and no code yet.
+///
+/// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
+/// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
+/// matches — still pays `PER_AUTH_BASE_COST`, and pays no `PER_EMPTY_ACCOUNT_COST` because such an
+/// account exists, so this is the worst case either way.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 /// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
@@ -275,16 +280,17 @@ pub struct SweepRequest {
     /// The IC time at which the sweep was decided.
     #[n(5)]
     pub created_at: u64,
-    /// Delegations to install on the way, one signed by each deposit address the sweep touches
-    /// that is not yet delegated to the sweeper contract. Empty once they all are, and a sweep
-    /// with none is a plain EIP-1559 transaction.
+    /// Delegations to install on the way, one signed by every deposit address the sweep touches,
+    /// whether or not that address is already delegated: the tuples are signed for nonce 0, which
+    /// installs a delegation that is missing and is skipped otherwise. A sweep that delegates
+    /// nothing at all carries none, and is then a plain EIP-1559 transaction.
     #[n(6)]
     pub authorizations: Vec<SignedAuthorization>,
     /// The deposits this sweep moves, one per `(account, token)` pair, in the order the sweep queue
     /// offered them. Not the shape of `data`, which names one item per deposit address: an account
     /// with two tokens queued is two deposits here and one item there. Recording them makes the
-    /// request self-describing — the sweep queue and the set of delegated addresses are both
-    /// reconstructible from the log, without decoding call data.
+    /// request self-describing — the sweep queue is reconstructible from the log, without decoding
+    /// call data.
     #[n(7)]
     pub deposits: Vec<SweptDeposit>,
 }
@@ -298,11 +304,6 @@ pub struct SweptDeposit {
     pub erc20_contract_address: Address,
     #[n(2)]
     pub address: DepositAddress,
-    /// Whether this sweep installs the delegation of `address`, i.e. whether that address'
-    /// authorization is in [`SweepRequest::authorizations`]. All of an account's deposits sit at the
-    /// one address, so they share one authorization and agree on this flag.
-    #[n(3)]
-    pub delegating: bool,
 }
 
 impl SweepRequest {
@@ -310,21 +311,19 @@ impl SweepRequest {
     /// the number of deposits: the delegate hands the whole token array to every address it sweeps,
     /// so both the balance checks and the transfers grow as distinct addresses × distinct tokens. It
     /// checks every pair, and moves any pair it finds a balance at — not only the pairs `deposits`
-    /// names. Only the addresses this sweep delegates pay an authorization on top.
+    /// names. Every address pays an authorization on top, since the sweep carries a tuple for each
+    /// of them.
     ///
     /// The enqueuing side sends one token per sweep, so the product is the addresses in practice;
     /// the general form is what keeps the limit safe for any request that reaches here.
     pub fn gas_limit(&self) -> GasAmount {
-        let pairs = self
-            .distinct_count(|deposit| deposit.address)
-            .saturating_mul(self.distinct_count(|deposit| deposit.erc20_contract_address));
+        let addresses = self.distinct_count(|deposit| deposit.address);
+        let pairs =
+            addresses.saturating_mul(self.distinct_count(|deposit| deposit.erc20_contract_address));
         [
             (SWEEP_GAS_PER_BALANCE_CHECK, pairs),
             (SWEEP_GAS_PER_TRANSFER, pairs),
-            (
-                SWEEP_GAS_PER_AUTHORIZATION,
-                as_u64(self.authorizations.len()),
-            ),
+            (SWEEP_GAS_PER_AUTHORIZATION, addresses),
         ]
         .into_iter()
         .fold(SWEEP_BASE_GAS, |total, (gas_per_unit, units)| {

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -5,6 +5,7 @@ pub(in crate::state) mod tests;
 
 pub use request::PipelineRequest;
 
+use crate::deposit_address::DepositAddress;
 use crate::endpoints::{EthTransaction, RetrieveEthStatus, TxFinalizedStatus, WithdrawalStatus};
 use crate::eth_logs::LedgerSubaccount;
 use crate::eth_rpc::Hash;
@@ -13,7 +14,7 @@ use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::logs::INFO;
 use crate::map::MultiKeyMap;
 use crate::numeric::{
-    CkTokenAmount, Erc20Value, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
+    CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
     TransactionNonce, Wei,
 };
 use crate::tx::{
@@ -212,6 +213,39 @@ impl SweepId {
     }
 }
 
+/// Gas a sweep transaction needs before any of the addresses it sweeps: the 21'000 intrinsic cost,
+/// the batch call's own dispatch and the two calldata arrays it copies into memory.
+///
+/// This and the constants below are derived from the EVM's own costs rather than from the ~42'000
+/// per deposit measured for a batch of 20, which does not record how many distinct tokens that
+/// batch covered and so cannot separate the work that grows with the pairs from the work that grows
+/// with the transfers. Each is deliberately generous: unspent gas is refunded, whereas an
+/// underestimate wastes the whole transaction.
+const SWEEP_BASE_GAS: GasAmount = GasAmount::new(60_000);
+
+/// Gas each `balanceOf` the delegate makes costs. `sweepErc20Batch` hands the whole token array to
+/// every item and `sweepErc20` loops over it, so a sweep pays one balance check per
+/// `(address, token)` pair whether or not the pair holds anything — and therefore at least one per
+/// address, which is where that address' calldata, `ecrecover` and delegated call are accounted
+/// for. A cold `balanceOf` is ~5'000 (2'600 account access, 2'100 cold slot, call overhead) and the
+/// per-address dispatch ~10'000.
+const SWEEP_GAS_PER_BALANCE_CHECK: GasAmount = GasAmount::new(15_000);
+
+/// Gas moving one pair costs beyond its balance check: the `approve` (a 20'000 slot write), the
+/// helper's `depositErc20` and the `transferFrom` it makes (two slot writes and two logs), ~55'000
+/// in the worst case, doubled.
+///
+/// Budgeted for every pair the batch touches rather than only for the deposits the queue named:
+/// `sweepErc20` moves whatever balance it finds, and a deposit address accumulates residue — a pair
+/// armed but not yet scanned, a pair whose watchlist window closed before the funds arrived, a token
+/// the sender was never asked for. A pair therefore costs a balance check and, on top of it,
+/// possibly a transfer.
+const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
+
+/// Gas one EIP-7702 authorization costs: 12'500 (`PER_AUTH_BASE_COST`) plus the 25'000
+/// (`PER_EMPTY_ACCOUNT_COST`) a deposit EOA pays, its account holding no ETH and no code yet.
+const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
+
 /// A sweep the minter issues **from its dedicated sweeper address**, on the sweeper's own nonce
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.
@@ -246,6 +280,69 @@ pub struct SweepRequest {
     /// with none is a plain EIP-1559 transaction.
     #[n(6)]
     pub authorizations: Vec<SignedAuthorization>,
+    /// The deposits this sweep moves, one per `(account, token)` pair, in the order the sweep queue
+    /// offered them. Not the shape of `data`, which names one item per deposit address: an account
+    /// with two tokens queued is two deposits here and one item there. Recording them makes the
+    /// request self-describing — the sweep queue and the set of delegated addresses are both
+    /// reconstructible from the log, without decoding call data.
+    #[n(7)]
+    pub deposits: Vec<SweptDeposit>,
+}
+
+/// One `(account, token)` deposit a sweep moves, and the address it moves it from.
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
+pub struct SweptDeposit {
+    #[n(0)]
+    pub account: Account,
+    #[n(1)]
+    pub erc20_contract_address: Address,
+    #[n(2)]
+    pub address: DepositAddress,
+    /// Whether this sweep installs the delegation of `address`, i.e. whether that address'
+    /// authorization is in [`SweepRequest::authorizations`]. All of an account's deposits sit at the
+    /// one address, so they share one authorization and agree on this flag.
+    #[n(3)]
+    pub delegating: bool,
+}
+
+impl SweepRequest {
+    /// Gas limit for this sweep's transaction, scaled to the work its delegate does rather than to
+    /// the number of deposits: the delegate hands the whole token array to every address it sweeps,
+    /// so both the balance checks and the transfers grow as distinct addresses × distinct tokens. It
+    /// checks every pair, and moves any pair it finds a balance at — not only the pairs `deposits`
+    /// names. Only the addresses this sweep delegates pay an authorization on top.
+    ///
+    /// The enqueuing side sends one token per sweep, so the product is the addresses in practice;
+    /// the general form is what keeps the limit safe for any request that reaches here.
+    pub fn gas_limit(&self) -> GasAmount {
+        let pairs = self
+            .distinct_count(|deposit| deposit.address)
+            .saturating_mul(self.distinct_count(|deposit| deposit.erc20_contract_address));
+        [
+            (SWEEP_GAS_PER_BALANCE_CHECK, pairs),
+            (SWEEP_GAS_PER_TRANSFER, pairs),
+            (
+                SWEEP_GAS_PER_AUTHORIZATION,
+                as_u64(self.authorizations.len()),
+            ),
+        ]
+        .into_iter()
+        .fold(SWEEP_BASE_GAS, |total, (gas_per_unit, units)| {
+            total
+                .checked_add(gas_per_unit.checked_mul(units).unwrap_or(GasAmount::MAX))
+                .unwrap_or(GasAmount::MAX)
+        })
+    }
+
+    /// How many distinct values `key` takes over the swept deposits.
+    fn distinct_count<K: Ord>(&self, key: impl FnMut(&SweptDeposit) -> K) -> u64 {
+        as_u64(self.deposits.iter().map(key).collect::<BTreeSet<_>>().len())
+    }
+}
+
+/// A count as the gas arithmetic takes it, saturating rather than wrapping.
+fn as_u64(count: usize) -> u64 {
+    u64::try_from(count).unwrap_or(u64::MAX)
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Decode, Encode)]

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -308,11 +308,13 @@ pub struct SweptDeposit {
 
 impl SweepRequest {
     /// Gas limit for this sweep's transaction, scaled to the work its delegate does rather than to
-    /// the number of deposits: the delegate hands the whole token array to every address it sweeps,
-    /// so both the balance checks and the transfers grow as distinct addresses × distinct tokens. It
-    /// checks every pair, and moves any pair it finds a balance at — not only the pairs `deposits`
-    /// names. Every address pays an authorization on top, since the sweep carries a tuple for each
-    /// of them.
+    /// the deposits the sweep names: the call data holds a single token array, the union of the
+    /// tokens over all of them, and `sweepErc20Batch` hands that one array to every address it
+    /// sweeps. A sweep of one address in USDC and a second in USDC and USDT therefore checks the
+    /// first address' USDT as well, and moves it if it finds a balance there — a deposit address
+    /// accumulates residue the queue never named. Both the balance checks and the transfers grow as
+    /// distinct addresses × distinct tokens, and every address pays an authorization on top, since
+    /// the sweep carries a tuple for each of them.
     ///
     /// The enqueuing side sends one token per sweep, so the product is the addresses in practice;
     /// the general form is what keeps the limit safe for any request that reaches here.

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -230,8 +230,8 @@ impl PipelineRequest for SweepRequest {
         );
     }
 
-    /// A sweep that must still install delegations becomes an EIP-7702 transaction, and a sweep of
-    /// addresses already delegated a plain EIP-1559 one.
+    /// A sweep that installs delegations becomes an EIP-7702 transaction, and one that installs
+    /// none a plain EIP-1559 one.
     fn create_transaction(
         &self,
         nonce: TransactionNonce,

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2973,8 +2973,8 @@ mod sweep_lane {
     use crate::lifecycle::EthereumNetwork;
     use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
-        SweepRequest, SweptDeposit, TransactionPipeline,
+        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError,
+        SWEEP_GAS_PER_AUTHORIZATION, SweepId, SweepRequest, SweptDeposit, TransactionPipeline,
     };
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
@@ -2983,6 +2983,7 @@ mod sweep_lane {
     use assert_matches::assert_matches;
     use ethnum::u256;
     use ic_ethereum_types::Address;
+    use std::collections::BTreeSet;
 
     const EIP1559_TX_ID: u8 = 2;
     const SET_CODE_TX_ID: u8 = 4;
@@ -3000,7 +3001,7 @@ mod sweep_lane {
         }
     }
 
-    /// A sweep of two deposit addresses that are not yet delegated to the sweeper contract.
+    /// A sweep of two deposit addresses, each authorizing its delegation to the sweeper contract.
     fn delegating_sweep_request(id: u64) -> SweepRequest {
         SweepRequest {
             authorizations: vec![authorization(1), authorization(2)],
@@ -3076,17 +3077,17 @@ mod sweep_lane {
 
         for case in [
             Case {
-                scenario: "every swept address already delegated",
+                scenario: "a sweep installing no delegation",
                 authorizations: vec![],
                 expected_transaction_type: EIP1559_TX_ID,
             },
             Case {
-                scenario: "one swept address still to delegate",
+                scenario: "a sweep installing one delegation",
                 authorizations: vec![authorization(1)],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
             Case {
-                scenario: "two swept addresses still to delegate",
+                scenario: "a sweep installing two delegations",
                 authorizations: vec![authorization(1), authorization(2)],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
@@ -3360,7 +3361,6 @@ mod sweep_lane {
         struct Case {
             scenario: &'static str,
             deposits: Vec<(u8, u8)>,
-            authorizations: usize,
             expected_gas_limit: u64,
         }
 
@@ -3368,42 +3368,31 @@ mod sweep_lane {
             Case {
                 scenario: "nothing to sweep",
                 deposits: vec![],
-                authorizations: 0,
                 expected_gas_limit: 60_000,
             },
             Case {
-                scenario: "one address already delegated, holding one token",
+                scenario: "one address holding one token",
                 deposits: vec![(1, 1)],
-                authorizations: 0,
-                expected_gas_limit: 60_000 + 15_000 + 110_000,
-            },
-            Case {
-                scenario: "one address to delegate, holding one token",
-                deposits: vec![(1, 1)],
-                authorizations: 1,
                 expected_gas_limit: 60_000 + 15_000 + 110_000 + 40_000,
             },
             Case {
                 scenario: "one address holding two tokens: two pairs, one authorization",
                 deposits: vec![(1, 1), (1, 2)],
-                authorizations: 1,
                 expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 40_000,
             },
             Case {
                 scenario: "two addresses holding the same token",
                 deposits: vec![(1, 1), (2, 1)],
-                authorizations: 2,
                 expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 2 * 40_000,
             },
             Case {
                 scenario: "two addresses holding a token each: every pair is checked and may move",
                 deposits: vec![(1, 1), (2, 2)],
-                authorizations: 2,
                 expected_gas_limit: 60_000 + 4 * 15_000 + 4 * 110_000 + 2 * 40_000,
             },
         ] {
             assert_eq!(
-                with_deposits(&case.deposits, case.authorizations).gas_limit(),
+                with_deposits(&case.deposits).gas_limit(),
                 GasAmount::from(case.expected_gas_limit),
                 "{}",
                 case.scenario
@@ -3412,13 +3401,28 @@ mod sweep_lane {
     }
 
     #[test]
+    fn should_budget_one_authorization_per_address() {
+        // Two batches of two pairs each, differing only in how the pairs are spread: one address
+        // holding two tokens carries a single tuple, two addresses holding one token each carry two.
+        let one_address = with_deposits(&[(1, 1), (1, 2)]);
+        let two_addresses = with_deposits(&[(1, 1), (2, 1)]);
+
+        assert_eq!(
+            two_addresses
+                .gas_limit()
+                .checked_sub(one_address.gas_limit()),
+            Some(SWEEP_GAS_PER_AUTHORIZATION)
+        );
+    }
+
+    #[test]
     fn should_budget_more_for_more_pairs_than_for_more_deposits() {
         // The delegate transfers any balance it finds at a pair, not only the pairs the sweep queue
         // named, so what the limit must follow is the pairs. Three addresses funded in three
         // different tokens are nine pairs from three deposits; six addresses sharing one token are
         // six pairs from twice the deposits.
-        let mixed = with_deposits(&[(1, 1), (2, 2), (3, 3)], 0);
-        let one_token = with_deposits(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)], 0);
+        let mixed = with_deposits(&[(1, 1), (2, 2), (3, 3)]);
+        let one_token = with_deposits(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]);
 
         assert!(mixed.deposits.len() < one_token.deposits.len());
         assert!(
@@ -3436,14 +3440,15 @@ mod sweep_lane {
         let one_token: Vec<_> = (1..=4).map(|seed| (seed, 1)).collect();
 
         assert!(
-            with_deposits(&mixed, 4).gas_limit() > with_deposits(&one_token, 4).gas_limit(),
+            with_deposits(&mixed).gas_limit() > with_deposits(&one_token).gas_limit(),
             "the balance checks of a mixed batch must not be priced as a single-token one"
         );
     }
 
-    /// A sweep of one deposit per `(address seed, token seed)` pair, installing `authorizations`
-    /// delegations on the way.
-    fn with_deposits(deposits: &[(u8, u8)], authorizations: usize) -> SweepRequest {
+    /// A sweep of one deposit per `(address seed, token seed)` pair, authorizing each of its
+    /// distinct addresses.
+    fn with_deposits(deposits: &[(u8, u8)]) -> SweepRequest {
+        let addresses: BTreeSet<u8> = deposits.iter().map(|(address, _)| *address).collect();
         SweepRequest {
             deposits: deposits
                 .iter()
@@ -3456,12 +3461,9 @@ mod sweep_lane {
                     address: crate::deposit_address::DepositAddress::new(Address::new(
                         [*address; 20],
                     )),
-                    delegating: true,
                 })
                 .collect(),
-            authorizations: (0..authorizations)
-                .map(|seed| authorization(u8::try_from(seed).unwrap()))
-                .collect(),
+            authorizations: addresses.into_iter().map(authorization).collect(),
             ..sweep_request(0)
         }
     }

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2971,12 +2971,11 @@ mod sweep_lane {
     use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
-    use crate::numeric::{TransactionCount, TransactionNonce, Wei, WeiPerGas};
+    use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
         CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
-        SweepRequest, TransactionPipeline,
+        SweepRequest, SweptDeposit, TransactionPipeline,
     };
-    use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
         SignableTransaction, SignedAuthorization, SweepTransaction,
@@ -2996,6 +2995,7 @@ mod sweep_lane {
             data: vec![0xaa, 0xbb, 0xcc],
             max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
             created_at: 1_620_328_630_000_000_000,
+            deposits: vec![],
             authorizations: vec![],
         }
     }
@@ -3040,7 +3040,7 @@ mod sweep_lane {
             .create_transaction(
                 pipeline.next_transaction_nonce(),
                 gas_fee_estimate(),
-                SWEEP_TRANSACTION_GAS_LIMIT,
+                request.gas_limit(),
                 EthereumNetwork::Sepolia,
             )
             .expect("BUG: the fixture allowance covers the fixture fee");
@@ -3242,7 +3242,7 @@ mod sweep_lane {
             .create_transaction(
                 pipeline.next_transaction_nonce(),
                 gas_fee_estimate(),
-                SWEEP_TRANSACTION_GAS_LIMIT,
+                request.gas_limit(),
                 EthereumNetwork::Sepolia,
             )
             .expect("BUG: the fixture allowance covers the fixture fee")
@@ -3259,9 +3259,15 @@ mod sweep_lane {
         };
 
         assert_eq!(
-            tx.max_fee_per_gas
-                .transaction_cost(SWEEP_TRANSACTION_GAS_LIMIT),
-            Some(request.max_transaction_fee)
+            tx.max_fee_per_gas,
+            request
+                .max_transaction_fee
+                .into_wei_per_gas(request.gas_limit())
+                .unwrap()
+        );
+        assert!(
+            tx.max_fee_per_gas.transaction_cost(request.gas_limit())
+                <= Some(request.max_transaction_fee)
         );
         assert_eq!(
             tx.max_priority_fee_per_gas,
@@ -3280,7 +3286,7 @@ mod sweep_lane {
         let created = request.create_transaction(
             TransactionNonce::ZERO,
             spiked_fee,
-            SWEEP_TRANSACTION_GAS_LIMIT,
+            request.gas_limit(),
             EthereumNetwork::Sepolia,
         );
 
@@ -3306,14 +3312,14 @@ mod sweep_lane {
             gas_fee_estimate().max_priority_fee_per_gas
                 > request
                     .max_transaction_fee
-                    .into_wei_per_gas(SWEEP_TRANSACTION_GAS_LIMIT)
+                    .into_wei_per_gas(request.gas_limit())
                     .unwrap()
         );
 
         let created = request.create_transaction(
             TransactionNonce::ZERO,
             gas_fee_estimate(),
-            SWEEP_TRANSACTION_GAS_LIMIT,
+            request.gas_limit(),
             EthereumNetwork::Sepolia,
         );
 
@@ -3347,6 +3353,117 @@ mod sweep_lane {
                 && *allowed_max_transaction_fee == sweep_request(0).max_transaction_fee
                 && *max_transaction_fee > sweep_request(0).max_transaction_fee
         );
+    }
+
+    #[test]
+    fn should_scale_the_gas_limit_with_the_work_the_delegate_does() {
+        struct Case {
+            scenario: &'static str,
+            deposits: Vec<(u8, u8)>,
+            authorizations: usize,
+            expected_gas_limit: u64,
+        }
+
+        for case in [
+            Case {
+                scenario: "nothing to sweep",
+                deposits: vec![],
+                authorizations: 0,
+                expected_gas_limit: 60_000,
+            },
+            Case {
+                scenario: "one address already delegated, holding one token",
+                deposits: vec![(1, 1)],
+                authorizations: 0,
+                expected_gas_limit: 60_000 + 15_000 + 110_000,
+            },
+            Case {
+                scenario: "one address to delegate, holding one token",
+                deposits: vec![(1, 1)],
+                authorizations: 1,
+                expected_gas_limit: 60_000 + 15_000 + 110_000 + 40_000,
+            },
+            Case {
+                scenario: "one address holding two tokens: two pairs, one authorization",
+                deposits: vec![(1, 1), (1, 2)],
+                authorizations: 1,
+                expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 40_000,
+            },
+            Case {
+                scenario: "two addresses holding the same token",
+                deposits: vec![(1, 1), (2, 1)],
+                authorizations: 2,
+                expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 2 * 40_000,
+            },
+            Case {
+                scenario: "two addresses holding a token each: every pair is checked and may move",
+                deposits: vec![(1, 1), (2, 2)],
+                authorizations: 2,
+                expected_gas_limit: 60_000 + 4 * 15_000 + 4 * 110_000 + 2 * 40_000,
+            },
+        ] {
+            assert_eq!(
+                with_deposits(&case.deposits, case.authorizations).gas_limit(),
+                GasAmount::from(case.expected_gas_limit),
+                "{}",
+                case.scenario
+            );
+        }
+    }
+
+    #[test]
+    fn should_budget_more_for_more_pairs_than_for_more_deposits() {
+        // The delegate transfers any balance it finds at a pair, not only the pairs the sweep queue
+        // named, so what the limit must follow is the pairs. Three addresses funded in three
+        // different tokens are nine pairs from three deposits; six addresses sharing one token are
+        // six pairs from twice the deposits.
+        let mixed = with_deposits(&[(1, 1), (2, 2), (3, 3)], 0);
+        let one_token = with_deposits(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)], 0);
+
+        assert!(mixed.deposits.len() < one_token.deposits.len());
+        assert!(
+            mixed.gas_limit() > one_token.gas_limit(),
+            "a limit that follows the deposits cannot tell the two batches apart"
+        );
+    }
+
+    #[test]
+    fn should_charge_a_mixed_token_batch_more_than_a_single_token_one() {
+        // The delegate hands the whole token array to every address, so a batch of four addresses
+        // funded in four different tokens makes sixteen balance checks for four transfers. A limit
+        // linear in the number of deposits cannot tell the two batches apart.
+        let mixed: Vec<_> = (1..=4).map(|seed| (seed, seed)).collect();
+        let one_token: Vec<_> = (1..=4).map(|seed| (seed, 1)).collect();
+
+        assert!(
+            with_deposits(&mixed, 4).gas_limit() > with_deposits(&one_token, 4).gas_limit(),
+            "the balance checks of a mixed batch must not be priced as a single-token one"
+        );
+    }
+
+    /// A sweep of one deposit per `(address seed, token seed)` pair, installing `authorizations`
+    /// delegations on the way.
+    fn with_deposits(deposits: &[(u8, u8)], authorizations: usize) -> SweepRequest {
+        SweepRequest {
+            deposits: deposits
+                .iter()
+                .map(|(address, token)| SweptDeposit {
+                    account: icrc_ledger_types::icrc1::account::Account {
+                        owner: candid::Principal::management_canister(),
+                        subaccount: None,
+                    },
+                    erc20_contract_address: Address::new([*token; 20]),
+                    address: crate::deposit_address::DepositAddress::new(Address::new(
+                        [*address; 20],
+                    )),
+                    delegating: true,
+                })
+                .collect(),
+            authorizations: (0..authorizations)
+                .map(|seed| authorization(u8::try_from(seed).unwrap()))
+                .collect(),
+            ..sweep_request(0)
+        }
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2969,20 +2969,23 @@ pub mod arbitrary {
 
 mod sweep_lane {
     use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
+    use crate::deposit_address::DepositAddress;
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
     use crate::numeric::{GasAmount, TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError,
-        SWEEP_GAS_PER_AUTHORIZATION, SweepId, SweepRequest, SweptDeposit, TransactionPipeline,
+        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
+        SweepRequest, SweptDeposit, TransactionPipeline,
     };
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
         SignableTransaction, SignedAuthorization, SweepTransaction,
     };
     use assert_matches::assert_matches;
+    use candid::Principal;
     use ethnum::u256;
     use ic_ethereum_types::Address;
+    use icrc_ledger_types::icrc1::account::Account;
     use std::collections::BTreeSet;
 
     const EIP1559_TX_ID: u8 = 2;
@@ -3358,114 +3361,72 @@ mod sweep_lane {
 
     #[test]
     fn should_scale_the_gas_limit_with_the_work_the_delegate_does() {
-        struct Case {
-            scenario: &'static str,
-            deposits: Vec<(u8, u8)>,
-            expected_gas_limit: u64,
-        }
+        const BASE: u64 = 60_000;
+        const PER_PAIR: u64 = 15_000 + 110_000;
+        const PER_ADDRESS: u64 = 40_000;
+        let (alice, bob) = (deposit_address(1), deposit_address(2));
+        let (usdc, usdt) = (erc20(1), erc20(2));
 
-        for case in [
-            Case {
-                scenario: "nothing to sweep",
-                deposits: vec![],
-                expected_gas_limit: 60_000,
-            },
-            Case {
-                scenario: "one address holding one token",
-                deposits: vec![(1, 1)],
-                expected_gas_limit: 60_000 + 15_000 + 110_000 + 40_000,
-            },
-            Case {
-                scenario: "one address holding two tokens: two pairs, one authorization",
-                deposits: vec![(1, 1), (1, 2)],
-                expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 40_000,
-            },
-            Case {
-                scenario: "two addresses holding the same token",
-                deposits: vec![(1, 1), (2, 1)],
-                expected_gas_limit: 60_000 + 2 * 15_000 + 2 * 110_000 + 2 * 40_000,
-            },
-            Case {
-                scenario: "two addresses holding a token each: every pair is checked and may move",
-                deposits: vec![(1, 1), (2, 2)],
-                expected_gas_limit: 60_000 + 4 * 15_000 + 4 * 110_000 + 2 * 40_000,
-            },
+        for (deposits, pairs, addresses) in [
+            (vec![], 0, 0),
+            (vec![(alice, usdc)], 1, 1),
+            (vec![(alice, usdc), (alice, usdt)], 2, 1),
+            (vec![(alice, usdc), (bob, usdc)], 2, 2),
+            (vec![(alice, usdc), (bob, usdt)], 4, 2),
         ] {
             assert_eq!(
-                with_deposits(&case.deposits).gas_limit(),
-                GasAmount::from(case.expected_gas_limit),
-                "{}",
-                case.scenario
+                sweep_of(&deposits).gas_limit(),
+                GasAmount::from(BASE + pairs * PER_PAIR + addresses * PER_ADDRESS),
+                "{deposits:?}"
             );
         }
     }
 
     #[test]
-    fn should_budget_one_authorization_per_address() {
-        // Two batches of two pairs each, differing only in how the pairs are spread: one address
-        // holding two tokens carries a single tuple, two addresses holding one token each carry two.
-        let one_address = with_deposits(&[(1, 1), (1, 2)]);
-        let two_addresses = with_deposits(&[(1, 1), (2, 1)]);
-
-        assert_eq!(
-            two_addresses
-                .gas_limit()
-                .checked_sub(one_address.gas_limit()),
-            Some(SWEEP_GAS_PER_AUTHORIZATION)
-        );
-    }
-
-    #[test]
     fn should_budget_more_for_more_pairs_than_for_more_deposits() {
-        // The delegate transfers any balance it finds at a pair, not only the pairs the sweep queue
-        // named, so what the limit must follow is the pairs. Three addresses funded in three
-        // different tokens are nine pairs from three deposits; six addresses sharing one token are
-        // six pairs from twice the deposits.
-        let mixed = with_deposits(&[(1, 1), (2, 2), (3, 3)]);
-        let one_token = with_deposits(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]);
+        let three_addresses_in_three_tokens: Vec<_> = (1..=3)
+            .map(|seed| (deposit_address(seed), erc20(seed)))
+            .collect();
+        let six_addresses_in_one_token: Vec<_> = (1..=6)
+            .map(|seed| (deposit_address(seed), erc20(1)))
+            .collect();
 
-        assert!(mixed.deposits.len() < one_token.deposits.len());
+        assert!(three_addresses_in_three_tokens.len() < six_addresses_in_one_token.len());
         assert!(
-            mixed.gas_limit() > one_token.gas_limit(),
-            "a limit that follows the deposits cannot tell the two batches apart"
+            sweep_of(&three_addresses_in_three_tokens).gas_limit()
+                > sweep_of(&six_addresses_in_one_token).gas_limit(),
+            "nine pairs from three deposits must cost more than six pairs from six deposits"
         );
     }
 
-    #[test]
-    fn should_charge_a_mixed_token_batch_more_than_a_single_token_one() {
-        // The delegate hands the whole token array to every address, so a batch of four addresses
-        // funded in four different tokens makes sixteen balance checks for four transfers. A limit
-        // linear in the number of deposits cannot tell the two batches apart.
-        let mixed: Vec<_> = (1..=4).map(|seed| (seed, seed)).collect();
-        let one_token: Vec<_> = (1..=4).map(|seed| (seed, 1)).collect();
-
-        assert!(
-            with_deposits(&mixed).gas_limit() > with_deposits(&one_token).gas_limit(),
-            "the balance checks of a mixed batch must not be priced as a single-token one"
-        );
-    }
-
-    /// A sweep of one deposit per `(address seed, token seed)` pair, authorizing each of its
-    /// distinct addresses.
-    fn with_deposits(deposits: &[(u8, u8)]) -> SweepRequest {
-        let addresses: BTreeSet<u8> = deposits.iter().map(|(address, _)| *address).collect();
+    fn sweep_of(deposits: &[(DepositAddress, Address)]) -> SweepRequest {
+        let addresses: BTreeSet<_> = deposits.iter().map(|(address, _)| *address).collect();
         SweepRequest {
             deposits: deposits
                 .iter()
                 .map(|(address, token)| SweptDeposit {
-                    account: icrc_ledger_types::icrc1::account::Account {
-                        owner: candid::Principal::management_canister(),
+                    account: Account {
+                        owner: Principal::management_canister(),
                         subaccount: None,
                     },
-                    erc20_contract_address: Address::new([*token; 20]),
-                    address: crate::deposit_address::DepositAddress::new(Address::new(
-                        [*address; 20],
-                    )),
+                    erc20_contract_address: *token,
+                    address: *address,
                 })
                 .collect(),
-            authorizations: addresses.into_iter().map(authorization).collect(),
+            authorizations: addresses
+                .iter()
+                .map(|address| authorization(address.as_address().into_bytes()[0]))
+                .collect(),
             ..sweep_request(0)
         }
+    }
+
+    fn deposit_address(seed: u8) -> DepositAddress {
+        DepositAddress::new(Address::new([seed; 20]))
+    }
+
+    fn erc20(seed: u8) -> Address {
+        Address::new([0xe0 | seed; 20])
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/tx/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/tx/sweep.rs
@@ -12,16 +12,17 @@ use rlp::RlpStream;
 /// `SignedSweepTransaction::from()` if the signature is already known.
 pub type SignedSweepTransaction = Signed<SweepTransaction>;
 
-/// A transaction sent from the minter's dedicated sweeper address: a plain EIP-1559 transaction
-/// (`0x02`), or an EIP-7702 one (`0x04`) whose authorization list additionally installs the
-/// delegation to the sweeper contract of those deposit addresses it sweeps that are not delegated
-/// yet. The ones already delegated are swept without an authorization tuple, so the list can be
-/// shorter than the set of addresses swept.
+/// A transaction sent from the minter's dedicated sweeper address: an EIP-7702 transaction
+/// (`0x04`) whose authorization list carries one tuple per deposit address it sweeps, or a plain
+/// EIP-1559 one (`0x02`) for a sweep that delegates nothing — the native-ETH deposit addresses are
+/// deliberately never delegated, so their sweeps take that shape.
 ///
-/// A deposit address is delegated once and stays delegated, so a sweep needs type `0x04` only as
-/// long as it still touches an address no earlier sweep delegated. The
-/// [`SweepTransaction::Eip7702`] variant therefore always carries a non-empty authorization list:
-/// [`SweepTransaction::new`] is what decides the variant, and it decides on exactly that.
+/// An address already delegated is not exempt from the list: the tuples are signed for nonce 0,
+/// which installs a delegation that is missing and is skipped for an address that has one, so no
+/// sweep has to know which is which. The [`SweepTransaction::Eip7702`] variant still always
+/// carries a non-empty authorization list, a type-`0x04` transaction with an empty one being
+/// invalid: [`SweepTransaction::new`] is what decides the variant, and it decides on exactly
+/// whether there is anything to put in that list.
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub enum SweepTransaction {
     #[n(0)]

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -7,7 +7,7 @@ use ic_cketh_minter::checked_amount::CheckedAmountOf;
 use ic_cketh_minter::endpoints::events::{
     AccessListItem as CandidAccessListItem, Event as CandidEvent, EventSource as CandidEventSource,
     GetEventsResult, ReimbursementIndex as CandidReimbursementIndex,
-    SignedAuthorization as CandidSignedAuthorization,
+    SignedAuthorization as CandidSignedAuthorization, SweptDeposit as CandidSweptDeposit,
     TransactionReceipt as CandidTransactionReceipt, TransactionStatus as CandidTransactionStatus,
     UnsignedSweeperTransaction, UnsignedTransaction,
 };
@@ -234,6 +234,20 @@ fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTran
     )
 }
 
+fn map_swept_deposit(
+    deposit: CandidSweptDeposit,
+) -> ic_cketh_minter::state::transactions::SweptDeposit {
+    ic_cketh_minter::state::transactions::SweptDeposit {
+        account: Account {
+            owner: deposit.owner,
+            subaccount: deposit.subaccount,
+        },
+        erc20_contract_address: deposit.erc20_contract_address.parse().unwrap(),
+        address: deposit.address.parse().unwrap(),
+        delegating: deposit.delegating,
+    }
+}
+
 fn map_authorizations(authorizations: Vec<CandidSignedAuthorization>) -> Vec<SignedAuthorization> {
     fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
         ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
@@ -409,6 +423,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 max_transaction_fee,
                 created_at,
                 authorizations,
+                deposits,
             } => ET::AcceptedSweepRequest(SweepRequest {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
@@ -417,6 +432,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,
                 authorizations: map_authorizations(authorizations),
+                deposits: deposits.into_iter().map(map_swept_deposit).collect(),
             }),
             EventPayload::CreatedSweeperTransaction {
                 sweep_id,

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -244,7 +244,6 @@ fn map_swept_deposit(
         },
         erc20_contract_address: deposit.erc20_contract_address.parse().unwrap(),
         address: deposit.address.parse().unwrap(),
-        delegating: deposit.delegating,
     }
 }
 


### PR DESCRIPTION
## Why

- A sweep request said what call data it carried but not which deposits it took, so the sweep queue could only be reconstructed by decoding the call data.
- Its gas limit was a flat base plus a per-deposit cost, which cannot bound what the delegate actually executes.

## What

- The request records the `(account, token)` deposits it moves, so the sweep queue and the set of delegated addresses are both reconstructible from the event log.
- The gas limit follows the delegate's work: `sweepErc20Batch` hands the whole token array to every address it sweeps, so balance checks and transfers both grow as distinct addresses times distinct tokens.
- It budgets a transfer for every such pair, not only the pairs the request names: `sweepErc20` moves any balance it finds, and a deposit address accumulates residue.
- Only the addresses a sweep delegates pay an authorization cost on top.

## Tests

- A table over batch shapes pins each term of the limit.
- One test asserts a batch of more pairs from fewer deposits costs more, so a limit that followed the deposit count would fail it.
