### PR TITLE
feat(cketh): act on a sweep's outcome

### DIFF
--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1276,6 +1276,14 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Number of deposit address attestations the minter has signed and stored.",
                 )?;
 
+                let sweep_queue = s.automatic_deposits.sweep_queue_depth();
+                w.gauge_vec(
+                    "cketh_minter_sweep_queue_deposits",
+                    "Queued ckERC20 deposits by where they stand in sweeping",
+                )?
+                .value(&[("state", "in_flight")], sweep_queue.in_flight as f64)?
+                .value(&[("state", "sweepable")], sweep_queue.sweepable as f64)?;
+
                 w.encode_gauge(
                     "cketh_minter_last_max_fee_per_gas",
                     s.last_transaction_price_estimate

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -29,7 +29,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashSet, btree_map};
 use std::fmt::{Display, Formatter};
 use strum_macros::EnumIter;
-use transactions::{SweepId, SweeperTransactionPipeline, WithdrawalTransactions};
+use transactions::{SweepId, SweeperTransactionPipeline, SweptDeposit, WithdrawalTransactions};
 
 pub mod audit;
 pub mod automatic_deposits;
@@ -435,6 +435,39 @@ impl State {
         self.withdrawal_transactions
             .record_finalized_transaction(*withdrawal_id, receipt.clone());
         self.update_balance_upon_withdrawal(withdrawal_id, receipt);
+    }
+
+    /// Drop a failed sweep's deposits from the sweep queue. A reverted sweep moved nothing, so the
+    /// funds stay at their deposit addresses; the minter just stops trying (see
+    /// [`crate::state::automatic_deposits::AutomaticDeposits::record_sweep_failed`]).
+    ///
+    /// # Panics
+    ///
+    /// If the sweep has no processed request, which recording its transaction established.
+    pub fn record_failed_sweep(&mut self, sweep_id: SweepId) {
+        let deposits = self.swept_deposits(sweep_id);
+        self.automatic_deposits
+            .record_sweep_failed(sweep_id, &deposits);
+    }
+
+    /// Release a successful sweep's deposits: the funds moved, so each pair leaves the queue as it
+    /// entered it and can be armed again for the next deposit.
+    ///
+    /// # Panics
+    ///
+    /// If the sweep has no processed request, which recording its transaction established.
+    pub fn record_successful_sweep(&mut self, sweep_id: SweepId) {
+        let deposits = self.swept_deposits(sweep_id);
+        self.automatic_deposits
+            .record_sweep_succeeded(sweep_id, &deposits);
+    }
+
+    fn swept_deposits(&self, sweep_id: SweepId) -> Vec<SweptDeposit> {
+        self.sweeper_transactions
+            .get_processed_request(&sweep_id)
+            .expect("BUG: missing sweep request")
+            .deposits
+            .clone()
     }
 
     pub fn next_request_id(&mut self) -> u64 {

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -4,6 +4,7 @@ mod tests;
 use super::State;
 pub use super::event::{Event, EventType};
 use crate::erc20::CkTokenSymbol;
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::eth_logs_scraping::LogScrapingId::Erc20DepositWithoutSubaccount;
 use crate::state::transactions::{Reimbursed, ReimbursementIndex, WithdrawalRequest};
@@ -117,6 +118,9 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         }
         EventType::AcceptedSweepRequest(request) => {
             state.next_sweep_id = request.id.next();
+            state
+                .automatic_deposits
+                .record_sweep_scheduled(request.id, &request.deposits);
             state.sweeper_transactions.record_request(request.clone());
         }
         EventType::CreatedSweeperTransaction {
@@ -152,6 +156,10 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             let _ = state
                 .sweeper_transactions
                 .record_finalized_transaction(*sweep_id, transaction_receipt);
+            match transaction_receipt.status {
+                TransactionStatus::Failure => state.record_failed_sweep(*sweep_id),
+                TransactionStatus::Success => state.record_successful_sweep(*sweep_id),
+            }
         }
         EventType::ReimbursedEthWithdrawal(Reimbursed {
             burn_in_block: withdrawal_id,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -4,10 +4,13 @@ mod tests;
 use crate::attestation::AttestationRequest;
 use crate::deposit_address::DepositAddress;
 use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, DetectedDeposit};
+use crate::logs::INFO;
 use crate::numeric::{BlockNumber, Erc20Value};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
+use crate::state::transactions::{SweepId, SweptDeposit};
 use crate::timed_sized_map::{Entry, InsertError, TimedSizedMap, Timestamp};
 use crate::tx::TransactionSignature;
+use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
@@ -103,6 +106,9 @@ impl AutomaticDeposits {
         address: DepositAddress,
     ) -> Result<Entry<ScanProgress>, DepositErc20Error> {
         let request = DepositRequest::new(account, token);
+        // Unreachable from `deposit_erc20`, which returns a pair's status whenever it has one and a
+        // queued pair always does, so a caller sees `AwaitingSweep` instead of arriving here. Its
+        // last such check is followed by no await, so no scan can queue the pair in between.
         assert!(
             !self.sweep.contains_key(&request),
             "BUG: cannot arm {request:?}, it already has funds queued for sweeping"
@@ -268,6 +274,7 @@ impl AutomaticDeposits {
                 last_scanned_block: deposit.last_scanned_block,
                 scan_count: deposit.scan_count,
                 scanned_balance: deposit.scanned_balance,
+                swept_by: None,
             },
         );
         assert!(
@@ -303,6 +310,123 @@ impl AutomaticDeposits {
         }
     }
 
+    /// The queued deposits waiting for a sweep to take them.
+    ///
+    /// Yielded in `(account, token)` key order: by principal, then by subaccount, then by token
+    /// address, which says nothing about when each was queued — nothing here records that. A sweep
+    /// takes a bounded prefix of this iterator, so the same order decides which deposits get into
+    /// the next batch.
+    pub fn sweep_targets_iter(&self) -> impl Iterator<Item = SweepTarget> + '_ {
+        self.sweep
+            .iter()
+            .filter(|(_request, entry)| entry.swept_by.is_none())
+            .map(|(request, entry)| SweepTarget {
+                request: *request,
+                address: entry.address,
+                scanned_balance: entry.scanned_balance,
+            })
+    }
+
+    /// Record that `sweep_id` took these deposits: each leaves the pool of sweepable entries until
+    /// the sweep is done with it.
+    ///
+    /// # Panics
+    ///
+    /// If a deposit is not queued, or another sweep already took it. Sweeping the same funds twice
+    /// would move a balance the minter has already accounted for.
+    pub fn record_sweep_scheduled(&mut self, sweep_id: SweepId, deposits: &[SweptDeposit]) {
+        for deposit in deposits {
+            let request = DepositRequest::new(deposit.account, deposit.erc20_contract_address);
+            let entry = self
+                .sweep
+                .get_mut(&request)
+                .unwrap_or_else(|| panic!("BUG: {request:?} is not queued for sweeping"));
+            assert_eq!(
+                entry.swept_by, None,
+                "BUG: {request:?} was already taken by another sweep"
+            );
+            entry.swept_by = Some(sweep_id);
+        }
+    }
+
+    /// Drop the deposits `sweep_id` took, its transaction having failed, logging each one.
+    ///
+    /// The minter does not retry them. The funds are not lost — a reverted sweep moved nothing, so
+    /// the balance the scan found is still at the deposit address — but nothing here remembers them
+    /// any more, and getting them moving again means arming the pair afresh.
+    ///
+    /// Dropping rather than retrying is deliberate, and interim: a sweep's call data is rebuilt from
+    /// the queue in the same key order, so a batch that reverted for a reason of its own reverts
+    /// again on the next tick, and every attempt burns the sweeper address' gas. What to retry, how
+    /// often, and how to isolate the deposit actually at fault is DEFI-2981.
+    ///
+    /// # Panics
+    ///
+    /// If a deposit is not queued, or is held by another sweep. Either means the queue no longer
+    /// describes which sweep owns which funds.
+    pub fn record_sweep_failed(&mut self, sweep_id: SweepId, deposits: &[SweptDeposit]) {
+        for deposit in deposits {
+            let request = DepositRequest::new(deposit.account, deposit.erc20_contract_address);
+            let entry = self
+                .sweep
+                .remove(&request)
+                .unwrap_or_else(|| panic!("BUG: {request:?} is not queued for sweeping"));
+            assert_eq!(
+                entry.swept_by,
+                Some(sweep_id),
+                "BUG: {request:?} is not held by sweep {sweep_id:?}"
+            );
+            log!(
+                INFO,
+                "[record_sweep_failed]: DROPPING {request:?} from the sweep queue: {sweep_id:?} \
+                 failed and the minter does not retry. Its {:?} stays at {}, and reaching it again \
+                 needs the pair armed afresh.",
+                entry.scanned_balance,
+                entry.address
+            );
+        }
+    }
+
+    /// Drop the deposits `sweep_id` moved: the balance the scan found is no longer at the deposit
+    /// address, so there is nothing left to sweep and nothing to keep an entry for. The pair leaves
+    /// the queue exactly as it entered it, which is what lets it be armed again for the next
+    /// deposit to the same address.
+    ///
+    /// # Panics
+    ///
+    /// If a deposit is not queued, or is held by another sweep. Either means the queue no longer
+    /// describes which sweep owns which funds.
+    pub fn record_sweep_succeeded(&mut self, sweep_id: SweepId, deposits: &[SweptDeposit]) {
+        for deposit in deposits {
+            let request = DepositRequest::new(deposit.account, deposit.erc20_contract_address);
+            let entry = self
+                .sweep
+                .remove(&request)
+                .unwrap_or_else(|| panic!("BUG: {request:?} is not queued for sweeping"));
+            assert_eq!(
+                entry.swept_by,
+                Some(sweep_id),
+                "BUG: {request:?} is not held by sweep {sweep_id:?}"
+            );
+        }
+    }
+
+    /// Where the sweep queue's entries stand, counted in one pass: the metrics endpoint asks for
+    /// both numbers together, and only the two together say whether sweeping is making progress.
+    ///
+    /// One pass over the queue per call. The queue holds only deposits a sweep has yet to finish
+    /// with, so it is bounded by what is in flight rather than by every deposit ever swept.
+    pub fn sweep_queue_depth(&self) -> SweepQueueDepth {
+        let mut depth = SweepQueueDepth::default();
+        for entry in self.sweep.values() {
+            match entry.swept_by {
+                Some(_) => depth.in_flight += 1,
+                None => depth.sweepable += 1,
+            }
+        }
+        depth
+    }
+
     pub fn watchlist_len(&self) -> usize {
         self.watchlist.len()
     }
@@ -317,7 +441,7 @@ impl AutomaticDeposits {
 
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
     /// funds queued for sweeping (so it must be registered). Reports
-    /// [`DepositStatus::AwaitingSweep`] once funds have been detected and queued, otherwise
+    /// [`DepositStatus::AwaitingSweep`] once funds have been detected and queued, and otherwise
     /// [`DepositStatus::Scanning`] while the address is armed and being scanned as of `now`.
     /// `minimum_deposit_amount` is the balance the address must hold for the scan to detect it,
     /// reported back to the caller alongside the status.
@@ -328,14 +452,15 @@ impl AutomaticDeposits {
         minimum_deposit_amount: Erc20Value,
     ) -> Option<DepositErc20Response> {
         if let Some(entry) = self.sweep.get(request) {
+            let detected = DetectedDeposit {
+                erc20_contract_address: request.token().to_string(),
+                scanned_balance: entry.scanned_balance.into(),
+                detected_at_block: entry.last_scanned_block.into(),
+            };
             return Some(DepositErc20Response {
                 address: entry.address.to_string(),
                 minimum_deposit_amount: minimum_deposit_amount.into(),
-                status: DepositStatus::AwaitingSweep(DetectedDeposit {
-                    erc20_contract_address: request.token().to_string(),
-                    scanned_balance: entry.scanned_balance.into(),
-                    detected_at_block: entry.last_scanned_block.into(),
-                }),
+                status: DepositStatus::AwaitingSweep(detected),
             });
         }
         self.get_entry(now, request)
@@ -420,6 +545,15 @@ impl ScanTarget {
     }
 }
 
+/// How many queued deposits are in each of the two states the sweep queue holds them in.
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug)]
+pub struct SweepQueueDepth {
+    /// Held by a sweep that has not been finalized yet.
+    pub in_flight: usize,
+    /// Waiting for a sweep to take them.
+    pub sweepable: usize,
+}
+
 /// A funded token awaiting sweeping at a [`DepositRequest`]'s deposit address.
 #[derive(Clone, PartialEq, Debug)]
 struct SweepEntry {
@@ -431,6 +565,36 @@ struct SweepEntry {
     scan_count: u32,
     /// The balance read for the token at `last_scanned_block`.
     scanned_balance: Erc20Value,
+    /// The sweep that took this entry, once one has been enqueued for it. Set so a later scan tick
+    /// does not enqueue the same funds twice; the entry stays until the sweep is finalized.
+    swept_by: Option<SweepId>,
+}
+
+/// A queued deposit a sweep can move: the `(account, token)` pair, the address its funds sit at,
+/// and the balance the scan found there.
+#[derive(Clone, Copy, Debug)]
+pub struct SweepTarget {
+    request: DepositRequest,
+    address: DepositAddress,
+    scanned_balance: Erc20Value,
+}
+
+impl SweepTarget {
+    pub fn account(&self) -> Account {
+        self.request.account
+    }
+
+    pub fn token(&self) -> Address {
+        self.request.token
+    }
+
+    pub fn address(&self) -> DepositAddress {
+        self.address
+    }
+
+    pub fn scanned_balance(&self) -> Erc20Value {
+        self.scanned_balance
+    }
 }
 
 /// The watchlist value held against one [`DepositRequest`]: the deposit address derived for its

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -720,6 +720,7 @@ fn sweep_entry(
         last_scanned_block,
         scan_count,
         scanned_balance: Erc20Value::new(scanned_balance),
+        swept_by: None,
     }
 }
 
@@ -748,6 +749,277 @@ fn entry(account: &Account, expires_at: Timestamp) -> Entry<ScanProgress> {
     Entry {
         value: ScanProgress::from(deposit_address(account)),
         expires_at,
+    }
+}
+
+mod record_sweep_scheduled {
+    use super::{account, automatic_deposit, deposit_address, usdc, usdt};
+    use crate::numeric::BlockNumber;
+    use crate::state::automatic_deposits::AutomaticDeposits;
+    use crate::state::transactions::{SweepId, SweptDeposit};
+    use crate::test_fixtures::expect_panic_with_message;
+    use ic_ethereum_types::Address;
+    use icrc_ledger_types::icrc1::account::Account;
+
+    #[test]
+    fn should_offer_a_queued_deposit_until_a_sweep_takes_it() {
+        let mut deposits = queued();
+
+        assert_eq!(targets(&deposits), vec![usdc(), usdt()]);
+
+        deposits.record_sweep_scheduled(SweepId(7), &[swept(account(0), usdc())]);
+
+        assert_eq!(targets(&deposits), vec![usdt()]);
+        // The entry stays queued, it is only no longer sweepable.
+        assert_eq!(deposits.sweep_len(), 2);
+    }
+
+    #[test]
+    fn should_carry_the_scanned_balance_to_the_sweeper() {
+        let deposits = queued();
+
+        let target = deposits.sweep_targets_iter().next().unwrap();
+
+        assert_eq!(target.account(), account(0));
+        assert_eq!(target.token(), usdc());
+        assert_eq!(target.address(), deposit_address(&account(0)));
+        assert_eq!(target.scanned_balance(), 10_u8.into());
+    }
+
+    #[test]
+    fn should_trap_when_two_sweeps_take_the_same_deposit() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept(account(0), usdc())]);
+
+        expect_panic_with_message(
+            || {
+                deposits.record_sweep_scheduled(SweepId(1), &[swept(account(0), usdc())]);
+            },
+            "was already taken by another sweep",
+        );
+    }
+
+    #[test]
+    fn should_trap_when_a_sweep_takes_a_deposit_that_is_not_queued() {
+        let mut deposits = queued();
+
+        expect_panic_with_message(
+            || {
+                deposits.record_sweep_scheduled(SweepId(0), &[swept(account(1), usdc())]);
+            },
+            "is not queued for sweeping",
+        );
+    }
+
+    /// One account with two funded tokens at the same deposit address, both awaiting a sweep.
+    fn queued() -> AutomaticDeposits {
+        let mut deposits = AutomaticDeposits::default();
+        for token in [usdc(), usdt()] {
+            deposits.record_automatic_deposit_received(&automatic_deposit(
+                account(0),
+                token,
+                10,
+                BlockNumber::new(900),
+                3,
+            ));
+        }
+        deposits
+    }
+
+    fn targets(deposits: &AutomaticDeposits) -> Vec<Address> {
+        deposits
+            .sweep_targets_iter()
+            .map(|target| target.token())
+            .collect()
+    }
+
+    fn swept(account: Account, token: Address) -> SweptDeposit {
+        SweptDeposit {
+            account,
+            erc20_contract_address: token,
+            address: deposit_address(&account),
+        }
+    }
+}
+
+mod record_sweep_failed {
+    use crate::endpoints::DepositStatus;
+    use crate::numeric::BlockNumber;
+    use crate::numeric::Erc20Value;
+    use crate::state::automatic_deposits::tests::{
+        account, automatic_deposit, deposit_address, ts, usdc, usdt,
+    };
+    use crate::state::automatic_deposits::{AutomaticDeposits, DepositRequest, SweepQueueDepth};
+    use crate::state::transactions::{SweepId, SweptDeposit};
+    use crate::test_fixtures::expect_panic_with_message;
+    use assert_matches::assert_matches;
+    use ic_ethereum_types::Address;
+
+    #[test]
+    fn should_drop_the_deposits_of_a_sweep_that_failed() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept(usdc())]);
+        assert_eq!(sweepable(&deposits), vec![usdt()]);
+
+        deposits.record_sweep_failed(SweepId(0), &[swept(usdc())]);
+
+        assert_eq!(sweepable(&deposits), vec![usdt()]);
+        assert_eq!(deposits.sweep_len(), 1);
+        assert_eq!(
+            deposits.sweep_queue_depth(),
+            SweepQueueDepth {
+                in_flight: 0,
+                sweepable: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn should_report_a_dropped_deposit_as_unknown_rather_than_awaiting_a_sweep() {
+        let mut deposits = queued();
+        assert_matches!(status(&deposits), Some(DepositStatus::AwaitingSweep(_)));
+        deposits.record_sweep_scheduled(SweepId(0), &[swept(usdc())]);
+
+        deposits.record_sweep_failed(SweepId(0), &[swept(usdc())]);
+
+        assert_eq!(status(&deposits), None);
+    }
+
+    #[test]
+    fn should_let_a_pair_whose_sweep_failed_be_armed_again() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept(usdc())]);
+        deposits.record_sweep_failed(SweepId(0), &[swept(usdc())]);
+
+        let armed = deposits.watch_deposit(ts(0), account(0), usdc(), deposit_address(&account(0)));
+
+        assert_matches!(armed, Ok(_));
+    }
+
+    fn status(deposits: &AutomaticDeposits) -> Option<DepositStatus> {
+        deposits
+            .deposit_status(
+                ts(0),
+                &DepositRequest::new(account(0), usdc()),
+                Erc20Value::ONE,
+            )
+            .map(|response| response.status)
+    }
+
+    #[test]
+    fn should_trap_when_a_sweep_that_does_not_hold_a_deposit_fails() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept(usdc())]);
+
+        expect_panic_with_message(
+            || deposits.record_sweep_failed(SweepId(1), &[swept(usdc())]),
+            "is not held by sweep",
+        );
+    }
+
+    /// One account with two funded tokens at the same deposit address, both awaiting a sweep.
+    fn queued() -> AutomaticDeposits {
+        let mut deposits = AutomaticDeposits::default();
+        for token in [usdc(), usdt()] {
+            deposits.record_automatic_deposit_received(&automatic_deposit(
+                account(0),
+                token,
+                10,
+                BlockNumber::new(900),
+                3,
+            ));
+        }
+        deposits
+    }
+
+    fn sweepable(deposits: &AutomaticDeposits) -> Vec<Address> {
+        deposits
+            .sweep_targets_iter()
+            .map(|target| target.token())
+            .collect()
+    }
+
+    fn swept(token: Address) -> SweptDeposit {
+        SweptDeposit {
+            account: account(0),
+            erc20_contract_address: token,
+            address: deposit_address(&account(0)),
+        }
+    }
+}
+
+mod record_sweep_succeeded {
+    use crate::numeric::BlockNumber;
+    use crate::state::automatic_deposits::AutomaticDeposits;
+    use crate::state::automatic_deposits::tests::{
+        account, automatic_deposit, deposit_address, ts, usdc,
+    };
+    use crate::state::transactions::{SweepId, SweptDeposit};
+    use crate::test_fixtures::expect_panic_with_message;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn should_drop_a_deposit_a_sweep_moved() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept()]);
+
+        deposits.record_sweep_succeeded(SweepId(0), &[swept()]);
+
+        assert_eq!(deposits.sweep_len(), 0);
+    }
+
+    #[test]
+    fn should_let_a_pair_whose_sweep_succeeded_be_armed_again() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept()]);
+        deposits.record_sweep_succeeded(SweepId(0), &[swept()]);
+
+        let armed = deposits.watch_deposit(ts(0), account(0), usdc(), deposit_address(&account(0)));
+
+        assert_matches!(armed, Ok(_));
+    }
+
+    #[test]
+    fn should_trap_when_a_sweep_that_does_not_hold_a_deposit_succeeds() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept()]);
+
+        expect_panic_with_message(
+            || deposits.record_sweep_succeeded(SweepId(1), &[swept()]),
+            "is not held by sweep",
+        );
+    }
+
+    #[test]
+    fn should_trap_when_a_sweep_succeeds_with_a_deposit_that_was_dropped() {
+        let mut deposits = queued();
+        deposits.record_sweep_scheduled(SweepId(0), &[swept()]);
+        deposits.record_sweep_failed(SweepId(0), &[swept()]);
+
+        expect_panic_with_message(
+            || deposits.record_sweep_succeeded(SweepId(0), &[swept()]),
+            "is not queued for sweeping",
+        );
+    }
+
+    fn queued() -> AutomaticDeposits {
+        let mut deposits = AutomaticDeposits::default();
+        deposits.record_automatic_deposit_received(&automatic_deposit(
+            account(0),
+            usdc(),
+            10,
+            BlockNumber::new(900),
+            3,
+        ));
+        deposits
+    }
+
+    fn swept() -> SweptDeposit {
+        SweptDeposit {
+            account: account(0),
+            erc20_contract_address: usdc(),
+            address: deposit_address(&account(0)),
+        }
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -1536,6 +1536,226 @@ mod sweeper_funding {
     }
 }
 
+mod sweeps {
+    use crate::deposit_address::DepositAddress;
+    use crate::eth_rpc::Hash;
+    use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+    use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce, Wei, WeiPerGas};
+    use crate::state::State;
+    use crate::state::audit::{EventType, apply_state_transition};
+    use crate::state::event::AutomaticDeposit;
+    use crate::state::transactions::{PipelineRequest, SweepId, SweepRequest, SweptDeposit};
+    use crate::test_fixtures::initial_state;
+    use crate::test_fixtures::transaction_signature;
+    use crate::tx::{GasFeeEstimate, SignableTransaction, Signed, SignedAuthorization};
+    use ic_ethereum_types::Address;
+    use icrc_ledger_types::icrc1::account::Account;
+
+    #[test]
+    fn should_release_the_deposits_of_a_sweep_whose_transaction_was_finalized() {
+        for status in [TransactionStatus::Failure, TransactionStatus::Success] {
+            let mut state = state_with_queued_deposits(&[usdc()]);
+            apply_state_transition(
+                &mut state,
+                &EventType::AcceptedSweepRequest(delegating_sweep_request(&[usdc()])),
+            );
+            create_sweep_transaction(&mut state, SweepId(0));
+            assert_eq!(sweepable_tokens(&state), Vec::<Address>::new());
+
+            finalize_sweep_transaction(&mut state, SweepId(0), status);
+
+            // A finalized sweep leaves nothing behind either way: it moved the funds, or it did
+            // not and the minter does not retry.
+            assert_eq!(
+                sweepable_tokens(&state),
+                Vec::<Address>::new(),
+                "{status:?}"
+            );
+            assert_eq!(state.automatic_deposits.sweep_len(), 0, "{status:?}");
+        }
+    }
+
+    fn sweepable_tokens(state: &State) -> Vec<Address> {
+        state
+            .automatic_deposits
+            .sweep_targets_iter()
+            .map(|target| target.token())
+            .collect()
+    }
+
+    fn finalize_sweep_transaction(state: &mut State, sweep_id: SweepId, status: TransactionStatus) {
+        let (_sweep_id, transaction) = state
+            .sweeper_transactions
+            .transactions_to_sign_batch(1)
+            .pop()
+            .expect("BUG: the sweep has no transaction to sign");
+        let transaction = Signed::from((transaction, transaction_signature()));
+        apply_state_transition(
+            state,
+            &EventType::SignedSweeperTransaction {
+                sweep_id,
+                transaction: transaction.clone(),
+            },
+        );
+        apply_state_transition(
+            state,
+            &EventType::FinalizedSweeperTransaction {
+                sweep_id,
+                transaction_receipt: TransactionReceipt {
+                    block_hash: Hash([0x33; 32]),
+                    block_number: BlockNumber::new(4_190_269),
+                    effective_gas_price: transaction.transaction().max_fee_per_gas(),
+                    gas_used: transaction.transaction().gas_limit(),
+                    status,
+                    transaction_hash: transaction.hash(),
+                },
+            },
+        );
+    }
+
+    #[test]
+    fn should_give_a_sweep_created_later_a_higher_nonce() {
+        let mut state = state_with_queued_deposits(&[usdc(), usdt()]);
+        apply_state_transition(
+            &mut state,
+            &EventType::AcceptedSweepRequest(delegating_sweep_request(&[usdc()])),
+        );
+        let later = SweepRequest {
+            id: SweepId(1),
+            ..delegating_sweep_request(&[usdt()])
+        };
+        apply_state_transition(&mut state, &EventType::AcceptedSweepRequest(later));
+
+        // Every sweep is sent from the one sweeper address and the nonce is assigned at creation,
+        // so creation order is the order in which the chain executes them.
+        create_sweep_transaction(&mut state, SweepId(0));
+        create_sweep_transaction(&mut state, SweepId(1));
+
+        assert_eq!(
+            nonce_of(&state, SweepId(0)).checked_increment(),
+            Some(nonce_of(&state, SweepId(1)))
+        );
+    }
+
+    fn nonce_of(state: &State, sweep_id: SweepId) -> TransactionNonce {
+        state
+            .sweeper_transactions
+            .transactions_to_sign_batch(2)
+            .into_iter()
+            .find(|(id, _transaction)| id == &sweep_id)
+            .map(|(_id, transaction)| transaction.nonce())
+            .expect("BUG: the sweep has no created transaction")
+    }
+
+    /// A state whose sweep queue holds one funded pair per token, all at the same deposit address.
+    fn state_with_queued_deposits(tokens: &[Address]) -> State {
+        let mut state = initial_state();
+        for token in tokens {
+            apply_state_transition(
+                &mut state,
+                &EventType::AutomaticDepositReceived(AutomaticDeposit {
+                    owner: account().owner,
+                    subaccount: account().subaccount,
+                    address: deposit_address(),
+                    erc20_contract_address: *token,
+                    last_scanned_block: BlockNumber::new(900),
+                    scan_count: 1,
+                    scanned_balance: Erc20Value::new(1_000),
+                }),
+            );
+        }
+        state
+    }
+
+    /// A sweep of every given token at [`deposit_address`], carrying the authorization that
+    /// delegates that address to the sweeper contract.
+    fn delegating_sweep_request(tokens: &[Address]) -> SweepRequest {
+        SweepRequest {
+            id: SweepId(0),
+            destination: sweeper_contract(),
+            amount: Wei::ZERO,
+            data: vec![0xaa, 0xbb, 0xcc],
+            max_transaction_fee: Wei::new(1_000_000_000_000_000_000),
+            created_at: 1_620_328_630_000_000_000,
+            authorizations: vec![authorization()],
+            deposits: tokens.iter().copied().map(swept_deposit).collect(),
+        }
+    }
+
+    fn swept_deposit(token: Address) -> SweptDeposit {
+        SweptDeposit {
+            account: account(),
+            erc20_contract_address: token,
+            address: deposit_address(),
+        }
+    }
+
+    fn create_sweep_transaction(state: &mut State, sweep_id: SweepId) {
+        let request = state
+            .sweeper_transactions
+            .requests_iter()
+            .find(|request| request.id == sweep_id)
+            .expect("BUG: the sweep is not pending")
+            .clone();
+        let transaction = request
+            .create_transaction(
+                state.sweeper_transactions.next_transaction_nonce(),
+                gas_fee_estimate(),
+                request.gas_limit(),
+                state.ethereum_network(),
+            )
+            .expect("BUG: the fixture allowance covers the fixture fee");
+        apply_state_transition(
+            state,
+            &EventType::CreatedSweeperTransaction {
+                sweep_id,
+                transaction,
+            },
+        );
+    }
+
+    fn authorization() -> SignedAuthorization {
+        SignedAuthorization {
+            chain_id: 11155111,
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ZERO,
+            y_parity: false,
+            r: ethnum::u256::ONE,
+            s: ethnum::u256::ONE,
+        }
+    }
+
+    fn gas_fee_estimate() -> GasFeeEstimate {
+        GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::from(25_u8),
+            max_priority_fee_per_gas: WeiPerGas::new(0x59682f00),
+        }
+    }
+
+    fn account() -> Account {
+        Account {
+            owner: candid::Principal::from_slice(&[1, 2, 3, 4]),
+            subaccount: Some([42_u8; 32]),
+        }
+    }
+
+    fn deposit_address() -> DepositAddress {
+        DepositAddress::new(Address::new([0x11; 20]))
+    }
+
+    fn sweeper_contract() -> Address {
+        Address::new([0xde; 20])
+    }
+
+    fn usdc() -> Address {
+        Address::new([0xaa; 20])
+    }
+
+    fn usdt() -> Address {
+        Address::new([0xbb; 20])
+    }
+}
+
 mod eth_balance {
     use super::*;
     use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};


### PR DESCRIPTION
## Why

- The sweep queue only knew how to hand deposits out: nothing marked them as taken, and nothing recorded what became of a sweep once its transaction was finalized.

## What

- A sweep now owns the deposits it takes: they are marked taken when its request is accepted, so no second sweep can move the same funds.
- A sweep whose transaction failed drops its deposits from the queue. No funds are lost — a reverted sweep moved nothing — but the minter stops trying: the same batch would revert again on the next tick and burn more of the sweeper's gas. What to retry, and how, is DEFI-2981.
- A sweep that moved its deposits releases them: each pair leaves the queue as it entered it, so it can be armed again for the next deposit to the same address.
- A gauge reports where the queue's entries stand (sweepable vs. in flight).

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
