### PR TITLE
docs: fix typo targetted -> targeted

### DIFF
--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -807,7 +807,7 @@ use `PocketIcBuilder::with_icp_config` when creating a new PocketIC instance.
 To use a new management canister endpoint that is not yet supported by a dedicated (Rust) PocketIC library function,
 the generic PocketIC library API, e.g., `PocketIc::update_call_with_effective_principal` should be used:
 - the `canister_id` argument should be the management canister principal (`aaaaa-aa`),
-- the `effective_principal` argument should be the actual canister or subnet to which the call is targetted
+- the `effective_principal` argument should be the actual canister or subnet to which the call is targeted
   (e.g., `RawEffectivePrincipal::CanisterId(canister_id.as_slice().to_vec())` for a `canister_id` of type `Principal`;
   in particular, `RawEffectivePrincipal::None` must not be used),
 - and the `payload` argument should be the Candid-encoded binary input to the new management canister endpoint


### PR DESCRIPTION
One-word typo fix in `packages/pocket-ic/HOWTO.md:810`: "the \`effective_principal\` ar..." → `targeted`.
