### PR TITLE
perf(cketh): reuse the delegation authorization a deposit address signed

### DIFF
--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1279,6 +1279,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Number of deposit address attestations the minter has signed and stored.",
                 )?;
 
+                w.encode_gauge(
+                    "cketh_minter_stored_authorizations",
+                    s.automatic_deposits.authorizations_len() as f64,
+                    "Number of deposit address delegation authorizations the minter has signed and stored.",
+                )?;
+
                 let sweep_queue = s.automatic_deposits.sweep_queue_depth();
                 w.gauge_vec(
                     "cketh_minter_sweep_queue_deposits",

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -1,6 +1,8 @@
 use crate::address::ecdsa_public_key_to_address;
 use crate::attestation::AttestationRequest;
-use crate::deposit_address::{DepositAddressSchema, deposit_address, sweeper_address};
+use crate::deposit_address::{
+    DepositAddress, DepositAddressSchema, deposit_address, sweeper_address,
+};
 use crate::endpoints::{CandidBlockTag, DepositErc20Error};
 use crate::erc20::{CkErc20Token, CkTokenSymbol};
 use crate::eth_logs::{EventSource, ReceivedEvent};
@@ -18,7 +20,7 @@ use crate::state::sweeper_funding::{SweeperFundingAccounting, SweeperFundingConf
 use crate::state::transactions::{Erc20WithdrawalRequest, TransactionCallData, WithdrawalRequest};
 use crate::timed_sized_map::{Entry, Timestamp};
 use crate::tx::GasFeeEstimate;
-use crate::tx::TransactionSignature;
+use crate::tx::{SignedAuthorization, TransactionSignature};
 use candid::Principal;
 use ic_canister_log::log;
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
@@ -289,6 +291,34 @@ impl State {
     fn record_attestation(&mut self, request: AttestationRequest, signature: TransactionSignature) {
         self.automatic_deposits
             .record_attestation(request, signature);
+    }
+
+    /// The delegation authorization `address` has already signed for the configuration this minter
+    /// runs against, if any: signing another would cost a threshold-ECDSA signature for a tuple the
+    /// minter already holds. `None` while the sweeper contract is unknown.
+    ///
+    /// A stored tuple is checked rather than trusted. It names the chain and the delegate it
+    /// authorizes, so one signed for a sweeper contract the minter no longer calls fails the check
+    /// and is simply re-signed. Losing an entry costs a signature, never a sweep, which is why the
+    /// store lives on the heap alone: an upgrade empties it and every address pays one signature
+    /// again on its next sweep, rather than the minter carrying an event per address forever.
+    pub fn authorization(&self, address: &DepositAddress) -> Option<&SignedAuthorization> {
+        let delegate = self.sweeper_contract_address?;
+        self.automatic_deposits
+            .authorization(address)
+            .filter(|authorization| {
+                authorization.chain_id == self.ethereum_network.chain_id()
+                    && authorization.delegate == delegate
+            })
+    }
+
+    pub fn record_authorization(
+        &mut self,
+        address: DepositAddress,
+        authorization: SignedAuthorization,
+    ) {
+        self.automatic_deposits
+            .record_authorization(address, authorization);
     }
 
     pub fn is_ckerc20_feature_active(&self) -> bool {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -9,7 +9,7 @@ use crate::numeric::{BlockNumber, Erc20Value};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
 use crate::state::transactions::{SweepId, SweptDeposit};
 use crate::timed_sized_map::{Entry, InsertError, TimedSizedMap, Timestamp};
-use crate::tx::TransactionSignature;
+use crate::tx::{SignedAuthorization, TransactionSignature};
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -69,6 +69,20 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::attestations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     attestations: BTreeMap<AttestationRequest, TransactionSignature>,
+    /// Delegation authorizations the minter has signed, keyed by the deposit address that signed
+    /// each one. A tuple is signed for nonce 0 and names the chain and the delegate it authorizes,
+    /// so it never expires and every later sweep of that address reuses it instead of paying for
+    /// another threshold-ECDSA signature.
+    ///
+    /// Purely a cost optimization: the stored tuple is validated against the configuration before
+    /// being reused (see [`crate::state::State::authorization`]), and losing an entry costs one
+    /// signature, never a sweep. Which is why this map is heap-only, unlike the rest of the state:
+    /// no event records it, an upgrade empties it, and each address pays one signature again on its
+    /// next sweep. Persisting it would mean an event per address in the log forever, replayed on
+    /// every upgrade, to save a cost that is bounded by the addresses in flight. Nothing prunes it
+    /// within a canister version — [`Self::authorizations_len`] is exported as a metric so its
+    /// growth is visible before it needs bounding.
+    authorizations: BTreeMap<DepositAddress, SignedAuthorization>,
 }
 
 impl AutomaticDeposits {
@@ -84,6 +98,21 @@ impl AutomaticDeposits {
         signature: TransactionSignature,
     ) {
         self.attestations.insert(request, signature);
+    }
+
+    /// The authorization `address` has already signed, whatever it authorizes. Callers go through
+    /// [`crate::state::State::authorization`], which is where a stored tuple is checked against the
+    /// configuration the minter runs against.
+    pub fn authorization(&self, address: &DepositAddress) -> Option<&SignedAuthorization> {
+        self.authorizations.get(address)
+    }
+
+    pub fn record_authorization(
+        &mut self,
+        address: DepositAddress,
+        authorization: SignedAuthorization,
+    ) {
+        self.authorizations.insert(address, authorization);
     }
 
     /// Arm the `(account, token)` pair, whose deposit `address` is derived for `account`.
@@ -439,6 +468,10 @@ impl AutomaticDeposits {
         self.attestations.len()
     }
 
+    pub fn authorizations_len(&self) -> usize {
+        self.authorizations.len()
+    }
+
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
     /// funds queued for sweeping (so it must be registered). Reports
     /// [`DepositStatus::AwaitingSweep`] once funds have been detected and queued, and otherwise
@@ -482,6 +515,7 @@ impl Default for AutomaticDeposits {
             watchlist: TimedSizedMap::new(DEPOSIT_ADDRESS_SCAN_WINDOW, MAX_ACTIVE_DEPOSITS),
             sweep: BTreeMap::new(),
             attestations: BTreeMap::new(),
+            authorizations: BTreeMap::new(),
         }
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -1756,6 +1756,101 @@ mod sweeps {
     }
 }
 
+mod authorizations {
+    use crate::deposit_address::DepositAddress;
+    use crate::numeric::TransactionNonce;
+    use crate::state::State;
+    use crate::test_fixtures::initial_state;
+    use crate::tx::SignedAuthorization;
+    use ic_ethereum_types::Address;
+
+    #[test]
+    fn should_reuse_the_authorization_a_deposit_address_signed() {
+        let mut state = state_with_sweeper_contract();
+
+        record(&mut state, authorization(sweeper_contract()));
+
+        assert_eq!(
+            state.authorization(&deposit_address()),
+            Some(&authorization(sweeper_contract()))
+        );
+    }
+
+    #[test]
+    fn should_not_reuse_an_authorization_naming_another_delegate() {
+        let mut state = state_with_sweeper_contract();
+
+        record(&mut state, authorization(previous_sweeper_contract()));
+
+        assert_eq!(state.authorization(&deposit_address()), None);
+
+        // A newly deployed sweeper contract only costs the signature the stored tuple saved.
+        record(&mut state, authorization(sweeper_contract()));
+
+        assert_eq!(
+            state.authorization(&deposit_address()),
+            Some(&authorization(sweeper_contract()))
+        );
+    }
+
+    #[test]
+    fn should_not_reuse_an_authorization_naming_another_chain() {
+        let mut state = state_with_sweeper_contract();
+
+        let another_chain = SignedAuthorization {
+            chain_id: state.ethereum_network().chain_id() + 1,
+            ..authorization(sweeper_contract())
+        };
+
+        record(&mut state, another_chain);
+
+        assert_eq!(state.authorization(&deposit_address()), None);
+    }
+
+    #[test]
+    fn should_not_reuse_an_authorization_while_the_sweeper_contract_is_unknown() {
+        let mut state = initial_state();
+        assert_eq!(state.sweeper_contract_address, None);
+
+        record(&mut state, authorization(sweeper_contract()));
+
+        assert_eq!(state.authorization(&deposit_address()), None);
+    }
+
+    fn record(state: &mut State, authorization: SignedAuthorization) {
+        state.record_authorization(deposit_address(), authorization);
+    }
+
+    fn state_with_sweeper_contract() -> State {
+        let mut state = initial_state();
+        state.sweeper_contract_address = Some(sweeper_contract());
+        state
+    }
+
+    fn authorization(delegate: Address) -> SignedAuthorization {
+        SignedAuthorization {
+            chain_id: initial_state().ethereum_network().chain_id(),
+            delegate,
+            nonce: TransactionNonce::ZERO,
+            y_parity: false,
+            r: ethnum::u256::ONE,
+            s: ethnum::u256::ONE,
+        }
+    }
+
+    fn deposit_address() -> DepositAddress {
+        DepositAddress::new(Address::new([0x11; 20]))
+    }
+
+    fn sweeper_contract() -> Address {
+        Address::new([0xde; 20])
+    }
+
+    fn previous_sweeper_contract() -> Address {
+        Address::new([0xdd; 20])
+    }
+}
+
 mod eth_balance {
     use super::*;
     use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -652,36 +652,68 @@ fn attested_addresses(
         .collect()
 }
 
+/// The authorizations the minter already holds for these addresses, keyed by account.
+///
+/// Only the ones still usable: [`State::authorization`] checks a stored tuple against the chain and
+/// the delegate the minter runs against, so an address delegated by a retired sweeper contract falls
+/// through to a fresh signature rather than being swept through the wrong delegate.
+fn stored_authorizations(
+    addresses: &BTreeMap<Account, DepositAddress>,
+) -> BTreeMap<Account, SignedAuthorization> {
+    read_state(|s| {
+        addresses
+            .iter()
+            .filter_map(|(account, address)| {
+                s.authorization(address)
+                    .map(|authorization| (*account, authorization.clone()))
+            })
+            .collect()
+    })
+}
+
 /// One authorization per account, keyed by it, missing where it could not be signed.
 ///
-/// Every address is signed afresh: the tuple names the chain and the delegate, and its nonce is
-/// fixed at 0, so nothing a sweep does can invalidate it — see [`delegation_authorization`].
+/// A tuple is signed once per address and reused by every later sweep of it: it names the chain and
+/// the delegate, and its nonce is fixed at 0, so nothing a sweep does can invalidate it. Only the
+/// addresses the minter holds no usable tuple for cost a signature, and each is recorded the moment
+/// it exists.
+///
+/// Reuse is a cost optimization, not correctness state — see [`delegation_authorization`]. A tuple
+/// the store never had, or one it holds under a delegate the minter no longer calls, costs one
+/// threshold-ECDSA signature; it can never cost a sweep.
 async fn sign_authorizations_batch(
     addresses: &BTreeMap<Account, DepositAddress>,
     sweeper_contract: Address,
 ) -> BTreeMap<Account, SignedAuthorization> {
+    let mut authorizations = stored_authorizations(addresses);
     let chain_id = read_state(State::ethereum_network).chain_id();
-    let signed = join_all(addresses.keys().map(|account| {
-        let account = *account;
-        let authorization = delegation_authorization(chain_id, sweeper_contract);
-        async move {
-            (
-                account,
-                authorization
-                    .sign(deposit_derivation_path(
-                        DepositAddressSchema::CkErc20,
-                        &account,
-                    ))
-                    .await,
-            )
-        }
-    }))
+    let signed = join_all(
+        addresses
+            .iter()
+            .filter(|(account, _address)| !authorizations.contains_key(*account))
+            .map(|(account, address)| {
+                let (account, address) = (*account, *address);
+                let authorization = delegation_authorization(chain_id, sweeper_contract);
+                async move {
+                    (
+                        account,
+                        address,
+                        authorization
+                            .sign(deposit_derivation_path(
+                                DepositAddressSchema::CkErc20,
+                                &account,
+                            ))
+                            .await,
+                    )
+                }
+            }),
+    )
     .await;
-    let mut authorizations = BTreeMap::new();
     let mut errors = Vec::new();
-    for (account, result) in signed {
+    for (account, address, result) in signed {
         match result {
             Ok(authorization) => {
+                mutate_state(|s| s.record_authorization(address, authorization.clone()));
                 authorizations.insert(account, authorization);
             }
             Err(e) => errors.push(format!("{account:?}: {e}")),

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     MAX_DEPOSITS_PER_SWEEP, PreparedDeposit, SweepBatch, attested_addresses,
-    delegation_authorization, prepared_deposits, sweep_batches_by_token,
+    delegation_authorization, prepared_deposits, stored_authorizations, sweep_batches_by_token,
 };
 use crate::deposit_address::DepositAddress;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
@@ -304,6 +304,75 @@ mod attested_addresses {
             attested_addresses(&targets, &attestations),
             BTreeMap::from([(account(0), deposit_address(0))])
         );
+    }
+}
+
+mod stored_authorizations {
+    use super::{
+        account, authorization, deposit_address, queued_state, stored_authorizations,
+        sweeper_contract, usdc,
+    };
+    use crate::deposit_address::DepositAddress;
+    use crate::state::State;
+    use crate::test_fixtures::init_state;
+    use crate::tx::SignedAuthorization;
+    use ic_ethereum_types::Address;
+    use icrc_ledger_types::icrc1::account::Account;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_reuse_the_tuple_stored_for_the_configured_delegate() {
+        init_state(state_authorizing(sweeper_contract()));
+
+        let stored = stored_authorizations(&addresses());
+
+        assert_eq!(stored, BTreeMap::from([(account(0), authorization())]));
+    }
+
+    #[test]
+    fn should_re_sign_a_tuple_stored_for_a_retired_delegate() {
+        init_state(state_authorizing(previous_sweeper_contract()));
+
+        let stored = stored_authorizations(&addresses());
+
+        assert_eq!(stored, BTreeMap::new());
+    }
+
+    #[test]
+    fn should_hold_nothing_for_an_address_never_authorized() {
+        init_state(configured_state());
+
+        let stored = stored_authorizations(&addresses());
+
+        assert_eq!(stored, BTreeMap::new());
+    }
+
+    fn addresses() -> BTreeMap<Account, DepositAddress> {
+        BTreeMap::from([(account(0), deposit_address(0))])
+    }
+
+    /// A configured state that has already recorded account 0's authorization to `delegate`.
+    fn state_authorizing(delegate: Address) -> State {
+        let mut state = configured_state();
+        state.record_authorization(
+            deposit_address(0),
+            SignedAuthorization {
+                delegate,
+                ..authorization()
+            },
+        );
+        state
+    }
+
+    fn configured_state() -> State {
+        let mut state = queued_state(&[(0, usdc())]);
+        state.sweeper_contract_address = Some(sweeper_contract());
+        state
+    }
+
+    /// The sweeper contract a previous deployment delegated to.
+    fn previous_sweeper_contract() -> Address {
+        Address::new([0xdd; 20])
     }
 }
 


### PR DESCRIPTION
## Why

- Every sweep signed a fresh EIP-7702 authorization for each deposit address it touched, paying a threshold-ECDSA signature for a tuple that never changes: nonce 0, one chain, one delegate.

## What

- The minter remembers the authorization a deposit address signed and reuses it on every later sweep of that address; only addresses without a usable stored tuple cost a signature.
- A stored tuple is checked against the configuration before reuse — one naming a retired sweeper contract or another chain misses and is simply re-signed.
- The store lives on the heap alone: losing it costs one signature per address, never a sweep, so an upgrade may empty it rather than the event log carrying an entry per address forever.
- A gauge reports the store's size, so growth is visible before it needs bounding.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
