### PR TITLE
fix(cketh): provision sweep gas out of the sweeper balance bound

### DIFF
--- a/rs/ethereum/cketh/docs/deposit_from_cex.md
+++ b/rs/ethereum/cketh/docs/deposit_from_cex.md
@@ -351,12 +351,16 @@ with an `icrc1_balance_of` of `1_762_128_000_000_000_000` wei ≈ 1.76 ckETH as 
 
 * The sweeper address' balance is the `prepaid_sweep_gas` counter, and the minter
   tracks a lower bound on it from its own events — what finalized fundings
-  delivered, less the gas submitted sweeps provisioned — and may reconcile that
-  bound against the chain whenever it chooses. The bound errs low: ETH anyone else
-  sends to the address only pushes the true balance above it. That is the safe
-  direction for both readers, in opposite ways — a funding may be triggered earlier
-  than strictly needed, never skipped; a sweep may be held back, never authorised
-  against gas that is not there.
+  delivered, less what accepted sweeps have provisioned, plus what finalized
+  sweeps handed back — and may reconcile that bound against the chain whenever it
+  chooses. A sweep provisions the most it can cost the moment it is accepted — its
+  fee ceiling, which caps every resubmission, an ERC-20 sweep moving no ETH value of
+  its own — and gets back what it did not need when it finalizes, so a sweep whose
+  finalization is never observed leaves the bound too *low* rather than too high.
+  ETH anyone else sends to the address only pushes the true balance further above
+  it. The bound therefore errs low in the safe direction for both readers: a funding
+  may be triggered earlier than strictly needed, never skipped; a sweep may be held
+  back, never authorised against gas that is not there.
   Sweep gas draws it down; burned ckETH is
   **never re-minted**, so "cumulative burned ≥ cumulative spent" holds at every
   instant. Each funding round burns for its own transfer alone: the fee a previous

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -527,12 +527,12 @@ impl State {
     }
 
     /// Takes the whole cost an accepted sweep can put on the sweeper address out of the balance
-    /// bound: the ETH it will transfer plus its fee ceiling, which caps every resubmission the
-    /// pipeline makes for it. An ERC-20 sweep moves its tokens through call data and carries no
-    /// ETH value, so the fee is all it can cost.
+    /// bound: its fee ceiling, which caps every resubmission the pipeline makes for it. An ERC-20
+    /// sweep moves its tokens through call data and carries no ETH value, so the fee is all it
+    /// can cost.
     pub fn update_sweeper_balance_upon_accepted_sweep(&mut self, request: &SweepRequest) {
         self.sweeper_funding
-            .record_accepted_sweep(Wei::ZERO, request.max_transaction_fee);
+            .record_accepted_sweep(request.max_transaction_fee);
     }
 
     fn update_balance_upon_withdrawal(

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -497,10 +497,16 @@ impl State {
         sweep_id: &SweepId,
         receipt: &TransactionReceipt,
     ) {
-        let _ = self
+        let max_transaction_fee = self
+            .automatic_deposits
+            .processed_sweep_request(sweep_id)
+            .expect("BUG: missing sweep request")
+            .max_transaction_fee;
+        let finalized = self
             .automatic_deposits
             .record_finalized_sweep_transaction(*sweep_id, receipt);
-        self.update_sweeper_balance_upon_sweep(sweep_id, receipt);
+        self.sweeper_funding
+            .record_finalized_sweep(max_transaction_fee, &finalized);
     }
 
     pub fn next_request_id(&mut self) -> u64 {
@@ -520,36 +526,13 @@ impl State {
         };
     }
 
-    /// Takes the most an accepted sweep can cost the sweeper address out of the balance bound: its
-    /// fee ceiling, which caps every resubmission the pipeline makes for it. An ERC-20 sweep moves
-    /// its tokens through call data and carries no ETH value, so the fee is all it can cost.
+    /// Takes the whole cost an accepted sweep can put on the sweeper address out of the balance
+    /// bound: the ETH it will transfer plus its fee ceiling, which caps every resubmission the
+    /// pipeline makes for it. An ERC-20 sweep moves its tokens through call data and carries no
+    /// ETH value, so the fee is all it can cost.
     pub fn update_sweeper_balance_upon_accepted_sweep(&mut self, request: &SweepRequest) {
         self.sweeper_funding
-            .record_accepted_sweep(request.max_transaction_fee);
-    }
-
-    /// Hands back the part of a finalized sweep's provision it did not need: the fee it did not
-    /// pay, which is the whole of it either way, a reverted sweep being charged for its gas like
-    /// any other.
-    fn update_sweeper_balance_upon_sweep(
-        &mut self,
-        sweep_id: &SweepId,
-        receipt: &TransactionReceipt,
-    ) {
-        let fee_ceiling = self
-            .automatic_deposits
-            .processed_sweep_request(sweep_id)
-            .expect("BUG: missing sweep request")
-            .max_transaction_fee;
-        // Cannot underflow: a sweep transaction is created, and resubmitted, only while its fee
-        // stays within this ceiling, and the fee it actually pays is at most the fee it was signed
-        // for.
-        let effective_fee = receipt.effective_transaction_fee();
-        let unspent_fee = fee_ceiling
-            .checked_sub(effective_fee)
-            .expect("BUG: a sweep may not pay more than its fee ceiling");
-        self.sweeper_funding
-            .record_finalized_sweep(effective_fee, unspent_fee);
+            .record_accepted_sweep(Wei::ZERO, request.max_transaction_fee);
     }
 
     fn update_balance_upon_withdrawal(

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -16,7 +16,9 @@ use crate::runtime::CanisterRuntime;
 use crate::state::automatic_deposits::{AutomaticDeposits, ScanProgress};
 use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
 use crate::state::sweeper_funding::{SweeperFundingAccounting, SweeperFundingConfig};
-use crate::state::transactions::{Erc20WithdrawalRequest, TransactionCallData, WithdrawalRequest};
+use crate::state::transactions::{
+    Erc20WithdrawalRequest, SweepRequest, TransactionCallData, WithdrawalRequest,
+};
 use crate::timed_sized_map::{Entry, Timestamp};
 use crate::tx::AuthorizationRequest;
 use crate::tx::GasFeeEstimate;
@@ -487,6 +489,20 @@ impl State {
         self.update_balance_upon_withdrawal(withdrawal_id, receipt);
     }
 
+    /// Finalizes a sweep: releases the deposits it held and settles what it actually cost the
+    /// sweeper address. The sweeper pipeline is never reimbursed and holds no ckETH balance, so
+    /// unlike the main pipeline there is no reimbursement tail and no ckETH accounting here.
+    pub fn record_finalized_sweeper_transaction(
+        &mut self,
+        sweep_id: &SweepId,
+        receipt: &TransactionReceipt,
+    ) {
+        let _ = self
+            .automatic_deposits
+            .record_finalized_sweep_transaction(*sweep_id, receipt);
+        self.update_sweeper_balance_upon_sweep(sweep_id, receipt);
+    }
+
     pub fn next_request_id(&mut self) -> u64 {
         let current_request_id = self.http_request_counter;
         // overflow is not an issue here because we only use `next_request_id` to correlate
@@ -502,6 +518,36 @@ impl State {
                 .erc20_balances
                 .erc20_add(event.erc20_contract_address, event.value),
         };
+    }
+
+    /// Takes the most an accepted sweep can cost the sweeper address out of the balance bound: its
+    /// fee ceiling, which caps every resubmission the pipeline makes for it. An ERC-20 sweep moves
+    /// its tokens through call data and carries no ETH value, so the fee is all it can cost.
+    pub fn update_sweeper_balance_upon_accepted_sweep(&mut self, request: &SweepRequest) {
+        self.sweeper_funding
+            .record_accepted_sweep(request.max_transaction_fee);
+    }
+
+    /// Hands back the part of a finalized sweep's provision it did not need: the fee it did not
+    /// pay, which is the whole of it either way, a reverted sweep being charged for its gas like
+    /// any other.
+    fn update_sweeper_balance_upon_sweep(
+        &mut self,
+        sweep_id: &SweepId,
+        receipt: &TransactionReceipt,
+    ) {
+        let fee_ceiling = self
+            .automatic_deposits
+            .processed_sweep_request(sweep_id)
+            .expect("BUG: missing sweep request")
+            .max_transaction_fee;
+        // Cannot underflow: a sweep transaction is created, and resubmitted, only while its fee
+        // stays within this ceiling, and the fee it actually pays is at most the fee it was signed
+        // for.
+        let unspent_fee = fee_ceiling
+            .checked_sub(receipt.effective_transaction_fee())
+            .expect("BUG: a sweep may not pay more than its fee ceiling");
+        self.sweeper_funding.record_finalized_sweep(unspent_fee);
     }
 
     fn update_balance_upon_withdrawal(

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -544,10 +544,12 @@ impl State {
         // Cannot underflow: a sweep transaction is created, and resubmitted, only while its fee
         // stays within this ceiling, and the fee it actually pays is at most the fee it was signed
         // for.
+        let effective_fee = receipt.effective_transaction_fee();
         let unspent_fee = fee_ceiling
-            .checked_sub(receipt.effective_transaction_fee())
+            .checked_sub(effective_fee)
             .expect("BUG: a sweep may not pay more than its fee ceiling");
-        self.sweeper_funding.record_finalized_sweep(unspent_fee);
+        self.sweeper_funding
+            .record_finalized_sweep(effective_fee, unspent_fee);
     }
 
     fn update_balance_upon_withdrawal(

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -126,6 +126,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
                 request.token,
                 request.items.iter().map(|item| item.item.account),
             );
+            state.update_sweeper_balance_upon_accepted_sweep(request);
             state
                 .automatic_deposits
                 .record_sweep_request(request.clone());
@@ -158,11 +159,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             sweep_id,
             transaction_receipt,
         } => {
-            // The sweeper pipeline is never reimbursed and holds no ckETH balance, so unlike the main
-            // pipeline there is no reimbursement tail or balance update — just the finalize mechanics.
-            let _ = state
-                .automatic_deposits
-                .record_finalized_sweep_transaction(*sweep_id, transaction_receipt);
+            state.record_finalized_sweeper_transaction(sweep_id, transaction_receipt);
         }
         EventType::ReimbursedEthWithdrawal(Reimbursed {
             burn_in_block: withdrawal_id,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -157,6 +157,11 @@ impl AutomaticDeposits {
         self.sweeper_transactions.record_request(request)
     }
 
+    /// The request of a sweep the pipeline has taken up, still available once the sweep finalizes.
+    pub fn processed_sweep_request(&self, id: &SweepId) -> Option<&SweepRequest> {
+        self.sweeper_transactions.get_processed_request(id)
+    }
+
     pub fn reschedule_sweep_request(&mut self, id: SweepId) {
         self.sweeper_transactions.reschedule_request(id)
     }

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -12,20 +12,13 @@
 #[cfg(test)]
 mod tests;
 
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::numeric::Wei;
-use crate::state::EthBalance;
+use crate::tx::{Finalized, SweepTransaction};
 
 /// How much ckETH has been burned for sweeping and how much of it has actually been spent — the two
-/// sides of the invariant above — along with the sweeper address' own [`EthBalance`], which the
+/// sides of the invariant above — along with the sweeper address' own [`SweeperBalance`], which the
 /// spending side maintains.
-///
-/// The sweeper's [`EthBalance`] differs from the main address' in *when* it debits: the main
-/// address debits what a transaction actually cost once it finalizes, while the sweeper debits an
-/// accepted sweep's whole fee ceiling up front and is credited back the part it did not pay at
-/// finalization. Holding the gas early is what keeps the balance a lower bound while sweeps are in
-/// flight, and the sweep pipeline only accepts a sweep the balance covers, so an uncovered debit
-/// is a bug, exactly as on the main address. ETH anyone else sends to the sweeper is not tracked
-/// and only pushes its true balance above this record.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SweeperFundingAccounting {
     /// Grows when a funding is accepted, by the whole amount that funding may spend.
@@ -36,7 +29,7 @@ pub struct SweeperFundingAccounting {
     /// Grows at the same point by the fee the transaction paid, which it does either way. Together
     /// with the amount transferred it is the spend, which never overtakes the burn.
     cumulative_transaction_fees: Wei,
-    sweeper_balance: EthBalance,
+    sweeper_balance: SweeperBalance,
 }
 
 impl Default for SweeperFundingAccounting {
@@ -45,8 +38,60 @@ impl Default for SweeperFundingAccounting {
             cumulative_burned: Wei::ZERO,
             cumulative_transferred: Wei::ZERO,
             cumulative_transaction_fees: Wei::ZERO,
-            sweeper_balance: EthBalance::default(),
+            sweeper_balance: SweeperBalance::default(),
         }
+    }
+}
+
+/// The sweeper address' ETH, kept like [`EthBalance`] keeps the main address' but differing in
+/// *when* it debits: the main address debits what a transaction actually cost once it finalizes,
+/// while the sweeper debits an accepted sweep's whole possible cost — the ETH it will transfer
+/// plus its fee ceiling — up front, and is credited back at finalization whatever the sweep turned
+/// out not to spend. Holding the whole cost early is what keeps the balance a lower bound while
+/// sweeps are in flight, and the sweep pipeline only accepts a sweep the balance covers, so an
+/// uncovered debit is a bug, exactly as on the main address. There is no unspent-fee counter
+/// either: an unspent fee returns into the balance and is spent by a later sweep, unlike on the
+/// main address where it accrues as surplus. ETH anyone else sends to the sweeper is not tracked
+/// and only pushes its true balance above this record.
+///
+/// [`EthBalance`]: crate::state::EthBalance
+#[derive(Clone, Eq, PartialEq, Debug)]
+struct SweeperBalance {
+    eth_balance: Wei,
+    total_effective_tx_fees: Wei,
+}
+
+impl Default for SweeperBalance {
+    fn default() -> Self {
+        Self {
+            eth_balance: Wei::ZERO,
+            total_effective_tx_fees: Wei::ZERO,
+        }
+    }
+}
+
+impl SweeperBalance {
+    fn credit(&mut self, amount: Wei) {
+        self.eth_balance = self
+            .eth_balance
+            .checked_add(amount)
+            .expect("BUG: overflow in the sweeper balance");
+    }
+
+    fn debit(&mut self, amount: Wei) {
+        self.eth_balance = self.eth_balance.checked_sub(amount).unwrap_or_else(|| {
+            panic!(
+                "BUG: the sweeper balance {} cannot cover a debit of {amount}",
+                self.eth_balance
+            )
+        });
+    }
+
+    fn add_effective_tx_fee(&mut self, fee: Wei) {
+        self.total_effective_tx_fees = self
+            .total_effective_tx_fees
+            .checked_add(fee)
+            .expect("BUG: overflow in the sweeper's effective transaction fees");
     }
 }
 
@@ -70,30 +115,53 @@ impl SweeperFundingAccounting {
             .cumulative_transaction_fees
             .checked_add(transaction_fee)
             .expect("BUG: overflow in cumulative sweeper funding fees");
-        self.sweeper_balance.eth_balance_add(transferred);
+        self.sweeper_balance.credit(transferred);
         // Checked eagerly so a violation surfaces at the transition that caused it.
         let _ = self.burned_not_yet_spent();
     }
 
-    /// Debits the most an accepted sweep can cost the sweeper address: the ceiling on its
-    /// transaction fee, which caps every resubmission too, so a sweep is debited once however many
-    /// times the pipeline resubmits it.
+    /// Debits the whole cost an accepted sweep can put on the sweeper address — the ETH it will
+    /// transfer plus the ceiling on its transaction fee, which caps every resubmission too — so a
+    /// sweep is debited once however many times the pipeline resubmits it.
     ///
     /// Deliberately not added to [`Self::cumulative_spent`]: that counter is the minter's own ETH,
     /// and this ETH was counted there once already, when the funding that delivered it to the
     /// sweeper finalized. Counting it twice would make spend overtake burn and trip the invariant.
-    pub fn record_accepted_sweep(&mut self, provisioned: Wei) {
-        self.sweeper_balance.eth_balance_sub(provisioned);
+    pub fn record_accepted_sweep(&mut self, eth_transferred: Wei, max_transaction_fee: Wei) {
+        self.sweeper_balance.debit(
+            eth_transferred
+                .checked_add(max_transaction_fee)
+                .expect("BUG: overflow in the cost of an accepted sweep"),
+        );
     }
 
-    /// Settles a finalized sweep against the hold its acceptance took: the fee it did not pay
-    /// comes back into the balance, and both fees are recorded exactly as the main address records
-    /// its own.
-    pub fn record_finalized_sweep(&mut self, effective_fee: Wei, unspent_fee: Wei) {
-        self.sweeper_balance.eth_balance_add(unspent_fee);
-        self.sweeper_balance
-            .total_effective_tx_fees_add(effective_fee);
-        self.sweeper_balance.total_unspent_tx_fees_add(unspent_fee);
+    /// Settles a finalized sweep against the hold its acceptance took, reading what actually
+    /// happened off the transaction and its receipt: the part of `max_transaction_fee` the sweep
+    /// did not pay comes back into the balance — along with the ETH it never sent, if it failed —
+    /// and the fee it paid is recorded.
+    pub fn record_finalized_sweep(
+        &mut self,
+        max_transaction_fee: Wei,
+        sweep: &Finalized<SweepTransaction>,
+    ) {
+        let effective_fee = sweep.effective_transaction_fee();
+        let unspent_fee = max_transaction_fee
+            .checked_sub(effective_fee)
+            .expect("BUG: a sweep may not pay more than its fee ceiling");
+        let unspent = match sweep.transaction_status() {
+            TransactionStatus::Success => unspent_fee,
+            TransactionStatus::Failure => sweep
+                .transaction_amount()
+                .checked_add(unspent_fee)
+                .expect("BUG: overflow in the unspent cost of a failed sweep"),
+        };
+        self.sweeper_balance.credit(unspent);
+        self.sweeper_balance.add_effective_tx_fee(effective_fee);
+    }
+
+    /// Total transaction fees finalized sweeps actually paid out of the sweeper address.
+    pub fn total_effective_sweep_fees(&self) -> Wei {
+        self.sweeper_balance.total_effective_tx_fees
     }
 
     /// Total ETH debited from the main address on account of sweeping.
@@ -117,7 +185,7 @@ impl SweeperFundingAccounting {
     /// from wherever the bound sits — rather than too high, which would let the minter believe in
     /// gas that is gone.
     pub fn sweeper_balance_lower_bound(&self) -> Wei {
-        self.sweeper_balance.eth_balance()
+        self.sweeper_balance.eth_balance
     }
 
     /// ckETH burned for sweeping that has not been spent yet: the burn of a funding in flight, plus

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -26,6 +26,15 @@ pub struct SweeperFundingAccounting {
     /// Grows at the same point by the fee the transaction paid, which it does either way. Together
     /// with the amount transferred it is the spend, which never overtakes the burn.
     cumulative_transaction_fees: Wei,
+    /// Grows when a sweep is accepted, by the most that sweep can cost the sweeper address: the
+    /// ceiling on its transaction fee, which caps every resubmission too. Not part of the invariant
+    /// above — this ETH was already counted as spent when the funding that delivered it finalized —
+    /// but subtracted from the balance bound, so that gas a committed sweep will consume stops
+    /// counting as available the moment it is committed.
+    cumulative_sweep_provisioned: Wei,
+    /// Grows when a sweep finalizes, by the part of that provision it turned out not to need: the
+    /// fee it did not pay.
+    cumulative_sweep_refunded: Wei,
 }
 
 impl Default for SweeperFundingAccounting {
@@ -34,6 +43,8 @@ impl Default for SweeperFundingAccounting {
             cumulative_burned: Wei::ZERO,
             cumulative_transferred: Wei::ZERO,
             cumulative_transaction_fees: Wei::ZERO,
+            cumulative_sweep_provisioned: Wei::ZERO,
+            cumulative_sweep_refunded: Wei::ZERO,
         }
     }
 }
@@ -62,6 +73,30 @@ impl SweeperFundingAccounting {
         let _ = self.burned_not_yet_spent();
     }
 
+    /// Records the most an accepted sweep can cost the sweeper address, taking it out of the balance
+    /// bound up front. Recorded when the sweep is accepted rather than when its transaction is
+    /// signed, so that a sweep provisions once however many times the pipeline resubmits it — every
+    /// attempt is capped by the same fee ceiling.
+    ///
+    /// Deliberately not added to [`Self::cumulative_spent`]: that counter is the minter's own ETH,
+    /// and this ETH was counted there once already, when the funding that delivered it to the
+    /// sweeper finalized. Counting it twice would make spend overtake burn and trip the invariant.
+    pub fn record_accepted_sweep(&mut self, provisioned: Wei) {
+        self.cumulative_sweep_provisioned = self
+            .cumulative_sweep_provisioned
+            .checked_add(provisioned)
+            .expect("BUG: overflow in cumulative sweep provisioned");
+    }
+
+    /// Records the part of a finalized sweep's provision it did not need, putting it back into the
+    /// balance bound.
+    pub fn record_finalized_sweep(&mut self, refunded: Wei) {
+        self.cumulative_sweep_refunded = self
+            .cumulative_sweep_refunded
+            .checked_add(refunded)
+            .expect("BUG: overflow in cumulative sweep refunded");
+    }
+
     /// Total ETH debited from the main address on account of sweeping.
     pub fn cumulative_spent(&self) -> Wei {
         self.cumulative_transferred
@@ -73,12 +108,25 @@ impl SweeperFundingAccounting {
         self.cumulative_burned
     }
 
-    /// A lower bound on the sweeper address' ETH balance: what finalized fundings delivered. Nothing
-    /// debits it yet; when sweeping lands it will subtract the gas submitted sweeps provisioned, so
-    /// the bound stays conservative. ETH sent to the address by anyone else only pushes the true
-    /// balance above it.
+    /// A lower bound on the sweeper address' ETH balance: what finalized fundings delivered, less
+    /// what accepted sweeps have provisioned, plus what finalized sweeps handed back.
+    ///
+    /// Provisioning at acceptance rather than at spend is what keeps this a bound while sweeps are in
+    /// flight: gas a committed sweep will pay stops counting as available immediately, and a sweep
+    /// whose finalization is never observed leaves the bound too *low* — which delays a funding —
+    /// rather than too high, which would let the minter believe in gas that is gone. ETH sent to the
+    /// address by anyone else only pushes the true balance further above the bound.
+    ///
+    /// Saturating rather than checked: these counters are the minter's own record, and after an
+    /// upgrade that starts them from zero — or a sweeper address funded before the minter tracked it
+    /// — provisioning can legitimately exceed the deliveries. Trapping here would trap the replay of
+    /// every event after it, so it floors at zero, which reads as "assume nothing is prepaid".
     pub fn sweeper_balance_lower_bound(&self) -> Wei {
         self.cumulative_transferred
+            .checked_add(self.cumulative_sweep_refunded)
+            .expect("BUG: overflow in the sweeper balance bound")
+            .checked_sub(self.cumulative_sweep_provisioned)
+            .unwrap_or(Wei::ZERO)
     }
 
     /// ckETH burned for sweeping that has not been spent yet: the burn of a funding in flight, plus

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -16,8 +16,21 @@ use crate::numeric::Wei;
 use crate::tx::{Finalized, SweepTransaction};
 
 /// How much ckETH has been burned for sweeping and how much of it has actually been spent — the two
-/// sides of the invariant above — along with the sweeper address' own [`SweeperBalance`], which the
+/// sides of the invariant above — along with the sweeper address' own ETH balance, which the
 /// spending side maintains.
+///
+/// The sweeper's balance is kept like [`EthBalance`] keeps the main address' but differs in *when*
+/// it debits: the main address debits what a transaction actually cost once it finalizes, while
+/// the sweeper debits an accepted sweep's whole possible cost — its fee ceiling, a sweep sending
+/// no ETH — up front, and is credited back at finalization whatever the sweep turned out not to
+/// spend. Holding the whole cost early is what keeps the balance a lower bound while sweeps are in
+/// flight, and the sweep pipeline only accepts a sweep the balance covers, so an uncovered debit
+/// is a bug, exactly as on the main address. There is no unspent-fee counter either: an unspent
+/// fee returns into the balance and is spent by a later sweep, unlike on the main address where it
+/// accrues as surplus. ETH anyone else sends to the sweeper is not tracked and only pushes its
+/// true balance above this record.
+///
+/// [`EthBalance`]: crate::state::EthBalance
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SweeperFundingAccounting {
     /// Grows when a funding is accepted, by the whole amount that funding may spend.
@@ -42,18 +55,6 @@ impl Default for SweeperFundingAccounting {
     }
 }
 
-/// The sweeper address' ETH, kept like [`EthBalance`] keeps the main address' but differing in
-/// *when* it debits: the main address debits what a transaction actually cost once it finalizes,
-/// while the sweeper debits an accepted sweep's whole possible cost — its fee ceiling, a sweep
-/// sending no ETH — up front, and is credited back at finalization whatever the sweep turned out
-/// not to spend. Holding the whole cost early is what keeps the balance a lower bound while
-/// sweeps are in flight, and the sweep pipeline only accepts a sweep the balance covers, so an
-/// uncovered debit is a bug, exactly as on the main address. There is no unspent-fee counter
-/// either: an unspent fee returns into the balance and is spent by a later sweep, unlike on the
-/// main address where it accrues as surplus. ETH anyone else sends to the sweeper is not tracked
-/// and only pushes its true balance above this record.
-///
-/// [`EthBalance`]: crate::state::EthBalance
 #[derive(Clone, Eq, PartialEq, Debug)]
 struct SweeperBalance {
     eth_balance: Wei,

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -13,9 +13,19 @@
 mod tests;
 
 use crate::numeric::Wei;
+use crate::state::EthBalance;
 
-/// How much ckETH has been burned for sweeping and how much of it has actually been spent: the two
-/// sides of the invariant above.
+/// How much ckETH has been burned for sweeping and how much of it has actually been spent — the two
+/// sides of the invariant above — along with the sweeper address' own [`EthBalance`], which the
+/// spending side maintains.
+///
+/// The sweeper's [`EthBalance`] differs from the main address' in *when* it debits: the main
+/// address debits what a transaction actually cost once it finalizes, while the sweeper debits an
+/// accepted sweep's whole fee ceiling up front and is credited back the part it did not pay at
+/// finalization. Holding the gas early is what keeps the balance a lower bound while sweeps are in
+/// flight, and the sweep pipeline only accepts a sweep the balance covers, so an uncovered debit
+/// is a bug, exactly as on the main address. ETH anyone else sends to the sweeper is not tracked
+/// and only pushes its true balance above this record.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct SweeperFundingAccounting {
     /// Grows when a funding is accepted, by the whole amount that funding may spend.
@@ -26,15 +36,7 @@ pub struct SweeperFundingAccounting {
     /// Grows at the same point by the fee the transaction paid, which it does either way. Together
     /// with the amount transferred it is the spend, which never overtakes the burn.
     cumulative_transaction_fees: Wei,
-    /// Grows when a sweep is accepted, by the most that sweep can cost the sweeper address: the
-    /// ceiling on its transaction fee, which caps every resubmission too. Not part of the invariant
-    /// above — this ETH was already counted as spent when the funding that delivered it finalized —
-    /// but subtracted from the balance bound, so that gas a committed sweep will consume stops
-    /// counting as available the moment it is committed.
-    cumulative_sweep_provisioned: Wei,
-    /// Grows when a sweep finalizes, by the part of that provision it turned out not to need: the
-    /// fee it did not pay.
-    cumulative_sweep_refunded: Wei,
+    sweeper_balance: EthBalance,
 }
 
 impl Default for SweeperFundingAccounting {
@@ -43,8 +45,7 @@ impl Default for SweeperFundingAccounting {
             cumulative_burned: Wei::ZERO,
             cumulative_transferred: Wei::ZERO,
             cumulative_transaction_fees: Wei::ZERO,
-            cumulative_sweep_provisioned: Wei::ZERO,
-            cumulative_sweep_refunded: Wei::ZERO,
+            sweeper_balance: EthBalance::default(),
         }
     }
 }
@@ -69,32 +70,30 @@ impl SweeperFundingAccounting {
             .cumulative_transaction_fees
             .checked_add(transaction_fee)
             .expect("BUG: overflow in cumulative sweeper funding fees");
+        self.sweeper_balance.eth_balance_add(transferred);
         // Checked eagerly so a violation surfaces at the transition that caused it.
         let _ = self.burned_not_yet_spent();
     }
 
-    /// Records the most an accepted sweep can cost the sweeper address, taking it out of the balance
-    /// bound up front. Recorded when the sweep is accepted rather than when its transaction is
-    /// signed, so that a sweep provisions once however many times the pipeline resubmits it — every
-    /// attempt is capped by the same fee ceiling.
+    /// Debits the most an accepted sweep can cost the sweeper address: the ceiling on its
+    /// transaction fee, which caps every resubmission too, so a sweep is debited once however many
+    /// times the pipeline resubmits it.
     ///
     /// Deliberately not added to [`Self::cumulative_spent`]: that counter is the minter's own ETH,
     /// and this ETH was counted there once already, when the funding that delivered it to the
     /// sweeper finalized. Counting it twice would make spend overtake burn and trip the invariant.
     pub fn record_accepted_sweep(&mut self, provisioned: Wei) {
-        self.cumulative_sweep_provisioned = self
-            .cumulative_sweep_provisioned
-            .checked_add(provisioned)
-            .expect("BUG: overflow in cumulative sweep provisioned");
+        self.sweeper_balance.eth_balance_sub(provisioned);
     }
 
-    /// Records the part of a finalized sweep's provision it did not need, putting it back into the
-    /// balance bound.
-    pub fn record_finalized_sweep(&mut self, refunded: Wei) {
-        self.cumulative_sweep_refunded = self
-            .cumulative_sweep_refunded
-            .checked_add(refunded)
-            .expect("BUG: overflow in cumulative sweep refunded");
+    /// Settles a finalized sweep against the hold its acceptance took: the fee it did not pay
+    /// comes back into the balance, and both fees are recorded exactly as the main address records
+    /// its own.
+    pub fn record_finalized_sweep(&mut self, effective_fee: Wei, unspent_fee: Wei) {
+        self.sweeper_balance.eth_balance_add(unspent_fee);
+        self.sweeper_balance
+            .total_effective_tx_fees_add(effective_fee);
+        self.sweeper_balance.total_unspent_tx_fees_add(unspent_fee);
     }
 
     /// Total ETH debited from the main address on account of sweeping.
@@ -109,26 +108,16 @@ impl SweeperFundingAccounting {
     }
 
     /// A lower bound on the sweeper address' ETH balance: what finalized fundings delivered, less
-    /// what accepted sweeps have provisioned, plus what finalized sweeps handed back.
+    /// the gas held for every sweep in flight and the fees finalized sweeps actually paid.
     ///
-    /// Provisioning at acceptance rather than at spend is what keeps this a bound while sweeps are in
+    /// Holding at acceptance rather than at spend is what keeps this a bound while sweeps are in
     /// flight: gas a committed sweep will pay stops counting as available immediately, and a sweep
     /// whose finalization is never observed leaves the bound too *low* — which brings a funding
     /// forward and makes it larger, since [`SweeperFundingConfig::amount_due`] tops up to the target
     /// from wherever the bound sits — rather than too high, which would let the minter believe in
-    /// gas that is gone. ETH sent to the address by anyone else only pushes the true balance further
-    /// above the bound.
-    ///
-    /// Saturating rather than checked: these counters are the minter's own record, and after an
-    /// upgrade that starts them from zero — or a sweeper address funded before the minter tracked it
-    /// — provisioning can legitimately exceed the deliveries. Trapping here would trap the replay of
-    /// every event after it, so it floors at zero, which reads as "assume nothing is prepaid".
+    /// gas that is gone.
     pub fn sweeper_balance_lower_bound(&self) -> Wei {
-        self.cumulative_transferred
-            .checked_add(self.cumulative_sweep_refunded)
-            .expect("BUG: overflow in the sweeper balance bound")
-            .checked_sub(self.cumulative_sweep_provisioned)
-            .unwrap_or(Wei::ZERO)
+        self.sweeper_balance.eth_balance()
     }
 
     /// ckETH burned for sweeping that has not been spent yet: the burn of a funding in flight, plus

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -113,9 +113,11 @@ impl SweeperFundingAccounting {
     ///
     /// Provisioning at acceptance rather than at spend is what keeps this a bound while sweeps are in
     /// flight: gas a committed sweep will pay stops counting as available immediately, and a sweep
-    /// whose finalization is never observed leaves the bound too *low* — which delays a funding —
-    /// rather than too high, which would let the minter believe in gas that is gone. ETH sent to the
-    /// address by anyone else only pushes the true balance further above the bound.
+    /// whose finalization is never observed leaves the bound too *low* — which brings a funding
+    /// forward and makes it larger, since [`SweeperFundingConfig::amount_due`] tops up to the target
+    /// from wherever the bound sits — rather than too high, which would let the minter believe in
+    /// gas that is gone. ETH sent to the address by anyone else only pushes the true balance further
+    /// above the bound.
     ///
     /// Saturating rather than checked: these counters are the minter's own record, and after an
     /// upgrade that starts them from zero — or a sweeper address funded before the minter tracked it

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding.rs
@@ -12,7 +12,6 @@
 #[cfg(test)]
 mod tests;
 
-use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::numeric::Wei;
 use crate::tx::{Finalized, SweepTransaction};
 
@@ -45,9 +44,9 @@ impl Default for SweeperFundingAccounting {
 
 /// The sweeper address' ETH, kept like [`EthBalance`] keeps the main address' but differing in
 /// *when* it debits: the main address debits what a transaction actually cost once it finalizes,
-/// while the sweeper debits an accepted sweep's whole possible cost — the ETH it will transfer
-/// plus its fee ceiling — up front, and is credited back at finalization whatever the sweep turned
-/// out not to spend. Holding the whole cost early is what keeps the balance a lower bound while
+/// while the sweeper debits an accepted sweep's whole possible cost — its fee ceiling, a sweep
+/// sending no ETH — up front, and is credited back at finalization whatever the sweep turned out
+/// not to spend. Holding the whole cost early is what keeps the balance a lower bound while
 /// sweeps are in flight, and the sweep pipeline only accepts a sweep the balance covers, so an
 /// uncovered debit is a bug, exactly as on the main address. There is no unspent-fee counter
 /// either: an unspent fee returns into the balance and is spent by a later sweep, unlike on the
@@ -120,42 +119,37 @@ impl SweeperFundingAccounting {
         let _ = self.burned_not_yet_spent();
     }
 
-    /// Debits the whole cost an accepted sweep can put on the sweeper address — the ETH it will
-    /// transfer plus the ceiling on its transaction fee, which caps every resubmission too — so a
-    /// sweep is debited once however many times the pipeline resubmits it.
+    /// Debits the whole cost an accepted sweep can put on the sweeper address: the ceiling on its
+    /// transaction fee, which caps every resubmission too — so a sweep is debited once however
+    /// many times the pipeline resubmits it.
     ///
     /// Deliberately not added to [`Self::cumulative_spent`]: that counter is the minter's own ETH,
     /// and this ETH was counted there once already, when the funding that delivered it to the
     /// sweeper finalized. Counting it twice would make spend overtake burn and trip the invariant.
-    pub fn record_accepted_sweep(&mut self, eth_transferred: Wei, max_transaction_fee: Wei) {
-        self.sweeper_balance.debit(
-            eth_transferred
-                .checked_add(max_transaction_fee)
-                .expect("BUG: overflow in the cost of an accepted sweep"),
-        );
+    pub fn record_accepted_sweep(&mut self, max_transaction_fee: Wei) {
+        self.sweeper_balance.debit(max_transaction_fee);
     }
 
     /// Settles a finalized sweep against the hold its acceptance took, reading what actually
     /// happened off the transaction and its receipt: the part of `max_transaction_fee` the sweep
-    /// did not pay comes back into the balance — along with the ETH it never sent, if it failed —
-    /// and the fee it paid is recorded.
+    /// did not pay comes back into the balance, and the fee it paid is recorded. The fee is a
+    /// sweep's whole cost whether it succeeded or reverted — its acceptance held nothing else, so
+    /// a sweep that sent ETH is a bug.
     pub fn record_finalized_sweep(
         &mut self,
         max_transaction_fee: Wei,
         sweep: &Finalized<SweepTransaction>,
     ) {
+        assert_eq!(
+            *sweep.transaction_amount(),
+            Wei::ZERO,
+            "BUG: a sweep must not send ETH, its acceptance held only the transaction fee"
+        );
         let effective_fee = sweep.effective_transaction_fee();
         let unspent_fee = max_transaction_fee
             .checked_sub(effective_fee)
             .expect("BUG: a sweep may not pay more than its fee ceiling");
-        let unspent = match sweep.transaction_status() {
-            TransactionStatus::Success => unspent_fee,
-            TransactionStatus::Failure => sweep
-                .transaction_amount()
-                .checked_add(unspent_fee)
-                .expect("BUG: overflow in the unspent cost of a failed sweep"),
-        };
-        self.sweeper_balance.credit(unspent);
+        self.sweeper_balance.credit(unspent_fee);
         self.sweeper_balance.add_effective_tx_fee(effective_fee);
     }
 

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -134,6 +134,20 @@ mod accounting {
     }
 
     #[test]
+    fn should_hold_every_accepted_sweep() {
+        let mut accounting = funded_accounting();
+
+        accounting.record_accepted_sweep(Wei::new(FEE));
+        accounting.record_accepted_sweep(Wei::new(2 * FEE));
+
+        assert_eq!(
+            accounting.sweeper_balance_lower_bound(),
+            Wei::new(BURN - 3 * FEE),
+            "every accepted sweep adds its own hold"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "a sweep must not send ETH")]
     fn should_panic_when_a_finalized_sweep_sent_eth() {
         let mut accounting = funded_accounting();
@@ -296,7 +310,7 @@ mod config {
 mod sweep_events {
     use crate::eth_rpc::Hash;
     use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
-    use crate::numeric::{BlockNumber, Wei};
+    use crate::numeric::{BlockNumber, Wei, WeiPerGas};
     use crate::state::State;
     use crate::state::audit::{EventType, apply_state_transition};
     use crate::state::sweeper_funding::SWEEPER_FUNDING_TARGET_IN_MINIMUM_WITHDRAWAL_AMOUNTS;
@@ -306,7 +320,9 @@ mod sweep_events {
     use crate::test_fixtures::{
         PREPAID_SWEEP_GAS, account, gas_fee_estimate, state_with_enqueued_sweep, usdc,
     };
-    use crate::tx::{SignableTransaction, Signed, TransactionSignature};
+    use crate::tx::{
+        GasFeeEstimate, SignableTransaction, Signed, SweepTransaction, TransactionSignature,
+    };
 
     #[tokio::test]
     async fn should_provision_an_accepted_sweep_before_it_has_spent_anything() {
@@ -341,6 +357,38 @@ mod sweep_events {
                 "a {status:?} sweep must cost the sweeper exactly the {fee_paid} of gas it paid"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn should_settle_on_the_receipt_of_the_resubmission_that_finalized() {
+        let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+        let repriced = GasFeeEstimate {
+            max_priority_fee_per_gas: WeiPerGas::ZERO,
+            ..gas_fee_estimate()
+        };
+
+        let fee_paid = settle(
+            &mut state,
+            &request,
+            TransactionStatus::Success,
+            Some(repriced),
+        );
+
+        let original_price = gas_fee_estimate()
+            .base_fee_per_gas
+            .checked_add(gas_fee_estimate().max_priority_fee_per_gas)
+            .unwrap();
+        assert_ne!(
+            Some(fee_paid),
+            original_price.transaction_cost(request.gas_limit()),
+            "the replacement must pay a different fee, or this shows nothing"
+        );
+        assert_eq!(
+            sweeper_balance(&state),
+            PREPAID_SWEEP_GAS.checked_sub(fee_paid).unwrap(),
+            "one refund, measured against the request's ceiling, settled off the receipt of \
+             whichever resubmission finalized"
+        );
     }
 
     #[tokio::test]
@@ -400,15 +448,24 @@ mod sweep_events {
     }
 
     fn finalize(state: &mut State, request: &SweepRequest, status: TransactionStatus) -> Wei {
+        settle(state, request, status, None)
+    }
+
+    fn settle(
+        state: &mut State,
+        request: &SweepRequest,
+        status: TransactionStatus,
+        replacement_estimate: Option<GasFeeEstimate>,
+    ) -> Wei {
         let sweep_id = request.id;
-        let transaction = request
-            .create_transaction(
-                state.automatic_deposits.next_sweeper_transaction_nonce(),
-                gas_fee_estimate(),
-                request.gas_limit(),
-                state.ethereum_network,
-            )
-            .expect("BUG: the fixture prices the request with the estimate it creates with");
+        let nonce = state.automatic_deposits.next_sweeper_transaction_nonce();
+        let ethereum_network = state.ethereum_network;
+        let priced_with = |estimate: GasFeeEstimate| {
+            request
+                .create_transaction(nonce, estimate, request.gas_limit(), ethereum_network)
+                .expect("BUG: the fixture prices the request with the estimate it creates with")
+        };
+        let transaction = priced_with(gas_fee_estimate());
         apply_state_transition(
             state,
             &EventType::CreatedSweeperTransaction {
@@ -416,28 +473,50 @@ mod sweep_events {
                 transaction: transaction.clone(),
             },
         );
-        let signed = Signed::from((
-            transaction,
-            TransactionSignature {
-                signature_y_parity: false,
-                r: Default::default(),
-                s: Default::default(),
-            },
-        ));
+        let sign = |transaction: SweepTransaction| {
+            Signed::from((
+                transaction,
+                TransactionSignature {
+                    signature_y_parity: false,
+                    r: Default::default(),
+                    s: Default::default(),
+                },
+            ))
+        };
         apply_state_transition(
             state,
             &EventType::SignedSweeperTransaction {
                 sweep_id,
-                transaction: signed.clone(),
+                transaction: sign(transaction.clone()),
             },
         );
-        let estimate = gas_fee_estimate();
+        let mut effective_estimate = gas_fee_estimate();
+        let mut signed = sign(transaction);
+        if let Some(estimate) = replacement_estimate {
+            let replacement = priced_with(estimate.clone());
+            apply_state_transition(
+                state,
+                &EventType::ReplacedSweeperTransaction {
+                    sweep_id,
+                    transaction: replacement.clone(),
+                },
+            );
+            signed = sign(replacement);
+            apply_state_transition(
+                state,
+                &EventType::SignedSweeperTransaction {
+                    sweep_id,
+                    transaction: signed.clone(),
+                },
+            );
+            effective_estimate = estimate;
+        }
         let receipt = TransactionReceipt {
             block_hash: Hash([0x11; 32]),
             block_number: BlockNumber::new(4_190_269),
-            effective_gas_price: estimate
+            effective_gas_price: effective_estimate
                 .base_fee_per_gas
-                .checked_add(estimate.max_priority_fee_per_gas)
+                .checked_add(effective_estimate.max_priority_fee_per_gas)
                 .unwrap(),
             gas_used: signed.transaction().gas_limit(),
             status,

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -313,7 +313,7 @@ mod sweep_events {
         let (state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
 
         assert_eq!(
-            bound(&state),
+            sweeper_balance(&state),
             PREPAID_SWEEP_GAS
                 .checked_sub(request.max_transaction_fee)
                 .unwrap(),
@@ -336,7 +336,7 @@ mod sweep_events {
                 "the fixture must leave an unspent part to hand back"
             );
             assert_eq!(
-                bound(&state),
+                sweeper_balance(&state),
                 PREPAID_SWEEP_GAS.checked_sub(fee_paid).unwrap(),
                 "a {status:?} sweep must cost the sweeper exactly the {fee_paid} of gas it paid"
             );
@@ -346,7 +346,7 @@ mod sweep_events {
     #[tokio::test]
     async fn should_fund_again_once_accepted_sweeps_consume_the_prepaid_gas() {
         let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
-        state.cketh_minimum_withdrawal_amount = bound(&state)
+        state.cketh_minimum_withdrawal_amount = sweeper_balance(&state)
             .checked_div_floor(SWEEPER_FUNDING_TARGET_IN_MINIMUM_WITHDRAWAL_AMOUNTS / 2)
             .expect("test setup: dividing by a non-zero constant");
         state.eth_balance = eth_balance_of(state.sweeper_funding_config().target);
@@ -361,7 +361,7 @@ mod sweep_events {
         let target = state.sweeper_funding_config().target;
         match plan_funding(&state) {
             FundingDecision::Fund(amount) => assert_eq!(
-                amount.checked_add(bound(&state)),
+                amount.checked_add(sweeper_balance(&state)),
                 Some(target),
                 "the funding must top the sweeper back up to the target"
             ),
@@ -395,7 +395,7 @@ mod sweep_events {
             .record_accepted_sweep(PREPAID_SWEEP_GAS);
     }
 
-    fn bound(state: &State) -> Wei {
+    fn sweeper_balance(state: &State) -> Wei {
         state.sweeper_funding.sweeper_balance_lower_bound()
     }
 

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -9,6 +9,12 @@ const FEE: u128 = 1_000_000_000_000_000; // 0.001 ETH
 /// event-driven tests in [`crate::state::tests`] and [`crate::sweeper::tests`].
 mod accounting {
     use super::*;
+    use crate::eth_rpc::Hash;
+    use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+    use crate::numeric::{BlockNumber, GasAmount, TransactionNonce};
+    use crate::test_fixtures::{gas_fee_estimate, transaction_signature};
+    use crate::tx::{AccessList, Eip1559TransactionRequest, Finalized, Signed, SweepTransaction};
+    use ic_ethereum_types::Address;
 
     #[test]
     fn should_start_empty() {
@@ -125,6 +131,122 @@ mod accounting {
         accounting.record_burn(Wei::new(FEE));
 
         accounting.record_finalized_funding(Wei::new(BURN), Wei::new(FEE));
+    }
+
+    #[test]
+    fn should_hold_the_whole_cost_of_an_accepted_sweep() {
+        const VALUE_SENT: u128 = 12_345;
+        let mut accounting = funded_accounting();
+
+        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), Wei::new(FEE));
+
+        assert_eq!(
+            accounting.sweeper_balance_lower_bound(),
+            Wei::new(BURN - VALUE_SENT - FEE),
+            "the ETH a sweep will transfer must stop counting as available gas, like its fee"
+        );
+    }
+
+    #[test]
+    fn should_recredit_only_the_unspent_fee_of_a_successful_sweep() {
+        const VALUE_SENT: u128 = 12_345;
+        let mut accounting = funded_accounting();
+        let (sweep, fee_paid) = finalized_sweep(Wei::new(VALUE_SENT), TransactionStatus::Success);
+        let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
+        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), fee_ceiling);
+
+        accounting.record_finalized_sweep(fee_ceiling, &sweep);
+
+        assert_eq!(
+            accounting.sweeper_balance_lower_bound(),
+            Wei::new(BURN - VALUE_SENT).checked_sub(fee_paid).unwrap(),
+            "the transferred ETH left with the fee the sweep paid; only the unspent fee returns"
+        );
+    }
+
+    #[test]
+    fn should_recredit_the_eth_a_failed_sweep_did_not_send() {
+        const VALUE_SENT: u128 = 12_345;
+        let mut accounting = funded_accounting();
+        let (sweep, fee_paid) = finalized_sweep(Wei::new(VALUE_SENT), TransactionStatus::Failure);
+        let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
+        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), fee_ceiling);
+
+        accounting.record_finalized_sweep(fee_ceiling, &sweep);
+
+        assert_eq!(
+            accounting.sweeper_balance_lower_bound(),
+            Wei::new(BURN).checked_sub(fee_paid).unwrap(),
+            "a reverted sweep pays its gas but its ETH never leaves the sweeper address"
+        );
+    }
+
+    #[test]
+    fn should_record_the_fees_sweeps_paid() {
+        let mut accounting = funded_accounting();
+        let (sweep, fee_paid) = finalized_sweep(Wei::ZERO, TransactionStatus::Success);
+        let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
+        accounting.record_accepted_sweep(Wei::ZERO, fee_ceiling);
+
+        accounting.record_finalized_sweep(fee_ceiling, &sweep);
+
+        assert_eq!(accounting.total_effective_sweep_fees(), fee_paid);
+        assert_eq!(
+            accounting.sweeper_balance_lower_bound(),
+            Wei::new(BURN).checked_sub(fee_paid).unwrap(),
+            "the unspent fee must stay available to the sweeper"
+        );
+    }
+
+    fn funded_accounting() -> SweeperFundingAccounting {
+        let mut accounting = SweeperFundingAccounting::default();
+        accounting.record_burn(Wei::new(BURN));
+        accounting.record_finalized_funding(Wei::new(BURN), Wei::ZERO);
+        accounting
+    }
+
+    fn finalized_sweep(
+        amount: Wei,
+        status: TransactionStatus,
+    ) -> (Finalized<SweepTransaction>, Wei) {
+        let estimate = gas_fee_estimate();
+        let max_fee_per_gas = estimate
+            .base_fee_per_gas
+            .checked_mul(2_u8)
+            .unwrap()
+            .checked_add(estimate.max_priority_fee_per_gas)
+            .unwrap();
+        let gas_limit = GasAmount::new(100_000);
+        let signed = Signed::from((
+            SweepTransaction::Eip1559(Eip1559TransactionRequest {
+                chain_id: 1,
+                nonce: TransactionNonce::ZERO,
+                max_priority_fee_per_gas: estimate.max_priority_fee_per_gas,
+                max_fee_per_gas,
+                gas_limit,
+                destination: Address::new([0x5e; 20]),
+                amount,
+                data: Vec::new(),
+                access_list: AccessList::new(),
+            }),
+            transaction_signature(),
+        ));
+        let receipt = TransactionReceipt {
+            block_hash: Hash([0x11; 32]),
+            block_number: BlockNumber::new(4_190_269),
+            effective_gas_price: estimate
+                .base_fee_per_gas
+                .checked_add(estimate.max_priority_fee_per_gas)
+                .unwrap(),
+            gas_used: gas_limit,
+            status,
+            transaction_hash: signed.hash(),
+        };
+        let fee_paid = receipt.effective_transaction_fee();
+        let finalized = signed
+            .try_finalize(receipt)
+            .expect("test setup: the receipt matches the signed transaction");
+        (finalized, fee_paid)
     }
 }
 
@@ -304,13 +426,13 @@ mod sweep_events {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "underflow when subtracting")]
+    #[should_panic(expected = "cannot cover a debit")]
     async fn should_panic_when_provisioning_more_than_was_delivered() {
         let (mut state, _request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
 
         state
             .sweeper_funding
-            .record_accepted_sweep(PREPAID_SWEEP_GAS);
+            .record_accepted_sweep(Wei::ZERO, PREPAID_SWEEP_GAS);
     }
 
     fn bound(state: &State) -> Wei {

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -207,3 +207,153 @@ mod config {
         }
     }
 }
+
+/// The sweeper's own spending, driven through the state transitions the sweep pipeline records, so
+/// that the wiring is covered and not only the arithmetic. The funding that delivers the ETH is a
+/// precondition here rather than the subject, so it is arranged directly.
+mod sweep_events {
+    use crate::eth_rpc::Hash;
+    use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+    use crate::numeric::{BlockNumber, Wei};
+    use crate::state::State;
+    use crate::state::audit::{EventType, apply_state_transition};
+    use crate::state::transactions::{PipelineRequest, SweepRequest};
+    use crate::test_fixtures::{account, gas_fee_estimate, state_with_enqueued_sweep, usdc};
+    use crate::tx::{SignableTransaction, Signed, TransactionSignature};
+
+    /// What a funding is taken to have delivered to the sweeper, arranged directly: comfortably
+    /// above any fee a fixture sweep can be charged.
+    const DELIVERED: u128 = 1_000_000_000_000_000_000;
+
+    #[tokio::test]
+    async fn should_provision_an_accepted_sweep_before_it_has_spent_anything() {
+        let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+
+        deliver(&mut state);
+
+        assert_eq!(
+            bound(&state),
+            Wei::new(DELIVERED)
+                .checked_sub(request.max_transaction_fee)
+                .unwrap(),
+            "the whole of what the sweep may cost stops counting as available gas"
+        );
+    }
+
+    /// The refund rule in full: gas is paid whether the sweep succeeded or reverted, and the part
+    /// of the ceiling it did not pay always returns. An ERC-20 sweep moves no ETH value, so there
+    /// is nothing else either outcome can leave behind.
+    #[tokio::test]
+    async fn should_settle_the_bound_on_what_a_finalized_sweep_actually_cost() {
+        for status in [TransactionStatus::Success, TransactionStatus::Failure] {
+            let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+            deliver(&mut state);
+
+            let fee_paid = finalize(&mut state, &request, status);
+
+            assert!(
+                fee_paid < request.max_transaction_fee,
+                "the fixture must leave an unspent part to hand back"
+            );
+            assert_eq!(
+                bound(&state),
+                Wei::new(DELIVERED).checked_sub(fee_paid).unwrap(),
+                "a {status:?} sweep must cost the sweeper exactly the {fee_paid} of gas it paid"
+            );
+        }
+    }
+
+    /// Sweep spending is the sweeper's ETH, already counted as spent when the funding delivered it.
+    /// Counting it again here would make spend overtake burn and trip the invariant.
+    #[tokio::test]
+    async fn should_leave_the_burn_first_accounting_alone() {
+        let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+        deliver(&mut state);
+        let burned = state.sweeper_funding.cumulative_burned();
+        let spent = state.sweeper_funding.cumulative_spent();
+
+        finalize(&mut state, &request, TransactionStatus::Success);
+
+        assert_eq!(state.sweeper_funding.cumulative_burned(), burned);
+        assert_eq!(state.sweeper_funding.cumulative_spent(), spent);
+    }
+
+    /// Provisioning beyond what the minter has recorded as delivered — an upgrade that starts the
+    /// counters from zero, or a sweeper funded before it was tracked — floors the bound rather than
+    /// trapping, which would take the replay of every later event with it.
+    #[tokio::test]
+    async fn should_floor_the_bound_at_zero_rather_than_trap() {
+        let (state, _request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+
+        assert_eq!(bound(&state), Wei::ZERO);
+    }
+
+    fn bound(state: &State) -> Wei {
+        state.sweeper_funding.sweeper_balance_lower_bound()
+    }
+
+    /// Records a finalized funding that put [`DELIVERED`] at the sweeper address.
+    fn deliver(state: &mut State) {
+        state.sweeper_funding.record_burn(Wei::new(DELIVERED));
+        state
+            .sweeper_funding
+            .record_finalized_funding(Wei::new(DELIVERED), Wei::ZERO);
+    }
+
+    /// Drives the already-accepted `request` through the sweeper pipeline to a receipt of `status`,
+    /// priced below its ceiling so that part of the provision comes back, and returns the fee that
+    /// receipt charged.
+    fn finalize(state: &mut State, request: &SweepRequest, status: TransactionStatus) -> Wei {
+        let sweep_id = request.id;
+        let transaction = request
+            .create_transaction(
+                state.automatic_deposits.next_sweeper_transaction_nonce(),
+                gas_fee_estimate(),
+                request.gas_limit(),
+                state.ethereum_network,
+            )
+            .expect("BUG: the fixture prices the request with the estimate it creates with");
+        apply_state_transition(
+            state,
+            &EventType::CreatedSweeperTransaction {
+                sweep_id,
+                transaction: transaction.clone(),
+            },
+        );
+        let signed = Signed::from((
+            transaction,
+            TransactionSignature {
+                signature_y_parity: false,
+                r: Default::default(),
+                s: Default::default(),
+            },
+        ));
+        apply_state_transition(
+            state,
+            &EventType::SignedSweeperTransaction {
+                sweep_id,
+                transaction: signed.clone(),
+            },
+        );
+        let estimate = gas_fee_estimate();
+        let receipt = TransactionReceipt {
+            block_hash: Hash([0x11; 32]),
+            block_number: BlockNumber::new(4_190_269),
+            effective_gas_price: estimate
+                .base_fee_per_gas
+                .checked_add(estimate.max_priority_fee_per_gas)
+                .unwrap(),
+            gas_used: signed.transaction().gas_limit(),
+            status,
+            transaction_hash: signed.hash(),
+        };
+        apply_state_transition(
+            state,
+            &EventType::FinalizedSweeperTransaction {
+                sweep_id,
+                transaction_receipt: receipt.clone(),
+            },
+        );
+        receipt.effective_transaction_fee()
+    }
+}

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -293,9 +293,6 @@ mod config {
     }
 }
 
-/// The sweeper's own spending, driven through the state transitions the sweep pipeline records, so
-/// that the wiring is covered and not only the arithmetic. The funding that delivers the ETH is a
-/// precondition here rather than the subject, so it is arranged directly.
 mod sweep_events {
     use crate::eth_rpc::Hash;
     use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
@@ -402,9 +399,6 @@ mod sweep_events {
         state.sweeper_funding.sweeper_balance_lower_bound()
     }
 
-    /// Drives the already-accepted `request` through the sweeper pipeline to a receipt of `status`,
-    /// priced below its ceiling so that part of the provision comes back, and returns the fee that
-    /// receipt charged.
     fn finalize(state: &mut State, request: &SweepRequest, status: TransactionStatus) -> Wei {
         let sweep_id = request.id;
         let transaction = request

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -217,7 +217,10 @@ mod sweep_events {
     use crate::numeric::{BlockNumber, Wei};
     use crate::state::State;
     use crate::state::audit::{EventType, apply_state_transition};
+    use crate::state::sweeper_funding::SWEEPER_FUNDING_TARGET_IN_MINIMUM_WITHDRAWAL_AMOUNTS;
+    use crate::state::tests::eth_balance_of;
     use crate::state::transactions::{PipelineRequest, SweepRequest};
+    use crate::sweeper::{FundingDecision, plan_funding};
     use crate::test_fixtures::{account, gas_fee_estimate, state_with_enqueued_sweep, usdc};
     use crate::tx::{SignableTransaction, Signed, TransactionSignature};
 
@@ -260,6 +263,35 @@ mod sweep_events {
                 Wei::new(DELIVERED).checked_sub(fee_paid).unwrap(),
                 "a {status:?} sweep must cost the sweeper exactly the {fee_paid} of gas it paid"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_fund_again_once_accepted_sweeps_consume_the_prepaid_gas() {
+        let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+        deliver(&mut state);
+        state.cketh_minimum_withdrawal_amount = bound(&state)
+            .checked_div_floor(SWEEPER_FUNDING_TARGET_IN_MINIMUM_WITHDRAWAL_AMOUNTS / 2)
+            .expect("test setup: dividing by a non-zero constant");
+        state.eth_balance = eth_balance_of(state.sweeper_funding_config().target);
+        assert_eq!(
+            plan_funding(&state),
+            FundingDecision::NotDue,
+            "the gas already delivered must hold the sweeper at its low-water mark"
+        );
+
+        state.update_sweeper_balance_upon_accepted_sweep(&request);
+
+        let target = state.sweeper_funding_config().target;
+        match plan_funding(&state) {
+            FundingDecision::Fund(amount) => assert_eq!(
+                amount.checked_add(bound(&state)),
+                Some(target),
+                "the funding must top the sweeper back up to the target"
+            ),
+            other => panic!(
+                "gas a committed sweep will spend must bring a funding forward, got {other:?}"
+            ),
         }
     }
 

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -221,22 +221,18 @@ mod sweep_events {
     use crate::state::tests::eth_balance_of;
     use crate::state::transactions::{PipelineRequest, SweepRequest};
     use crate::sweeper::{FundingDecision, plan_funding};
-    use crate::test_fixtures::{account, gas_fee_estimate, state_with_enqueued_sweep, usdc};
+    use crate::test_fixtures::{
+        PREPAID_SWEEP_GAS, account, gas_fee_estimate, state_with_enqueued_sweep, usdc,
+    };
     use crate::tx::{SignableTransaction, Signed, TransactionSignature};
-
-    /// What a funding is taken to have delivered to the sweeper, arranged directly: comfortably
-    /// above any fee a fixture sweep can be charged.
-    const DELIVERED: u128 = 1_000_000_000_000_000_000;
 
     #[tokio::test]
     async fn should_provision_an_accepted_sweep_before_it_has_spent_anything() {
-        let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
-
-        deliver(&mut state);
+        let (state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
 
         assert_eq!(
             bound(&state),
-            Wei::new(DELIVERED)
+            PREPAID_SWEEP_GAS
                 .checked_sub(request.max_transaction_fee)
                 .unwrap(),
             "the whole of what the sweep may cost stops counting as available gas"
@@ -250,7 +246,6 @@ mod sweep_events {
     async fn should_settle_the_bound_on_what_a_finalized_sweep_actually_cost() {
         for status in [TransactionStatus::Success, TransactionStatus::Failure] {
             let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
-            deliver(&mut state);
 
             let fee_paid = finalize(&mut state, &request, status);
 
@@ -260,7 +255,7 @@ mod sweep_events {
             );
             assert_eq!(
                 bound(&state),
-                Wei::new(DELIVERED).checked_sub(fee_paid).unwrap(),
+                PREPAID_SWEEP_GAS.checked_sub(fee_paid).unwrap(),
                 "a {status:?} sweep must cost the sweeper exactly the {fee_paid} of gas it paid"
             );
         }
@@ -269,7 +264,6 @@ mod sweep_events {
     #[tokio::test]
     async fn should_fund_again_once_accepted_sweeps_consume_the_prepaid_gas() {
         let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
-        deliver(&mut state);
         state.cketh_minimum_withdrawal_amount = bound(&state)
             .checked_div_floor(SWEEPER_FUNDING_TARGET_IN_MINIMUM_WITHDRAWAL_AMOUNTS / 2)
             .expect("test setup: dividing by a non-zero constant");
@@ -300,7 +294,6 @@ mod sweep_events {
     #[tokio::test]
     async fn should_leave_the_burn_first_accounting_alone() {
         let (mut state, request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
-        deliver(&mut state);
         let burned = state.sweeper_funding.cumulative_burned();
         let spent = state.sweeper_funding.cumulative_spent();
 
@@ -315,21 +308,17 @@ mod sweep_events {
     /// trapping, which would take the replay of every later event with it.
     #[tokio::test]
     async fn should_floor_the_bound_at_zero_rather_than_trap() {
-        let (state, _request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+        let (mut state, _request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
+
+        state
+            .sweeper_funding
+            .record_accepted_sweep(PREPAID_SWEEP_GAS);
 
         assert_eq!(bound(&state), Wei::ZERO);
     }
 
     fn bound(state: &State) -> Wei {
         state.sweeper_funding.sweeper_balance_lower_bound()
-    }
-
-    /// Records a finalized funding that put [`DELIVERED`] at the sweeper address.
-    fn deliver(state: &mut State) {
-        state.sweeper_funding.record_burn(Wei::new(DELIVERED));
-        state
-            .sweeper_funding
-            .record_finalized_funding(Wei::new(DELIVERED), Wei::ZERO);
     }
 
     /// Drives the already-accepted `request` through the sweeper pipeline to a receipt of `status`,

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -303,18 +303,14 @@ mod sweep_events {
         assert_eq!(state.sweeper_funding.cumulative_spent(), spent);
     }
 
-    /// Provisioning beyond what the minter has recorded as delivered — an upgrade that starts the
-    /// counters from zero, or a sweeper funded before it was tracked — floors the bound rather than
-    /// trapping, which would take the replay of every later event with it.
     #[tokio::test]
-    async fn should_floor_the_bound_at_zero_rather_than_trap() {
+    #[should_panic(expected = "underflow when subtracting")]
+    async fn should_panic_when_provisioning_more_than_was_delivered() {
         let (mut state, _request) = state_with_enqueued_sweep(&[(account(), usdc())]).await;
 
         state
             .sweeper_funding
             .record_accepted_sweep(PREPAID_SWEEP_GAS);
-
-        assert_eq!(bound(&state), Wei::ZERO);
     }
 
     fn bound(state: &State) -> Wei {

--- a/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/sweeper_funding/tests.rs
@@ -134,51 +134,14 @@ mod accounting {
     }
 
     #[test]
-    fn should_hold_the_whole_cost_of_an_accepted_sweep() {
-        const VALUE_SENT: u128 = 12_345;
+    #[should_panic(expected = "a sweep must not send ETH")]
+    fn should_panic_when_a_finalized_sweep_sent_eth() {
         let mut accounting = funded_accounting();
-
-        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), Wei::new(FEE));
-
-        assert_eq!(
-            accounting.sweeper_balance_lower_bound(),
-            Wei::new(BURN - VALUE_SENT - FEE),
-            "the ETH a sweep will transfer must stop counting as available gas, like its fee"
-        );
-    }
-
-    #[test]
-    fn should_recredit_only_the_unspent_fee_of_a_successful_sweep() {
-        const VALUE_SENT: u128 = 12_345;
-        let mut accounting = funded_accounting();
-        let (sweep, fee_paid) = finalized_sweep(Wei::new(VALUE_SENT), TransactionStatus::Success);
+        let (sweep, fee_paid) = finalized_sweep(Wei::new(12_345), TransactionStatus::Success);
         let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
-        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), fee_ceiling);
+        accounting.record_accepted_sweep(fee_ceiling);
 
         accounting.record_finalized_sweep(fee_ceiling, &sweep);
-
-        assert_eq!(
-            accounting.sweeper_balance_lower_bound(),
-            Wei::new(BURN - VALUE_SENT).checked_sub(fee_paid).unwrap(),
-            "the transferred ETH left with the fee the sweep paid; only the unspent fee returns"
-        );
-    }
-
-    #[test]
-    fn should_recredit_the_eth_a_failed_sweep_did_not_send() {
-        const VALUE_SENT: u128 = 12_345;
-        let mut accounting = funded_accounting();
-        let (sweep, fee_paid) = finalized_sweep(Wei::new(VALUE_SENT), TransactionStatus::Failure);
-        let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
-        accounting.record_accepted_sweep(Wei::new(VALUE_SENT), fee_ceiling);
-
-        accounting.record_finalized_sweep(fee_ceiling, &sweep);
-
-        assert_eq!(
-            accounting.sweeper_balance_lower_bound(),
-            Wei::new(BURN).checked_sub(fee_paid).unwrap(),
-            "a reverted sweep pays its gas but its ETH never leaves the sweeper address"
-        );
     }
 
     #[test]
@@ -186,7 +149,7 @@ mod accounting {
         let mut accounting = funded_accounting();
         let (sweep, fee_paid) = finalized_sweep(Wei::ZERO, TransactionStatus::Success);
         let fee_ceiling = fee_paid.checked_add(Wei::new(FEE)).unwrap();
-        accounting.record_accepted_sweep(Wei::ZERO, fee_ceiling);
+        accounting.record_accepted_sweep(fee_ceiling);
 
         accounting.record_finalized_sweep(fee_ceiling, &sweep);
 
@@ -432,7 +395,7 @@ mod sweep_events {
 
         state
             .sweeper_funding
-            .record_accepted_sweep(Wei::ZERO, PREPAID_SWEEP_GAS);
+            .record_accepted_sweep(PREPAID_SWEEP_GAS);
     }
 
     fn bound(state: &State) -> Wei {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -159,6 +159,15 @@ fn enqueue_sweep<R: CanisterRuntime>(
             .clone()
             .to_price(sweep_gas_limit(&items))
             .max_transaction_fee();
+        let sweeper_gas = s.sweeper_funding.sweeper_balance_lower_bound();
+        if max_transaction_fee > sweeper_gas {
+            log!(
+                INFO,
+                "[create_pending_sweeper_requests]: SKIPPING {token}: the sweep needs \
+                 {max_transaction_fee} of gas but the sweeper holds at least {sweeper_gas}"
+            );
+            return;
+        }
         let request = SweepRequest {
             id: s.next_sweep_id,
             destination,

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -12,7 +12,7 @@ use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    state_with_deposit_helper, usdc, usdt,
+    prepay_sweep_gas, state_with_deposit_helper, usdc, usdt,
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
@@ -233,6 +233,30 @@ async fn should_carry_the_signed_attestation_and_authorization_of_every_swept_ac
 }
 
 #[tokio::test]
+async fn should_not_accept_a_sweep_the_sweeper_gas_cannot_pay_for() {
+    init_state(state_ready_to_sign_with_unfunded_sweeper(&[(
+        account(),
+        usdc(),
+    )]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        pending_sweeps(),
+        vec![],
+        "a sweep whose fee the sweeper's gas cannot cover must not be accepted"
+    );
+    assert_eq!(
+        read_state(|s| s.automatic_deposits.sweep_len()),
+        1,
+        "the deposit stays queued until a funding delivers the gas"
+    );
+}
+
+#[tokio::test]
 async fn should_not_offer_an_enqueued_deposit_to_a_second_sweep() {
     init_state(state_ready_to_sign(&[(account(), usdc())]));
     let mut runtime = mock();
@@ -365,6 +389,12 @@ fn derivation_path_bytes() -> Vec<Vec<u8>> {
 }
 
 fn state_ready_to_sign(deposits: &[(Account, Address)]) -> State {
+    let mut state = state_ready_to_sign_with_unfunded_sweeper(deposits);
+    prepay_sweep_gas(&mut state);
+    state
+}
+
+fn state_ready_to_sign_with_unfunded_sweeper(deposits: &[(Account, Address)]) -> State {
     let mut state = state_with_deposit_helper(DEPOSIT_HELPER);
     state.sweeper_contract_address = Some(SWEEPER_CONTRACT);
     state.last_transaction_price_estimate = Some((

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -138,12 +138,19 @@ pub fn automatic_deposit() -> AutomaticDeposit {
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs, all taken by the
 /// one sweep [`create_pending_sweeper_requests`] enqueued for them, returned along with that
-/// request. The deposits, attestations and authorizations the enqueue pairs up arrive through the
-/// event log, so the sweep is assembled by the production path without the runtime signing
-/// anything.
+/// request.
 pub async fn deposits_with_enqueued_sweep(
     pairs: &[(Account, Address)],
 ) -> (AutomaticDeposits, SweepRequest) {
+    let (state, request) = state_with_enqueued_sweep(pairs).await;
+    (state.automatic_deposits, request)
+}
+
+/// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
+/// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
+/// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
+/// the sweep is assembled by the production path without the runtime signing anything.
+pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
     const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
 
     let mut state = state_with_deposit_helper(deposit_helper());
@@ -197,7 +204,7 @@ pub async fn deposits_with_enqueued_sweep(
         let [request] =
             <[SweepRequest; 1]>::try_from(s.automatic_deposits.sweep_requests_batch(usize::MAX))
                 .expect("BUG: expected the pairs to become exactly one sweep");
-        (s.automatic_deposits.clone(), request)
+        (s.clone(), request)
     })
 }
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -146,6 +146,15 @@ pub async fn deposits_with_enqueued_sweep(
     (state.automatic_deposits, request)
 }
 
+pub const PREPAID_SWEEP_GAS: Wei = Wei::new(1_000_000_000_000_000_000);
+
+pub fn prepay_sweep_gas(state: &mut State) {
+    state.sweeper_funding.record_burn(PREPAID_SWEEP_GAS);
+    state
+        .sweeper_funding
+        .record_finalized_funding(PREPAID_SWEEP_GAS, Wei::ZERO);
+}
+
 /// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
@@ -154,6 +163,7 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
     const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
 
     let mut state = state_with_deposit_helper(deposit_helper());
+    prepay_sweep_gas(&mut state);
     state.sweeper_contract_address = Some(sweeper_contract());
     state.last_transaction_price_estimate = Some((SWEEP_DECIDED_AT, gas_fee_estimate()));
     let chain_id = state.ethereum_network.chain_id();

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -292,7 +292,7 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
     const USDT_DEPOSIT: u128 = 150_000_000;
 
     let sweeper = address_from_hex(SWEEPER_ADDRESS);
-    let setup = LiveSetup::new_sweep(&sweeper);
+    let setup = LiveSetup::new_sweep();
     let funded_gas = setup.anvil_eth_balance(&sweeper);
     let contracts = setup.sweep_contracts();
     let [usdc, usdt] = setup.supported_erc20_tokens() else {

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -290,11 +290,10 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
     // 6-decimal amounts, both far above the ~$10 per-token candidate minimum.
     const USDC_DEPOSIT: u128 = 100_000_000;
     const USDT_DEPOSIT: u128 = 150_000_000;
-    /// Enough for both batch sweeps at anvil's gas price, with room for a fee bump.
-    const SWEEPER_GAS_WEI: u128 = 1_000_000_000_000_000_000;
 
     let sweeper = address_from_hex(SWEEPER_ADDRESS);
-    let setup = LiveSetup::new_sweep(&sweeper, SWEEPER_GAS_WEI);
+    let setup = LiveSetup::new_sweep(&sweeper);
+    let funded_gas = setup.anvil_eth_balance(&sweeper);
     let contracts = setup.sweep_contracts();
     let [usdc, usdt] = setup.supported_erc20_tokens() else {
         panic!("expected exactly 2 supported tokens")
@@ -421,7 +420,7 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
         );
     }
     assert!(
-        setup.anvil().balance(&sweeper) < SWEEPER_GAS_WEI,
+        setup.anvil().balance(&sweeper) < funded_gas,
         "the sweeper address pays for the sweeps out of its own prepaid gas"
     );
 

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -130,6 +130,10 @@ const SWEEP_TICKS: u32 = 8;
 /// The mint follows the sweep through the log scrape, one more timer downstream.
 const CREDIT_TICKS: u32 = 6;
 
+/// A budget, not a cost: one tick sends the funding transfer, the spares cover a tick landing
+/// before the funding task has burned, and a tick lost to an outcall the jump timed out.
+const FUNDING_TICKS: u32 = 6;
+
 /// A balance to place on the owned anvil node: `amount` of `token` credited to the `deposit`
 /// address, so the scan reads a real balance for that (address, token) pair.
 pub struct Holding<'a> {
@@ -177,11 +181,11 @@ impl LiveSetup<CkErc20Setup> {
 
     /// Like [`Self::new_balance_scan`], but with the real deposit helper and the attested sweeper
     /// delegate deployed on the node first, so the minter is installed knowing both, and with the
-    /// minter's dedicated sweeper address pre-funded with `sweeper_gas_wei` of ETH.
-    ///
-    /// Funding the sweeper directly is a shortcut: in production its gas comes from a ckETH burn
-    /// out of the minter's fee account, which is a separate pipeline from sweeping.
-    pub fn new_sweep(sweeper: &Address, sweeper_gas_wei: u128) -> Self {
+    /// sweeper address at `sweeper` funded the way production funds it: a ckETH burn out of the
+    /// minter's fee account, delivered by the funding pipeline — which is also what lets the
+    /// minter know the sweeper can pay for a sweep, since it only accepts sweeps whose fee its
+    /// own funding accounting covers.
+    pub fn new_sweep(sweeper: &Address) -> Self {
         let anvil = Arc::new(Anvil::start_mainnet_like());
         // The helper pays out to the minter's main address, which the minter only derives once
         // installed. It is only ever read back out of the helper event, never by the helper
@@ -202,7 +206,23 @@ impl LiveSetup<CkErc20Setup> {
              control, so a sweep would move every balance out of reach while still minting"
         );
         setup.sweep_contracts = Some(contracts);
-        setup.anvil.set_balance(sweeper, sweeper_gas_wei);
+        setup.deposit_helper = Some(contracts.helper);
+
+        let depositor = Account {
+            owner: setup.cketh().caller.into(),
+            subaccount: None,
+        };
+        setup.deposit(depositor, DEPOSIT_AMOUNT);
+        setup.deposit(setup.fee_account(), FEE_ACCOUNT_BALANCE);
+        setup.await_deposits_credited(&[depositor, setup.fee_account()]);
+        setup.upgrade_minter();
+        assert_eq!(
+            setup.await_sweeper_address(),
+            *sweeper,
+            "BUG: the minter derived a sweeper address the test did not expect"
+        );
+        setup.await_eth_received(sweeper, FUNDING_TICKS);
+        setup.await_funding_finalized();
         setup
     }
 
@@ -466,20 +486,6 @@ impl LiveSetup<CkEthSetup> {
         });
         self
     }
-
-    /// Deposits `value` wei for `beneficiary` through the helper contract, as a depositor does.
-    fn deposit(&self, beneficiary: Account, value: u128) {
-        let helper = self
-            .deposit_helper
-            .expect("BUG: the funding fixture always deploys a deposit helper");
-        deposit_eth(
-            &self.anvil,
-            &helper,
-            &address_from_hex(DEV_ACCOUNT),
-            beneficiary,
-            value,
-        );
-    }
 }
 
 impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
@@ -679,6 +685,36 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
             owner: self.minter_id(),
             subaccount: Some(ic_cketh_minter::CKETH_FEE_SUBACCOUNT),
         }
+    }
+
+    /// Drives the minter until it has recorded the funding transfer as finalized, which is the
+    /// point its own accounting starts covering sweep gas with what that funding delivered —
+    /// merely seeing the ETH on anvil ([`Self::await_eth_received`]) is not it.
+    fn await_funding_finalized(&self) {
+        self.drive_until(
+            FUNDING_TICKS,
+            |_| "the minter never finalized the funding transfer".to_string(),
+            |setup| {
+                setup
+                    .minter_events()
+                    .iter()
+                    .any(|event| matches!(event.payload, EventPayload::FinalizedTransaction { .. }))
+            },
+        );
+    }
+
+    /// Deposits `value` wei for `beneficiary` through the helper contract, as a depositor does.
+    fn deposit(&self, beneficiary: Account, value: u128) {
+        let helper = self
+            .deposit_helper
+            .expect("BUG: the funding fixture always deploys a deposit helper");
+        deposit_eth(
+            &self.anvil,
+            &helper,
+            &address_from_hex(DEV_ACCOUNT),
+            beneficiary,
+            value,
+        );
     }
 
     /// The sweeper address the minter derived, scraped from its log line: there is no getter for it

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -47,7 +47,7 @@
 
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::PrincipalId;
-use ic_cketh_minter::endpoints::events::{Event, EventPayload};
+use ic_cketh_minter::endpoints::events::{Event, EventPayload, TransactionStatus};
 use ic_cketh_minter::endpoints::{
     CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode,
     DepositStatus,
@@ -69,7 +69,9 @@ use crate::anvil::{
     deploy_mock_erc20, deploy_sweep_contracts, deposit_eth, erc20_balance_slot, u256_be,
 };
 use crate::ckerc20::{CkErc20Setup, Erc20Token};
-use crate::{CkEthSetup, EthereumBackend, MINTER_ADDRESS, minter_wasm, switch_to_live};
+use crate::{
+    CkEthSetup, EthereumBackend, MINTER_ADDRESS, SWEEPER_ADDRESS, minter_wasm, switch_to_live,
+};
 
 /// Deposited for a test principal, so funding has deposit-backed ETH to spend. Comfortably above the
 /// 0.3 ETH funding target that the fixture's minimum withdrawal amount implies.
@@ -130,8 +132,6 @@ const SWEEP_TICKS: u32 = 8;
 /// The mint follows the sweep through the log scrape, one more timer downstream.
 const CREDIT_TICKS: u32 = 6;
 
-/// A budget, not a cost: one tick sends the funding transfer, the spares cover a tick landing
-/// before the funding task has burned, and a tick lost to an outcall the jump timed out.
 const FUNDING_TICKS: u32 = 6;
 
 /// A balance to place on the owned anvil node: `amount` of `token` credited to the `deposit`
@@ -181,11 +181,11 @@ impl LiveSetup<CkErc20Setup> {
 
     /// Like [`Self::new_balance_scan`], but with the real deposit helper and the attested sweeper
     /// delegate deployed on the node first, so the minter is installed knowing both, and with the
-    /// sweeper address at `sweeper` funded the way production funds it: a ckETH burn out of the
-    /// minter's fee account, delivered by the funding pipeline — which is also what lets the
-    /// minter know the sweeper can pay for a sweep, since it only accepts sweeps whose fee its
-    /// own funding accounting covers.
-    pub fn new_sweep(sweeper: &Address) -> Self {
+    /// minter's sweeper address ([`SWEEPER_ADDRESS`]) funded the way production funds it: a ckETH
+    /// burn out of the minter's fee account, delivered by the funding pipeline — which is also
+    /// what lets the minter know the sweeper can pay for a sweep, since it only accepts sweeps
+    /// whose fee its own funding accounting covers.
+    pub fn new_sweep() -> Self {
         let anvil = Arc::new(Anvil::start_mainnet_like());
         // The helper pays out to the minter's main address, which the minter only derives once
         // installed. It is only ever read back out of the helper event, never by the helper
@@ -208,20 +208,16 @@ impl LiveSetup<CkErc20Setup> {
         setup.sweep_contracts = Some(contracts);
         setup.deposit_helper = Some(contracts.helper);
 
-        let depositor = Account {
-            owner: setup.cketh().caller.into(),
-            subaccount: None,
-        };
-        setup.deposit(depositor, DEPOSIT_AMOUNT);
         setup.deposit(setup.fee_account(), FEE_ACCOUNT_BALANCE);
-        setup.await_deposits_credited(&[depositor, setup.fee_account()]);
+        setup.await_deposits_credited(&[setup.fee_account()]);
         setup.upgrade_minter();
+        let sweeper = address_from_hex(SWEEPER_ADDRESS);
         assert_eq!(
             setup.await_sweeper_address(),
-            *sweeper,
-            "BUG: the minter derived a sweeper address the test did not expect"
+            sweeper,
+            "BUG: the minter derived a sweeper address other than the pinned SWEEPER_ADDRESS"
         );
-        setup.await_eth_received(sweeper, FUNDING_TICKS);
+        setup.await_eth_received(&sweeper, FUNDING_TICKS);
         setup.await_funding_finalized();
         setup
     }
@@ -687,18 +683,20 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
         }
     }
 
-    /// Drives the minter until it has recorded the funding transfer as finalized, which is the
-    /// point its own accounting starts covering sweep gas with what that funding delivered —
-    /// merely seeing the ETH on anvil ([`Self::await_eth_received`]) is not it.
     fn await_funding_finalized(&self) {
         self.drive_until(
             FUNDING_TICKS,
-            |_| "the minter never finalized the funding transfer".to_string(),
+            |_| "the minter never finalized the funding transfer successfully".to_string(),
             |setup| {
-                setup
-                    .minter_events()
-                    .iter()
-                    .any(|event| matches!(event.payload, EventPayload::FinalizedTransaction { .. }))
+                setup.minter_events().iter().any(|event| {
+                    matches!(
+                        &event.payload,
+                        EventPayload::FinalizedTransaction {
+                            transaction_receipt,
+                            ..
+                        } if transaction_receipt.status == TransactionStatus::Success
+                    )
+                })
             },
         );
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -73,10 +73,6 @@ use crate::{
     CkEthSetup, EthereumBackend, MINTER_ADDRESS, SWEEPER_ADDRESS, minter_wasm, switch_to_live,
 };
 
-/// Deposited for a test principal, so funding has deposit-backed ETH to spend. Comfortably above the
-/// 0.3 ETH funding target that the fixture's minimum withdrawal amount implies.
-const DEPOSIT_AMOUNT: u128 = 5_000_000_000_000_000_000; // 5 ETH
-
 const FEE_ACCOUNT_BALANCE: u128 = 1_000_000_000_000_000_000; // 1 ckETH
 
 /// Ticks granted for the minter's log scrape to find the harness' deposits. One suffices, since a
@@ -208,8 +204,7 @@ impl LiveSetup<CkErc20Setup> {
         setup.sweep_contracts = Some(contracts);
         setup.deposit_helper = Some(contracts.helper);
 
-        setup.deposit(setup.fee_account(), FEE_ACCOUNT_BALANCE);
-        setup.await_deposits_credited(&[setup.fee_account()]);
+        setup.fund_fee_account();
         setup.upgrade_minter();
         let sweeper = address_from_hex(SWEEPER_ADDRESS);
         assert_eq!(
@@ -435,8 +430,8 @@ impl LiveSetup<CkErc20Setup> {
 }
 
 impl LiveSetup<CkEthSetup> {
-    /// The ckETH fixture alone — funding touches no ERC-20 — with a deposit already credited, so
-    /// there is deposit-backed ETH to spend, and the fee account holding the ckETH a funding burns.
+    /// The ckETH fixture alone — funding touches no ERC-20 — with the fee account already holding
+    /// the ckETH a funding burns, its deposit also being the deposit-backed ETH the funding spends.
     ///
     /// The minter's timers are left un-armed: a funding check runs on the next upgrade, so a test
     /// takes its ledger baselines and then calls [`Self::upgrade_minter`] when it is ready for the
@@ -449,19 +444,7 @@ impl LiveSetup<CkEthSetup> {
             sweep_contracts: None,
         });
         let setup = Self::go_live(cketh, anvil).with_deposit_helper();
-
-        // Funding may only spend ETH the minter received through deposits, so it needs a real one.
-        let depositor = Account {
-            owner: setup.cketh().caller.into(),
-            subaccount: None,
-        };
-        setup.deposit(depositor, DEPOSIT_AMOUNT);
-        // The fee account earns its ckETH the way it does in production — the ckETH ledger collects
-        // its fees there — but at 2e12 wei a transfer it would take 150'000 transfers to reach the
-        // funding target, so the harness deposits to that account directly instead. Deposited rather
-        // than minted so nothing here mints ckETH the minter did not back with ETH.
-        setup.deposit(setup.fee_account(), FEE_ACCOUNT_BALANCE);
-        setup.await_deposits_credited(&[depositor, setup.fee_account()]);
+        setup.fund_fee_account();
         setup
     }
 
@@ -699,6 +682,15 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
                 })
             },
         );
+    }
+
+    fn fund_fee_account(&self) {
+        // The fee account earns its ckETH the way it does in production — the ckETH ledger collects
+        // its fees there — but at 2e12 wei a transfer it would take 150'000 transfers to reach the
+        // funding target, so the harness deposits to that account directly instead. Deposited rather
+        // than minted so nothing here mints ckETH the minter did not back with ETH.
+        self.deposit(self.fee_account(), FEE_ACCOUNT_BALANCE);
+        self.await_deposits_credited(&[self.fee_account()]);
     }
 
     /// Deposits `value` wei for `beneficiary` through the helper contract, as a depositor does.


### PR DESCRIPTION
## Why

- The funding task decides whether to top the sweeper address up from a lower bound on its ETH balance, tracked from the minter's own events (#11086). Nothing debited that bound, which was true while nothing spent from the sweeper address — and the layers below connect the sweep queue to the pipeline that does.
- Without a debit the bound only ever grows: fundings top the sweeper up once, sweeps spend the gas, and every counter still reports a full sweeper — `amount_due` declines fundings the sweeper actually needs, and sweeping stalls while looking healthy.

## What

- An accepted sweep provisions the most it can cost the sweeper address: its fee ceiling, the same ceiling every resubmission is checked against. A sweep moves its ERC-20 through call data and sends no ETH — settlement reads the finalized transaction and its receipt, asserts exactly that, hands back the fee the sweep did not pay, and records the fee it did.
- A sweep is only *accepted* while the bound covers its ceiling, so every hold is backed by delivered gas. That lets the balance be checked like the main address' `EthBalance` instead of floored at zero: provisioning beyond deliveries is a bug to surface, not a state to tolerate (no deployed minter ever wrote a sweep event, so there is no legacy log to indulge).
- Provisioning at acceptance rather than debiting at spend keeps the bound erring *low* while sweeps are in flight: a sweep whose finalization is never observed brings a funding forward rather than letting the minter believe in gas that is gone. Acceptance also happens exactly once per sweep, where a signature happens once per resubmission.
- The holds stay out of `cumulative_spent` — that ETH was counted there when the funding delivered it, and counting it twice would trip the burn-first invariant (R14).
- The sweep e2e now funds the sweeper the way production does — ckETH burned from the fee account, delivered and finalized by the funding pipeline — since a minter that trusts only its own accounting no longer sweeps on gas credited behind its back.

This is #11329 (thanks @mbjorkqvist), integrated on top of the sweep stack per the hand-off on DEFI-2933: rebased onto the sweep-queue lifecycle, whose deposit release now lives in the same finalization transition the refund settles in.

[DEFI-2933]: https://dfinity.atlassian.net/browse/DEFI-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
