### PR TITLE
refactor(cketh): make event recording generic over a TimeProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7407,6 +7407,7 @@ dependencies = [
  "icrc-ledger-types",
  "maplit",
  "minicbor",
+ "mockall",
  "num-bigint 0.4.6",
  "num-traits",
  "phantom_newtype",

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -116,6 +116,7 @@ rust_test(
         "@crate_index//:flate2",
         "@crate_index//:ic-agent",
         "@crate_index//:maplit",
+        "@crate_index//:mockall",
         "@crate_index//:proptest",
         "@crate_index//:rand",
         "@crate_index//:tempfile",

--- a/rs/ethereum/cketh/minter/Cargo.toml
+++ b/rs/ethereum/cketh/minter/Cargo.toml
@@ -69,6 +69,7 @@ ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/rep
 ic-ledger-suite-orchestrator-test-utils = { path = "../../ledger-suite-orchestrator/test_utils" }
 ic-management-canister-types = { workspace = true }
 maplit = { workspace = true }
+mockall = { workspace = true }
 pocket-ic = { path = "../../../../packages/pocket-ic" }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -11,6 +11,7 @@ use crate::state::audit::process_event;
 use crate::state::automatic_deposits::{DepositRequest, ScanTarget};
 use crate::state::event::{AutomaticDeposit, EventType};
 use crate::state::{TaskType, mutate_state, read_state};
+use crate::time::TimeProvider;
 use crate::timed_sized_map::Timestamp;
 use batcher::BalanceOfCall;
 use evm_rpc_client::{CandidResponseConverter, DoubleCycles, EvmRpcClient};
@@ -36,17 +37,18 @@ use ic_ethereum_types::Address;
 /// re-measure (and lower if needed) if the supported tokens grow or skew more gas-heavy.
 const MAX_CALLS_PER_BATCH: usize = 1_000;
 
-pub async fn balance_scan() {
-    let now = Timestamp::from_nanos(ic_cdk::api::time());
+pub async fn balance_scan<T: TimeProvider>(time_provider: &T) {
+    let now = Timestamp::from_nanos(time_provider.time());
     // TODO DEFI-2923: use a lower threshold rpc client, e.g. 2-out-of-3 since we use latest block height
     // and only to notify the sweeper (no minting)
     let client = read_state(rpc_client);
-    scan(now, client).await;
+    scan(now, client, time_provider).await;
 }
 
-async fn scan<R: Runtime>(
+async fn scan<R: Runtime, T: TimeProvider>(
     now: Timestamp,
     client: EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
+    time_provider: &T,
 ) {
     let _guard = match TimerGuard::new(TaskType::BalanceScan) {
         Ok(guard) => guard,
@@ -87,9 +89,11 @@ async fn scan<R: Runtime>(
     mutate_state(|s| {
         for outcome in outcomes {
             match outcome {
-                ScanOutcome::Detected(deposit) => {
-                    process_event(s, EventType::AutomaticDepositReceived(deposit))
-                }
+                ScanOutcome::Detected(deposit) => process_event(
+                    s,
+                    EventType::AutomaticDepositReceived(deposit),
+                    time_provider,
+                ),
                 ScanOutcome::NothingFound(request) => {
                     s.automatic_deposits
                         .record_scan(now, &request, latest_block)

--- a/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::deposit_address::DepositAddress;
 use crate::state::automatic_deposits::{DepositRequest, ScanProgress};
 use crate::test_fixtures;
+use crate::test_fixtures::mock::MockTimeProvider;
 use evm_rpc_types::{ConsensusStrategy, Hex, MultiRpcResult, RpcServices};
 use ic_canister_runtime::{IcError, StubRuntime};
 use icrc_ledger_types::icrc1::account::Account;
@@ -96,7 +97,7 @@ async fn should_skip_without_scanning() {
         seed_state(case.latest_block, MIN_DEPOSITS[0].0, &case.holders, now);
 
         // No stub responses: the scan must short-circuit before any outcall.
-        scan(now, stub_client(vec![])).await;
+        scan(now, stub_client(vec![]), &records_no_event()).await;
 
         // A skipped scan advances no watchlist entry.
         for (account, _) in &case.holders {
@@ -119,7 +120,12 @@ async fn should_advance_scanned_non_candidate_pairs() {
 
     // Both balances are below the minimum, so neither is a candidate: they advance the schedule
     // and nothing is moved to the sweep queue.
-    scan(now, stub_client(vec![ok_balances(&[below_min, below_min])])).await;
+    scan(
+        now,
+        stub_client(vec![ok_balances(&[below_min, below_min])]),
+        &records_no_event(),
+    )
+    .await;
 
     for (account, _) in [a, b] {
         let entry = live_entry(now, &account, token);
@@ -156,6 +162,7 @@ async fn should_split_into_chunks_when_calls_exceed_the_batch_cap() {
             ok_balances(&vec![below_min; MAX_CALLS_PER_BATCH]),
             ok_balances(&vec![below_min; extra]),
         ]),
+        &records_no_event(),
     )
     .await;
 
@@ -198,7 +205,7 @@ async fn should_not_advance_pairs_when_the_chunk_fails() {
         let holder = (account(1), DepositAddress::new(Address::new([0xa1; 20])));
         seed_state(Some(latest), MIN_DEPOSITS[0].0, &[holder], now);
 
-        scan(now, stub_client(vec![case.response])).await;
+        scan(now, stub_client(vec![case.response]), &records_no_event()).await;
 
         let entry = live_entry(now, &holder.0, MIN_DEPOSITS[0].0);
         assert_eq!(
@@ -285,6 +292,36 @@ fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<ScanTarget> {
             .scan_targets_iter(now, latest)
             .collect()
     })
+}
+
+#[tokio::test]
+async fn should_timestamp_a_detected_deposit_with_the_current_time() {
+    const DETECTED_AT_NANOS: u64 = 1_620_328_630_000_000_000;
+    let now = ts();
+    let latest = BlockNumber::new(1_000);
+    let (token, min) = MIN_DEPOSITS[0];
+    let holder = (account(1), DepositAddress::new(Address::new([0xa1; 20])));
+    seed_state(Some(latest), token, &[holder], now);
+    let mut time_provider = MockTimeProvider::new();
+    time_provider
+        .expect_time()
+        .times(1)
+        .return_const(DETECTED_AT_NANOS);
+
+    scan(now, stub_client(vec![ok_balances(&[min])]), &time_provider).await;
+
+    let recorded = last_recorded_event().expect("the detected deposit should be recorded");
+    assert_eq!(recorded.timestamp, DETECTED_AT_NANOS);
+}
+
+fn last_recorded_event() -> Option<crate::state::event::Event> {
+    crate::storage::with_event_iter(|events| events.last())
+}
+
+/// A [`TimeProvider`] for scans that must not record any event: it has no expectation, so
+/// reading the time at all fails the test.
+fn records_no_event() -> MockTimeProvider {
+    MockTimeProvider::new()
 }
 
 fn ts() -> Timestamp {

--- a/rs/ethereum/cketh/minter/src/deposit.rs
+++ b/rs/ethereum/cketh/minter/src/deposit.rs
@@ -15,6 +15,7 @@ use crate::{
         State, TaskType, audit::process_event, eth_logs_scraping::LogScrapingId, event::EventType,
         mutate_state, read_state,
     },
+    time::TimeProvider,
 };
 use evm_rpc_client::{CandidResponseConverter, DoubleCycles, EvmRpcClient};
 use evm_rpc_types::{BlockTag, Hex32, LogEntry};
@@ -25,7 +26,7 @@ use num_traits::ToPrimitive;
 use scopeguard::ScopeGuard;
 use std::{collections::VecDeque, time::Duration};
 
-async fn mint() {
+async fn mint<T: TimeProvider + Clone + 'static>(time_provider: &T) {
     use icrc_ledger_client_cdk::{CdkRuntime, ICRC1Client};
     use icrc_ledger_types::icrc1::transfer::TransferArg;
 
@@ -47,6 +48,7 @@ async fn mint() {
                     EventType::QuarantinedDeposit {
                         event_source: event.source(),
                     },
+                    time_provider,
                 )
             });
         });
@@ -116,6 +118,7 @@ async fn mint() {
                         ckerc20_token_symbol: token_symbol.clone(),
                     },
                 },
+                time_provider,
             )
         });
         log!(
@@ -133,11 +136,14 @@ async fn mint() {
             INFO,
             "Failed to mint {error_count} events, rescheduling the minting"
         );
-        ic_cdk_timers::set_timer(crate::MINT_RETRY_DELAY, async { mint().await });
+        let time_provider = time_provider.clone();
+        ic_cdk_timers::set_timer(crate::MINT_RETRY_DELAY, async move {
+            mint(&time_provider).await
+        });
     }
 }
 
-pub async fn scrape_logs() {
+pub async fn scrape_logs<T: TimeProvider + Clone + 'static>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::ScrapEthLogs) {
         Ok(guard) => guard,
         Err(_) => return,
@@ -153,9 +159,24 @@ pub async fn scrape_logs() {
         }
     };
     let max_block_spread = read_state(|s| s.max_block_spread_for_logs_scraping());
-    scrape_until_block::<ReceivedEthLogScraping>(last_block_number, max_block_spread).await;
-    scrape_until_block::<ReceivedErc20LogScraping>(last_block_number, max_block_spread).await;
-    scrape_until_block::<ReceivedEthOrErc20LogScraping>(last_block_number, max_block_spread).await;
+    scrape_until_block::<ReceivedEthLogScraping, T>(
+        last_block_number,
+        max_block_spread,
+        time_provider,
+    )
+    .await;
+    scrape_until_block::<ReceivedErc20LogScraping, T>(
+        last_block_number,
+        max_block_spread,
+        time_provider,
+    )
+    .await;
+    scrape_until_block::<ReceivedEthOrErc20LogScraping, T>(
+        last_block_number,
+        max_block_spread,
+        time_provider,
+    )
+    .await;
 }
 
 pub async fn update_last_observed_block_number() -> Option<BlockNumber> {
@@ -223,9 +244,13 @@ pub async fn refresh_latest_block_height() -> Option<BlockNumber> {
     }
 }
 
-async fn scrape_until_block<S>(last_block_number: BlockNumber, max_block_spread: u16)
-where
+async fn scrape_until_block<S, T>(
+    last_block_number: BlockNumber,
+    max_block_spread: u16,
+    time_provider: &T,
+) where
     S: LogScraping,
+    T: TimeProvider + Clone + 'static,
 {
     let scrape = match read_state(S::next_scrape) {
         Some(s) => s,
@@ -252,11 +277,12 @@ where
     );
     let rpc_client = read_state(rpc_client);
     for block_range in block_range.into_chunks(max_block_spread) {
-        match scrape_block_range::<S>(
+        match scrape_block_range::<S, T>(
             &rpc_client,
             scrape.contract_address,
             scrape.topics.clone(),
             block_range.clone(),
+            time_provider,
         )
         .await
         {
@@ -273,14 +299,16 @@ where
     }
 }
 
-async fn scrape_block_range<S>(
+async fn scrape_block_range<S, T>(
     rpc_client: &EvmRpcClient<IcRuntime, CandidResponseConverter, DoubleCycles>,
     contract_address: Address,
     topics: Vec<Topic>,
     block_range: BlockRangeInclusive,
+    time_provider: &T,
 ) -> Result<(), MultiCallError<Vec<LogEntry>>>
 where
     S: LogScraping,
+    T: TimeProvider + Clone + 'static,
 {
     let mut subranges = VecDeque::new();
     subranges.push_back(block_range);
@@ -305,7 +333,7 @@ where
 
         match result {
             Ok((events, errors)) => {
-                register_deposit_events(S::ID, events, errors);
+                register_deposit_events(S::ID, events, errors, time_provider);
                 mutate_state(|s| S::update_last_scraped_block_number(s, to_block));
             }
             Err(e) => {
@@ -319,6 +347,7 @@ where
                                     contract_address,
                                     block_number: to_block,
                                 },
+                                time_provider,
                             );
                         });
                         mutate_state(|s| S::update_last_scraped_block_number(s, to_block));
@@ -349,10 +378,11 @@ where
     Ok(())
 }
 
-pub fn register_deposit_events(
+pub fn register_deposit_events<T: TimeProvider + Clone + 'static>(
     scraping_id: LogScrapingId,
     transaction_events: Vec<ReceivedEvent>,
     errors: Vec<ReceivedEventError>,
+    time_provider: &T,
 ) {
     for event in transaction_events {
         log!(
@@ -375,14 +405,19 @@ pub fn register_deposit_events(
                         event_source: event.source(),
                         reason: format!("blocked address {}", event.from_address()),
                     },
+                    time_provider,
                 )
             });
         } else {
-            mutate_state(|s| process_event(s, event.into_deposit()));
+            mutate_state(|s| process_event(s, event.into_deposit(), time_provider));
         }
     }
     if read_state(State::has_events_to_mint) {
-        ic_cdk_timers::set_timer(Duration::from_secs(0), async { mint().await });
+        let time_provider = time_provider.clone();
+        ic_cdk_timers::set_timer(
+            Duration::from_secs(0),
+            async move { mint(&time_provider).await },
+        );
     }
     for error in errors {
         if let ReceivedEventError::InvalidEventSource { source, error } = &error {
@@ -393,6 +428,7 @@ pub fn register_deposit_events(
                         event_source: *source,
                         reason: error.to_string(),
                     },
+                    time_provider,
                 )
             });
         }

--- a/rs/ethereum/cketh/minter/src/deposit.rs
+++ b/rs/ethereum/cketh/minter/src/deposit.rs
@@ -26,7 +26,7 @@ use num_traits::ToPrimitive;
 use scopeguard::ScopeGuard;
 use std::{collections::VecDeque, time::Duration};
 
-async fn mint<T: TimeProvider + Clone + 'static>(time_provider: &T) {
+async fn mint<T: TimeProvider>(time_provider: &T) {
     use icrc_ledger_client_cdk::{CdkRuntime, ICRC1Client};
     use icrc_ledger_types::icrc1::transfer::TransferArg;
 
@@ -143,7 +143,7 @@ async fn mint<T: TimeProvider + Clone + 'static>(time_provider: &T) {
     }
 }
 
-pub async fn scrape_logs<T: TimeProvider + Clone + 'static>(time_provider: &T) {
+pub async fn scrape_logs<T: TimeProvider>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::ScrapEthLogs) {
         Ok(guard) => guard,
         Err(_) => return,
@@ -250,7 +250,7 @@ async fn scrape_until_block<S, T>(
     time_provider: &T,
 ) where
     S: LogScraping,
-    T: TimeProvider + Clone + 'static,
+    T: TimeProvider,
 {
     let scrape = match read_state(S::next_scrape) {
         Some(s) => s,
@@ -308,7 +308,7 @@ async fn scrape_block_range<S, T>(
 ) -> Result<(), MultiCallError<Vec<LogEntry>>>
 where
     S: LogScraping,
-    T: TimeProvider + Clone + 'static,
+    T: TimeProvider,
 {
     let mut subranges = VecDeque::new();
     subranges.push_back(block_range);
@@ -378,7 +378,7 @@ where
     Ok(())
 }
 
-pub fn register_deposit_events<T: TimeProvider + Clone + 'static>(
+pub fn register_deposit_events<T: TimeProvider>(
     scraping_id: LogScrapingId,
     transaction_events: Vec<ReceivedEvent>,
     errors: Vec<ReceivedEventError>,

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -24,6 +24,7 @@ pub mod storage;
 pub mod sweep;
 pub mod sweeper;
 pub mod sweeper_contract;
+pub mod time;
 pub mod timed_sized_map;
 pub mod tx;
 pub mod withdraw;

--- a/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
+++ b/rs/ethereum/cketh/minter/src/lifecycle/upgrade.rs
@@ -4,6 +4,7 @@ use crate::state::STATE;
 use crate::state::audit::{EventType, process_event, replay_events};
 use crate::state::mutate_state;
 use crate::storage::total_event_count;
+use crate::time::TimeProvider;
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_canister_log::log;
 use minicbor::{Decode, Encode};
@@ -38,14 +39,14 @@ pub struct UpgradeArg {
     pub next_sweeper_transaction_nonce: Option<Nat>,
 }
 
-pub fn post_upgrade(upgrade_args: Option<UpgradeArg>) {
+pub fn post_upgrade<T: TimeProvider>(upgrade_args: Option<UpgradeArg>, time_provider: &T) {
     let start = ic_cdk::api::instruction_counter();
 
     STATE.with(|cell| {
         *cell.borrow_mut() = Some(replay_events());
     });
     if let Some(args) = upgrade_args {
-        mutate_state(|s| process_event(s, EventType::Upgrade(args)))
+        mutate_state(|s| process_event(s, EventType::Upgrade(args), time_provider))
     }
 
     let end = ic_cdk::api::instruction_counter();

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -41,6 +41,7 @@ use ic_cketh_minter::state::{
 };
 use ic_cketh_minter::sweep::process_sweeper_transactions;
 use ic_cketh_minter::sweeper::fund_sweeper_address;
+use ic_cketh_minter::time::IC_TIME_PROVIDER;
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::lazy_refresh_gas_fee_estimate;
 use ic_cketh_minter::withdraw::{
@@ -87,14 +88,14 @@ fn setup_timers() {
         // Sequenced after the key rather than scheduled on a delay: the sweeper address cannot be
         // derived without it, and a delay only guesses at when it will be cached. Running here also
         // keeps the two off separate tasks, since two concurrent `ecdsa_public_key` calls trap.
-        fund_sweeper_address().await;
+        fund_sweeper_address(&IC_TIME_PROVIDER).await;
     });
     // Start scraping logs immediately after the install, then repeat with the interval.
     ic_cdk_timers::set_timer(Duration::from_secs(0), async {
-        scrape_logs().await;
+        scrape_logs(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(SCRAPING_ETH_LOGS_INTERVAL, async || {
-        scrape_logs().await;
+        scrape_logs(&IC_TIME_PROVIDER).await;
     });
     // Refresh the latest block height immediately after the install, then repeat
     // with the interval.
@@ -105,22 +106,22 @@ fn setup_timers() {
         refresh_latest_block_height().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
-        process_retrieve_eth_requests().await;
+        process_retrieve_eth_requests(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
-        process_sweeper_transactions().await;
+        process_sweeper_transactions(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_REIMBURSEMENT, async || {
-        process_reimbursement().await;
+        process_reimbursement(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer(Duration::from_secs(0), async {
-        balance_scan().await;
+        balance_scan(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(BALANCE_SCAN_INTERVAL, async || {
-        balance_scan().await;
+        balance_scan(&IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(SWEEPER_FUNDING_INTERVAL, async || {
-        fund_sweeper_address().await;
+        fund_sweeper_address(&IC_TIME_PROVIDER).await;
     });
 }
 
@@ -130,7 +131,7 @@ fn init(arg: MinterArg) {
         MinterArg::InitArg(init_arg) => {
             log!(INFO, "[init]: initialized minter with arg: {:?}", init_arg);
             STATE.with(|cell| {
-                storage::record_event(EventType::Init(init_arg.clone()));
+                storage::record_event(EventType::Init(init_arg.clone()), &IC_TIME_PROVIDER);
                 *cell.borrow_mut() =
                     Some(State::try_from(init_arg).expect("BUG: failed to initialize minter"))
             });
@@ -157,13 +158,16 @@ fn emit_preupgrade_events() {
                     EventType::SyncedDepositWithSubaccountToBlock { block_number }
                 }
             };
-            storage::record_event(event);
+            storage::record_event(event, &IC_TIME_PROVIDER);
         }
     });
 
     let registry = read_state(|s| s.automatic_deposits.watchlist_snapshot());
     if !registry.registrations.is_empty() {
-        storage::record_event(EventType::RegisteredDepositAddresses(registry));
+        storage::record_event(
+            EventType::RegisteredDepositAddresses(registry),
+            &IC_TIME_PROVIDER,
+        );
     }
 }
 
@@ -179,8 +183,10 @@ fn post_upgrade(minter_arg: Option<MinterArg>) {
         Some(MinterArg::InitArg(_)) => {
             ic_cdk::trap("cannot upgrade canister state with init args");
         }
-        Some(MinterArg::UpgradeArg(upgrade_args)) => lifecycle::post_upgrade(Some(upgrade_args)),
-        None => lifecycle::post_upgrade(None),
+        Some(MinterArg::UpgradeArg(upgrade_args)) => {
+            lifecycle::post_upgrade(Some(upgrade_args), &IC_TIME_PROVIDER)
+        }
+        None => lifecycle::post_upgrade(None, &IC_TIME_PROVIDER),
     }
     setup_timers();
 }
@@ -444,6 +450,7 @@ async fn withdraw_eth(
                 process_event(
                     s,
                     EventType::AcceptedEthWithdrawalRequest(withdrawal_request.clone()),
+                    &IC_TIME_PROVIDER,
                 );
             });
             Ok(RetrieveEthRequest::from(withdrawal_request))
@@ -621,6 +628,7 @@ async fn withdraw_erc20(
                         process_event(
                             s,
                             EventType::AcceptedErc20WithdrawalRequest(withdrawal_request.clone()),
+                            &IC_TIME_PROVIDER,
                         );
                     });
                     Ok(RetrieveErc20Request::from(withdrawal_request))
@@ -648,6 +656,7 @@ async fn withdraw_erc20(
                             process_event(
                                 s,
                                 EventType::FailedErc20WithdrawalRequest(reimbursement_request),
+                                &IC_TIME_PROVIDER,
                             );
                         });
                     }
@@ -692,7 +701,13 @@ async fn add_ckerc20_token(erc20_token: AddCkErc20Token) {
     }
     let ckerc20_token = erc20::CkErc20Token::try_from(erc20_token)
         .unwrap_or_else(|e| ic_cdk::trap(format!("ERROR: {e}")));
-    mutate_state(|s| process_event(s, EventType::AddedCkErc20Token(ckerc20_token)));
+    mutate_state(|s| {
+        process_event(
+            s,
+            EventType::AddedCkErc20Token(ckerc20_token),
+            &IC_TIME_PROVIDER,
+        )
+    });
 }
 
 #[update]

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -106,10 +106,10 @@ fn setup_timers() {
         refresh_latest_block_height().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
-        process_retrieve_eth_requests(&IC_TIME_PROVIDER).await;
+        process_retrieve_eth_requests(IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
-        process_sweeper_transactions(&IC_TIME_PROVIDER).await;
+        process_sweeper_transactions(IC_TIME_PROVIDER).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_REIMBURSEMENT, async || {
         process_reimbursement(&IC_TIME_PROVIDER).await;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -674,7 +674,7 @@ async fn withdraw_erc20(
 }
 
 async fn estimate_erc20_transaction_fee() -> Option<Wei> {
-    lazy_refresh_gas_fee_estimate()
+    lazy_refresh_gas_fee_estimate(&IC_TIME_PROVIDER)
         .await
         .map(|gas_fee_estimate| {
             gas_fee_estimate

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -8,10 +8,9 @@ use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::eth_logs_scraping::LogScrapingId::Erc20DepositWithoutSubaccount;
 use crate::state::transactions::{Reimbursed, ReimbursementIndex, WithdrawalRequest};
 use crate::storage::{record_event, with_event_iter};
+use crate::time::TimeProvider;
 
 /// Updates the state to reflect the given state transition.
-// public because it's used in tests since process_event
-// requires canister infrastructure to retrieve time
 pub fn apply_state_transition(state: &mut State, payload: &EventType) {
     match payload {
         EventType::Init(init_arg) => {
@@ -228,9 +227,9 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
 }
 
 /// Records the given event payload in the event log and updates the state to reflect the change.
-pub fn process_event(state: &mut State, payload: EventType) {
+pub fn process_event<T: TimeProvider>(state: &mut State, payload: EventType, time_provider: &T) {
     apply_state_transition(state, &payload);
-    record_event(payload);
+    record_event(payload, time_provider);
 }
 
 /// Recomputes the minter state from the event log.

--- a/rs/ethereum/cketh/minter/src/storage.rs
+++ b/rs/ethereum/cketh/minter/src/storage.rs
@@ -1,4 +1,5 @@
 use crate::state::event::{Event, EventType};
+use crate::time::TimeProvider;
 use ic_stable_structures::{
     DefaultMemoryImpl,
     log::Log as StableLog,
@@ -47,11 +48,11 @@ thread_local! {
 }
 
 /// Appends the event to the event log.
-pub fn record_event(payload: EventType) {
+pub fn record_event<T: TimeProvider>(payload: EventType, time_provider: &T) {
     EVENTS
         .with(|events| {
             events.borrow().append(&Event {
-                timestamp: ic_cdk::api::time(),
+                timestamp: time_provider.time(),
                 payload,
             })
         })
@@ -96,7 +97,7 @@ mod benches {
         assert_eq!(event_count, 62_006, "expected events in stable memory");
 
         canbench_rs::bench_fn(|| {
-            crate::lifecycle::upgrade::post_upgrade(None);
+            crate::lifecycle::upgrade::post_upgrade(None, &crate::time::IC_TIME_PROVIDER);
         })
     }
 }

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -39,7 +39,7 @@ const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
 
-pub async fn process_sweeper_transactions<T: TimeProvider + 'static>(time_provider: T) {
+pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
     let _guard = match TimerGuard::new(TaskType::SweeperSend) {
         Ok(guard) => guard,
         Err(e) => {
@@ -91,7 +91,7 @@ pub async fn process_sweeper_transactions<T: TimeProvider + 'static>(time_provid
     }
 }
 
-fn schedule_retry<T: TimeProvider + 'static>(time_provider: T) {
+fn schedule_retry<T: TimeProvider>(time_provider: T) {
     ic_cdk_timers::set_timer(
         crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL,
         async move { process_sweeper_transactions(time_provider).await },

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -63,7 +63,7 @@ pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
         return;
     };
 
-    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate().await {
+    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&time_provider).await {
         Some(gas_fee_estimate) => gas_fee_estimate,
         None => {
             // The withdrawal task refreshes the same estimate under a shared guard and runs first

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -20,6 +20,7 @@ use crate::{
         mutate_state, read_state,
         transactions::{CreateSweepTransactionError, PipelineRequest},
     },
+    time::TimeProvider,
     tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate},
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
@@ -38,7 +39,7 @@ const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
 
-pub async fn process_sweeper_transactions() {
+pub async fn process_sweeper_transactions<T: TimeProvider + Clone + 'static>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::SweeperSend) {
         Ok(guard) => guard,
         Err(e) => {
@@ -73,32 +74,35 @@ pub async fn process_sweeper_transactions() {
                 INFO,
                 "[process_sweeper_transactions]: failed retrieving gas fee estimate, retrying",
             );
-            schedule_retry();
+            schedule_retry(time_provider);
             return;
         }
     };
 
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
-    create_transactions_batch(&gas_fee_estimate);
-    sign_transactions_batch().await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, time_provider).await;
+    create_transactions_batch(&gas_fee_estimate, time_provider);
+    sign_transactions_batch(time_provider).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender).await;
+    finalize_transactions_batch(sender, time_provider).await;
 
     if read_state(|s| s.sweeper_transactions.has_pending_requests()) {
-        schedule_retry();
+        schedule_retry(time_provider);
     }
 }
 
-fn schedule_retry() {
-    ic_cdk_timers::set_timer(crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL, async {
-        process_sweeper_transactions().await
-    });
+fn schedule_retry<T: TimeProvider + Clone + 'static>(time_provider: &T) {
+    let time_provider = time_provider.clone();
+    ic_cdk_timers::set_timer(
+        crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL,
+        async move { process_sweeper_transactions(&time_provider).await },
+    );
 }
 
-async fn resubmit_transactions_batch(
+async fn resubmit_transactions_batch<T: TimeProvider>(
     latest_transaction_count: Option<TransactionCount>,
     gas_fee_estimate: &GasFeeEstimate,
+    time_provider: &T,
 ) {
     if read_state(|s| s.sweeper_transactions.is_sent_tx_empty()) {
         return;
@@ -124,6 +128,7 @@ async fn resubmit_transactions_batch(
                             sweep_id,
                             transaction,
                         },
+                        time_provider,
                     )
                 });
             }
@@ -137,7 +142,10 @@ async fn resubmit_transactions_batch(
     }
 }
 
-fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
+fn create_transactions_batch<T: TimeProvider>(
+    gas_fee_estimate: &GasFeeEstimate,
+    time_provider: &T,
+) {
     for request in read_state(|s| {
         s.sweeper_transactions
             .requests_batch(SWEEP_REQUESTS_BATCH_SIZE)
@@ -159,6 +167,7 @@ fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
                             sweep_id,
                             transaction,
                         },
+                        time_provider,
                     );
                 });
             }
@@ -177,7 +186,7 @@ fn create_transactions_batch(gas_fee_estimate: &GasFeeEstimate) {
     }
 }
 
-async fn sign_transactions_batch() {
+async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
     let transactions_batch: Vec<_> = read_state(|s| {
         s.sweeper_transactions
             .transactions_to_sign_batch(SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE)
@@ -202,6 +211,7 @@ async fn sign_transactions_batch() {
                         sweep_id,
                         transaction,
                     },
+                    time_provider,
                 )
             }),
             Err(e) => log!(
@@ -228,7 +238,7 @@ async fn send_transactions_batch(
     send_signed_transactions(sender, &transactions_to_send).await;
 }
 
-async fn finalize_transactions_batch(sender: Address) {
+async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_provider: &T) {
     if read_state(|s| s.sweeper_transactions.is_sent_tx_empty()) {
         return;
     }
@@ -247,6 +257,7 @@ async fn finalize_transactions_batch(sender: Address) {
                                 sweep_id,
                                 transaction_receipt: transaction_receipt.into(),
                             },
+                            time_provider,
                         );
                     });
                 }

--- a/rs/ethereum/cketh/minter/src/sweep.rs
+++ b/rs/ethereum/cketh/minter/src/sweep.rs
@@ -39,7 +39,7 @@ const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
 
-pub async fn process_sweeper_transactions<T: TimeProvider + Clone + 'static>(time_provider: &T) {
+pub async fn process_sweeper_transactions<T: TimeProvider + 'static>(time_provider: T) {
     let _guard = match TimerGuard::new(TaskType::SweeperSend) {
         Ok(guard) => guard,
         Err(e) => {
@@ -80,22 +80,21 @@ pub async fn process_sweeper_transactions<T: TimeProvider + Clone + 'static>(tim
     };
 
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, time_provider).await;
-    create_transactions_batch(&gas_fee_estimate, time_provider);
-    sign_transactions_batch(time_provider).await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &time_provider).await;
+    create_transactions_batch(&gas_fee_estimate, &time_provider);
+    sign_transactions_batch(&time_provider).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender, time_provider).await;
+    finalize_transactions_batch(sender, &time_provider).await;
 
     if read_state(|s| s.sweeper_transactions.has_pending_requests()) {
         schedule_retry(time_provider);
     }
 }
 
-fn schedule_retry<T: TimeProvider + Clone + 'static>(time_provider: &T) {
-    let time_provider = time_provider.clone();
+fn schedule_retry<T: TimeProvider + 'static>(time_provider: T) {
     ic_cdk_timers::set_timer(
         crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL,
-        async move { process_sweeper_transactions(&time_provider).await },
+        async move { process_sweeper_transactions(time_provider).await },
     );
 }
 

--- a/rs/ethereum/cketh/minter/src/sweeper.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper.rs
@@ -17,13 +17,14 @@ use crate::numeric::{LedgerBurnIndex, Wei};
 use crate::state::audit::{EventType, process_event};
 use crate::state::transactions::EthWithdrawalRequest;
 use crate::state::{State, TaskType, mutate_state, read_state};
+use crate::time::TimeProvider;
 use ic_canister_log::log;
-use ic_cdk::api::{canister_self, time};
+use ic_cdk::api::canister_self;
 
 /// Tops the sweeper address up when the balance the minter can vouch for has fallen below the
 /// configured low-water mark. Reads state, decides, burns, records — no chain read, because the
 /// minter already knows a lower bound on that balance from its own events.
-pub async fn fund_sweeper_address() {
+pub async fn fund_sweeper_address<T: TimeProvider>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::SweeperFunding) {
         Ok(guard) => guard,
         Err(_) => return,
@@ -114,10 +115,14 @@ pub async fn fund_sweeper_address() {
         ledger_burn_index,
         from: canister_self(),
         from_subaccount: LedgerSubaccount::from_bytes(CKETH_FEE_SUBACCOUNT),
-        created_at: Some(time()),
+        created_at: Some(time_provider.time()),
     };
     mutate_state(|s| {
-        process_event(s, EventType::AcceptedSweeperFundingRequest(request));
+        process_event(
+            s,
+            EventType::AcceptedSweeperFundingRequest(request),
+            time_provider,
+        );
     });
 }
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -115,6 +115,24 @@ pub fn valid_init_arg() -> InitArg {
     }
 }
 
+pub mod mock {
+    use crate::time::TimeProvider;
+    use mockall::mock;
+
+    mock! {
+        #[derive(Debug)]
+        pub TimeProvider {}
+
+        impl TimeProvider for TimeProvider {
+            fn time(&self) -> u64;
+        }
+
+        impl Clone for TimeProvider {
+            fn clone(&self) -> Self;
+        }
+    }
+}
+
 pub mod arb {
     use crate::checked_amount::CheckedAmountOf;
     use crate::eth_logs::LedgerSubaccount;

--- a/rs/ethereum/cketh/minter/src/time/mod.rs
+++ b/rs/ethereum/cketh/minter/src/time/mod.rs
@@ -1,0 +1,20 @@
+/// Source of the current time.
+///
+/// Abstracting the system API away lets code that timestamps its actions be exercised without a
+/// canister environment.
+pub trait TimeProvider {
+    /// Returns the current time, in nanoseconds since the Unix epoch (1970-01-01).
+    fn time(&self) -> u64;
+}
+
+/// The [`TimeProvider`] used in production, backed by the Internet Computer system API.
+pub const IC_TIME_PROVIDER: IcTimeProvider = IcTimeProvider;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct IcTimeProvider;
+
+impl TimeProvider for IcTimeProvider {
+    fn time(&self) -> u64 {
+        ic_cdk::api::time()
+    }
+}

--- a/rs/ethereum/cketh/minter/src/time/mod.rs
+++ b/rs/ethereum/cketh/minter/src/time/mod.rs
@@ -2,7 +2,7 @@
 ///
 /// Abstracting the system API away lets code that timestamps its actions be exercised without a
 /// canister environment.
-pub trait TimeProvider {
+pub trait TimeProvider: Clone + 'static {
     /// Returns the current time, in nanoseconds since the Unix epoch (1970-01-01).
     fn time(&self) -> u64;
 }

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     logs::{DEBUG, INFO},
     numeric::{GasAmount, Wei, WeiPerGas},
     state::{TaskType, lazy_call_ecdsa_public_key_with_chain_code, mutate_state, read_state},
+    time::TimeProvider,
 };
 use candid::Nat;
 use ethnum::u256;
@@ -336,10 +337,12 @@ impl TransactionPrice {
     }
 }
 
-pub async fn lazy_refresh_gas_fee_estimate() -> Option<GasFeeEstimate> {
+pub async fn lazy_refresh_gas_fee_estimate<T: TimeProvider>(
+    time_provider: &T,
+) -> Option<GasFeeEstimate> {
     const MAX_AGE_NS: u64 = 60_000_000_000_u64; //60 seconds
 
-    async fn do_refresh() -> Option<GasFeeEstimate> {
+    async fn do_refresh<T: TimeProvider>(time_provider: &T) -> Option<GasFeeEstimate> {
         let _guard = match TimerGuard::new(TaskType::RefreshGasFeeEstimate) {
             Ok(guard) => guard,
             Err(e) => {
@@ -366,7 +369,7 @@ pub async fn lazy_refresh_gas_fee_estimate() -> Option<GasFeeEstimate> {
             Ok(estimate) => {
                 mutate_state(|s| {
                     s.last_transaction_price_estimate =
-                        Some((ic_cdk::api::time(), estimate.clone()));
+                        Some((time_provider.time(), estimate.clone()));
                 });
                 estimate
             }
@@ -398,14 +401,14 @@ pub async fn lazy_refresh_gas_fee_estimate() -> Option<GasFeeEstimate> {
             }))
     }
 
-    let now_ns = ic_cdk::api::time();
+    let now_ns = time_provider.time();
     match read_state(|s| s.last_transaction_price_estimate.clone()) {
         Some((last_estimate_timestamp_ns, estimate))
             if now_ns < last_estimate_timestamp_ns.saturating_add(MAX_AGE_NS) =>
         {
             Some(estimate)
         }
-        _ => do_refresh().await,
+        _ => do_refresh(time_provider).await,
     }
 }
 #[derive(Eq, PartialEq, Debug)]

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -173,7 +173,7 @@ pub async fn process_retrieve_eth_requests<T: TimeProvider>(time_provider: T) {
         return;
     }
 
-    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate().await {
+    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&time_provider).await {
         Some(gas_fee_estimate) => gas_fee_estimate,
         None => {
             log!(

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -157,7 +157,7 @@ pub async fn process_reimbursement<T: TimeProvider>(time_provider: &T) {
     }
 }
 
-pub async fn process_retrieve_eth_requests<T: TimeProvider + Clone + 'static>(time_provider: &T) {
+pub async fn process_retrieve_eth_requests<T: TimeProvider + 'static>(time_provider: T) {
     let _guard = match TimerGuard::new(TaskType::RetrieveEth) {
         Ok(guard) => guard,
         Err(e) => {
@@ -186,17 +186,16 @@ pub async fn process_retrieve_eth_requests<T: TimeProvider + Clone + 'static>(ti
 
     let sender = minter_address().await;
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, time_provider).await;
-    create_transactions_batch(gas_fee_estimate, time_provider);
-    sign_transactions_batch(time_provider).await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &time_provider).await;
+    create_transactions_batch(gas_fee_estimate, &time_provider);
+    sign_transactions_batch(&time_provider).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender, time_provider).await;
+    finalize_transactions_batch(sender, &time_provider).await;
 
     if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
-        let time_provider = time_provider.clone();
         ic_cdk_timers::set_timer(
             crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
-            async move { process_retrieve_eth_requests(&time_provider).await },
+            async move { process_retrieve_eth_requests(time_provider).await },
         );
     }
 }

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -157,7 +157,7 @@ pub async fn process_reimbursement<T: TimeProvider>(time_provider: &T) {
     }
 }
 
-pub async fn process_retrieve_eth_requests<T: TimeProvider + 'static>(time_provider: T) {
+pub async fn process_retrieve_eth_requests<T: TimeProvider>(time_provider: T) {
     let _guard = match TimerGuard::new(TaskType::RetrieveEth) {
         Ok(guard) => guard,
         Err(e) => {

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -18,6 +18,7 @@ use crate::{
             ReimbursementRequest, WithdrawalRequest,
         },
     },
+    time::TimeProvider,
     tx::{GasFeeEstimate, SignableTransaction, Signed, lazy_refresh_gas_fee_estimate},
 };
 use candid::Nat;
@@ -46,7 +47,7 @@ const TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
 pub const CKETH_WITHDRAWAL_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(21_000);
 pub const CKERC20_WITHDRAWAL_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(65_000);
 
-pub async fn process_reimbursement() {
+pub async fn process_reimbursement<T: TimeProvider>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::Reimbursement) {
         Ok(guard) => guard,
         Err(e) => {
@@ -71,7 +72,13 @@ pub async fn process_reimbursement() {
         // Ensure that even if we were to panic in the callback, after having contacted the ledger to mint the tokens,
         // this reimbursement request will not be processed again.
         let prevent_double_minting_guard = scopeguard::guard(index.clone(), |index| {
-            mutate_state(|s| process_event(s, EventType::QuarantinedReimbursement { index }));
+            mutate_state(|s| {
+                process_event(
+                    s,
+                    EventType::QuarantinedReimbursement { index },
+                    time_provider,
+                )
+            });
         });
         let ledger_canister_id = match index {
             ReimbursementIndex::CkEth { .. } => read_state(|s| s.cketh_ledger_id),
@@ -138,7 +145,7 @@ pub async fn process_reimbursement() {
                 reimbursed,
             },
         };
-        mutate_state(|s| process_event(s, event));
+        mutate_state(|s| process_event(s, event, time_provider));
         // minting succeeded, defuse guard
         ScopeGuard::into_inner(prevent_double_minting_guard);
     }
@@ -150,7 +157,7 @@ pub async fn process_reimbursement() {
     }
 }
 
-pub async fn process_retrieve_eth_requests() {
+pub async fn process_retrieve_eth_requests<T: TimeProvider + Clone + 'static>(time_provider: &T) {
     let _guard = match TimerGuard::new(TaskType::RetrieveEth) {
         Ok(guard) => guard,
         Err(e) => {
@@ -179,16 +186,17 @@ pub async fn process_retrieve_eth_requests() {
 
     let sender = minter_address().await;
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate).await;
-    create_transactions_batch(gas_fee_estimate);
-    sign_transactions_batch().await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, time_provider).await;
+    create_transactions_batch(gas_fee_estimate, time_provider);
+    sign_transactions_batch(time_provider).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender).await;
+    finalize_transactions_batch(sender, time_provider).await;
 
     if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
+        let time_provider = time_provider.clone();
         ic_cdk_timers::set_timer(
             crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
-            async { process_retrieve_eth_requests().await },
+            async move { process_retrieve_eth_requests(&time_provider).await },
         );
     }
 }
@@ -214,9 +222,10 @@ pub(crate) async fn latest_transaction_count(sender: Address) -> Option<Transact
         }
     }
 }
-async fn resubmit_transactions_batch(
+async fn resubmit_transactions_batch<T: TimeProvider>(
     latest_transaction_count: Option<TransactionCount>,
     gas_fee_estimate: &GasFeeEstimate,
+    time_provider: &T,
 ) {
     if read_state(|s| s.withdrawal_transactions.is_sent_tx_empty()) {
         return;
@@ -245,6 +254,7 @@ async fn resubmit_transactions_batch(
                             withdrawal_id,
                             transaction,
                         },
+                        time_provider,
                     )
                 });
             }
@@ -255,7 +265,7 @@ async fn resubmit_transactions_batch(
     }
 }
 
-fn create_transactions_batch(gas_fee_estimate: GasFeeEstimate) {
+fn create_transactions_batch<T: TimeProvider>(gas_fee_estimate: GasFeeEstimate, time_provider: &T) {
     for request in read_state(|s| {
         s.withdrawal_transactions
             .requests_batch(WITHDRAWAL_REQUESTS_BATCH_SIZE)
@@ -283,6 +293,7 @@ fn create_transactions_batch(gas_fee_estimate: GasFeeEstimate) {
                             withdrawal_id: request.cketh_ledger_burn_index(),
                             transaction,
                         },
+                        time_provider,
                     );
                 });
             }
@@ -313,7 +324,7 @@ pub fn estimate_gas_limit(withdrawal_request: &WithdrawalRequest) -> GasAmount {
     }
 }
 
-async fn sign_transactions_batch() {
+async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
     let transactions_batch: Vec<_> = read_state(|s| {
         s.withdrawal_transactions
             .transactions_to_sign_batch(TRANSACTIONS_TO_SIGN_BATCH_SIZE)
@@ -340,6 +351,7 @@ async fn sign_transactions_batch() {
                         withdrawal_id,
                         transaction,
                     },
+                    time_provider,
                 )
             }),
             Err(e) => errors.push(e),
@@ -416,7 +428,7 @@ pub(crate) async fn send_signed_transactions<T: SignableTransaction + std::fmt::
     }
 }
 
-async fn finalize_transactions_batch(sender: Address) {
+async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_provider: &T) {
     if read_state(|s| s.withdrawal_transactions.is_sent_tx_empty()) {
         return;
     }
@@ -436,6 +448,7 @@ async fn finalize_transactions_batch(sender: Address) {
                                 withdrawal_id,
                                 transaction_receipt: transaction_receipt.into(),
                             },
+                            time_provider,
                         );
                     });
                 }


### PR DESCRIPTION
Reading the current time was an ambient dependency on the IC system API buried deep in the ckETH minter's event-sourcing paths, which made anything that records an event impossible to unit test outside a canister.

This introduces a `TimeProvider` trait (new `time` module) with the production implementation delegating to `ic_cdk::api::time()`, and makes `record_event` — and every caller up to the canister entry points in `main.rs` — generic over it. Only `main.rs` names the concrete implementation.

A mockall-based mock of the trait is added to the crate's test fixtures, and the balance-scan tests now use it, including a new test asserting a detected deposit is recorded with the time the provider returns.

Follows the `CanisterRuntime` pattern already used in the ckBTC minter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)