### PR TITLE
feat(cketh): task skeleton to create sweeper requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7371,6 +7371,7 @@ version = "0.9.0"
 dependencies = [
  "askama",
  "assert_matches",
+ "async-trait",
  "canbench-rs",
  "candid",
  "candid_parser",

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
         crate_name = "ic_cketh_minter",
         proc_macro_deps = [
             # Keep sorted.
+            "@crate_index//:async-trait",
             "@crate_index//:strum_macros",
         ],
         version = "0.1.0",

--- a/rs/ethereum/cketh/minter/Cargo.toml
+++ b/rs/ethereum/cketh/minter/Cargo.toml
@@ -16,6 +16,7 @@ path = "bin/principal_to_hex.rs"
 
 [dependencies]
 askama = { workspace = true }
+async-trait = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }
 ethnum = { workspace = true }

--- a/rs/ethereum/cketh/minter/src/attestation/mod.rs
+++ b/rs/ethereum/cketh/minter/src/attestation/mod.rs
@@ -13,6 +13,7 @@ mod tests;
 use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
 use crate::eth_logs::encode_principal;
 use crate::eth_rpc::Hash;
+use crate::runtime::CanisterRuntime;
 use crate::tx::{TransactionSignature, sign_digest};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -96,12 +97,14 @@ impl AttestationRequest {
 ///
 /// # Errors
 /// * a description of why the threshold-ECDSA signature could not be produced.
-pub async fn sign_attestation(
+pub async fn sign_attestation<R: CanisterRuntime>(
     request: &AttestationRequest,
+    runtime: &R,
 ) -> Result<TransactionSignature, String> {
     sign_digest(
         &request.digest(),
         &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account),
+        runtime,
     )
     .await
 }

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -45,6 +45,10 @@ pub const REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL: Duration = Duration::from_secs(3
 pub const BALANCE_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 pub const SWEEPER_FUNDING_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);
+/// How often the minter turns detected deposits into sweeper requests. Far shorter than the
+/// intervals that send transactions: the mint follows the sweep, so this interval is part of a
+/// user's crediting latency, and creating a request is cheap — it signs, but sends nothing.
+pub const SWEEP_ENQUEUE_INTERVAL: Duration = Duration::from_secs(60);
 pub const PROCESS_REIMBURSEMENT: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL: Duration = Duration::from_secs(3 * 60);
 pub const PROCESS_SWEEPER_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(6 * 60);

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -19,6 +19,7 @@ pub mod management;
 pub mod map;
 pub mod memo;
 pub mod numeric;
+pub mod runtime;
 pub mod state;
 pub mod storage;
 pub mod sweep;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -29,6 +29,7 @@ use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::logs::INFO;
 use ic_cketh_minter::memo::{self, BurnMemo};
 use ic_cketh_minter::numeric::{Erc20Value, LedgerBurnIndex, Wei};
+use ic_cketh_minter::runtime::IC_CANISTER_RUNTIME;
 use ic_cketh_minter::state::audit::{Event, EventType, process_event};
 use ic_cketh_minter::state::automatic_deposits::DepositRequest;
 use ic_cketh_minter::state::eth_logs_scraping::{LogScrapingId, LogScrapingInfo};
@@ -39,7 +40,7 @@ use ic_cketh_minter::state::transactions::{
 use ic_cketh_minter::state::{
     STATE, State, lazy_call_ecdsa_public_key, mutate_state, read_state, transactions,
 };
-use ic_cketh_minter::sweep::process_sweeper_transactions;
+use ic_cketh_minter::sweep::{create_pending_sweeper_requests, process_sweeper_transactions};
 use ic_cketh_minter::sweeper::fund_sweeper_address;
 use ic_cketh_minter::time::IC_TIME_PROVIDER;
 use ic_cketh_minter::timed_sized_map::Timestamp;
@@ -51,7 +52,7 @@ use ic_cketh_minter::withdraw::{
 use ic_cketh_minter::{
     BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, PROCESS_REIMBURSEMENT,
     PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL,
-    SCRAPING_ETH_LOGS_INTERVAL, SWEEPER_FUNDING_INTERVAL, state, storage,
+    SCRAPING_ETH_LOGS_INTERVAL, SWEEP_ENQUEUE_INTERVAL, SWEEPER_FUNDING_INTERVAL, state, storage,
 };
 use ic_cketh_minter::{endpoints, erc20};
 use ic_ethereum_types::Address;
@@ -107,6 +108,9 @@ fn setup_timers() {
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
         process_retrieve_eth_requests(IC_TIME_PROVIDER).await;
+    });
+    ic_cdk_timers::set_timer_interval(SWEEP_ENQUEUE_INTERVAL, async || {
+        create_pending_sweeper_requests(&IC_CANISTER_RUNTIME).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
         process_sweeper_transactions(IC_TIME_PROVIDER).await;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -107,13 +107,13 @@ fn setup_timers() {
         refresh_latest_block_height().await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL, async || {
-        process_retrieve_eth_requests(IC_TIME_PROVIDER).await;
+        process_retrieve_eth_requests(IC_CANISTER_RUNTIME).await;
     });
     ic_cdk_timers::set_timer_interval(SWEEP_ENQUEUE_INTERVAL, async || {
         create_pending_sweeper_requests(&IC_CANISTER_RUNTIME).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_SWEEPER_TRANSACTIONS_INTERVAL, async || {
-        process_sweeper_transactions(IC_TIME_PROVIDER).await;
+        process_sweeper_transactions(IC_CANISTER_RUNTIME).await;
     });
     ic_cdk_timers::set_timer_interval(PROCESS_REIMBURSEMENT, async || {
         process_reimbursement(&IC_TIME_PROVIDER).await;

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -85,7 +85,7 @@ fn validate_ckerc20_active() {
 fn setup_timers() {
     ic_cdk_timers::set_timer(Duration::from_secs(0), async {
         // Initialize the minter's public key to make the address known.
-        let _ = lazy_call_ecdsa_public_key().await;
+        let _ = lazy_call_ecdsa_public_key(&IC_CANISTER_RUNTIME).await;
         // Sequenced after the key rather than scheduled on a delay: the sweeper address cannot be
         // derived without it, and a delay only guesses at when it will be cached. Running here also
         // keeps the two off separate tasks, since two concurrent `ecdsa_public_key` calls trap.
@@ -197,7 +197,9 @@ fn post_upgrade(minter_arg: Option<MinterArg>) {
 
 #[update]
 async fn minter_address() -> String {
-    state::minter_address().await.to_string()
+    state::minter_address(&IC_CANISTER_RUNTIME)
+        .await
+        .to_string()
 }
 
 #[update]
@@ -244,7 +246,7 @@ async fn deposit_erc20(arg: DepositErc20Arg) -> Result<DepositErc20Response, Dep
 
     // Not armed yet: register. Ensure the minter's ECDSA public key has been fetched and cached in
     // the state so that the (synchronous) registration below can derive the address.
-    state::lazy_call_ecdsa_public_key_with_chain_code().await;
+    state::lazy_call_ecdsa_public_key_with_chain_code(&IC_CANISTER_RUNTIME).await;
     let now = Timestamp::from_nanos(ic_cdk::api::time());
     // Re-check the status after the await: a concurrent balance scan may have detected a deposit and
     // moved this pair into the sweep queue while we waited for the ECDSA key (only possible right

--- a/rs/ethereum/cketh/minter/src/management/mod.rs
+++ b/rs/ethereum/cketh/minter/src/management/mod.rs
@@ -1,4 +1,4 @@
-use ic_cdk::call::{CallFailed, RejectCode};
+use ic_cdk::call::{CallFailed, Error as CdkCallError, RejectCode};
 use ic_cdk_management_canister::SignCallError;
 use ic_management_canister_types_private::DerivationPath;
 use std::fmt;
@@ -79,6 +79,17 @@ impl Reason {
         }
     }
 
+    fn from_cdk_call_error(error: CdkCallError) -> Self {
+        match error {
+            CdkCallError::CandidDecodeFailed(e) => {
+                Self::InternalError(format!("candid decode failed: {e}"))
+            }
+            CdkCallError::CallRejected(rejected) => Self::from_call_failed(rejected.into()),
+            CdkCallError::InsufficientLiquidCycleBalance(e) => Self::from_call_failed(e.into()),
+            CdkCallError::CallPerformFailed(e) => Self::from_call_failed(e.into()),
+        }
+    }
+
     fn from_call_failed(failed: CallFailed) -> Self {
         match failed {
             CallFailed::CallRejected(rejected) => {
@@ -102,6 +113,28 @@ impl Reason {
             }
         }
     }
+}
+
+/// Fetches the canister's tECDSA public key and chain code from the management canister.
+pub async fn ecdsa_public_key(
+    key_name: String,
+    derivation_path: DerivationPath,
+) -> Result<ic_cdk_management_canister::EcdsaPublicKeyResult, CallError> {
+    use ic_cdk_management_canister::{EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs};
+
+    ic_cdk_management_canister::ecdsa_public_key(&EcdsaPublicKeyArgs {
+        canister_id: None,
+        derivation_path: derivation_path.into_inner(),
+        key_id: EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: key_name,
+        },
+    })
+    .await
+    .map_err(|error| CallError {
+        method: "ecdsa_public_key".to_string(),
+        reason: Reason::from_cdk_call_error(error),
+    })
 }
 
 /// Signs a message hash using the tECDSA API.

--- a/rs/ethereum/cketh/minter/src/runtime/mod.rs
+++ b/rs/ethereum/cketh/minter/src/runtime/mod.rs
@@ -1,6 +1,8 @@
 use crate::management::CallError;
-use crate::time::TimeProvider;
+use crate::time::{IC_TIME_PROVIDER, TimeProvider};
 use async_trait::async_trait;
+use ic_management_canister_types_private::DerivationPath;
+use serde_bytes::ByteBuf;
 
 /// The canister capabilities the minter needs from its environment.
 ///
@@ -14,4 +16,33 @@ pub trait CanisterRuntime: TimeProvider {
         derivation_path: Vec<Vec<u8>>,
         message_hash: [u8; 32],
     ) -> Result<[u8; 64], CallError>;
+}
+
+/// The [`CanisterRuntime`] used in production, backed by the Internet Computer system API.
+pub const IC_CANISTER_RUNTIME: IcCanisterRuntime = IcCanisterRuntime;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct IcCanisterRuntime;
+
+impl TimeProvider for IcCanisterRuntime {
+    fn time(&self) -> u64 {
+        IC_TIME_PROVIDER.time()
+    }
+}
+
+#[async_trait]
+impl CanisterRuntime for IcCanisterRuntime {
+    async fn sign_with_ecdsa(
+        &self,
+        key_name: String,
+        derivation_path: Vec<Vec<u8>>,
+        message_hash: [u8; 32],
+    ) -> Result<[u8; 64], CallError> {
+        crate::management::sign_with_ecdsa(
+            key_name,
+            DerivationPath::new(derivation_path.into_iter().map(ByteBuf::from).collect()),
+            message_hash,
+        )
+        .await
+    }
 }

--- a/rs/ethereum/cketh/minter/src/runtime/mod.rs
+++ b/rs/ethereum/cketh/minter/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 use crate::management::CallError;
 use crate::time::{IC_TIME_PROVIDER, TimeProvider};
 use async_trait::async_trait;
+use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_management_canister_types_private::DerivationPath;
 use serde_bytes::ByteBuf;
 
@@ -16,6 +17,13 @@ pub trait CanisterRuntime: TimeProvider {
         derivation_path: Vec<Vec<u8>>,
         message_hash: [u8; 32],
     ) -> Result<[u8; 64], CallError>;
+
+    /// The tECDSA public key `key_name` derived along `derivation_path`, with its chain code.
+    async fn ecdsa_public_key(
+        &self,
+        key_name: String,
+        derivation_path: Vec<Vec<u8>>,
+    ) -> Result<EcdsaPublicKeyResult, CallError>;
 }
 
 /// The [`CanisterRuntime`] used in production, backed by the Internet Computer system API.
@@ -42,6 +50,18 @@ impl CanisterRuntime for IcCanisterRuntime {
             key_name,
             DerivationPath::new(derivation_path.into_iter().map(ByteBuf::from).collect()),
             message_hash,
+        )
+        .await
+    }
+
+    async fn ecdsa_public_key(
+        &self,
+        key_name: String,
+        derivation_path: Vec<Vec<u8>>,
+    ) -> Result<EcdsaPublicKeyResult, CallError> {
+        crate::management::ecdsa_public_key(
+            key_name,
+            DerivationPath::new(derivation_path.into_iter().map(ByteBuf::from).collect()),
         )
         .await
     }

--- a/rs/ethereum/cketh/minter/src/runtime/mod.rs
+++ b/rs/ethereum/cketh/minter/src/runtime/mod.rs
@@ -1,0 +1,17 @@
+use crate::management::CallError;
+use crate::time::TimeProvider;
+use async_trait::async_trait;
+
+/// The canister capabilities the minter needs from its environment.
+///
+/// Abstracting them away lets the logic that drives them be exercised without a canister.
+#[async_trait]
+pub trait CanisterRuntime: TimeProvider {
+    /// Signs a message hash with the tECDSA key `key_name` derived along `derivation_path`.
+    async fn sign_with_ecdsa(
+        &self,
+        key_name: String,
+        derivation_path: Vec<Vec<u8>>,
+        message_hash: [u8; 32],
+    ) -> Result<[u8; 64], CallError>;
+}

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -986,4 +986,5 @@ pub enum TaskType {
     BalanceScan,
     SweeperFunding,
     SweeperSend,
+    SweeperEnqueue,
 }

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -12,6 +12,7 @@ use crate::map::DedupMultiKeyMap;
 use crate::numeric::{
     BlockNumber, Erc20Value, LedgerBurnIndex, LedgerMintIndex, TransactionNonce, Wei,
 };
+use crate::runtime::CanisterRuntime;
 use crate::state::automatic_deposits::{AutomaticDeposits, ScanProgress};
 use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
 use crate::state::sweeper_funding::{SweeperFundingAccounting, SweeperFundingConfig};
@@ -799,11 +800,9 @@ where
     })
 }
 
-pub async fn lazy_call_ecdsa_public_key_with_chain_code() -> (PublicKey, [u8; 32]) {
-    use ic_cdk_management_canister::{
-        EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, ecdsa_public_key,
-    };
-
+pub async fn lazy_call_ecdsa_public_key_with_chain_code<R: CanisterRuntime>(
+    runtime: &R,
+) -> (PublicKey, [u8; 32]) {
     fn to_public_key_and_chain_code(response: &EcdsaPublicKeyResult) -> (PublicKey, [u8; 32]) {
         let public_key = PublicKey::deserialize_sec1(&response.public_key).unwrap_or_else(|e| {
             ic_cdk::trap(format!("failed to decode minter's public key: {e:?}"))
@@ -823,29 +822,26 @@ pub async fn lazy_call_ecdsa_public_key_with_chain_code() -> (PublicKey, [u8; 32
     }
     let key_name = read_state(|s| s.ecdsa_key_name.clone());
     log!(DEBUG, "Fetching the ECDSA public key {key_name}");
-    let response = ecdsa_public_key(&EcdsaPublicKeyArgs {
-        canister_id: None,
-        derivation_path: crate::MAIN_DERIVATION_PATH
-            .into_iter()
-            .map(|x| x.to_vec())
-            .collect(),
-        key_id: EcdsaKeyId {
-            curve: EcdsaCurve::Secp256k1,
-            name: key_name,
-        },
-    })
-    .await
-    .unwrap_or_else(|err| ic_cdk::trap(format!("failed to get minter's public key: {err}")));
+    let response = runtime
+        .ecdsa_public_key(
+            key_name,
+            crate::MAIN_DERIVATION_PATH
+                .into_iter()
+                .map(|x| x.to_vec())
+                .collect(),
+        )
+        .await
+        .unwrap_or_else(|err| ic_cdk::trap(format!("failed to get minter's public key: {err}")));
     mutate_state(|s| s.ecdsa_public_key = Some(response.clone()));
     to_public_key_and_chain_code(&response)
 }
 
-pub async fn lazy_call_ecdsa_public_key() -> PublicKey {
-    lazy_call_ecdsa_public_key_with_chain_code().await.0
+pub async fn lazy_call_ecdsa_public_key<R: CanisterRuntime>(runtime: &R) -> PublicKey {
+    lazy_call_ecdsa_public_key_with_chain_code(runtime).await.0
 }
 
-pub async fn minter_address() -> Address {
-    ecdsa_public_key_to_address(&lazy_call_ecdsa_public_key().await)
+pub async fn minter_address<R: CanisterRuntime>(runtime: &R) -> Address {
+    ecdsa_public_key_to_address(&lazy_call_ecdsa_public_key(runtime).await)
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -9,11 +9,15 @@
 //! `fetch_finalized_receipts`), but signing with the sweeper derivation path (`[3]`) and reading
 //! the sweeper address' own transaction count.
 
+#[cfg(test)]
+mod tests;
+
 use crate::{
     deposit_address::sweeper_derivation_path,
     guard::TimerGuard,
     logs::{DEBUG, INFO},
     numeric::{GasAmount, TransactionCount},
+    runtime::CanisterRuntime,
     state::{
         State, TaskType,
         audit::{EventType, process_event},
@@ -38,6 +42,21 @@ pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
+
+/// Turns the deposits the balance scan queued into the sweep requests that
+/// [`process_sweeper_transactions`] prices, signs, sends and finalizes.
+pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(_runtime: &R) {
+    let _guard = match TimerGuard::new(TaskType::SweeperEnqueue) {
+        Ok(guard) => guard,
+        Err(e) => {
+            log!(
+                DEBUG,
+                "Failed retrieving timer guard to create pending sweeper requests: {e:?}",
+            );
+            return;
+        }
+    };
+}
 
 pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
     let _guard = match TimerGuard::new(TaskType::SweeperSend) {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -58,7 +58,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(_runtime: &R) {
     };
 }
 
-pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
+pub async fn process_sweeper_transactions<R: CanisterRuntime>(runtime: R) {
     let _guard = match TimerGuard::new(TaskType::SweeperSend) {
         Ok(guard) => guard,
         Err(e) => {
@@ -82,7 +82,7 @@ pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
         return;
     };
 
-    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&time_provider).await {
+    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&runtime).await {
         Some(gas_fee_estimate) => gas_fee_estimate,
         None => {
             // The withdrawal task refreshes the same estimate under a shared guard and runs first
@@ -93,27 +93,27 @@ pub async fn process_sweeper_transactions<T: TimeProvider>(time_provider: T) {
                 INFO,
                 "[process_sweeper_transactions]: failed retrieving gas fee estimate, retrying",
             );
-            schedule_retry(time_provider);
+            schedule_retry(runtime);
             return;
         }
     };
 
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &time_provider).await;
-    create_transactions_batch(&gas_fee_estimate, &time_provider);
-    sign_transactions_batch(&time_provider).await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &runtime).await;
+    create_transactions_batch(&gas_fee_estimate, &runtime);
+    sign_transactions_batch(&runtime).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender, &time_provider).await;
+    finalize_transactions_batch(sender, &runtime).await;
 
     if read_state(|s| s.automatic_deposits.has_pending_sweeps()) {
-        schedule_retry(time_provider);
+        schedule_retry(runtime);
     }
 }
 
-fn schedule_retry<T: TimeProvider>(time_provider: T) {
+fn schedule_retry<R: CanisterRuntime>(runtime: R) {
     ic_cdk_timers::set_timer(
         crate::PROCESS_SWEEPER_TRANSACTIONS_RETRY_INTERVAL,
-        async move { process_sweeper_transactions(time_provider).await },
+        async move { process_sweeper_transactions(runtime).await },
     );
 }
 
@@ -204,7 +204,7 @@ fn create_transactions_batch<T: TimeProvider>(
     }
 }
 
-async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
+async fn sign_transactions_batch<R: CanisterRuntime>(runtime: &R) {
     let transactions_batch: Vec<_> = read_state(|s| {
         s.automatic_deposits
             .sweep_transactions_to_sign_batch(SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE)
@@ -215,7 +215,7 @@ async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
             .map(|(sweep_id, tx)| async move {
                 (
                     sweep_id,
-                    crate::tx::sign(tx, sweeper_derivation_path()).await,
+                    crate::tx::sign(tx, sweeper_derivation_path(), runtime).await,
                 )
             }),
     )
@@ -229,7 +229,7 @@ async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
                         sweep_id,
                         transaction,
                     },
-                    time_provider,
+                    runtime,
                 )
             }),
             Err(e) => log!(

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,0 +1,25 @@
+use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::{State, read_state};
+use crate::sweep::create_pending_sweeper_requests;
+use crate::test_fixtures::mock::MockCanisterRuntime;
+use crate::test_fixtures::{automatic_deposit, init_state, initial_state};
+
+#[tokio::test]
+async fn should_leave_a_queued_deposit_untouched() {
+    init_state(state_with_a_queued_deposit());
+    assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 1);
+    let before = read_state(State::clone);
+
+    create_pending_sweeper_requests(&MockCanisterRuntime::new()).await;
+
+    assert_eq!(read_state(State::clone), before);
+}
+
+fn state_with_a_queued_deposit() -> State {
+    let mut state = initial_state();
+    apply_state_transition(
+        &mut state,
+        &EventType::AutomaticDepositReceived(automatic_deposit()),
+    );
+    state
+}

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -7,7 +7,6 @@ use crate::test_fixtures::{automatic_deposit, init_state, initial_state};
 #[tokio::test]
 async fn should_leave_a_queued_deposit_untouched() {
     init_state(state_with_a_queued_deposit());
-    assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 1);
     let before = read_state(State::clone);
 
     create_pending_sweeper_requests(&MockCanisterRuntime::new()).await;
@@ -21,5 +20,6 @@ fn state_with_a_queued_deposit() -> State {
         &mut state,
         &EventType::AutomaticDepositReceived(automatic_deposit()),
     );
+    assert_eq!(state.automatic_deposits.sweep_len(), 1);
     state
 }

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -134,6 +134,7 @@ pub mod mock {
     use crate::runtime::CanisterRuntime;
     use crate::time::TimeProvider;
     use async_trait::async_trait;
+    use ic_cdk_management_canister::EcdsaPublicKeyResult;
     use mockall::mock;
 
     mock! {
@@ -165,6 +166,12 @@ pub mod mock {
                 derivation_path: Vec<Vec<u8>>,
                 message_hash: [u8; 32],
             ) -> Result<[u8; 64], CallError>;
+
+            async fn ecdsa_public_key(
+                &self,
+                key_name: String,
+                derivation_path: Vec<Vec<u8>>,
+            ) -> Result<EcdsaPublicKeyResult, CallError>;
         }
 
         impl Clone for CanisterRuntime {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -1,9 +1,11 @@
 use crate::EVM_RPC_ID_STAGING;
+use crate::deposit_address::DepositAddress;
 use crate::eth_logs::LedgerSubaccount;
 use crate::lifecycle::init::InitArg;
-use crate::numeric::{LedgerBurnIndex, Wei};
+use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, Wei};
 use crate::state::State;
 use crate::state::eth_logs_scraping::LogScrapingId;
+use crate::state::event::AutomaticDeposit;
 use crate::state::transactions::EthWithdrawalRequest;
 use crate::tx::TransactionSignature;
 use candid::{Nat, Principal};
@@ -89,6 +91,18 @@ pub fn sweeper_funding_request(withdrawal_amount: Wei) -> EthWithdrawalRequest {
             .unwrap(),
         from_subaccount: LedgerSubaccount::from_bytes(crate::CKETH_FEE_SUBACCOUNT),
         created_at: Some(1699527697000000000),
+    }
+}
+
+pub fn automatic_deposit() -> AutomaticDeposit {
+    AutomaticDeposit {
+        owner: account().owner,
+        subaccount: account().subaccount,
+        address: DepositAddress::new(Address::new([0xa1; 20])),
+        erc20_contract_address: Address::new([0x22; 20]),
+        last_scanned_block: BlockNumber::new(1_000),
+        scan_count: 1,
+        scanned_balance: Erc20Value::from(1_000_000_u64),
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -116,7 +116,10 @@ pub fn valid_init_arg() -> InitArg {
 }
 
 pub mod mock {
+    use crate::management::CallError;
+    use crate::runtime::CanisterRuntime;
     use crate::time::TimeProvider;
+    use async_trait::async_trait;
     use mockall::mock;
 
     mock! {
@@ -128,6 +131,29 @@ pub mod mock {
         }
 
         impl Clone for TimeProvider {
+            fn clone(&self) -> Self;
+        }
+    }
+
+    mock! {
+        #[derive(Debug)]
+        pub CanisterRuntime {}
+
+        impl TimeProvider for CanisterRuntime {
+            fn time(&self) -> u64;
+        }
+
+        #[async_trait]
+        impl CanisterRuntime for CanisterRuntime {
+            async fn sign_with_ecdsa(
+                &self,
+                key_name: String,
+                derivation_path: Vec<Vec<u8>>,
+                message_hash: [u8; 32],
+            ) -> Result<[u8; 64], CallError>;
+        }
+
+        impl Clone for CanisterRuntime {
             fn clone(&self) -> Self;
         }
     }

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -6,6 +6,7 @@ use crate::{
     checked_amount::CheckedAmountOf,
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
+    runtime::CanisterRuntime,
 };
 use ethnum::u256;
 use ic_ethereum_types::Address;
@@ -81,14 +82,18 @@ impl Authorization {
         Hash(ic_sha3::Keccak256::hash(bytes))
     }
 
-    pub async fn sign(self, derivation_path: Vec<ByteBuf>) -> Result<SignedAuthorization, String> {
+    pub async fn sign<R: CanisterRuntime>(
+        self,
+        derivation_path: Vec<ByteBuf>,
+        runtime: &R,
+    ) -> Result<SignedAuthorization, String> {
         if self.chain_id == 0 {
             return Err(
                 "BUG: EIP-7702 authorization chain_id must be set explicitly and never 0"
                     .to_string(),
             );
         }
-        let signature = super::sign_digest(&self.hash(), &derivation_path).await?;
+        let signature = super::sign_digest(&self.hash(), &derivation_path, runtime).await?;
         Ok(SignedAuthorization {
             chain_id: self.chain_id,
             delegate: self.delegate,

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     guard::TimerGuard,
     logs::{DEBUG, INFO},
     numeric::{GasAmount, Wei, WeiPerGas},
+    runtime::CanisterRuntime,
     state::{TaskType, lazy_call_ecdsa_public_key_with_chain_code, mutate_state, read_state},
     time::TimeProvider,
 };
@@ -182,18 +183,20 @@ pub fn encode_u256<T: Into<u256>>(stream: &mut RlpStream, value: T) {
 
 /// Sign `digest` with the minter's ECDSA key under `derivation_path`, resolving the signature's
 /// parity bit against the key that made it.
-pub(crate) async fn sign_digest(
+pub(crate) async fn sign_digest<R: CanisterRuntime>(
     digest: &Hash,
     derivation_path: &[ByteBuf],
+    runtime: &R,
 ) -> Result<TransactionSignature, String> {
     let key_name = read_state(|s| s.ecdsa_key_name.clone());
-    let signature = crate::management::sign_with_ecdsa(
-        key_name,
-        ic_management_canister_types_private::DerivationPath::new(derivation_path.to_vec()),
-        digest.0,
-    )
-    .await
-    .map_err(|e| format!("failed to sign digest: {e}"))?;
+    let signature = runtime
+        .sign_with_ecdsa(
+            key_name,
+            derivation_path.iter().map(|path| path.to_vec()).collect(),
+            digest.0,
+        )
+        .await
+        .map_err(|e| format!("failed to sign digest: {e}"))?;
     let recid = compute_recovery_id(digest, &signature, derivation_path).await;
     if recid.is_x_reduced() {
         return Err("BUG: affine x-coordinate of r is reduced which is so unlikely to happen that it's probably a bug".to_string());

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -197,7 +197,7 @@ pub(crate) async fn sign_digest<R: CanisterRuntime>(
         )
         .await
         .map_err(|e| format!("failed to sign digest: {e}"))?;
-    let recid = compute_recovery_id(digest, &signature, derivation_path).await;
+    let recid = compute_recovery_id(digest, &signature, derivation_path, runtime).await;
     if recid.is_x_reduced() {
         return Err("BUG: affine x-coordinate of r is reduced which is so unlikely to happen that it's probably a bug".to_string());
     }
@@ -213,12 +213,13 @@ pub(crate) async fn sign_digest<R: CanisterRuntime>(
 ///
 /// Recovery only succeeds against the public key that produced the signature, so the master key is
 /// derived along the same path first.
-async fn compute_recovery_id(
+async fn compute_recovery_id<R: CanisterRuntime>(
     digest: &Hash,
     signature: &[u8],
     derivation_path: &[ByteBuf],
+    runtime: &R,
 ) -> RecoveryId {
-    let (master_public_key, chain_code) = lazy_call_ecdsa_public_key_with_chain_code().await;
+    let (master_public_key, chain_code) = lazy_call_ecdsa_public_key_with_chain_code(runtime).await;
     let ecdsa_public_key = derive_public_key(&master_public_key, &chain_code, derivation_path);
     debug_assert!(
         ecdsa_public_key.verify_signature_prehashed(&digest.0, signature),

--- a/rs/ethereum/cketh/minter/src/tx/signed.rs
+++ b/rs/ethereum/cketh/minter/src/tx/signed.rs
@@ -2,6 +2,7 @@ use super::{AccessList, TransactionPrice, encode_u256};
 use crate::{
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
+    runtime::CanisterRuntime,
 };
 use ethnum::u256;
 use ic_ethereum_types::Address;
@@ -210,11 +211,12 @@ impl<T: SignableTransaction> Signed<T> {
 
 /// Sign `transaction` with the minter's ECDSA key at `derivation_path` and wrap it into a
 /// [`Signed`] transaction.
-pub async fn sign<T: SignableTransaction>(
+pub async fn sign<T: SignableTransaction, R: CanisterRuntime>(
     transaction: T,
     derivation_path: Vec<ByteBuf>,
+    runtime: &R,
 ) -> Result<Signed<T>, String> {
     let hash = transaction.hash();
-    let signature = super::sign_digest(&hash, &derivation_path).await?;
+    let signature = super::sign_digest(&hash, &derivation_path, runtime).await?;
     Ok(Signed::new(transaction, signature))
 }

--- a/rs/ethereum/cketh/minter/src/tx/tests.rs
+++ b/rs/ethereum/cketh/minter/src/tx/tests.rs
@@ -791,3 +791,50 @@ fn arb_gas_fee_estimate() -> impl Strategy<Value = GasFeeEstimate> {
         }
     })
 }
+
+mod sign_digest {
+    use crate::eth_rpc::Hash;
+    use crate::test_fixtures::mock::MockCanisterRuntime;
+    use crate::test_fixtures::{init_state, initial_state};
+    use crate::tx::{TransactionSignature, sign_digest, split_in_two};
+    use ethnum::u256;
+    use ic_cdk_management_canister::EcdsaPublicKeyResult;
+    use ic_secp256k1::PrivateKey;
+
+    #[tokio::test]
+    async fn should_sign_digest_through_the_runtime() {
+        let private_key = PrivateKey::deserialize_sec1(&[0x46_u8; 32]).unwrap();
+        let digest = Hash([0x11_u8; 32]);
+        let signature = private_key.sign_digest_with_ecdsa(&digest.0);
+        let public_key = EcdsaPublicKeyResult {
+            public_key: private_key.public_key().serialize_sec1(true),
+            chain_code: vec![0_u8; 32],
+        };
+        init_state(initial_state());
+        let mut runtime = MockCanisterRuntime::new();
+        runtime
+            .expect_ecdsa_public_key()
+            .times(1)
+            .return_once(move |_, _| Ok(public_key));
+        runtime
+            .expect_sign_with_ecdsa()
+            .times(1)
+            .return_once(move |_, _, _| Ok(signature));
+
+        let signed = sign_digest(&digest, &[], &runtime).await.unwrap();
+
+        let (r_bytes, s_bytes) = split_in_two(signature);
+        let recovery_id = private_key
+            .public_key()
+            .try_recovery_from_digest(&digest.0, &signature)
+            .unwrap();
+        assert_eq!(
+            signed,
+            TransactionSignature {
+                signature_y_parity: recovery_id.is_y_odd(),
+                r: u256::from_be_bytes(r_bytes),
+                s: u256::from_be_bytes(s_bytes),
+            }
+        );
+    }
+}

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -9,6 +9,7 @@ use crate::{
     guard::TimerGuard,
     logs::{DEBUG, INFO},
     numeric::{GasAmount, LedgerMintIndex, TransactionCount},
+    runtime::CanisterRuntime,
     state::{
         State, TaskType,
         audit::{EventType, process_event},
@@ -157,7 +158,7 @@ pub async fn process_reimbursement<T: TimeProvider>(time_provider: &T) {
     }
 }
 
-pub async fn process_retrieve_eth_requests<T: TimeProvider>(time_provider: T) {
+pub async fn process_retrieve_eth_requests<R: CanisterRuntime>(runtime: R) {
     let _guard = match TimerGuard::new(TaskType::RetrieveEth) {
         Ok(guard) => guard,
         Err(e) => {
@@ -173,7 +174,7 @@ pub async fn process_retrieve_eth_requests<T: TimeProvider>(time_provider: T) {
         return;
     }
 
-    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&time_provider).await {
+    let gas_fee_estimate = match lazy_refresh_gas_fee_estimate(&runtime).await {
         Some(gas_fee_estimate) => gas_fee_estimate,
         None => {
             log!(
@@ -186,16 +187,16 @@ pub async fn process_retrieve_eth_requests<T: TimeProvider>(time_provider: T) {
 
     let sender = minter_address().await;
     let latest_transaction_count = latest_transaction_count(sender).await;
-    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &time_provider).await;
-    create_transactions_batch(gas_fee_estimate, &time_provider);
-    sign_transactions_batch(&time_provider).await;
+    resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &runtime).await;
+    create_transactions_batch(gas_fee_estimate, &runtime);
+    sign_transactions_batch(&runtime).await;
     send_transactions_batch(sender, latest_transaction_count).await;
-    finalize_transactions_batch(sender, &time_provider).await;
+    finalize_transactions_batch(sender, &runtime).await;
 
     if read_state(|s| s.withdrawal_transactions.has_pending_requests()) {
         ic_cdk_timers::set_timer(
             crate::PROCESS_ETH_RETRIEVE_TRANSACTIONS_RETRY_INTERVAL,
-            async move { process_retrieve_eth_requests(time_provider).await },
+            async move { process_retrieve_eth_requests(runtime).await },
         );
     }
 }
@@ -323,7 +324,7 @@ pub fn estimate_gas_limit(withdrawal_request: &WithdrawalRequest) -> GasAmount {
     }
 }
 
-async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
+async fn sign_transactions_batch<R: CanisterRuntime>(runtime: &R) {
     let transactions_batch: Vec<_> = read_state(|s| {
         s.withdrawal_transactions
             .transactions_to_sign_batch(TRANSACTIONS_TO_SIGN_BATCH_SIZE)
@@ -335,7 +336,7 @@ async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
             .map(|(withdrawal_id, tx)| async move {
                 (
                     withdrawal_id,
-                    crate::tx::sign(tx, MAIN_DERIVATION_PATH).await,
+                    crate::tx::sign(tx, MAIN_DERIVATION_PATH, runtime).await,
                 )
             }),
     )
@@ -350,7 +351,7 @@ async fn sign_transactions_batch<T: TimeProvider>(time_provider: &T) {
                         withdrawal_id,
                         transaction,
                     },
-                    time_provider,
+                    runtime,
                 )
             }),
             Err(e) => errors.push(e),

--- a/rs/ethereum/cketh/minter/src/withdraw.rs
+++ b/rs/ethereum/cketh/minter/src/withdraw.rs
@@ -185,7 +185,7 @@ pub async fn process_retrieve_eth_requests<R: CanisterRuntime>(runtime: R) {
         }
     };
 
-    let sender = minter_address().await;
+    let sender = minter_address(&runtime).await;
     let latest_transaction_count = latest_transaction_count(sender).await;
     resubmit_transactions_batch(latest_transaction_count, &gas_fee_estimate, &runtime).await;
     create_transactions_batch(gas_fee_estimate, &runtime);


### PR DESCRIPTION
## Why

- The sweep queue that the balance scan fills has nothing turning its deposits into sweeps, and the signing that will do so needs a canister — which is what makes it untestable today.

## What

- An async `CanisterRuntime` trait extending `TimeProvider` with tECDSA signing as its first capability, plus the implementation backed by the system API and a mock for tests.
- A skeleton `create_pending_sweeper_requests`, its task type, and the timer that runs it.
- The skeleton does nothing yet, and a unit test pins that down: a deposit sits in the sweep queue, the runtime carries no expectation, and the whole state comes back unchanged. Each later commit then shows up as a diff against a passing test.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926