### PR TITLE
feat(cketh): sign the attestations a batched sweep needs

### DIFF
--- a/rs/ethereum/cketh/minter/src/attestation/mod.rs
+++ b/rs/ethereum/cketh/minter/src/attestation/mod.rs
@@ -18,6 +18,7 @@ use crate::tx::{TransactionSignature, sign_digest};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use minicbor::{Decode, Encode};
+use serde_bytes::ByteBuf;
 
 /// Domain separator of the attestation preimage. Its first byte (`0x63`) cannot collide with any
 /// other preimage the minter's key signs: typed transactions start `0x00`-`0x04`, EIP-7702
@@ -68,6 +69,10 @@ impl AttestationRequest {
         &self.account
     }
 
+    pub fn derivation_path(&self) -> Vec<ByteBuf> {
+        deposit_derivation_path(DepositAddressSchema::CkErc20, &self.account)
+    }
+
     /// `"ck-deposit-owner" || chain_id || deposit_helper || principal || subaccount`, exactly what
     /// `abi.encodePacked` produces in `CkSweeperAttested._attestationDigest`. Every field is
     /// fixed-length, so no two requests share a preimage.
@@ -103,7 +108,7 @@ pub async fn sign_attestation<R: CanisterRuntime>(
 ) -> Result<TransactionSignature, String> {
     sign_digest(
         &request.digest(),
-        &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account),
+        &request.derivation_path(),
         runtime,
     )
     .await

--- a/rs/ethereum/cketh/minter/src/attestation/mod.rs
+++ b/rs/ethereum/cketh/minter/src/attestation/mod.rs
@@ -106,10 +106,5 @@ pub async fn sign_attestation<R: CanisterRuntime>(
     request: &AttestationRequest,
     runtime: &R,
 ) -> Result<TransactionSignature, String> {
-    sign_digest(
-        &request.digest(),
-        &request.derivation_path(),
-        runtime,
-    )
-    .await
+    sign_digest(&request.digest(), &request.derivation_path(), runtime).await
 }

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -276,6 +276,27 @@ impl State {
         ))
     }
 
+    pub fn attestation_requests<T: AsRef<Account>>(
+        &self,
+        accounts: &[T],
+    ) -> Option<Vec<AttestationRequest>> {
+        let deposit_helper = *self
+            .log_scrapings
+            .contract_address(LogScrapingId::EthOrErc20DepositWithSubaccount)?;
+        Some(
+            accounts
+                .iter()
+                .map(|account| {
+                    AttestationRequest::new(
+                        self.ethereum_network.chain_id(),
+                        deposit_helper,
+                        *account.as_ref(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
     /// The attestation `account`'s ckERC20 deposit address has already signed for the configuration
     /// this minter runs against, if any: signing another would cost a threshold-ECDSA signature for
     /// the same digest.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -473,6 +473,23 @@ impl AutomaticDeposits {
                 },
             })
     }
+
+    pub fn requests_batch(
+        &self,
+        requested_batch_size: usize,
+    ) -> BTreeMap<Address, Vec<SweepTarget>> {
+        let mut batches = BTreeMap::new();
+        for (deposit_request, sweep_entry) in &self.sweep {
+            let batch: &mut Vec<_> = batches.entry(deposit_request.token).or_default();
+            if batch.len() < requested_batch_size {
+                batch.push(SweepTarget {
+                    account: deposit_request.account,
+                    address: sweep_entry.address,
+                });
+            }
+        }
+        batches
+    }
 }
 
 impl Default for AutomaticDeposits {
@@ -576,5 +593,29 @@ impl From<DepositAddress> for ScanProgress {
             last_scanned_block: None,
             scan_count: 0,
         }
+    }
+}
+
+/// A queued deposit a sweep can move: the account it credits and the address its funds sit at.
+/// The token is the key its batch is grouped under, so it is not repeated here.
+#[derive(Clone, Copy, Debug)]
+pub struct SweepTarget {
+    account: Account,
+    address: DepositAddress,
+}
+
+impl SweepTarget {
+    pub fn account(&self) -> Account {
+        self.account
+    }
+
+    pub fn address(&self) -> DepositAddress {
+        self.address
+    }
+}
+
+impl AsRef<Account> for SweepTarget {
+    fn as_ref(&self) -> &Account {
+        &self.account
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -6,10 +6,10 @@ use crate::deposit_address::DepositAddress;
 use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, DetectedDeposit};
 use crate::numeric::{BlockNumber, Erc20Value};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
+use crate::test_fixtures::{deposit_address, usdc, usdt};
 use crate::timed_sized_map::{Entry, Timestamp};
 use candid::{Nat, Principal};
 use ic_ethereum_types::Address;
-use ic_sha3::Keccak256;
 use icrc_ledger_types::icrc1::account::Account;
 
 #[test]
@@ -679,14 +679,6 @@ fn token(byte: u8) -> Address {
     Address::new([byte; 20])
 }
 
-fn usdc() -> Address {
-    token(0xaa)
-}
-
-fn usdt() -> Address {
-    token(0xbb)
-}
-
 fn request(account: Account, token: Address) -> DepositRequest {
     DepositRequest::new(account, token)
 }
@@ -754,15 +746,6 @@ fn entry(account: &Account, expires_at: Timestamp) -> Entry<ScanProgress> {
 /// The deposit address is a deterministic function of the account, so a given
 /// account always maps to the same address (mirroring the production key
 /// derivation).
-fn deposit_address(account: &Account) -> DepositAddress {
-    let mut preimage = account.owner.as_slice().to_vec();
-    preimage.extend_from_slice(account.effective_subaccount());
-    let hash = Keccak256::hash(&preimage);
-    let mut bytes = [0_u8; 20];
-    bytes.copy_from_slice(&hash[12..32]);
-    DepositAddress::new(Address::new(bytes))
-}
-
 fn registration(
     account: Account,
     token: Address,

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -56,6 +56,14 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(_runtime: &R) {
             return;
         }
     };
+
+    let Some(_sweeper_contract) = read_state(|s| s.sweeper_contract_address) else {
+        log!(
+            DEBUG,
+            "[create_pending_sweeper_requests]: SKIPPING: no sweeper contract address is configured"
+        );
+        return;
+    };
 }
 
 pub async fn process_sweeper_transactions<R: CanisterRuntime>(runtime: R) {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -42,10 +42,11 @@ pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
+const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.
-pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(_runtime: &R) {
+pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
     let _guard = match TimerGuard::new(TaskType::SweeperEnqueue) {
         Ok(guard) => guard,
         Err(e) => {
@@ -64,6 +65,30 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(_runtime: &R) {
         );
         return;
     };
+
+    let Some(_gas_fee_estimate) = lazy_refresh_gas_fee_estimate(runtime).await else {
+        log!(
+            INFO,
+            "[create_pending_sweeper_requests]: SKIPPING: failed retrieving gas fee estimate"
+        );
+        return;
+    };
+
+    let batch_per_token =
+        read_state(|s| s.automatic_deposits.requests_batch(MAX_DEPOSITS_PER_SWEEP));
+    if batch_per_token.is_empty() {
+        return;
+    }
+
+    for (_token, targets) in batch_per_token {
+        let Some(_attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
+            log!(
+                DEBUG,
+                "[create_pending_sweeper_requests]: SKIPPING: no deposit helper with subaccount is configured"
+            );
+            return;
+        };
+    }
 }
 
 pub async fn process_sweeper_transactions<R: CanisterRuntime>(runtime: R) {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -114,7 +114,13 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
     for (request, signing_result) in signing_results {
         match signing_result {
             Ok(signature) => {
-                mutate_state(|s| s.automatic_deposits.record_attestation(request, signature));
+                mutate_state(|s| {
+                    process_event(
+                        s,
+                        EventType::AttestedDepositAddress { request, signature },
+                        runtime,
+                    )
+                });
             }
             Err(e) => errors.push((request, e)),
         }

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -12,6 +12,7 @@
 #[cfg(test)]
 mod tests;
 
+use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::{
     deposit_address::sweeper_derivation_path,
     guard::TimerGuard,
@@ -34,6 +35,7 @@ use crate::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
+use std::collections::BTreeSet;
 
 /// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
 /// with the real delegate sweep call.
@@ -81,13 +83,45 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
     }
 
     for (_token, targets) in batch_per_token {
-        let Some(_attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
+        let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
             log!(
                 DEBUG,
                 "[create_pending_sweeper_requests]: SKIPPING: no deposit helper with subaccount is configured"
             );
             return;
         };
+        sign_attestations_batch(attestation_requests, runtime).await;
+    }
+}
+
+async fn sign_attestations_batch<R: CanisterRuntime>(
+    requests: Vec<AttestationRequest>,
+    runtime: &R,
+) {
+    let requests_to_sign: BTreeSet<_> = read_state(|s| {
+        requests
+            .into_iter()
+            .filter(|request| s.automatic_deposits.attestation(request).is_none())
+            .collect()
+    });
+
+    let signing_results = join_all(requests_to_sign.into_iter().map(|request| async move {
+        (request.clone(), sign_attestation(&request, runtime).await)
+    }))
+    .await;
+
+    let mut errors = Vec::new();
+    for (request, signing_result) in signing_results {
+        match signing_result {
+            Ok(signature) => {
+                mutate_state(|s| s.automatic_deposits.record_attestation(request, signature));
+            }
+            Err(e) => errors.push((request, e)),
+        }
+    }
+
+    if !errors.is_empty() {
+        log!(INFO, "Errors encountered during signing: {errors:?}");
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,10 +1,19 @@
-use crate::numeric::BlockNumber;
+use crate::attestation::AttestationRequest;
+use crate::numeric::{BlockNumber, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::{State, read_state};
+use crate::storage::with_event_iter;
 use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
-use crate::test_fixtures::{automatic_deposit, init_state, initial_state};
+use crate::test_fixtures::{
+    account, automatic_deposit, init_state, initial_state, state_with_deposit_helper,
+};
+use crate::tx::{GasFeeEstimate, TransactionSignature};
+use ethnum::u256;
+use ic_cdk_management_canister::EcdsaPublicKeyResult;
+use ic_ethereum_types::Address;
+use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
 
 #[tokio::test]
 async fn should_be_no_op_when_no_sweeper_contract() {
@@ -31,23 +40,155 @@ async fn should_be_no_op_when_no_deposit_helper_contract() {
 }
 
 #[tokio::test]
-async fn should_leave_a_queued_deposit_untouched() {
-    init_state(state_with_a_queued_deposit());
-    let before = read_state(State::clone);
+async fn should_sign_missing_attestation() {
+    init_state(state_ready_to_sign());
+    let request = attestation_request();
+    let signature = sign_with_derived_key(&request);
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    runtime
+        .expect_ecdsa_public_key()
+        .times(1)
+        .return_once(move |_, _| Ok(master_public_key()));
+    runtime
+        .expect_sign_with_ecdsa()
+        .times(1)
+        .return_once(move |_, _, _| Ok(signature));
 
-    create_pending_sweeper_requests(&mock()).await;
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        read_state(|s| s.automatic_deposits.attestation(&request).cloned()),
+        Some(expected_signature(&request))
+    );
+}
+
+#[tokio::test]
+async fn should_record_a_signed_attestation_in_the_event_log() {
+    init_state(state_ready_to_sign());
+    let request = attestation_request();
+    let signature = sign_with_derived_key(&request);
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    runtime
+        .expect_ecdsa_public_key()
+        .times(1)
+        .return_once(move |_, _| Ok(master_public_key()));
+    runtime
+        .expect_sign_with_ecdsa()
+        .times(1)
+        .return_once(move |_, _, _| Ok(signature));
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        last_recorded_event(),
+        Some(EventType::AttestedDepositAddress {
+            request: request.clone(),
+            signature: expected_signature(&request),
+        })
+    );
+}
+
+#[tokio::test]
+async fn should_not_resign_already_signed_attestation() {
+    let request = attestation_request();
+    let mut state = state_ready_to_sign();
+    apply_state_transition(
+        &mut state,
+        &EventType::AttestedDepositAddress {
+            request: request.clone(),
+            signature: expected_signature(&request),
+        },
+    );
+    init_state(state);
+    let before = read_state(State::clone);
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+
+    create_pending_sweeper_requests(&runtime).await;
 
     assert_eq!(read_state(State::clone), before);
 }
 
-fn state_with_a_queued_deposit() -> State {
-    let mut state = initial_state();
+const NOW: u64 = 1_620_328_630_000_000_000;
+const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
+const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
+const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
+const CHAIN_CODE: [u8; 32] = [0_u8; 32];
+
+fn state_ready_to_sign() -> State {
+    let mut state = state_with_deposit_helper(DEPOSIT_HELPER);
+    state.sweeper_contract_address = Some(SWEEPER_CONTRACT);
+    state.last_transaction_price_estimate = Some((
+        NOW - GAS_FEE_ESTIMATE_AGE_NANOS,
+        GasFeeEstimate {
+            base_fee_per_gas: WeiPerGas::ONE,
+            max_priority_fee_per_gas: WeiPerGas::ONE,
+        },
+    ));
     apply_state_transition(
         &mut state,
         &EventType::AutomaticDepositReceived(automatic_deposit()),
     );
     assert_eq!(state.automatic_deposits.sweep_len(), 1);
     state
+}
+
+fn attestation_request() -> AttestationRequest {
+    AttestationRequest::new(
+        initial_state().ethereum_network.chain_id(),
+        DEPOSIT_HELPER,
+        account(),
+    )
+}
+
+fn derivation_path(request: &AttestationRequest) -> DerivationPath {
+    DerivationPath::new(
+        request
+            .derivation_path()
+            .iter()
+            .map(|index| DerivationIndex(index.to_vec()))
+            .collect(),
+    )
+}
+
+fn master_private_key() -> PrivateKey {
+    PrivateKey::deserialize_sec1(&[0x46_u8; 32]).unwrap()
+}
+
+fn master_public_key() -> EcdsaPublicKeyResult {
+    EcdsaPublicKeyResult {
+        public_key: master_private_key().public_key().serialize_sec1(true),
+        chain_code: CHAIN_CODE.to_vec(),
+    }
+}
+
+fn sign_with_derived_key(request: &AttestationRequest) -> [u8; 64] {
+    master_private_key()
+        .derive_subkey_with_chain_code(&derivation_path(request), &CHAIN_CODE)
+        .0
+        .sign_digest_with_ecdsa(&request.digest().0)
+}
+
+fn expected_signature(request: &AttestationRequest) -> TransactionSignature {
+    let signature = sign_with_derived_key(request);
+    let recovery_id = master_private_key()
+        .public_key()
+        .derive_subkey_with_chain_code(&derivation_path(request), &CHAIN_CODE)
+        .0
+        .try_recovery_from_digest(&request.digest().0, &signature)
+        .unwrap();
+    let (r_bytes, s_bytes) = signature.split_at(32);
+    TransactionSignature {
+        signature_y_parity: recovery_id.is_y_odd(),
+        r: u256::from_be_bytes(r_bytes.try_into().unwrap()),
+        s: u256::from_be_bytes(s_bytes.try_into().unwrap()),
+    }
+}
+
+fn last_recorded_event() -> Option<EventType> {
+    with_event_iter(|events| events.last().map(|event| event.payload))
 }
 
 fn mock() -> MockCanisterRuntime {

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -2,18 +2,27 @@ use crate::attestation::AttestationRequest;
 use crate::numeric::{BlockNumber, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
+use crate::state::event::AutomaticDeposit;
 use crate::state::{State, read_state};
 use crate::storage::with_event_iter;
 use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
-    account, automatic_deposit, init_state, initial_state, state_with_deposit_helper,
+    account, automatic_deposit, deposit_address, init_state, initial_state,
+    state_with_deposit_helper, usdc, usdt,
 };
 use crate::tx::{GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
 use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
+use icrc_ledger_types::icrc1::account::Account;
+
+const NOW: u64 = 1_620_328_630_000_000_000;
+const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
+const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
+const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
+const CHAIN_CODE: [u8; 32] = [0_u8; 32];
 
 #[tokio::test]
 async fn should_be_no_op_when_no_sweeper_contract() {
@@ -40,9 +49,12 @@ async fn should_be_no_op_when_no_deposit_helper_contract() {
 }
 
 #[tokio::test]
-async fn should_sign_missing_attestation() {
-    init_state(state_ready_to_sign());
-    let request = attestation_request();
+async fn should_sign_one_attestation_for_every_token_of_an_account() {
+    init_state(state_ready_to_sign(&[
+        (account(), usdc()),
+        (account(), usdt()),
+    ]));
+    let request = attestation_request(account());
     let signature = sign_with_derived_key(&request);
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
@@ -57,67 +69,20 @@ async fn should_sign_missing_attestation() {
 
     create_pending_sweeper_requests(&runtime).await;
 
+    assert_eq!(
+        recorded_events(),
+        vec![EventType::AttestedDepositAddress {
+            request: request.clone(),
+            signature: expected_signature(&request),
+        }]
+    );
     assert_eq!(
         read_state(|s| s.automatic_deposits.attestation(&request).cloned()),
         Some(expected_signature(&request))
     );
 }
 
-#[tokio::test]
-async fn should_record_a_signed_attestation_in_the_event_log() {
-    init_state(state_ready_to_sign());
-    let request = attestation_request();
-    let signature = sign_with_derived_key(&request);
-    let mut runtime = mock();
-    runtime.expect_time().return_const(NOW);
-    runtime
-        .expect_ecdsa_public_key()
-        .times(1)
-        .return_once(move |_, _| Ok(master_public_key()));
-    runtime
-        .expect_sign_with_ecdsa()
-        .times(1)
-        .return_once(move |_, _, _| Ok(signature));
-
-    create_pending_sweeper_requests(&runtime).await;
-
-    assert_eq!(
-        last_recorded_event(),
-        Some(EventType::AttestedDepositAddress {
-            request: request.clone(),
-            signature: expected_signature(&request),
-        })
-    );
-}
-
-#[tokio::test]
-async fn should_not_resign_already_signed_attestation() {
-    let request = attestation_request();
-    let mut state = state_ready_to_sign();
-    apply_state_transition(
-        &mut state,
-        &EventType::AttestedDepositAddress {
-            request: request.clone(),
-            signature: expected_signature(&request),
-        },
-    );
-    init_state(state);
-    let before = read_state(State::clone);
-    let mut runtime = mock();
-    runtime.expect_time().return_const(NOW);
-
-    create_pending_sweeper_requests(&runtime).await;
-
-    assert_eq!(read_state(State::clone), before);
-}
-
-const NOW: u64 = 1_620_328_630_000_000_000;
-const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
-const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
-const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
-const CHAIN_CODE: [u8; 32] = [0_u8; 32];
-
-fn state_ready_to_sign() -> State {
+fn state_ready_to_sign(deposits: &[(Account, Address)]) -> State {
     let mut state = state_with_deposit_helper(DEPOSIT_HELPER);
     state.sweeper_contract_address = Some(SWEEPER_CONTRACT);
     state.last_transaction_price_estimate = Some((
@@ -127,19 +92,27 @@ fn state_ready_to_sign() -> State {
             max_priority_fee_per_gas: WeiPerGas::ONE,
         },
     ));
-    apply_state_transition(
-        &mut state,
-        &EventType::AutomaticDepositReceived(automatic_deposit()),
-    );
-    assert_eq!(state.automatic_deposits.sweep_len(), 1);
+    for (account, token) in deposits {
+        apply_state_transition(
+            &mut state,
+            &EventType::AutomaticDepositReceived(AutomaticDeposit {
+                owner: account.owner,
+                subaccount: account.subaccount,
+                address: deposit_address(account),
+                erc20_contract_address: *token,
+                ..automatic_deposit()
+            }),
+        );
+    }
+    assert_eq!(state.automatic_deposits.sweep_len(), deposits.len());
     state
 }
 
-fn attestation_request() -> AttestationRequest {
+fn attestation_request(account: Account) -> AttestationRequest {
     AttestationRequest::new(
         initial_state().ethereum_network.chain_id(),
         DEPOSIT_HELPER,
-        account(),
+        account,
     )
 }
 
@@ -187,8 +160,8 @@ fn expected_signature(request: &AttestationRequest) -> TransactionSignature {
     }
 }
 
-fn last_recorded_event() -> Option<EventType> {
-    with_event_iter(|events| events.last().map(|event| event.payload))
+fn recorded_events() -> Vec<EventType> {
+    with_event_iter(|events| events.map(|event| event.payload).collect())
 }
 
 fn mock() -> MockCanisterRuntime {

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -5,11 +5,23 @@ use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{automatic_deposit, init_state, initial_state};
 
 #[tokio::test]
+async fn should_be_no_op_when_no_sweeper_contract() {
+    let mut state = initial_state();
+    state.sweeper_contract_address = None;
+    init_state(state);
+    let before = read_state(State::clone);
+
+    create_pending_sweeper_requests(&mock()).await;
+
+    assert_eq!(read_state(State::clone), before);
+}
+
+#[tokio::test]
 async fn should_leave_a_queued_deposit_untouched() {
     init_state(state_with_a_queued_deposit());
     let before = read_state(State::clone);
 
-    create_pending_sweeper_requests(&MockCanisterRuntime::new()).await;
+    create_pending_sweeper_requests(&mock()).await;
 
     assert_eq!(read_state(State::clone), before);
 }
@@ -22,4 +34,8 @@ fn state_with_a_queued_deposit() -> State {
     );
     assert_eq!(state.automatic_deposits.sweep_len(), 1);
     state
+}
+
+fn mock() -> MockCanisterRuntime {
+    MockCanisterRuntime::new()
 }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,4 +1,6 @@
+use crate::numeric::BlockNumber;
 use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::{State, read_state};
 use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
@@ -8,6 +10,18 @@ use crate::test_fixtures::{automatic_deposit, init_state, initial_state};
 async fn should_be_no_op_when_no_sweeper_contract() {
     let mut state = initial_state();
     state.sweeper_contract_address = None;
+    init_state(state);
+    let before = read_state(State::clone);
+
+    create_pending_sweeper_requests(&mock()).await;
+
+    assert_eq!(read_state(State::clone), before);
+}
+
+#[tokio::test]
+async fn should_be_no_op_when_no_deposit_helper_contract() {
+    let mut state = initial_state();
+    state.log_scrapings = LogScrapings::new(BlockNumber::ONE);
     init_state(state);
     let before = read_state(State::clone);
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -94,6 +94,23 @@ pub fn sweeper_funding_request(withdrawal_amount: Wei) -> EthWithdrawalRequest {
     }
 }
 
+pub fn deposit_address(account: &Account) -> DepositAddress {
+    let mut preimage = account.owner.as_slice().to_vec();
+    preimage.extend_from_slice(account.effective_subaccount());
+    let hash = ic_sha3::Keccak256::hash(&preimage);
+    let mut bytes = [0_u8; 20];
+    bytes.copy_from_slice(&hash[12..32]);
+    DepositAddress::new(Address::new(bytes))
+}
+
+pub fn usdc() -> Address {
+    Address::new([0xaa; 20])
+}
+
+pub fn usdt() -> Address {
+    Address::new([0xbb; 20])
+}
+
 pub fn automatic_deposit() -> AutomaticDeposit {
     AutomaticDeposit {
         owner: account().owner,


### PR DESCRIPTION
## Why

- The sweep queue folds deposits into a batch per token, but nothing produced the attestation each deposit needs before it can be swept: the delegate recovers that signature against the deposit address it moves funds from, so an unattested deposit cannot be swept at all.

## What

- Each batch resolves the attestation request its deposits need and signs the ones the minter has not signed before.
- An attestation binds an account to one chain and one deposit helper — never to a token — so an account depositing several tokens is attested once and the signature is reused across its batches.
- Signatures are recorded through the event log, so replaying after an upgrade keeps them rather than paying for another threshold-ECDSA signature.
- A deposit whose attestation cannot be signed is reported and left for the next tick.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926