### PR TITLE
fix: Only complete auto progress after the certified time has been set

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `SubnetCoolingDown` variant to the `ErrorCode` enum: ingress messages addressed to a subnet that is "cooling down" are rejected with this error code.
 
 ### Changed
+- The functions `PocketIc::auto_progress`, `PocketIc::make_live`, and their variants only return
+  after the certified time of the PocketIC instance has been updated for the first time
+  (the same applies to building an instance with automatic progress enabled).
 - No hard TTL is set on PocketIC servers started implicitly by the library (e.g. by `PocketIc::new` or `PocketIcBuilder::build`); previously a default of 10 minutes was used.
   The hard TTL is an absolute deadline measured from the server's launch which is not extended by activity, so a test suite whose total runtime exceeded it had its server terminated while still serving requests, failing in-flight calls with `Connection reset by peer`.
   Orphaned servers remain bounded by the (activity-based) soft TTL.

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -707,6 +707,8 @@ pub enum InitialTime {
     /// Configures the new instance to make progress automatically,
     /// i.e., periodically update the time of the IC instance
     /// to the real time and execute rounds on the subnets.
+    /// Creating the instance only returns after the certified time
+    /// of the IC instance has been updated for the first time.
     AutoProgress(AutoProgressConfig),
 }
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -491,6 +491,8 @@ impl PocketIcBuilder {
     /// Configures the new instance to make progress automatically,
     /// i.e., periodically update the time of the IC instance
     /// to the real time and execute rounds on the subnets.
+    /// Building the instance only returns after the certified time
+    /// of the IC instance has been updated for the first time.
     pub fn with_auto_progress(mut self) -> Self {
         let config = AutoProgressConfig {
             artificial_delay_ms: None,
@@ -842,6 +844,8 @@ impl PocketIc {
     /// and configures the PocketIC instance to make progress automatically, i.e.,
     /// periodically update the time of the PocketIC instance to the real time
     /// and process messages on the PocketIC instance.
+    /// Only returns after the certified time of the PocketIC instance
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]
@@ -858,6 +862,8 @@ impl PocketIc {
     /// and configures the PocketIC instance to make progress automatically, i.e.,
     /// periodically update the time of the PocketIC instance to the real time
     /// and process messages on the PocketIC instance.
+    /// Only returns after the certified time of the PocketIC instance
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -805,6 +805,8 @@ impl PocketIc {
     /// Configures the IC to make progress automatically,
     /// i.e., periodically update the time of the IC
     /// to the real time and execute rounds on the subnets.
+    /// Only returns after the certified time of the IC
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -434,6 +434,8 @@ impl PocketIc {
     /// and configures the PocketIC instance to make progress automatically, i.e.,
     /// periodically update the time of the PocketIC instance to the real time
     /// and process messages on the PocketIC instance.
+    /// Only returns after the certified time of the PocketIC instance
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.instance_id))]
@@ -450,6 +452,8 @@ impl PocketIc {
     /// and configures the PocketIC instance to make progress automatically, i.e.,
     /// periodically update the time of the PocketIC instance to the real time
     /// and process messages on the PocketIC instance.
+    /// Only returns after the certified time of the PocketIC instance
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.instance_id))]

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -384,6 +384,8 @@ impl PocketIc {
     /// Configures the IC to make progress automatically,
     /// i.e., periodically update the time of the IC
     /// to the real time and execute rounds on the subnets.
+    /// Only returns after the certified time of the IC
+    /// has been updated for the first time.
     /// Returns the URL at which `/api` requests
     /// for this instance can be made.
     #[instrument(skip(self), fields(instance_id=self.instance_id))]

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -530,6 +530,25 @@ fn test_auto_progress() {
     assert!(pic.auto_progress_enabled());
 }
 
+#[test]
+fn test_auto_progress_updates_certified_time() {
+    let pic = PocketIc::new();
+
+    // We create a test canister.
+    let canister = pic.create_canister();
+    pic.add_cycles(canister, INIT_CYCLES);
+    pic.install_canister(canister, test_canister_wasm(), vec![], None);
+
+    let before = SystemTime::now();
+    pic.auto_progress();
+
+    // Enabling auto progress only returns after the certified time has been updated
+    // for the first time and thus a query call (which reads the certified time)
+    // must observe a time no earlier than the time before enabling auto progress.
+    let t: (u64,) = query_candid(&pic, canister, "time", ((),)).unwrap();
+    assert!(t.0 >= Time::from(before).as_nanos_since_unix_epoch());
+}
+
 fn query_and_check_time(pic: &PocketIc, test_canister: Principal) {
     let current_time = pic.get_time().as_nanos_since_unix_epoch();
     let t: (u64,) = query_candid(pic, test_canister, "time", ((),)).unwrap();

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- The endpoint `/instances/<instance_id>/auto_progress` (and creating an instance with automatic progress enabled)
+  only returns after the certified time of the PocketIC instance has been updated for the first time.
+
 
 
 ## 15.0.0 - 2026-06-26

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -287,6 +287,8 @@ where
         // Configures an IC instance to make progress automatically,
         // i.e., periodically update the time of the IC instance
         // to the real time and execute rounds on the subnets.
+        // Only returns after the certified time of the IC instance
+        // has been updated for the first time.
         .api_route("/{id}/auto_progress", post(auto_progress))
         // Returns whether automatic progress is enabled for an IC instance.
         .api_route("/{id}/auto_progress", get(get_auto_progress))

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -1006,8 +1006,8 @@ impl ApiState {
                 .await
                 .is_some()
                 {
-                    // The receiver might have been dropped if this function returned early,
-                    // e.g., because auto progress was stopped, and thus we ignore the result.
+                    // The receiver is dropped if the `auto_progress` future was cancelled
+                    // (e.g., because the client disconnected) and thus we ignore the result.
                     let _ = certified_time_tx.send(());
                     debug!("Starting auto progress for instance {}.", instance_id);
                     loop {

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -68,7 +68,7 @@ use std::{
 use tokio::{
     sync::mpsc::Receiver,
     sync::mpsc::error::TryRecvError,
-    sync::{Mutex, RwLock, mpsc},
+    sync::{Mutex, RwLock, mpsc, oneshot},
     task::{JoinHandle, JoinSet, spawn, spawn_blocking},
     time::{self, sleep},
 };
@@ -985,6 +985,9 @@ impl ApiState {
         let mut instance = instances[instance_id].lock().await;
         if instance.progress_thread.is_none() {
             let (tx, mut rx) = mpsc::channel::<()>(1);
+            // Used to signal that the certified time has been set for the first time
+            // so that this function only returns after that happened.
+            let (certified_time_tx, certified_time_rx) = oneshot::channel::<()>();
             let handle = spawn(async move {
                 let mut now = SystemTime::now();
                 let time = ic_types::Time::from_nanos_since_unix_epoch(
@@ -1003,6 +1006,9 @@ impl ApiState {
                 .await
                 .is_some()
                 {
+                    // The receiver might have been dropped if this function returned early,
+                    // e.g., because auto progress was stopped, and thus we ignore the result.
+                    let _ = certified_time_tx.send(());
                     debug!("Starting auto progress for instance {}.", instance_id);
                     loop {
                         let old = std::mem::replace(&mut now, SystemTime::now());
@@ -1042,6 +1048,14 @@ impl ApiState {
                 }
             });
             instance.progress_thread = Some(ProgressThread { handle, sender: tx });
+            // Drop the locks so that the progress thread can execute its first operation
+            // setting the certified time.
+            drop(instance);
+            drop(instances);
+            // Wait until the certified time has been set for the first time.
+            // The sender is dropped without sending if the progress thread stopped
+            // before setting the certified time and thus we ignore the result.
+            let _ = certified_time_rx.await;
             Ok(())
         } else {
             Err("Auto progress mode has already been enabled.".to_string())


### PR DESCRIPTION
Enabling auto progress on a PocketIC instance spawned the progress thread and returned immediately, i.e., before the thread executed its initial `SetCertifiedTime` operation. Hence, a client could observe a stale certified time right after enabling auto progress (also when creating an instance with auto progress enabled or making an instance live).

Now the progress thread signals via a oneshot channel once the certified time has been set for the first time and `ApiState::auto_progress` awaits that signal before returning. The instance locks are dropped before awaiting since the progress thread needs them to execute the operation.