### PR TITLE
feat: [DSM-148] Track unhealthy nodes in XNet payload builder

### DIFF
--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -10,6 +10,8 @@ mod tests;
 #[cfg(test)]
 mod xnet_client_tests;
 
+pub use proximity::{GenRangeFn, ProximityMap, UNHEALTHY_NODE_TTL, UnhealthyNodes};
+
 use crate::certified_slice_pool::{
     CertifiedSliceError, CertifiedSlicePool, CertifiedSliceResult, certified_slice_count_bytes,
 };
@@ -47,7 +49,6 @@ use ic_types::{Height, NodeId, NumBytes, RegistryVersion, SubnetId};
 use ic_xnet_hyper::TlsConnector;
 use ic_xnet_uri::XNetAuthority;
 use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge};
-pub use proximity::{GenRangeFn, ProximityMap};
 use rand::{Rng, rngs::StdRng, thread_rng};
 use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
@@ -336,9 +337,13 @@ impl XNetPayloadBuilderImpl {
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
     ) -> XNetPayloadBuilderImpl {
+        // Shared by the node selection of every component talking to other
+        // subnets: `ProximityMap` below, the advert task once it exists.
+        let unhealthy_nodes = Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, metrics_registry));
         let proximity_map = Arc::new(ProximityMap::new(
             node_id,
             registry.clone(),
+            unhealthy_nodes.clone(),
             metrics_registry,
             log.clone(),
         ));
@@ -346,6 +351,7 @@ impl XNetPayloadBuilderImpl {
             metrics_registry,
             tls_handshake,
             proximity_map.clone(),
+            unhealthy_nodes,
         ));
 
         let deterministic_rng_for_testing = Arc::new(None);
@@ -1718,6 +1724,9 @@ struct XNetClientImpl {
 
     /// Proximity map to update after every query with the time-to-first-byte.
     proximity_map: Arc<ProximityMap>,
+
+    /// Unhealthy node set to update after every query with its outcome.
+    unhealthy_nodes: Arc<UnhealthyNodes>,
 }
 
 impl XNetClientImpl {
@@ -1727,6 +1736,7 @@ impl XNetClientImpl {
         metrics_registry: &MetricsRegistry,
         tls: Arc<dyn TlsConfig>,
         proximity_map: Arc<ProximityMap>,
+        unhealthy_nodes: Arc<UnhealthyNodes>,
     ) -> XNetClientImpl {
         #[cfg(not(test))]
         let https = TlsConnector::new(tls);
@@ -1771,13 +1781,11 @@ impl XNetClientImpl {
             http_client,
             response_body_size,
             proximity_map,
+            unhealthy_nodes,
         }
     }
-}
 
-#[async_trait]
-impl XNetClient for XNetClientImpl {
-    async fn query(
+    async fn query_impl(
         &self,
         endpoint: &EndpointLocator,
     ) -> Result<CertifiedStreamSlice, XNetClientError> {
@@ -1841,6 +1849,25 @@ impl XNetClient for XNetClientImpl {
     }
 }
 
+#[async_trait]
+impl XNetClient for XNetClientImpl {
+    async fn query(
+        &self,
+        endpoint: &EndpointLocator,
+    ) -> Result<CertifiedStreamSlice, XNetClientError> {
+        let result = self.query_impl(endpoint).await;
+
+        // Record whether the node served the request, so that node selection
+        // can skip the ones that don't.
+        match &result {
+            Err(e) if e.is_node_failure() => self.unhealthy_nodes.observe_failure(endpoint.node_id),
+            _ => self.unhealthy_nodes.observe_success(endpoint.node_id),
+        }
+
+        result
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum XNetClientError {
     #[error("XNet request timed out")]
@@ -1858,6 +1885,32 @@ pub enum XNetClientError {
 }
 
 impl XNetClientError {
+    /// Returns `true` if this error means that the node failed to serve the
+    /// request: we could not connect to it, it timed out, or it responded with
+    /// a 5xx status code or something we could not make sense of. Whereas a 204
+    /// (`NoContent`) or 4xx status code point to a (likely) healthy node.
+    fn is_node_failure(&self) -> bool {
+        match self {
+            // Self-explanatory.
+            XNetClientError::Timeout
+            // Could be anything, but usually "XNet request failed: client error (Connect)".
+            | XNetClientError::RequestFailed(..)
+            // Not observed in the wild, but it would likely imply a misbehaving server (e.g.
+            // oversized response).
+            | XNetClientError::BodyReadError(..)
+            // Not observed in the wild, but it would likely imply a misbehaving server.
+            | XNetClientError::ProxyDecodeError(..) => true,
+
+            // Only a failure if the server returned a 5xx status code. Even though 503 is
+            // transient (full queue), it is probably a good idea to give the server some
+            // breathing room.
+            XNetClientError::ErrorResponse(status_code, ..) => status_code.is_server_error(),
+
+            // Definitely not an error, there's merely no new content.
+            XNetClientError::NoContent => false,
+        }
+    }
+
     /// Maps an `XNetClientError` to a `status` label value.
     fn to_label_value(&self) -> String {
         match self {
@@ -1876,7 +1929,7 @@ pub mod testing {
     pub use super::{
         EndpointLocator, GenRangeFn, LABEL_STATUS, METRIC_BUILD_PAYLOAD_DURATION,
         METRIC_SLICE_MESSAGES, METRIC_SLICE_PAYLOAD_SIZE, POOL_SLICE_BYTE_SIZE_MAX, PoolRefillTask,
-        ProximityMap, RefillTaskHandle, STATUS_SUCCESS, XNetClient, XNetClientError,
-        XNetEndpointResolver, XNetPayloadBuilderMetrics,
+        ProximityMap, RefillTaskHandle, STATUS_SUCCESS, UNHEALTHY_NODE_TTL, UnhealthyNodes,
+        XNetClient, XNetClientError, XNetEndpointResolver, XNetPayloadBuilderMetrics,
     };
 }

--- a/rs/xnet/payload_builder/src/proximity.rs
+++ b/rs/xnet/payload_builder/src/proximity.rs
@@ -40,14 +40,17 @@ const LABEL_TO: &str = "to";
 
 const OPERATOR_UNKNOWN: &str = "unknown";
 
-/// Helper for probabilistically selecting a node on a given subnet, weighted by
-/// proximity.
+/// Helper for probabilistically selecting a healthy node on a given subnet,
+/// weighted by proximity.
 ///
 /// Proximity is modeled as the exponential moving average (EMA) of roundtrip
 /// time (RTT) per datacenter operator (under the assumption that all nodes
 /// belonging to a datacenter operator are colocated). The probability of a
 /// specific node on a given subnet being selected is inversely proportional to
 /// the RTT EMA of its operator.
+///
+/// Node health is sourced from a shared `UnhealthyNodes` instance, and is based
+/// on recent XNet query outcomes.
 pub struct ProximityMap {
     /// Exponential moving averages (EMA) of roundtrip times by datacenter
     /// operator.
@@ -56,7 +59,7 @@ pub struct ProximityMap {
     /// Used for retrieving subnet node lists and node transport info.
     registry: Arc<dyn RegistryClient>,
 
-    /// The nodes to not pick, because they are unhealthy.
+    /// Tracks recently unhealthy nodes, based on recent XNet query outcomes.
     unhealthy_nodes: Arc<UnhealthyNodes>,
 
     /// Generates a random value in the range [`low`, `high`), i.e. inclusive of
@@ -276,7 +279,7 @@ impl UnhealthyNodes {
             ttl,
             metric_unhealthy_nodes: metrics_registry.int_gauge(
                 METRIC_UNHEALTHY_NODES,
-                "Number of unhealthy nodes, i.e. whose last XNet request failed.",
+                "Number of unhealthy XNet nodes, i.e. nodes whose last XNet request failed within the unhealthy node TTL.",
             ),
         }
     }

--- a/rs/xnet/payload_builder/src/proximity.rs
+++ b/rs/xnet/payload_builder/src/proximity.rs
@@ -9,13 +9,13 @@ use ic_registry_client_helpers::{
     node::{NodeRecord, NodeRegistry},
     subnet::SubnetRegistry,
 };
-use prometheus::{GaugeVec, IntCounter, Opts};
+use prometheus::{GaugeVec, IntCounter, IntGauge, Opts};
 use rand::{Rng, thread_rng};
 use std::{
     collections::BTreeMap,
     convert::TryFrom,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use super::{Error, get_node_operator_id};
@@ -26,8 +26,14 @@ pub type GenRangeFn = Box<dyn Fn(u64, u64) -> u64 + Sync + Send>;
 
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
+/// How long a node is considered unhealthy after a failed request. It may be
+/// tried again after this long, so a node that stays down costs one failed
+/// request per TTL.
+pub const UNHEALTHY_NODE_TTL: Duration = Duration::from_secs(10);
+
 const METRIC_RTT_EMA: &str = "xnet_builder_rtt_ema_seconds";
 const METRIC_UNKNOWN_DCOP: &str = "xnet_builder_unknown_dcop_total";
+pub(crate) const METRIC_UNHEALTHY_NODES: &str = "xnet_builder_unhealthy_nodes";
 
 const LABEL_FROM: &str = "from";
 const LABEL_TO: &str = "to";
@@ -50,6 +56,9 @@ pub struct ProximityMap {
     /// Used for retrieving subnet node lists and node transport info.
     registry: Arc<dyn RegistryClient>,
 
+    /// The nodes to not pick, because they are unhealthy.
+    unhealthy_nodes: Arc<UnhealthyNodes>,
+
     /// Generates a random value in the range [`low`, `high`), i.e. inclusive of
     /// `low` and exclusive of `high`, to use for picking a replica.
     gen_range: GenRangeFn,
@@ -68,6 +77,7 @@ impl ProximityMap {
     pub fn new(
         node: NodeId,
         registry: Arc<dyn RegistryClient>,
+        unhealthy_nodes: Arc<UnhealthyNodes>,
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
     ) -> ProximityMap {
@@ -79,6 +89,7 @@ impl ProximityMap {
             Box::new(thread_rng_gen_range),
             node,
             registry,
+            unhealthy_nodes,
             metrics_registry,
             log,
         )
@@ -90,6 +101,7 @@ impl ProximityMap {
         gen_range: GenRangeFn,
         node: NodeId,
         registry: Arc<dyn RegistryClient>,
+        unhealthy_nodes: Arc<UnhealthyNodes>,
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
     ) -> ProximityMap {
@@ -110,6 +122,7 @@ impl ProximityMap {
         Self {
             roundtrip_ema_nanos: Default::default(),
             registry,
+            unhealthy_nodes,
             gen_range,
             metric_rtt_ema,
             metric_unknown_dcop,
@@ -119,7 +132,8 @@ impl ProximityMap {
 
     /// Picks a random node on `subnet` (as defined at registry version
     /// `version`) weighted by proximity (nodes belonging to operators with
-    /// lower RTT are picked with higher probability).
+    /// lower RTT are picked with higher probability). Unhealthy nodes are not
+    /// picked, unless all of the subnet's nodes are unhealthy.
     ///
     /// E.g. given  mean RTTs of `[0.1s, 0.5s. 1s]` the computed weights
     /// (`[10_000, 2_000, 1_000]`) would result in cumulative weights `[10_000,
@@ -135,13 +149,14 @@ impl ProximityMap {
         subnet: SubnetId,
         version: RegistryVersion,
     ) -> Result<(NodeId, NodeRecord), Error> {
-        // Retrieve `subnet`'s nodes.
-        let nodes = self
+        // Retrieve `subnet`'s nodes, minus the unhealthy ones.
+        let mut nodes = self
             .registry
             .get_node_ids_on_subnet(subnet, version)
             .map_err(|e| Error::RegistryGetSubnetInfoFailed(subnet, e))?
             .filter(|nodes| !nodes.is_empty())
             .ok_or(Error::MissingSubnet(subnet))?;
+        self.unhealthy_nodes.filter_at_least(1, &mut nodes);
 
         // Compute the individual and total weight of all nodes with explicit weights
         // (nodes of operators for which we've recorded at least one roundtrip time).
@@ -231,6 +246,81 @@ impl ProximityMap {
             .unwrap()
             .get(node_operator)
             .map(|ema_nanos| 1_000 * NANOS_PER_SEC / ema_nanos)
+    }
+}
+
+/// The set of nodes whose last request failed, with entries expiring after a
+/// TTL.
+///
+/// Populated by `XNetClient`; consulted by whoever selects such nodes, so that
+/// a node that is not serving requests is skipped instead of being picked again
+/// and again.
+///
+/// Entries are keyed by `NodeId` alone; the per-subnet semantics of
+/// `filter_at_least()` come from the node list it is given.
+pub struct UnhealthyNodes {
+    /// Expiry times of the entries.
+    nodes: Mutex<BTreeMap<NodeId, Instant>>,
+
+    /// How long a node is considered unhealthy after a failed request.
+    ttl: Duration,
+
+    /// Exported number of unhealthy nodes.
+    metric_unhealthy_nodes: IntGauge,
+}
+
+impl UnhealthyNodes {
+    pub fn new(ttl: Duration, metrics_registry: &MetricsRegistry) -> Self {
+        Self {
+            nodes: Default::default(),
+            ttl,
+            metric_unhealthy_nodes: metrics_registry.int_gauge(
+                METRIC_UNHEALTHY_NODES,
+                "Number of unhealthy nodes, i.e. whose last XNet request failed.",
+            ),
+        }
+    }
+
+    /// Records a failed request to `node`.
+    pub fn observe_failure(&self, node: NodeId) {
+        let mut nodes = self.nodes.lock().unwrap();
+        nodes.insert(node, Instant::now() + self.ttl);
+        self.prune(&mut nodes);
+    }
+
+    /// Records a successful request to `node`.
+    pub fn observe_success(&self, node: NodeId) {
+        let mut nodes = self.nodes.lock().unwrap();
+        nodes.remove(&node);
+        self.prune(&mut nodes);
+    }
+
+    /// Drops the unhealthy nodes from `nodes`, as long as at least `minimum`
+    /// remain; else leaves `nodes` as it is. So that a subnet-wide endpoint
+    /// problem or a local network fault cannot leave the caller with too few
+    /// nodes to choose from -- or none at all.
+    pub fn filter_at_least(&self, minimum: usize, nodes: &mut Vec<NodeId>) {
+        let mut unhealthy = self.nodes.lock().unwrap();
+        self.prune(&mut unhealthy);
+
+        let is_healthy = |node: &NodeId| !unhealthy.contains_key(node);
+        if nodes
+            .iter()
+            .filter(|node| is_healthy(node))
+            .take(minimum)
+            .count()
+            < minimum
+        {
+            return;
+        }
+        nodes.retain(is_healthy);
+    }
+
+    /// Drops the expired entries and updates the metric.
+    fn prune(&self, nodes: &mut BTreeMap<NodeId, Instant>) {
+        let now = Instant::now();
+        nodes.retain(|_, expiry| *expiry > now);
+        self.metric_unhealthy_nodes.set(nodes.len() as i64);
     }
 }
 

--- a/rs/xnet/payload_builder/src/proximity/tests.rs
+++ b/rs/xnet/payload_builder/src/proximity/tests.rs
@@ -1,7 +1,9 @@
 use super::super::test_fixtures::*;
 use super::*;
 use ic_test_utilities_logger::with_test_replica_logger;
-use ic_test_utilities_metrics::{MetricVec, fetch_gauge_vec, fetch_int_counter, metric_vec};
+use ic_test_utilities_metrics::{
+    MetricVec, fetch_gauge_vec, fetch_int_counter, fetch_int_gauge, metric_vec,
+};
 
 /// Asserts that `proximity_map.pick_node()` will pick `expected_node` for all
 /// `gen_range()` values in the `[low + numerator_low * (high - low) /
@@ -50,6 +52,7 @@ async fn pick_node_no_roundtrip_times() {
             mock_gen_range_low(0, 0),
             LOCAL_NODE,
             registry,
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics)),
             &metrics,
             log,
         );
@@ -77,6 +80,7 @@ async fn pick_node_some_roundtrip_times() {
             mock_gen_range_low(0, 0),
             LOCAL_NODE,
             registry,
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics)),
             &metrics,
             log,
         );
@@ -104,6 +108,7 @@ async fn pick_node_all_roundtrip_times() {
             mock_gen_range_low(0, 0),
             LOCAL_NODE,
             registry,
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics)),
             &metrics,
             log,
         );
@@ -138,6 +143,7 @@ async fn pick_node_extreme_roundtrip_times() {
             mock_gen_range_low(0, 0),
             LOCAL_NODE,
             registry,
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics)),
             &metrics,
             log,
         );
@@ -183,4 +189,97 @@ async fn pick_node_extreme_roundtrip_times() {
         );
         assert_eq!(Some(0), fetch_int_counter(&metrics, METRIC_UNKNOWN_DCOP));
     });
+}
+
+#[tokio::test]
+async fn pick_node_unhealthy_nodes() {
+    with_test_replica_logger(|log| {
+        let registry = create_xnet_endpoint_url_test_fixture();
+        let metrics = MetricsRegistry::new();
+        let unhealthy_nodes = Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics));
+
+        let mut proximity_map = ProximityMap::with_rng(
+            mock_gen_range_low(0, 0),
+            LOCAL_NODE,
+            registry,
+            unhealthy_nodes.clone(),
+            &metrics,
+            log,
+        );
+
+        // With node 1 unhealthy, the other two nodes are picked from.
+        unhealthy_nodes.observe_failure(REMOTE_NODE_1_OPERATOR_1);
+        assert_pick_node(REMOTE_NODE_2_OPERATOR_1, &mut proximity_map, 0, 1, 2);
+        assert_pick_node(REMOTE_NODE_3_OPERATOR_2, &mut proximity_map, 1, 2, 2);
+
+        // With all three unhealthy, all three are picked from again.
+        unhealthy_nodes.observe_failure(REMOTE_NODE_2_OPERATOR_1);
+        unhealthy_nodes.observe_failure(REMOTE_NODE_3_OPERATOR_2);
+        assert_pick_node(REMOTE_NODE_1_OPERATOR_1, &mut proximity_map, 0, 1, 3);
+        assert_pick_node(REMOTE_NODE_2_OPERATOR_1, &mut proximity_map, 1, 2, 3);
+        assert_pick_node(REMOTE_NODE_3_OPERATOR_2, &mut proximity_map, 2, 3, 3);
+        assert_eq!(Some(3), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+
+        // A successful request to node 1 leaves it as the only node to pick.
+        unhealthy_nodes.observe_success(REMOTE_NODE_1_OPERATOR_1);
+        assert_pick_node(REMOTE_NODE_1_OPERATOR_1, &mut proximity_map, 0, 1, 1);
+        assert_eq!(Some(2), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+    });
+}
+
+#[test]
+fn unhealthy_nodes_filter_at_least() {
+    let all_nodes = vec![
+        REMOTE_NODE_1_OPERATOR_1,
+        REMOTE_NODE_2_OPERATOR_1,
+        REMOTE_NODE_3_OPERATOR_2,
+    ];
+    let filter_at_least = |unhealthy_nodes: &UnhealthyNodes, minimum| {
+        let mut nodes = all_nodes.clone();
+        unhealthy_nodes.filter_at_least(minimum, &mut nodes);
+        nodes
+    };
+
+    let metrics = MetricsRegistry::new();
+    let unhealthy_nodes = UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics);
+
+    // No unhealthy nodes, all nodes retained.
+    assert_eq!(all_nodes, filter_at_least(&unhealthy_nodes, 3));
+
+    unhealthy_nodes.observe_failure(REMOTE_NODE_1_OPERATOR_1);
+    assert_eq!(
+        vec![REMOTE_NODE_2_OPERATOR_1, REMOTE_NODE_3_OPERATOR_2],
+        filter_at_least(&unhealthy_nodes, 2)
+    );
+    // Too few healthy nodes left, all nodes retained.
+    assert_eq!(all_nodes, filter_at_least(&unhealthy_nodes, 3));
+
+    // All nodes unhealthy, all nodes retained.
+    unhealthy_nodes.observe_failure(REMOTE_NODE_2_OPERATOR_1);
+    unhealthy_nodes.observe_failure(REMOTE_NODE_3_OPERATOR_2);
+    assert_eq!(all_nodes, filter_at_least(&unhealthy_nodes, 1));
+
+    unhealthy_nodes.observe_success(REMOTE_NODE_2_OPERATOR_1);
+    assert_eq!(
+        vec![REMOTE_NODE_2_OPERATOR_1],
+        filter_at_least(&unhealthy_nodes, 1)
+    );
+    assert_eq!(Some(2), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+}
+
+#[test]
+fn unhealthy_nodes_expire() {
+    let metrics = MetricsRegistry::new();
+    // A zero TTL, i.e. entries expire as soon as they are recorded.
+    let unhealthy_nodes = UnhealthyNodes::new(Duration::ZERO, &metrics);
+
+    unhealthy_nodes.observe_failure(REMOTE_NODE_1_OPERATOR_1);
+
+    let mut nodes = vec![REMOTE_NODE_1_OPERATOR_1, REMOTE_NODE_2_OPERATOR_1];
+    unhealthy_nodes.filter_at_least(1, &mut nodes);
+    assert_eq!(
+        vec![REMOTE_NODE_1_OPERATOR_1, REMOTE_NODE_2_OPERATOR_1],
+        nodes
+    );
+    assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }

--- a/rs/xnet/payload_builder/src/tests.rs
+++ b/rs/xnet/payload_builder/src/tests.rs
@@ -61,6 +61,7 @@ fn resolve_xnet_endpoint(remote_node_index: u64, log: ReplicaLogger) -> Endpoint
         mock_gen_range_low(remote_node_index, 3),
         LOCAL_NODE,
         registry.clone(),
+        Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics)),
         &metrics,
         log.clone(),
     ));

--- a/rs/xnet/payload_builder/src/xnet_client_tests.rs
+++ b/rs/xnet/payload_builder/src/xnet_client_tests.rs
@@ -74,7 +74,7 @@ async fn query_success() {
         get(move || proto_axum_response::<_, pb::CertifiedStreamSlice>(slice.clone()));
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(&metrics, log), respond_with_slice).await
+        do_xnet_client_query(&make_xnet_client(&metrics, log), respond_with_slice).await
     })
     .await;
 
@@ -89,6 +89,35 @@ async fn query_success() {
     assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
+/// Tests that a successful query makes a previously unhealthy node healthy
+/// again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_success_resets_unhealthy_node() {
+    let metrics = MetricsRegistry::new();
+
+    let respond_with_server_error =
+        get(|| async { (StatusCode::SERVICE_UNAVAILABLE, b"Oops".to_vec()) });
+    let slice = get_stream_slice_for_testing();
+    let respond_with_slice =
+        get(move || proto_axum_response::<_, pb::CertifiedStreamSlice>(slice.clone()));
+
+    with_test_replica_logger(|log| async {
+        // Both queries go to `LOCAL_NODE`, regardless of the server they hit.
+        let xnet_client = make_xnet_client(&metrics, log);
+
+        do_xnet_client_query(&xnet_client, respond_with_server_error)
+            .await
+            .unwrap_err();
+        assert_eq!(Some(1), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+
+        do_xnet_client_query(&xnet_client, respond_with_slice)
+            .await
+            .unwrap();
+        assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_garbage_response() {
     let metrics = MetricsRegistry::new();
@@ -96,7 +125,7 @@ async fn query_garbage_response() {
     let respond_with_garbage = get(|| async { b"garbage".to_vec() });
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(&metrics, log), respond_with_garbage).await
+        do_xnet_client_query(&make_xnet_client(&metrics, log), respond_with_garbage).await
     })
     .await;
 
@@ -124,7 +153,7 @@ async fn query_invalid_proto() {
         get(move || proto_axum_response::<_, pb::CertifiedStreamSlice>(slice.clone()));
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(&metrics, log), respond_with_invalid_proto).await
+        do_xnet_client_query(&make_xnet_client(&metrics, log), respond_with_invalid_proto).await
     })
     .await;
 
@@ -146,10 +175,10 @@ async fn query_invalid_proto() {
 async fn query_no_content() {
     let metrics = MetricsRegistry::new();
 
-    let respond_with_garbage = get(|| async { StatusCode::NO_CONTENT });
+    let respond_with_no_content = get(|| async { StatusCode::NO_CONTENT });
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(&metrics, log), respond_with_garbage).await
+        do_xnet_client_query(&make_xnet_client(&metrics, log), respond_with_no_content).await
     })
     .await;
 
@@ -168,19 +197,19 @@ async fn query_no_content() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_error_response() {
+async fn query_server_error() {
     let metrics = MetricsRegistry::new();
 
-    let respond_with_error =
-        get(|| async { (StatusCode::INTERNAL_SERVER_ERROR, b"Oops".to_vec()) });
+    let respond_with_server_error =
+        get(|| async { (StatusCode::SERVICE_UNAVAILABLE, b"Oops".to_vec()) });
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(&metrics, log), respond_with_error).await
+        do_xnet_client_query(&make_xnet_client(&metrics, log), respond_with_server_error).await
     })
     .await;
 
     match result {
-        Err(XNetClientError::ErrorResponse(hyper::StatusCode::INTERNAL_SERVER_ERROR, _)) => (),
+        Err(XNetClientError::ErrorResponse(hyper::StatusCode::SERVICE_UNAVAILABLE, _)) => (),
         _ => panic!("Expecting Err(ErrorResponse(_)), got {result:?}"),
     }
     assert_eq!(
@@ -193,6 +222,38 @@ async fn query_error_response() {
     assert_eq!(Some(1), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
+/// A 416 response means that the node does not have the messages we asked for
+/// (e.g. because it is lagging behind), not that it is unhealthy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_range_not_satisfiable() {
+    let metrics = MetricsRegistry::new();
+
+    let respond_with_range_not_satisfiable =
+        get(|| async { (StatusCode::RANGE_NOT_SATISFIABLE, b"Oops".to_vec()) });
+
+    let result = with_test_replica_logger(|log| async {
+        do_xnet_client_query(
+            &make_xnet_client(&metrics, log),
+            respond_with_range_not_satisfiable,
+        )
+        .await
+    })
+    .await;
+
+    match result {
+        Err(XNetClientError::ErrorResponse(hyper::StatusCode::RANGE_NOT_SATISFIABLE, _)) => (),
+        _ => panic!("Expecting Err(ErrorResponse(_)), got {result:?}"),
+    }
+    assert_eq!(
+        metric_vec(&[
+            (&[("status", "success")], 0),
+            (&[("status", "ProxyDecodeError")], 0)
+        ]),
+        response_counts(&metrics)
+    );
+    assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_request_timeout() {
     let metrics = &MetricsRegistry::new();
@@ -202,7 +263,7 @@ async fn query_request_timeout() {
     });
 
     let result = with_test_replica_logger(|log| async {
-        do_xnet_client_query(make_xnet_client(metrics, log), sleep_when_responding).await
+        do_xnet_client_query(&make_xnet_client(metrics, log), sleep_when_responding).await
     })
     .await;
 
@@ -250,7 +311,7 @@ async fn query_request_failed() {
     let url = format!("http://{sa}").parse::<Uri>().unwrap();
 
     let result = with_test_replica_logger(|log| async {
-        do_async_query(make_xnet_client(metrics, log), url).await
+        do_async_query(&make_xnet_client(metrics, log), url).await
     })
     .await;
 
@@ -271,7 +332,7 @@ async fn query_request_failed() {
 /// Returns the result of invoking `xnet_client.query()` against an HTTP server
 /// in a spawned thread that processes a single request using `handle_request`.
 async fn do_xnet_client_query(
-    xnet_client: XNetClientImpl,
+    xnet_client: &XNetClientImpl,
     method_router: MethodRouter,
 ) -> Result<CertifiedStreamSlice, XNetClientError> {
     let router = Router::new().route("/", method_router);
@@ -286,7 +347,7 @@ async fn do_xnet_client_query(
 /// Helper for synchronously calling `query()` on the given `XNetClientImpl`,
 /// with the given URL.
 async fn do_async_query(
-    xnet_client: XNetClientImpl,
+    xnet_client: &XNetClientImpl,
     url: Uri,
 ) -> Result<CertifiedStreamSlice, XNetClientError> {
     let endpoint = EndpointLocator {

--- a/rs/xnet/payload_builder/src/xnet_client_tests.rs
+++ b/rs/xnet/payload_builder/src/xnet_client_tests.rs
@@ -3,6 +3,7 @@
 
 use super::test_fixtures::*;
 use super::*;
+use crate::proximity::METRIC_UNHEALTHY_NODES;
 use axum::{
     Router,
     http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
@@ -14,7 +15,9 @@ use ic_crypto_tls_interfaces_mocks::MockTlsConfig;
 use ic_protobuf::messaging::xnet::v1 as pb;
 use ic_protobuf::proxy::ProxyDecodeError;
 use ic_test_utilities_logger::with_test_replica_logger;
-use ic_test_utilities_metrics::{MetricVec, fetch_histogram_vec_count, metric_vec};
+use ic_test_utilities_metrics::{
+    MetricVec, fetch_histogram_vec_count, fetch_int_gauge, metric_vec,
+};
 use ic_test_utilities_types::ids::SUBNET_6;
 use ic_types::{SubnetId, xnet::CertifiedStreamSlice};
 use std::{net::SocketAddr, sync::Arc};
@@ -46,10 +49,18 @@ where
 
 fn make_xnet_client(metrics: &MetricsRegistry, log: ReplicaLogger) -> XNetClientImpl {
     let registry = get_simple_registry_for_test();
+    let unhealthy_nodes = Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, metrics));
     XNetClientImpl::new(
         metrics,
         Arc::new(MockTlsConfig::new()) as Arc<_>,
-        Arc::new(ProximityMap::new(LOCAL_NODE, registry, metrics, log)),
+        Arc::new(ProximityMap::new(
+            LOCAL_NODE,
+            registry,
+            unhealthy_nodes.clone(),
+            metrics,
+            log,
+        )),
+        unhealthy_nodes,
     )
 }
 
@@ -75,6 +86,7 @@ async fn query_success() {
         ]),
         response_counts(&metrics)
     );
+    assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -99,6 +111,7 @@ async fn query_garbage_response() {
         ]),
         response_counts(&metrics)
     );
+    assert_eq!(Some(1), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -126,6 +139,7 @@ async fn query_invalid_proto() {
         ]),
         response_counts(&metrics)
     );
+    assert_eq!(Some(1), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -150,6 +164,7 @@ async fn query_no_content() {
         ]),
         response_counts(&metrics)
     );
+    assert_eq!(Some(0), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -175,6 +190,7 @@ async fn query_error_response() {
         ]),
         response_counts(&metrics)
     );
+    assert_eq!(Some(1), fetch_int_gauge(&metrics, METRIC_UNHEALTHY_NODES));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -201,6 +217,7 @@ async fn query_request_timeout() {
         ]),
         response_counts(metrics)
     );
+    assert_eq!(Some(1), fetch_int_gauge(metrics, METRIC_UNHEALTHY_NODES));
 }
 
 // For some reason `bind()` on Darwin behaves the same as `bind() + listen()`,
@@ -248,6 +265,7 @@ async fn query_request_failed() {
         ]),
         response_counts(metrics)
     );
+    assert_eq!(Some(1), fetch_int_gauge(metrics, METRIC_UNHEALTHY_NODES));
 }
 
 /// Returns the result of invoking `xnet_client.query()` against an HTTP server

--- a/rs/xnet/payload_builder/tests/xnet_payload_builder.rs
+++ b/rs/xnet/payload_builder/tests/xnet_payload_builder.rs
@@ -1011,6 +1011,7 @@ fn refill_pool_empty(
         let proximity_map = Arc::new(ProximityMap::new(
             OWN_NODE,
             registry.clone(),
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics_registry)),
             &metrics_registry,
             log.clone(),
         ));
@@ -1141,6 +1142,7 @@ fn refill_pool_append(
         let proximity_map = Arc::new(ProximityMap::new(
             OWN_NODE,
             registry.clone(),
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics_registry)),
             &metrics_registry,
             log.clone(),
         ));
@@ -1240,6 +1242,7 @@ fn refill_pool_put_invalid_slice(
         let proximity_map = Arc::new(ProximityMap::new(
             OWN_NODE,
             registry.clone(),
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics_registry)),
             &metrics_registry,
             log.clone(),
         ));
@@ -1370,6 +1373,7 @@ fn refill_pool_append_invalid_slice(
         let proximity_map = Arc::new(ProximityMap::new(
             OWN_NODE,
             registry.clone(),
+            Arc::new(UnhealthyNodes::new(UNHEALTHY_NODE_TTL, &metrics_registry)),
             &metrics_registry,
             log.clone(),
         ));


### PR DESCRIPTION
Both for stream polling (where we otherwise pick an unhealthy node with the same probability as a healthy one); and, in the future, for adverts (where we want to make it more likely for healthy nodes to learn our stream header); maintain a set of recently (10s) unhealthy nodes to be avoided.

Hook it into `XNetClientImpl` (to update the set) and into `ProximityMap` (to avoid unhealthy nodes when picking).