### PR TITLE
fix: Use the same registry version in `CatchUpPackageParam` and verification 

### DIFF
--- a/rs/consensus/cup_utils/src/lib.rs
+++ b/rs/consensus/cup_utils/src/lib.rs
@@ -251,7 +251,8 @@ mod tests {
     use ic_interfaces_registry::{RegistryClient, RegistryVersionedRecord};
     use ic_logger::no_op_logger;
     use ic_protobuf::registry::subnet::v1::{
-        CatchUpPackageContents, RecoveryArgs, SubnetRecord, catch_up_package_contents::CupType,
+        CatchUpPackageContents, RecoveryArgs, RegistryStoreUri, SubnetRecord,
+        catch_up_package_contents::CupType,
     };
     use ic_types::{
         Height, NodeId, PrincipalId, RegistryVersion, ReplicaVersion, Time,
@@ -261,9 +262,12 @@ mod tests {
     };
     use ic_types_test_utils::ids::subnet_test_id;
 
-    #[test]
-    fn test_make_registry_cup() {
-        let registry_client = MockRegistryClient::new(RegistryVersion::from(12345), |key, _| {
+    const LATEST_REGISTRY_VERSION: RegistryVersion = RegistryVersion::new(12345);
+
+    /// Builds a registry client serving the CUP contents and the subnet record which
+    /// [`make_registry_cup`] needs, with the given `registry_store_uri` in the CUP contents.
+    fn setup_registry(registry_store_uri: Option<RegistryStoreUri>) -> impl RegistryClient {
+        MockRegistryClient::new(LATEST_REGISTRY_VERSION, move |key, _| {
             use prost::Message;
             if key.starts_with("catch_up_package_contents_") {
                 // Build a dummy cup
@@ -279,7 +283,7 @@ mod tests {
                         height: 54321,
                         time: 1,
                         state_hash: vec![1, 2, 3, 4, 5],
-                        registry_store_uri: None,
+                        registry_store_uri: registry_store_uri.clone(),
                         ecdsa_initializations: vec![],
                         chain_key_initializations: vec![],
                         cup_type: Some(CupType::Recovery(RecoveryArgs {
@@ -310,7 +314,12 @@ mod tests {
             } else {
                 None
             }
-        });
+        })
+    }
+
+    #[test]
+    fn test_make_registry_cup() {
+        let registry_client = setup_registry(/*registry_store_uri=*/ None);
         let result =
             make_registry_cup(&registry_client, subnet_test_id(0), &no_op_logger()).unwrap();
 
@@ -320,7 +329,7 @@ mod tests {
         );
         assert_eq!(
             result.content.block.get_value().context.registry_version,
-            RegistryVersion::from(12345)
+            LATEST_REGISTRY_VERSION
         );
         assert_eq!(
             result.content.block.get_value().context.certified_height,
@@ -331,6 +340,37 @@ mod tests {
             &ReplicaVersion::from_str("TestID").unwrap()
         );
         assert_eq!(result.signature.signer.dealer_subnet, subnet_test_id(0));
+    }
+
+    /// A registry CUP must reference the same registry version in the DKG summary of its block and
+    /// in that block's validation context.
+    #[test]
+    fn test_registry_cup_registry_versions_agree() {
+        for registry_store_uri in [
+            None,
+            Some(RegistryStoreUri {
+                uri: "https://localhost/registry.tar.gz".to_string(),
+                hash: "".to_string(),
+                registry_version: 999,
+            }),
+        ] {
+            let expected_registry_version = registry_store_uri
+                .as_ref()
+                .map(|uri| RegistryVersion::from(uri.registry_version))
+                .unwrap_or(LATEST_REGISTRY_VERSION);
+
+            let registry_client = setup_registry(registry_store_uri.clone());
+            let cup = make_registry_cup(&registry_client, subnet_test_id(0), &no_op_logger())
+                .expect("Failed to create the registry CUP");
+
+            assert_eq!(
+                cup.content.registry_version(),
+                cup.content.block.get_value().context.registry_version,
+                "Registry versions of the DKG summary and the block context disagree \
+                 for registry_store_uri {registry_store_uri:?}"
+            );
+            assert_eq!(cup.content.registry_version(), expected_registry_version);
+        }
     }
 
     /// `RegistryClient` implementation that allows to provide a custom function

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -1200,6 +1200,23 @@ mod tests {
                 let expected_block = post_split_block(expected_new_subnet_id);
                 let other_block = post_split_block(other_subnet_id);
 
+                // Like a genesis or recovery CUP block, a post-split block is built from registry
+                // CUP contents, and records the same registry version in its DKG summary and in
+                // its validation context.
+                assert_eq!(
+                    expected_block
+                        .payload
+                        .as_ref()
+                        .as_summary()
+                        .dkg
+                        .registry_version,
+                    expected_block.context.registry_version,
+                );
+                assert_eq!(
+                    expected_block.context.registry_version,
+                    SPLITTING_REGISTRY_VERSION,
+                );
+
                 // The DKG transcripts of the post-split block are the ones of the subnet the node
                 // lands on, i.e. their committee is that subnet's membership ...
                 let expected_committee =

--- a/rs/orchestrator/src/catch_up_package_provider.rs
+++ b/rs/orchestrator/src/catch_up_package_provider.rs
@@ -715,8 +715,6 @@ pub(crate) mod tests {
         let context_registry_version = RegistryVersion::from(7);
         let cup_proto =
             cup_with_distinct_registry_versions(summary_registry_version, context_registry_version);
-        // Guards the premise of this test: the CUP must actually distinguish the two fields.
-        assert_ne!(summary_registry_version, context_registry_version);
 
         let server_addr =
             start_server(TestService::SendCup(Arc::new(cup_proto.encode_to_vec()))).await;

--- a/rs/orchestrator/src/catch_up_package_provider.rs
+++ b/rs/orchestrator/src/catch_up_package_provider.rs
@@ -293,7 +293,7 @@ impl CatchUpPackageProvider {
                 &CombinedThresholdSigOf::new(CombinedThresholdSig(protobuf.signature.clone())),
                 &CatchUpContentProtobufBytes::from(&protobuf),
                 subnet_id,
-                cup.content.block.get_value().context.registry_version,
+                cup.content.registry_version(),
             )
             .map_err(|e| format!("Failed to verify CUP signature at: {uri:?} with: {e:?}"))?;
 
@@ -536,11 +536,22 @@ pub(crate) mod tests {
     use ic_crypto_test_utils_crypto_returning_ok::CryptoReturningOk;
     use ic_crypto_tls_interfaces_mocks::MockTlsConfig;
     use ic_logger::no_op_logger;
+    use ic_protobuf::registry::node::v1::ConnectionEndpoint;
     use ic_registry_client_fake::FakeRegistryClient;
     use ic_registry_keys::make_node_record_key;
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
+    use ic_test_utilities_consensus::fake::{Fake, FakeContent};
     use ic_test_utilities_registry::{SubnetRecordBuilder, add_single_subnet_record};
     use ic_test_utilities_types::ids::{SUBNET_0, node_test_id};
+    use ic_types::{
+        ReplicaVersion,
+        batch::ValidationContext,
+        consensus::{
+            Block, BlockPayload, CatchUpContent, HashedBlock, HashedRandomBeacon, Payload,
+            RandomBeacon, RandomBeaconContent, Rank, SummaryPayload, dkg::DkgSummary,
+        },
+        time::UNIX_EPOCH,
+    };
     use rcgen::{CertificateParams, KeyPair};
     use rustls::{
         ClientConfig, DigitallySignedStruct, ServerConfig, SignatureScheme,
@@ -566,6 +577,8 @@ pub(crate) mod tests {
         NoContent,
         /// Service that responds with an error
         BadRequest,
+        /// Service that serves the given serialized CUP
+        SendCup(Arc<Vec<u8>>),
     }
 
     async fn test_service(
@@ -576,7 +589,17 @@ pub(crate) mod tests {
             TestService::Unresponsive => unresponsive_service().await,
             TestService::NoContent => no_content_service().await,
             TestService::BadRequest => error_service().await,
+            TestService::SendCup(cup) => cup_service(cup).await,
         }
+    }
+
+    async fn cup_service(
+        cup: Arc<Vec<u8>>,
+    ) -> Result<Response<BoxBody<Bytes, Infallible>>, hyper::Error> {
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::from(cup.to_vec())).boxed())
+            .unwrap())
     }
 
     async fn slow_body_service(
@@ -616,6 +639,120 @@ pub(crate) mod tests {
             .status(StatusCode::BAD_REQUEST)
             .body(Full::new(Bytes::from("error message")).boxed())
             .unwrap())
+    }
+
+    /// A [`ThresholdSigVerifierByPublicKey`] that accepts every signature and records the registry
+    /// version it was asked to verify at.
+    #[derive(Default)]
+    struct RegistryVersionRecordingCrypto {
+        verified_at: Mutex<Option<RegistryVersion>>,
+    }
+
+    impl ThresholdSigVerifierByPublicKey<CatchUpContentProtobufBytes>
+        for RegistryVersionRecordingCrypto
+    {
+        fn verify_combined_threshold_sig_by_public_key(
+            &self,
+            _signature: &CombinedThresholdSigOf<CatchUpContentProtobufBytes>,
+            _message: &CatchUpContentProtobufBytes,
+            _subnet_id: SubnetId,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()> {
+            *self.verified_at.lock().unwrap() = Some(registry_version);
+            Ok(())
+        }
+    }
+
+    /// Builds a CUP whose DKG summary registry version differs from the registry version of its
+    /// block's validation context.
+    fn cup_with_distinct_registry_versions(
+        summary_registry_version: RegistryVersion,
+        context_registry_version: RegistryVersion,
+    ) -> pb::CatchUpPackage {
+        let height = Height::from(10);
+        let replica_version = ReplicaVersion::try_from("test").unwrap();
+
+        let mut dkg = DkgSummary::fake();
+        dkg.registry_version = summary_registry_version;
+
+        let block = Block::new(
+            CryptoHashOf::from(CryptoHash(vec![])),
+            Payload::new(
+                crypto_hash,
+                BlockPayload::Summary(SummaryPayload { dkg, idkg: None }),
+            ),
+            height,
+            Rank(0),
+            ValidationContext {
+                certified_height: height,
+                registry_version: context_registry_version,
+                time: UNIX_EPOCH,
+            },
+            replica_version.clone(),
+        );
+
+        let random_beacon = RandomBeacon::fake(RandomBeaconContent {
+            version: replica_version,
+            height,
+            parent: CryptoHashOf::from(CryptoHash(vec![])),
+        });
+
+        let cup = CatchUpPackage::fake(CatchUpContent::new(
+            HashedBlock::new(crypto_hash, block),
+            HashedRandomBeacon::new(crypto_hash, random_beacon),
+            CryptoHashOf::from(CryptoHash(vec![])),
+            /*oldest_registry_version_in_use_by_replicated_state=*/ None,
+        ));
+
+        pb::CatchUpPackage::from(cup)
+    }
+
+    /// The registry version at which a peer CUP's signature is verified must be the same one that
+    /// [`CatchUpPackageParam`] orders by, i.e. the DKG summary's registry version.
+    #[tokio::test]
+    async fn test_peer_cup_is_verified_at_the_dkg_summary_registry_version() {
+        let summary_registry_version = RegistryVersion::from(3);
+        let context_registry_version = RegistryVersion::from(7);
+        let cup_proto =
+            cup_with_distinct_registry_versions(summary_registry_version, context_registry_version);
+        // Guards the premise of this test: the CUP must actually distinguish the two fields.
+        assert_ne!(summary_registry_version, context_registry_version);
+
+        let server_addr =
+            start_server(TestService::SendCup(Arc::new(cup_proto.encode_to_vec()))).await;
+        let node_id = node_test_id(1);
+        let node_record = NodeRecord {
+            http: Some(ConnectionEndpoint {
+                ip_addr: server_addr.ip().to_string(),
+                port: server_addr.port() as u32,
+            }),
+            ..Default::default()
+        };
+
+        let crypto = Arc::new(RegistryVersionRecordingCrypto::default());
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let mut cup_provider = make_cup_provider_with_crypto(
+            tmp_dir.path().to_path_buf(),
+            node_id,
+            Duration::from_secs(5),
+            setup_registry(),
+            crypto.clone(),
+        );
+
+        let (_, cup) = cup_provider
+            .fetch_and_verify_catch_up_package(&node_id, &node_record, None, SUBNET_0)
+            .await
+            .expect("failed to fetch and verify the CUP")
+            .expect("expected a CUP to be served");
+
+        assert_eq!(
+            *crypto.verified_at.lock().unwrap(),
+            Some(summary_registry_version)
+        );
+        assert_eq!(
+            CatchUpPackageParam::from(&cup),
+            CatchUpPackageParam::from(&CatchUpPackage::try_from(&cup_proto).unwrap()),
+        );
     }
 
     fn fake_cup() -> pb::CatchUpPackage {
@@ -786,10 +923,26 @@ pub(crate) mod tests {
         backoff: Duration,
         registry: Arc<RegistryHelper>,
     ) -> CatchUpPackageProvider {
+        make_cup_provider_with_crypto(
+            cup_dir,
+            node_id,
+            backoff,
+            registry,
+            Arc::new(CryptoReturningOk::default()),
+        )
+    }
+
+    fn make_cup_provider_with_crypto(
+        cup_dir: PathBuf,
+        node_id: NodeId,
+        backoff: Duration,
+        registry: Arc<RegistryHelper>,
+        crypto: Arc<dyn ThresholdSigVerifierByPublicKey<CatchUpContentProtobufBytes> + Send + Sync>,
+    ) -> CatchUpPackageProvider {
         CatchUpPackageProvider::new_with_initial_backoff(
             registry,
             LocalCUPReader::new(cup_dir, no_op_logger()),
-            Arc::new(CryptoReturningOk::default()),
+            crypto,
             Arc::new(mock_tls_config()),
             no_op_logger(),
             node_id,

--- a/rs/orchestrator/src/catch_up_package_provider.rs
+++ b/rs/orchestrator/src/catch_up_package_provider.rs
@@ -743,10 +743,9 @@ pub(crate) mod tests {
             .expect("failed to fetch and verify the CUP")
             .expect("expected a CUP to be served");
 
-        assert_eq!(
-            *crypto.verified_at.lock().unwrap(),
-            Some(summary_registry_version)
-        );
+        let verified_at = *crypto.verified_at.lock().unwrap();
+        assert_eq!(verified_at, Some(summary_registry_version));
+        assert_ne!(verified_at, Some(context_registry_version));
         assert_eq!(
             CatchUpPackageParam::from(&cup),
             CatchUpPackageParam::from(&CatchUpPackage::try_from(&cup_proto).unwrap()),


### PR DESCRIPTION
The orchestrator only fetches a CUP if it has a higher height and registry version than the local CUP. Here, the relevant registry version is the one of the DKG summary.

However, when validating the CUPs signature, we used the version of the validation context, which in principal could be smaller than the one of the DKG summary. This could lead to the CUP being verified with an old public key from the registry.

With this PR, we also use the registry version of the DKG summary for signature verification. This is fine, since under normal operation, both versions should always point to the same public key:

1. The public key can only change via recovery and subnet splitting, during which both versions are equal. 
2. A recovery CUP may only be adopted if the subnet is stalled, it is therefore not possible to create a summary whose validation context points to the new key, while the DKG version still points to the old key.
3. During a subnet split, the version of the validation context is intentionally frozen to one version below the one introducing the new key. The "scheduled split" summary (which bumps the context's version to the new key) is never part of a CUP. Instead, a new summary is derived for which both versions point to the new key (like in a recovery).