### PR TITLE
feat(cketh): sign the authorizations a batched sweep needs

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -791,6 +791,14 @@ type Event = record {
             r : blob;
             s : blob;
         };
+        AuthorizedDepositAddress : record {
+            owner : principal;
+            subaccount : opt blob;
+            // The tuple the deposit address signed, delegating its code to the
+            // sweeper contract. Its nonce is always zero: the delegation is
+            // installed the first time the tuple is applied.
+            authorization : SignedAuthorization;
+        };
     };
 };
 

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -573,6 +573,11 @@ pub mod events {
             /// 32-byte signature component.
             s: ByteBuf,
         },
+        AuthorizedDepositAddress {
+            owner: Principal,
+            subaccount: Option<ByteBuf>,
+            authorization: SignedAuthorization,
+        },
         AcceptedSweepRequest {
             sweep_id: Nat,
             destination: String,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1297,6 +1297,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                 )?;
 
                 w.encode_gauge(
+                    "cketh_minter_stored_authorizations",
+                    s.automatic_deposits.authorizations_len() as f64,
+                    "Number of delegation authorizations the minter has signed and stored.",
+                )?;
+
+                w.encode_gauge(
                     "cketh_minter_last_max_fee_per_gas",
                     s.last_transaction_price_estimate
                         .clone()

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -999,6 +999,16 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                         s: ByteBuf::from(signature.s.to_be_bytes()),
                     }
                 }
+                EventType::AuthorizedDepositAddress { request, signature } => {
+                    let account = request.account();
+                    EP::AuthorizedDepositAddress {
+                        owner: account.owner,
+                        subaccount: account.subaccount.map(ByteBuf::from),
+                        authorization: map_authorizations(&[request.signed_with(signature)])
+                            .pop()
+                            .expect("BUG: one authorization in, one out"),
+                    }
+                }
                 EventType::AcceptedSweepRequest(SweepRequest {
                     id,
                     destination,

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -18,6 +18,7 @@ use crate::state::eth_logs_scraping::{LogScrapingId, LogScrapings};
 use crate::state::sweeper_funding::{SweeperFundingAccounting, SweeperFundingConfig};
 use crate::state::transactions::{Erc20WithdrawalRequest, TransactionCallData, WithdrawalRequest};
 use crate::timed_sized_map::{Entry, Timestamp};
+use crate::tx::AuthorizationRequest;
 use crate::tx::GasFeeEstimate;
 use crate::tx::TransactionSignature;
 use candid::Principal;
@@ -291,6 +292,36 @@ impl State {
                         self.ethereum_network.chain_id(),
                         deposit_helper,
                         *account.as_ref(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// What every deposit address in `accounts` authorizes to let the configured sweeper contract
+    /// sweep it: the tuple naming this minter's chain, that contract, and nonce zero. `None` while
+    /// no sweeper contract is configured.
+    ///
+    /// The nonce is always zero, whatever the address actually holds. A deposit address is at
+    /// nonce zero exactly while it has never been delegated — applying an authorization spends it
+    /// — so the tuple either installs the delegation or is skipped, and both are correct in any
+    /// order the sweeps carrying them land. That is what lets a sweep authorize every address it
+    /// touches without tracking which ones are already delegated, at the price of the intrinsic
+    /// gas a skipped tuple still costs.
+    pub fn authorization_requests<T: AsRef<Account>>(
+        &self,
+        accounts: &[T],
+    ) -> Option<Vec<AuthorizationRequest>> {
+        let delegate = self.sweeper_contract_address?;
+        Some(
+            accounts
+                .iter()
+                .map(|account| {
+                    AuthorizationRequest::new(
+                        *account.as_ref(),
+                        self.ethereum_network.chain_id(),
+                        delegate,
+                        TransactionNonce::ZERO,
                     )
                 })
                 .collect(),

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -114,6 +114,11 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         EventType::AttestedDepositAddress { request, signature } => {
             state.record_attestation(request.clone(), signature.clone());
         }
+        EventType::AuthorizedDepositAddress { request, signature } => {
+            state
+                .automatic_deposits
+                .record_authorization(request.clone(), signature.clone());
+        }
         EventType::AcceptedSweepRequest(request) => {
             state.next_sweep_id = request.id.next();
             state

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -16,9 +16,9 @@ use crate::state::transactions::{
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
-    AccessList, AccessListItem, DelegatingSweep, Eip1559TransactionRequest, SignedAuthorization,
-    SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
-    StorageKey, SweepTransaction, TransactionSignature,
+    AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
+    SignedAuthorization, SignedEip1559TransactionRequest, SignedEip7702TransactionRequest,
+    SignedSweepTransaction, StorageKey, SweepTransaction, TransactionSignature,
 };
 use candid::Principal;
 use ic_agent::identity::AnonymousIdentity;
@@ -455,6 +455,34 @@ impl GetEventsFile {
                         s: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(s.as_slice()).unwrap()),
                     },
                 },
+                EventPayload::AuthorizedDepositAddress {
+                    owner,
+                    subaccount,
+                    authorization,
+                } => {
+                    let account = Account {
+                        owner,
+                        subaccount: subaccount.map(|subaccount| {
+                            <[u8; 32]>::try_from(subaccount.into_vec().as_slice()).unwrap()
+                        }),
+                    };
+                    let authorization = map_authorizations(vec![authorization])
+                        .pop()
+                        .expect("BUG: one authorization in, one out");
+                    ET::AuthorizedDepositAddress {
+                        request: AuthorizationRequest::new(
+                            account,
+                            authorization.chain_id,
+                            authorization.delegate,
+                            authorization.nonce,
+                        ),
+                        signature: TransactionSignature {
+                            signature_y_parity: authorization.y_parity,
+                            r: authorization.r,
+                            s: authorization.s,
+                        },
+                    }
+                }
                 EventPayload::AcceptedSweepRequest {
                     sweep_id,
                     destination,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -77,6 +77,10 @@ pub struct AutomaticDeposits {
     /// signature only delegates the chain, the sweeper contract and the nonce its request names, so
     /// re-pointing the minter at another sweeper contract misses this map rather than reusing a
     /// tuple that delegates the old one.
+    ///
+    /// Nothing prunes this map: it grows with the number of accounts that have ever been swept, and
+    /// entries naming a retired helper stay behind forever. [`Self::authorizations_len`] is exported
+    /// as a metric so that growth is visible before it needs bounding.
     authorizations: BTreeMap<AuthorizationRequest, TransactionSignature>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
@@ -460,6 +464,10 @@ impl AutomaticDeposits {
 
     pub fn attestations_len(&self) -> usize {
         self.attestations.len()
+    }
+
+    pub fn authorizations_len(&self) -> usize {
+        self.authorizations.len()
     }
 
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -12,7 +12,9 @@ use crate::state::transactions::{
     ResubmitTransactionError, SweepId, SweepRequest, SweeperTransactionPipeline,
 };
 use crate::timed_sized_map::{Entry, InsertError, TimedSizedMap, Timestamp};
-use crate::tx::{Finalized, GasFeeEstimate, Signed, SweepTransaction, TransactionSignature};
+use crate::tx::{
+    AuthorizationRequest, Finalized, GasFeeEstimate, Signed, SweepTransaction, TransactionSignature,
+};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
@@ -71,6 +73,11 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::attestations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     attestations: BTreeMap<AttestationRequest, TransactionSignature>,
+    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed. A
+    /// signature only delegates the chain, the sweeper contract and the nonce its request names, so
+    /// re-pointing the minter at another sweeper contract misses this map rather than reusing a
+    /// tuple that delegates the old one.
+    authorizations: BTreeMap<AuthorizationRequest, TransactionSignature>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -184,12 +191,14 @@ impl AutomaticDeposits {
             watchlist,
             sweep,
             attestations,
+            authorizations,
             sweeper_transactions,
         } = self;
 
         ensure_eq!(watchlist, &other.watchlist);
         ensure_eq!(sweep, &other.sweep);
         ensure_eq!(attestations, &other.attestations);
+        ensure_eq!(authorizations, &other.authorizations);
         sweeper_transactions.is_equivalent_to(&other.sweeper_transactions)
     }
 
@@ -205,6 +214,20 @@ impl AutomaticDeposits {
         signature: TransactionSignature,
     ) {
         self.attestations.insert(request, signature);
+    }
+
+    /// The authorization already stored for `account`, if any: signing another would cost a
+    /// threshold-ECDSA signature for the same tuple.
+    pub fn authorization(&self, request: &AuthorizationRequest) -> Option<&TransactionSignature> {
+        self.authorizations.get(request)
+    }
+
+    pub fn record_authorization(
+        &mut self,
+        request: AuthorizationRequest,
+        signature: TransactionSignature,
+    ) {
+        self.authorizations.insert(request, signature);
     }
 
     /// Arm the `(account, token)` pair, whose deposit `address` is derived for `account`.
@@ -498,6 +521,7 @@ impl Default for AutomaticDeposits {
             watchlist: TimedSizedMap::new(DEPOSIT_ADDRESS_SCAN_WINDOW, MAX_ACTIVE_DEPOSITS),
             sweep: BTreeMap::new(),
             attestations: BTreeMap::new(),
+            authorizations: BTreeMap::new(),
             sweeper_transactions: SweeperTransactionPipeline::new(TransactionNonce::ZERO),
         }
     }

--- a/rs/ethereum/cketh/minter/src/state/event.rs
+++ b/rs/ethereum/cketh/minter/src/state/event.rs
@@ -11,8 +11,8 @@ use crate::state::transactions::{
 };
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
-    Eip1559TransactionRequest, SignedEip1559TransactionRequest, SignedSweepTransaction,
-    SweepTransaction, TransactionSignature,
+    AuthorizationRequest, Eip1559TransactionRequest, SignedEip1559TransactionRequest,
+    SignedSweepTransaction, SweepTransaction, TransactionSignature,
 };
 use candid::Principal;
 use ic_ethereum_types::Address;
@@ -234,6 +234,18 @@ pub enum EventType {
         /// usable for the chain, the deposit helper and the account named here.
         #[n(0)]
         request: AttestationRequest,
+        #[n(1)]
+        signature: TransactionSignature,
+    },
+    /// A deposit address authorized the sweeper contract to run as its code. Signing costs a
+    /// threshold-ECDSA signature, so the tuple is recorded and every later sweep of the same
+    /// address reuses it rather than signing another.
+    #[n(34)]
+    AuthorizedDepositAddress {
+        /// What was signed, which is also what replay keys the authorization by: a signature is
+        /// only usable for the chain, the delegate and the nonce named here.
+        #[n(0)]
+        request: AuthorizationRequest,
         #[n(1)]
         signature: TransactionSignature,
     },

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -14,23 +14,19 @@ mod tests;
 
 use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::{
-    deposit_address::{DepositAddressSchema, deposit_derivation_path, sweeper_derivation_path},
+    deposit_address::sweeper_derivation_path,
     guard::TimerGuard,
     logs::{DEBUG, INFO},
-    numeric::{GasAmount, TransactionCount, TransactionNonce},
+    numeric::{GasAmount, TransactionCount},
     runtime::CanisterRuntime,
     state::{
         State, TaskType,
         audit::{EventType, process_event},
-        automatic_deposits::SweepTarget,
         mutate_state, read_state,
         transactions::{CreateSweepTransactionError, PipelineRequest},
     },
     time::TimeProvider,
-    tx::{
-        AuthorizationRequest, GasFeeEstimate, SignedAuthorization, lazy_refresh_gas_fee_estimate,
-        sign_digest,
-    },
+    tx::{AuthorizationRequest, GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -39,8 +35,7 @@ use crate::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use icrc_ledger_types::icrc1::account::Account;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 /// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
 /// with the real delegate sweep call.
@@ -65,13 +60,13 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         }
     };
 
-    let Some(sweeper_contract) = read_state(|s| s.sweeper_contract_address) else {
+    if read_state(|s| s.sweeper_contract_address).is_none() {
         log!(
             DEBUG,
             "[create_pending_sweeper_requests]: SKIPPING: no sweeper contract address is configured"
         );
         return;
-    };
+    }
 
     let batch_per_token =
         read_state(|s| s.automatic_deposits.requests_batch(MAX_DEPOSITS_PER_SWEEP));
@@ -95,8 +90,16 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             );
             return;
         };
+        let Some(authorization_requests) = read_state(|s| s.authorization_requests(&targets))
+        else {
+            log!(
+                DEBUG,
+                "[create_pending_sweeper_requests]: SKIPPING: the sweeper contract address was cleared while enqueueing"
+            );
+            return;
+        };
         sign_attestations_batch(attestation_requests, runtime).await;
-        let _authorizations = sign_authorizations_batch(&targets, sweeper_contract, runtime).await;
+        sign_authorizations_batch(authorization_requests, runtime).await;
     }
 }
 
@@ -140,49 +143,26 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
     }
 }
 
-/// One authorization per attested deposit address, keyed by the account it delegates.
+/// Signs the authorizations in `requests` that the minter has not signed before, recording each so
+/// a later sweep of the same address reuses it.
 ///
-/// Only attested addresses are signed: a deposit that could not be attested drops out of the sweep
-/// anyway, so authorizing it would spend a signature on nothing. A tuple already recorded for the
-/// address is reused rather than signed again — it names nonce 0, so it stays applicable for every
-/// later sweep, see [`AuthorizationRequest`].
+/// A request names the chain, the delegate and the nonce it authorizes, so re-pointing the minter
+/// at another sweeper contract misses the recorded ones and signs afresh.
 async fn sign_authorizations_batch<R: CanisterRuntime>(
-    targets: &[SweepTarget],
-    sweeper_contract: Address,
+    requests: Vec<AuthorizationRequest>,
     runtime: &R,
-) -> BTreeMap<Account, SignedAuthorization> {
-    let chain_id = read_state(State::ethereum_network).chain_id();
-    let (mut authorizations, to_sign): (BTreeMap<Account, SignedAuthorization>, Vec<_>) =
-        read_state(|s| {
-            let mut stored = BTreeMap::new();
-            let mut to_sign = Vec::new();
-            for request in targets
-                .iter()
-                .map(SweepTarget::account)
-                .filter(|account| s.attestation(*account).is_some())
-                .map(|account| {
-                    AuthorizationRequest::new(
-                        account,
-                        chain_id,
-                        sweeper_contract,
-                        TransactionNonce::ZERO,
-                    )
-                })
-            {
-                match s.automatic_deposits.authorization(&request) {
-                    Some(signature) => {
-                        stored.insert(request.account(), request.signed_with(signature.clone()));
-                    }
-                    None => to_sign.push(request),
-                }
-            }
-            (stored, to_sign)
-        });
+) {
+    let requests_to_sign: BTreeSet<_> = read_state(|s| {
+        requests
+            .into_iter()
+            .filter(|request| s.automatic_deposits.authorization(request).is_none())
+            .collect()
+    });
 
-    let signing_results = join_all(to_sign.into_iter().map(|request| async move {
+    let signing_results = join_all(requests_to_sign.into_iter().map(|request| async move {
         let signature = sign_digest(
             &request.authorization().hash(),
-            &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account()),
+            &request.derivation_path(),
             runtime,
         )
         .await;
@@ -194,7 +174,6 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
     for (request, signing_result) in signing_results {
         match signing_result {
             Ok(signature) => {
-                authorizations.insert(request.account(), request.signed_with(signature.clone()));
                 mutate_state(|s| {
                     process_event(
                         s,
@@ -203,7 +182,7 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
                     )
                 });
             }
-            Err(e) => errors.push((request.account(), e)),
+            Err(e) => errors.push((request, e)),
         }
     }
 
@@ -213,7 +192,6 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
             "[create_pending_sweeper_requests]: leaving out the deposits this sweep could not authorize: {errors:?}"
         );
     }
-    authorizations
 }
 
 pub async fn process_sweeper_transactions<R: CanisterRuntime>(runtime: R) {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -14,19 +14,20 @@ mod tests;
 
 use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::{
-    deposit_address::sweeper_derivation_path,
+    deposit_address::{DepositAddressSchema, deposit_derivation_path, sweeper_derivation_path},
     guard::TimerGuard,
     logs::{DEBUG, INFO},
-    numeric::{GasAmount, TransactionCount},
+    numeric::{GasAmount, TransactionCount, TransactionNonce},
     runtime::CanisterRuntime,
     state::{
         State, TaskType,
         audit::{EventType, process_event},
+        automatic_deposits::SweepTarget,
         mutate_state, read_state,
         transactions::{CreateSweepTransactionError, PipelineRequest},
     },
     time::TimeProvider,
-    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate},
+    tx::{Authorization, GasFeeEstimate, SignedAuthorization, lazy_refresh_gas_fee_estimate},
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -35,7 +36,8 @@ use crate::{
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use std::collections::BTreeSet;
+use icrc_ledger_types::icrc1::account::Account;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
 /// with the real delegate sweep call.
@@ -60,7 +62,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         }
     };
 
-    let Some(_sweeper_contract) = read_state(|s| s.sweeper_contract_address) else {
+    let Some(sweeper_contract) = read_state(|s| s.sweeper_contract_address) else {
         log!(
             DEBUG,
             "[create_pending_sweeper_requests]: SKIPPING: no sweeper contract address is configured"
@@ -91,6 +93,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             return;
         };
         sign_attestations_batch(attestation_requests, runtime).await;
+        let _authorizations = sign_authorizations_batch(&targets, sweeper_contract, runtime).await;
     }
 }
 
@@ -131,6 +134,87 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
             INFO,
             "[create_pending_sweeper_requests]: leaving out the deposits this sweep could not attest: {errors:?}"
         );
+    }
+}
+
+/// One authorization per attested deposit address, keyed by the account it delegates.
+///
+/// Only attested addresses are signed: a deposit that could not be attested drops out of the sweep
+/// anyway, so authorizing it would spend a signature on nothing. Every address is signed afresh,
+/// since nothing a sweep does can invalidate the tuple — see [`delegation_authorization`].
+async fn sign_authorizations_batch<R: CanisterRuntime>(
+    targets: &[SweepTarget],
+    sweeper_contract: Address,
+    runtime: &R,
+) -> BTreeMap<Account, SignedAuthorization> {
+    let chain_id = read_state(State::ethereum_network).chain_id();
+    let attested: Vec<Account> = read_state(|s| {
+        targets
+            .iter()
+            .map(SweepTarget::account)
+            .filter(|account| s.attestation(*account).is_some())
+            .collect()
+    });
+
+    let signing_results = join_all(attested.into_iter().map(|account| async move {
+        (
+            account,
+            delegation_authorization(chain_id, sweeper_contract)
+                .sign(
+                    deposit_derivation_path(DepositAddressSchema::CkErc20, &account),
+                    runtime,
+                )
+                .await,
+        )
+    }))
+    .await;
+
+    let mut authorizations = BTreeMap::new();
+    let mut errors = Vec::new();
+    for (account, signing_result) in signing_results {
+        match signing_result {
+            Ok(authorization) => {
+                authorizations.insert(account, authorization);
+            }
+            Err(e) => errors.push((account, e)),
+        }
+    }
+
+    if !errors.is_empty() {
+        log!(
+            INFO,
+            "[create_pending_sweeper_requests]: leaving out the deposits this sweep could not authorize: {errors:?}"
+        );
+    }
+    authorizations
+}
+
+/// The tuple every deposit address signs to delegate its code to `sweeper_contract`: the minter's
+/// chain, that delegate, and **nonce 0**, whatever nonce the address actually holds.
+///
+/// Applying an EIP-7702 authorization increments the authority's nonce, and nothing else ever
+/// touches a deposit address' nonce — the minter never broadcasts a transaction from a deposit key,
+/// it only signs attestation digests and authorization tuples with it, and receiving an ERC-20
+/// transfer spends no nonce. So a deposit address holds nonce 0 exactly while it has never been
+/// delegated, and a tuple signed for nonce 0 either
+///
+/// * installs the delegation, the address never having had one; or
+/// * is skipped, the address already being delegated and its nonce no longer matching. The
+///   transaction stays valid, the delegation designator already in place is untouched, and the
+///   delegated call works.
+///
+/// Both outcomes are correct in every ordering of the sweeps that carry them, with nothing stored
+/// and nothing read from chain. That is what lets a sweep authorize every address it touches
+/// instead of tracking which ones are delegated.
+///
+/// The one thing this forecloses is **re-delegation**: an address delegated to an earlier sweeper
+/// contract holds nonce >= 1, so a nonce-0 tuple naming the new one is skipped and its code keeps
+/// pointing at the old contract.
+fn delegation_authorization(chain_id: u64, sweeper_contract: Address) -> Authorization {
+    Authorization {
+        chain_id,
+        delegate: sweeper_contract,
+        nonce: TransactionNonce::ZERO,
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -27,7 +27,10 @@ use crate::{
         transactions::{CreateSweepTransactionError, PipelineRequest},
     },
     time::TimeProvider,
-    tx::{Authorization, GasFeeEstimate, SignedAuthorization, lazy_refresh_gas_fee_estimate},
+    tx::{
+        AuthorizationRequest, GasFeeEstimate, SignedAuthorization, lazy_refresh_gas_fee_estimate,
+        sign_digest,
+    },
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -140,43 +143,67 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
 /// One authorization per attested deposit address, keyed by the account it delegates.
 ///
 /// Only attested addresses are signed: a deposit that could not be attested drops out of the sweep
-/// anyway, so authorizing it would spend a signature on nothing. Every address is signed afresh,
-/// since nothing a sweep does can invalidate the tuple — see [`delegation_authorization`].
+/// anyway, so authorizing it would spend a signature on nothing. A tuple already recorded for the
+/// address is reused rather than signed again — it names nonce 0, so it stays applicable for every
+/// later sweep, see [`AuthorizationRequest`].
 async fn sign_authorizations_batch<R: CanisterRuntime>(
     targets: &[SweepTarget],
     sweeper_contract: Address,
     runtime: &R,
 ) -> BTreeMap<Account, SignedAuthorization> {
     let chain_id = read_state(State::ethereum_network).chain_id();
-    let attested: Vec<Account> = read_state(|s| {
-        targets
-            .iter()
-            .map(SweepTarget::account)
-            .filter(|account| s.attestation(*account).is_some())
-            .collect()
-    });
+    let (mut authorizations, to_sign): (BTreeMap<Account, SignedAuthorization>, Vec<_>) =
+        read_state(|s| {
+            let mut stored = BTreeMap::new();
+            let mut to_sign = Vec::new();
+            for request in targets
+                .iter()
+                .map(SweepTarget::account)
+                .filter(|account| s.attestation(*account).is_some())
+                .map(|account| {
+                    AuthorizationRequest::new(
+                        account,
+                        chain_id,
+                        sweeper_contract,
+                        TransactionNonce::ZERO,
+                    )
+                })
+            {
+                match s.automatic_deposits.authorization(&request) {
+                    Some(signature) => {
+                        stored.insert(request.account(), request.signed_with(signature.clone()));
+                    }
+                    None => to_sign.push(request),
+                }
+            }
+            (stored, to_sign)
+        });
 
-    let signing_results = join_all(attested.into_iter().map(|account| async move {
-        (
-            account,
-            delegation_authorization(chain_id, sweeper_contract)
-                .sign(
-                    deposit_derivation_path(DepositAddressSchema::CkErc20, &account),
-                    runtime,
-                )
-                .await,
+    let signing_results = join_all(to_sign.into_iter().map(|request| async move {
+        let signature = sign_digest(
+            &request.authorization().hash(),
+            &deposit_derivation_path(DepositAddressSchema::CkErc20, &request.account()),
+            runtime,
         )
+        .await;
+        (request, signature)
     }))
     .await;
 
-    let mut authorizations = BTreeMap::new();
     let mut errors = Vec::new();
-    for (account, signing_result) in signing_results {
+    for (request, signing_result) in signing_results {
         match signing_result {
-            Ok(authorization) => {
-                authorizations.insert(account, authorization);
+            Ok(signature) => {
+                authorizations.insert(request.account(), request.signed_with(signature.clone()));
+                mutate_state(|s| {
+                    process_event(
+                        s,
+                        EventType::AuthorizedDepositAddress { request, signature },
+                        runtime,
+                    )
+                });
             }
-            Err(e) => errors.push((account, e)),
+            Err(e) => errors.push((request.account(), e)),
         }
     }
 
@@ -187,35 +214,6 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
         );
     }
     authorizations
-}
-
-/// The tuple every deposit address signs to delegate its code to `sweeper_contract`: the minter's
-/// chain, that delegate, and **nonce 0**, whatever nonce the address actually holds.
-///
-/// Applying an EIP-7702 authorization increments the authority's nonce, and nothing else ever
-/// touches a deposit address' nonce — the minter never broadcasts a transaction from a deposit key,
-/// it only signs attestation digests and authorization tuples with it, and receiving an ERC-20
-/// transfer spends no nonce. So a deposit address holds nonce 0 exactly while it has never been
-/// delegated, and a tuple signed for nonce 0 either
-///
-/// * installs the delegation, the address never having had one; or
-/// * is skipped, the address already being delegated and its nonce no longer matching. The
-///   transaction stays valid, the delegation designator already in place is untouched, and the
-///   delegated call works.
-///
-/// Both outcomes are correct in every ordering of the sweeps that carry them, with nothing stored
-/// and nothing read from chain. That is what lets a sweep authorize every address it touches
-/// instead of tracking which ones are delegated.
-///
-/// The one thing this forecloses is **re-delegation**: an address delegated to an earlier sweeper
-/// contract holds nonce >= 1, so a nonce-0 tuple naming the new one is skipped and its code keeps
-/// pointing at the old contract.
-fn delegation_authorization(chain_id: u64, sweeper_contract: Address) -> Authorization {
-    Authorization {
-        chain_id,
-        delegate: sweeper_contract,
-        nonce: TransactionNonce::ZERO,
-    }
 }
 
 pub async fn process_sweeper_transactions<R: CanisterRuntime>(runtime: R) {

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -5,7 +5,7 @@ use crate::numeric::{BlockNumber, TransactionNonce, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
-use crate::state::{State, read_state};
+use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
 use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
@@ -13,7 +13,7 @@ use crate::test_fixtures::{
     account, automatic_deposit, deposit_address, init_state, initial_state,
     state_with_deposit_helper, usdc, usdt,
 };
-use crate::tx::{Authorization, GasFeeEstimate, TransactionSignature};
+use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
@@ -24,6 +24,7 @@ const NOW: u64 = 1_620_328_630_000_000_000;
 const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
 const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
 const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
+const ANOTHER_SWEEPER_CONTRACT: Address = Address::new([0x99; 20]);
 const CHAIN_CODE: [u8; 32] = [0_u8; 32];
 
 #[tokio::test]
@@ -78,7 +79,10 @@ async fn should_sign_one_attestation_for_every_token_of_an_account() {
     create_pending_sweeper_requests(&runtime).await;
 
     assert_eq!(
-        recorded_events(),
+        recorded_events()
+            .into_iter()
+            .filter(|event| matches!(event, EventType::AttestedDepositAddress { .. }))
+            .collect::<Vec<_>>(),
         vec![EventType::AttestedDepositAddress {
             request: request.clone(),
             signature: expected_signature(&request),
@@ -91,24 +95,59 @@ async fn should_sign_one_attestation_for_every_token_of_an_account() {
 }
 
 #[tokio::test]
-async fn should_sign_one_authorization_for_every_deposit_of_an_account() {
+async fn should_sign_and_record_one_authorization_for_every_account() {
     init_state(state_ready_to_sign(&[
         (account(), usdc()),
         (account(), usdt()),
     ]));
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, 2);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        recorded_events()
+            .into_iter()
+            .filter(|event| matches!(event, EventType::AuthorizedDepositAddress { .. }))
+            .count(),
+        1
+    );
+    assert!(stored_authorization(SWEEPER_CONTRACT).is_some());
+}
+
+#[tokio::test]
+async fn should_resign_the_authorization_when_the_sweeper_contract_changes() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
+    expect_authorization_signing(&mut runtime, ANOTHER_SWEEPER_CONTRACT, 1);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+    let first = stored_authorization(SWEEPER_CONTRACT);
+    assert!(first.is_some());
+
+    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+
+    create_pending_sweeper_requests(&runtime).await;
+    let second = stored_authorization(ANOTHER_SWEEPER_CONTRACT);
+    assert!(second.is_some());
+    assert_ne!(first, second);
+    assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
 }
 
 /// Expects `times` signatures over the authorization tuple every deposit address delegates with:
-/// the minter's chain, the configured sweeper contract, and nonce 0, signed along the deposit
-/// address' own derivation path.
-fn expect_authorization_signing(runtime: &mut MockCanisterRuntime, times: usize) {
-    let digest = authorization_digest();
+/// the minter's chain, `delegate`, and nonce 0, signed along the deposit address' own derivation
+/// path.
+fn expect_authorization_signing(
+    runtime: &mut MockCanisterRuntime,
+    delegate: Address,
+    times: usize,
+) {
+    let digest = authorization_digest(delegate);
     let path = derivation_path_bytes();
     runtime
         .expect_sign_with_ecdsa()
@@ -144,10 +183,27 @@ fn sign_digest_with_derived_key(
 /// Spelled out rather than taken from `delegation_authorization`, so that changing the tuple the
 /// minter signs — its delegate, or the nonce 0 that makes a stale authorization skip harmlessly
 /// rather than sink the sweep — fails here.
-fn authorization_digest() -> [u8; 32] {
+fn stored_authorization(delegate: Address) -> Option<TransactionSignature> {
+    read_state(|s| {
+        s.automatic_deposits
+            .authorization(&authorization_request(delegate))
+            .cloned()
+    })
+}
+
+fn authorization_request(delegate: Address) -> AuthorizationRequest {
+    AuthorizationRequest::new(
+        account(),
+        initial_state().ethereum_network.chain_id(),
+        delegate,
+        TransactionNonce::ZERO,
+    )
+}
+
+fn authorization_digest(delegate: Address) -> [u8; 32] {
     Authorization {
         chain_id: initial_state().ethereum_network.chain_id(),
-        delegate: SWEEPER_CONTRACT,
+        delegate,
         nonce: TransactionNonce::ZERO,
     }
     .hash()

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,5 +1,7 @@
 use crate::attestation::AttestationRequest;
-use crate::numeric::{BlockNumber, WeiPerGas};
+use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
+use crate::management::CallError;
+use crate::numeric::{BlockNumber, TransactionNonce, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
@@ -11,7 +13,7 @@ use crate::test_fixtures::{
     account, automatic_deposit, deposit_address, init_state, initial_state,
     state_with_deposit_helper, usdc, usdt,
 };
-use crate::tx::{GasFeeEstimate, TransactionSignature};
+use crate::tx::{Authorization, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
@@ -69,17 +71,9 @@ async fn should_sign_one_attestation_for_every_token_of_an_account() {
         (account(), usdt()),
     ]));
     let request = attestation_request(account());
-    let signature = sign_with_derived_key(&request);
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    runtime
-        .expect_ecdsa_public_key()
-        .times(1)
-        .return_once(move |_, _| Ok(master_public_key()));
-    runtime
-        .expect_sign_with_ecdsa()
-        .times(1)
-        .return_once(move |_, _, _| Ok(signature));
+    expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
 
@@ -94,6 +88,77 @@ async fn should_sign_one_attestation_for_every_token_of_an_account() {
         read_state(|s| s.automatic_deposits.attestation(&request).cloned()),
         Some(expected_signature(&request))
     );
+}
+
+#[tokio::test]
+async fn should_sign_one_authorization_for_every_deposit_of_an_account() {
+    init_state(state_ready_to_sign(&[
+        (account(), usdc()),
+        (account(), usdt()),
+    ]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, 2);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+}
+
+/// Expects `times` signatures over the authorization tuple every deposit address delegates with:
+/// the minter's chain, the configured sweeper contract, and nonce 0, signed along the deposit
+/// address' own derivation path.
+fn expect_authorization_signing(runtime: &mut MockCanisterRuntime, times: usize) {
+    let digest = authorization_digest();
+    let path = derivation_path_bytes();
+    runtime
+        .expect_sign_with_ecdsa()
+        .withf(move |_, derivation_path, message_hash| {
+            *message_hash == digest && *derivation_path == path
+        })
+        .times(times)
+        .returning(sign_digest_with_derived_key);
+}
+
+/// Signs whatever it is handed with the key the given path derives, the way the subnet would.
+fn expect_signing(runtime: &mut MockCanisterRuntime) {
+    runtime
+        .expect_ecdsa_public_key()
+        .return_once(move |_, _| Ok(master_public_key()));
+    runtime
+        .expect_sign_with_ecdsa()
+        .returning(sign_digest_with_derived_key);
+}
+
+fn sign_digest_with_derived_key(
+    _key_name: String,
+    derivation_path: Vec<Vec<u8>>,
+    message_hash: [u8; 32],
+) -> Result<[u8; 64], CallError> {
+    let path = DerivationPath::new(derivation_path.into_iter().map(DerivationIndex).collect());
+    Ok(master_private_key()
+        .derive_subkey_with_chain_code(&path, &CHAIN_CODE)
+        .0
+        .sign_digest_with_ecdsa(&message_hash))
+}
+
+/// Spelled out rather than taken from `delegation_authorization`, so that changing the tuple the
+/// minter signs — its delegate, or the nonce 0 that makes a stale authorization skip harmlessly
+/// rather than sink the sweep — fails here.
+fn authorization_digest() -> [u8; 32] {
+    Authorization {
+        chain_id: initial_state().ethereum_network.chain_id(),
+        delegate: SWEEPER_CONTRACT,
+        nonce: TransactionNonce::ZERO,
+    }
+    .hash()
+    .0
+}
+
+fn derivation_path_bytes() -> Vec<Vec<u8>> {
+    deposit_derivation_path(DepositAddressSchema::CkErc20, &account())
+        .into_iter()
+        .map(|index| index.into_vec())
+        .collect()
 }
 
 fn state_ready_to_sign(deposits: &[(Account, Address)]) -> State {

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -118,6 +118,26 @@ async fn should_sign_and_record_one_authorization_for_every_account() {
 }
 
 #[tokio::test]
+async fn should_reuse_the_recorded_authorization_on_a_later_sweep() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        recorded_events()
+            .into_iter()
+            .filter(|event| matches!(event, EventType::AuthorizedDepositAddress { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn should_resign_the_authorization_when_the_sweeper_contract_changes() {
     init_state(state_ready_to_sign(&[(account(), usdc())]));
     let mut runtime = mock();

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -138,7 +138,7 @@ async fn should_reuse_the_recorded_authorization_on_a_later_sweep() {
 }
 
 #[tokio::test]
-async fn should_resign_the_authorization_when_the_sweeper_contract_changes() {
+async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     init_state(state_ready_to_sign(&[(account(), usdc())]));
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::{
     checked_amount::CheckedAmountOf,
+    deposit_address::{DepositAddressSchema, deposit_derivation_path},
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
     runtime::CanisterRuntime,
@@ -89,6 +90,10 @@ impl AuthorizationRequest {
 
     pub fn account(&self) -> Account {
         self.account
+    }
+
+    pub fn derivation_path(&self) -> Vec<ByteBuf> {
+        deposit_derivation_path(DepositAddressSchema::CkErc20, &self.account)
     }
 
     pub fn authorization(&self) -> Authorization {

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -7,7 +7,6 @@ use crate::{
     deposit_address::{DepositAddressSchema, deposit_derivation_path},
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
-    runtime::CanisterRuntime,
 };
 use ethnum::u256;
 use ic_ethereum_types::Address;
@@ -143,28 +142,6 @@ impl Authorization {
         let mut bytes = self.rlp_bytes().to_vec();
         bytes.insert(0, EIP7702_AUTHORIZATION_MAGIC);
         Hash(ic_sha3::Keccak256::hash(bytes))
-    }
-
-    pub async fn sign<R: CanisterRuntime>(
-        self,
-        derivation_path: Vec<ByteBuf>,
-        runtime: &R,
-    ) -> Result<SignedAuthorization, String> {
-        if self.chain_id == 0 {
-            return Err(
-                "BUG: EIP-7702 authorization chain_id must be set explicitly and never 0"
-                    .to_string(),
-            );
-        }
-        let signature = super::sign_digest(&self.hash(), &derivation_path, runtime).await?;
-        Ok(SignedAuthorization {
-            chain_id: self.chain_id,
-            delegate: self.delegate,
-            nonce: self.nonce,
-            y_parity: signature.signature_y_parity,
-            r: signature.r,
-            s: signature.s,
-        })
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use ethnum::u256;
 use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
 use minicbor::{Decode, Encode};
 use rlp::{Rlp, RlpStream};
 use serde_bytes::ByteBuf;
@@ -50,6 +51,63 @@ pub struct Eip7702TransactionRequest {
 impl AsRef<Eip7702TransactionRequest> for Eip7702TransactionRequest {
     fn as_ref(&self) -> &Eip7702TransactionRequest {
         self
+    }
+}
+
+/// What a deposit address authorizes, and what a stored signature over it is valid for: the tuple
+/// itself, plus the account whose deposit address signed it.
+///
+/// This is the key an authorization is cached under, so any change to what is authorized — another
+/// chain, another sweeper contract, another nonce — misses the cache and is signed afresh instead
+/// of reusing a tuple that no longer says what the minter means.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Decode, Encode)]
+pub struct AuthorizationRequest {
+    #[n(0)]
+    account: Account,
+    #[n(1)]
+    chain_id: u64,
+    #[n(2)]
+    delegate: Address,
+    #[n(3)]
+    nonce: TransactionNonce,
+}
+
+impl AuthorizationRequest {
+    pub fn new(
+        account: Account,
+        chain_id: u64,
+        delegate: Address,
+        nonce: TransactionNonce,
+    ) -> Self {
+        Self {
+            account,
+            chain_id,
+            delegate,
+            nonce,
+        }
+    }
+
+    pub fn account(&self) -> Account {
+        self.account
+    }
+
+    pub fn authorization(&self) -> Authorization {
+        Authorization {
+            chain_id: self.chain_id,
+            delegate: self.delegate,
+            nonce: self.nonce,
+        }
+    }
+
+    pub fn signed_with(&self, signature: TransactionSignature) -> SignedAuthorization {
+        SignedAuthorization {
+            chain_id: self.chain_id,
+            delegate: self.delegate,
+            nonce: self.nonce,
+            y_parity: signature.signature_y_parity,
+            r: signature.r,
+            s: signature.s,
+        }
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/tx/mod.rs
+++ b/rs/ethereum/cketh/minter/src/tx/mod.rs
@@ -12,7 +12,8 @@ pub use eip_1559::{
     SignedTransactionRequest, TransactionRequest,
 };
 pub use eip_7702::{
-    Authorization, Eip7702TransactionRequest, SignedAuthorization, SignedEip7702TransactionRequest,
+    Authorization, AuthorizationRequest, Eip7702TransactionRequest, SignedAuthorization,
+    SignedEip7702TransactionRequest,
 };
 pub use finalized::Finalized;
 pub use signed::{SignableTransaction, Signed, TransactionSignature, sign};

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -321,6 +321,59 @@ fn a_non_minter_cannot_sweep_a_deposit() {
     assert_eq!(events[0].principal, encode_principal(&principal));
 }
 
+#[test]
+fn a_zero_nonce_authorization_cannot_redelegate() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter_key = key_from_hex(MINTER_PRIVATE_KEY);
+    let minter = eth_address(&minter_key.public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+
+    let Contracts {
+        usdt,
+        via_helper,
+        attested,
+        ..
+    } = deploy_contracts(&anvil, &minter, &cex);
+
+    let key = derive_deposit_key(&Principal::self_authenticating([43_u8]));
+    let deposit = eth_address(&key.public_key());
+    let delegate_only = call(
+        "sweepErc20Batch(address[],bytes32[],bytes32[],address[])",
+        &[
+            Token::Array(vec![]),
+            Token::Array(vec![]),
+            Token::Array(vec![]),
+            Token::Array(vec![address_token(&usdt)]),
+        ],
+    );
+    let delegation_designator =
+        |delegate: &Address| [&[0xef_u8, 0x01, 0x00][..], delegate.as_ref()].concat();
+    let delegate_with_a_zero_nonce_tuple = |delegate: &Address| {
+        let receipt = anvil.send_eip7702(
+            &minter_key,
+            chain_id,
+            &via_helper,
+            delegate_only.clone(),
+            vec![sign_authorization(&key, chain_id, delegate, 0)],
+        );
+        assert!(status_ok(&receipt), "delegation attempt reverted");
+        anvil.code(&deposit)
+    };
+
+    assert_eq!(
+        delegate_with_a_zero_nonce_tuple(&via_helper),
+        delegation_designator(&via_helper),
+        "deposit should be delegated to the first sweeper"
+    );
+    assert_eq!(
+        delegate_with_a_zero_nonce_tuple(&attested),
+        delegation_designator(&via_helper),
+        "a zero-nonce tuple must not re-delegate an already delegated address"
+    );
+}
+
 /// The proposed permissionless variant: the same batch sweeps, but through the
 /// attested sweeper and submitted by a relayer that is NOT the minter.
 #[test]

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -25,9 +25,9 @@ use ic_cketh_minter::state::transactions::{
 };
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
-    AccessList, AccessListItem, DelegatingSweep, Eip1559TransactionRequest, SignedAuthorization,
-    SignedEip1559TransactionRequest, SignedEip7702TransactionRequest, SignedSweepTransaction,
-    SweepTransaction, TransactionSignature,
+    AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
+    SignedAuthorization, SignedEip1559TransactionRequest, SignedEip7702TransactionRequest,
+    SignedSweepTransaction, SweepTransaction, TransactionSignature,
 };
 use ic_stable_structures::Memory;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
@@ -401,6 +401,34 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                     s: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(s.as_slice()).unwrap()),
                 },
             },
+            EventPayload::AuthorizedDepositAddress {
+                owner,
+                subaccount,
+                authorization,
+            } => {
+                let account = Account {
+                    owner,
+                    subaccount: subaccount.map(|subaccount| {
+                        <[u8; 32]>::try_from(subaccount.into_vec().as_slice()).unwrap()
+                    }),
+                };
+                let authorization = map_authorizations(vec![authorization])
+                    .pop()
+                    .expect("BUG: one authorization in, one out");
+                ET::AuthorizedDepositAddress {
+                    request: AuthorizationRequest::new(
+                        account,
+                        authorization.chain_id,
+                        authorization.delegate,
+                        authorization.nonce,
+                    ),
+                    signature: TransactionSignature {
+                        signature_y_parity: authorization.y_parity,
+                        r: authorization.r,
+                        s: authorization.s,
+                    },
+                }
+            }
             EventPayload::AcceptedSweepRequest {
                 sweep_id,
                 destination,


### PR DESCRIPTION
## Why

- The attestations the previous layer signs name the account a sweep credits, but nothing yet lets the delegate move the funds: a deposit address only executes the sweeper contract's code once it has signed an EIP-7702 authorization delegating to it.

## What

- Each deposit address in a batch signs the tuple delegating its code to the configured sweeper contract.
- The tuple carries **nonce 0** whatever nonce the address actually holds. A deposit address is at nonce 0 exactly while it has never been delegated, so the authorization either installs the delegation or is skipped — both correct, in any ordering of the sweeps carrying them. That is what lets a sweep authorize every address it touches without tracking which ones are already delegated, at the price of a skipped tuple's intrinsic gas.
- Signatures are recorded through the event log, keyed by what was signed, so a later sweep of the same address reuses one rather than paying for another threshold-ECDSA signature. Keying by the request rather than the account is what makes that safe: re-pointing the minter at another sweeper contract changes the tuple, so it misses the cache and is signed afresh instead of reusing one that delegates the old contract.
- Attestations and authorizations are signed independently. A deposit needs both before it can be swept, but neither signature depends on the other, so authorizing an address whose attestation failed costs nothing: the tuple is recorded and reused once the attestation lands.
- Recording the tuple is a shortcut: it saves the signature but not the gas, since an address that is already delegated still gets sent a tuple the chain skips. Recording that the address is delegated, rather than what it signed, would save both — left for a later layer.

## Candid compatibility

- Needs the `CI_OVERRIDE_DIDC_CHECK` label: `get_events` returns a variant, and `AuthorizedDepositAddress` adds a case to it. A variant with more cases is not a Candid subtype of one with fewer, so the check against the merge base rejects it, exactly as it did for the attestation event in #11319.
- The case is additive: no existing case changes shape, so every event emitted so far decodes as before. Only a client reading an event of the new kind needs to know it.

[DEFI-2926]: https://dfinity.atlassian.net/browse/DEFI-2926