### PR TITLE
feat(ci): Disclose Hotfix workflow

### DIFF
--- a/.github/workflows/disclose-hotfix.yml
+++ b/.github/workflows/disclose-hotfix.yml
@@ -1,0 +1,264 @@
+name: Disclose Hotfix
+
+# Publish ("disclose") a security hotfix that was built and deployed from the
+# private dfinity/ic-private repository: push its exact elected commit to this
+# repository as the same hotfix-* branch. The push triggers the Release
+# Testing workflow, which re-builds the commit, re-uploads its artifacts to
+# the CDN (rclone --checksum --immutable: identical bytes are a no-op,
+# differing bytes fail the run) and mints the build-provenance attestation
+# that release workflows and the mainnet-revisions updater verify their CDN
+# downloads against.
+#
+# Invariants:
+#   - The pushed tip must be EXACTLY the requested commit: the attestation
+#     binds to the branch tip, so a descendant or different commit would
+#     attest the wrong sha. The push is create-only (--force-with-lease with
+#     an empty expected value): it can create the branch but never move an
+#     existing one.
+#   - Fail closed: the branch already existing at the requested commit is a
+#     successful no-op; existing at any other commit is a hard failure that
+#     needs manual investigation.
+#   - A downstream "immutable file modified" upload failure means the public
+#     rebuild differs from the CDN bytes that were deployed — an incident
+#     signal for the security team. Never retry around it and never
+#     delete/overwrite CDN objects to make it pass.
+#   - Do not push further commits to the branch until its attest-uploads job
+#     is green: Release Testing cancels in-flight runs per ref, and a new tip
+#     would attest a different sha.
+#
+# The DISCLOSE_HOTFIX environment gates the "Push to RC Branch" app
+# credentials: required reviewers approve each run, and the environment's
+# deployment branch policy (master only) prevents dispatching a modified copy
+# of this workflow from an unreviewed branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'hotfix-* branch name on dfinity/ic-private (created here under the same name)'
+        required: true
+      commit:
+        description: 'Full 40-hex commit sha the branch tip must be at (the elected/deployed build)'
+        required: true
+      confirm:
+        description: 'Check this box to confirm the hotfix has been deployed, so it can safely be disclosed'
+        required: true
+        type: boolean
+
+# Queued re-runs for the same branch re-validate and converge to a no-op or a
+# conflict failure instead of racing each other.
+concurrency:
+  group: disclose-hotfix-${{ inputs.branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  disclose-hotfix:
+    name: Disclose Hotfix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # The synced copy of this workflow in ic-private must stay inert.
+    if: github.repository == 'dfinity/ic'
+    environment: DISCLOSE_HOTFIX
+    env:
+      GIT_TERMINAL_PROMPT: "0"
+    steps:
+      - name: Validate inputs
+        shell: bash
+        env:
+          BRANCH: ${{ inputs.branch }}
+          COMMIT: ${{ inputs.commit }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+
+          # For boolean workflow_dispatch inputs, 'required: true' does not
+          # enforce that the box is ticked, so check it here.
+          if [ "$CONFIRM" != "true" ]; then
+            echo "confirm must be checked: it acknowledges the hotfix has been deployed and can safely be disclosed" >&2
+            exit 1
+          fi
+
+          # Only branch names of this exact shape trigger Release Testing, are
+          # push-restricted and are accepted by attestation verification. The
+          # charset also keeps '/', whitespace, '..', refspec metacharacters
+          # and a leading '-' out of the git invocations below.
+          if ! [[ "$BRANCH" =~ ^hotfix-[A-Za-z0-9._-]+$ ]]; then
+            echo "branch must match hotfix-<suffix> with <suffix> of [A-Za-z0-9._-], got: $BRANCH" >&2
+            exit 1
+          fi
+          # Independent second gate for anything the regex might miss.
+          git check-ref-format "refs/heads/$BRANCH"
+
+          if ! [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit must be a full 40-hex lowercase sha, got: $COMMIT" >&2
+            exit 1
+          fi
+
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.PUSH_TO_RC_BRANCH_APP_ID }}
+          private-key: ${{ secrets.PUSH_TO_RC_BRANCH_PRIVATE_KEY }}
+          owner: dfinity
+          repositories: |
+            ic
+            ic-private
+
+      - name: Validate branch state on both repositories
+        id: precheck
+        shell: bash
+        env:
+          BRANCH: ${{ inputs.branch }}
+          COMMIT: ${{ inputs.commit }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          ref="refs/heads/$BRANCH"
+
+          # ls-remote prints TAB-separated "<sha> <refname>" lines; require
+          # the exact refname.
+          private_tip="$(git ls-remote "https://x-access-token:${TOKEN}@github.com/dfinity/ic-private.git" "$ref" \
+            | awk -v ref="$ref" '$2 == ref {print $1}')"
+          if [ -z "$private_tip" ]; then
+            echo "branch $BRANCH does not exist on dfinity/ic-private" >&2
+            exit 1
+          fi
+          if [ "$private_tip" != "$COMMIT" ]; then
+            echo "dfinity/ic-private $BRANCH is at $private_tip, not at $COMMIT:" >&2
+            echo "the tip must be EXACTLY the disclosed commit" >&2
+            exit 1
+          fi
+
+          public_tip="$(git ls-remote "https://github.com/dfinity/ic.git" "$ref" \
+            | awk -v ref="$ref" '$2 == ref {print $1}')"
+          if [ -z "$public_tip" ]; then
+            echo "already_disclosed=false" >>"$GITHUB_OUTPUT"
+          elif [ "$public_tip" = "$COMMIT" ]; then
+            echo "dfinity/ic $BRANCH is already at $COMMIT — nothing to do"
+            echo "already_disclosed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "refusing to move dfinity/ic $BRANCH (at $public_tip): the attestation" >&2
+            echo "binds to the branch tip — investigate manually" >&2
+            exit 1
+          fi
+
+      - name: Checkout dfinity/ic
+        if: steps.precheck.outputs.already_disclosed != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: dfinity/ic
+          ref: master
+          # Full history, so that the fetch from ic-private below only
+          # transfers the hotfix delta and the push pack stays minimal.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fetch, verify and push the hotfix commit
+        if: steps.precheck.outputs.already_disclosed != 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ inputs.branch }}
+          COMMIT: ${{ inputs.commit }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          ref="refs/heads/$BRANCH"
+
+          # Fetch the branch, not the sha (fetching an arbitrary sha needs
+          # server-side opt-in), and re-check the tip: this closes the race
+          # with the validation step above.
+          git fetch --no-tags "https://x-access-token:${TOKEN}@github.com/dfinity/ic-private.git" "$ref"
+          fetched="$(git rev-parse FETCH_HEAD)"
+          if [ "$fetched" != "$COMMIT" ]; then
+            echo "dfinity/ic-private $BRANCH moved to $fetched since validation; re-run" >&2
+            exit 1
+          fi
+          if [ "$(git cat-file -t "$COMMIT")" != "commit" ]; then
+            echo "$COMMIT is not a commit object" >&2
+            exit 1
+          fi
+
+          if ! git show "$COMMIT:.github/workflows/release-testing.yml" 2>/dev/null | grep -q attest-uploads; then
+            echo "::warning::the tree of $COMMIT has no attest-uploads job in release-testing.yml: the triggered run cannot mint an attestation"
+          fi
+
+          # --force-with-lease with an explicitly EMPTY expected value means
+          # "the remote ref must not exist": the push can only create the
+          # branch, never move one (a plain push would silently fast-forward
+          # a branch that exists at an ancestor commit).
+          if ! git push origin "$COMMIT:$ref" --force-with-lease="$ref:"; then
+            # A concurrent disclosure may have created the branch at the same
+            # commit, which is a benign race.
+            current="$(git ls-remote origin "$ref" | awk -v ref="$ref" '$2 == ref {print $1}')"
+            if [ "$current" = "$COMMIT" ]; then
+              echo "$BRANCH was concurrently created at $COMMIT — nothing left to do"
+            else
+              echo "push rejected; dfinity/ic $BRANCH is at: ${current:-<absent>}" >&2
+              exit 1
+            fi
+          fi
+
+          verified="$(git ls-remote origin "$ref" | awk -v ref="$ref" '$2 == ref {print $1}')"
+          if [ "$verified" != "$COMMIT" ]; then
+            echo "post-push verification failed: dfinity/ic $BRANCH is at ${verified:-<absent>}, expected $COMMIT" >&2
+            exit 1
+          fi
+
+      - name: Report
+        if: always()
+        shell: bash
+        env:
+          BRANCH: ${{ inputs.branch }}
+          COMMIT: ${{ inputs.commit }}
+          ALREADY_DISCLOSED: ${{ steps.precheck.outputs.already_disclosed }}
+          JOB_STATUS: ${{ job.status }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Disclose Hotfix"
+            echo
+            echo "- branch: \`$BRANCH\`"
+            echo "- commit: \`$COMMIT\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          if [ "$JOB_STATUS" != "success" ]; then
+            echo "- outcome: **failed** — see the step logs; nothing was pushed unless the push step reports otherwise" >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$ALREADY_DISCLOSED" = "true" ]; then
+            echo "- outcome: no-op — the branch was already at this commit" >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "- outcome: **branch created; Release Testing takes over**" >>"$GITHUB_STEP_SUMMARY"
+
+          run_url=""
+          for _ in $(seq 24); do
+            run_url="$(gh api "repos/dfinity/ic/actions/workflows/release-testing.yml/runs?head_sha=$COMMIT" \
+              --jq '.workflow_runs[0].html_url // empty' 2>/dev/null || true)"
+            if [ -n "$run_url" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$run_url" ]; then
+            run_url="https://github.com/dfinity/ic/actions/workflows/release-testing.yml?query=branch%3A$BRANCH"
+          fi
+          {
+            echo "- Release Testing: $run_url"
+            echo
+            echo "Watch the run's upload steps: rclone must report the uploads as"
+            echo "no-ops (byte-identical to what the private build published). An"
+            echo "\"immutable file modified\" failure means the public rebuild"
+            echo "differs from the deployed CDN bytes — an incident signal for the"
+            echo "security team; never retry around it and never delete or"
+            echo "overwrite CDN objects. Do not push further commits to the branch"
+            echo "until its attest-uploads job is green."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/disclose-hotfix.yml
+++ b/.github/workflows/disclose-hotfix.yml
@@ -26,14 +26,14 @@ run-name: "Disclose ${{ inputs.branch }} @ ${{ inputs.commit }} (confirm=${{ inp
 #     needs manual investigation.
 #   - A downstream "immutable file modified" upload failure means the public
 #     rebuild differs from the CDN bytes that were deployed — an incident
-#     signal for the security team. Never retry around it and never
+#     signal for the infra team. Never retry around it and never
 #     delete/overwrite CDN objects to make it pass.
 #   - Do not push further commits to the branch until its attest-uploads job
 #     is green: Release Testing cancels in-flight runs per ref, and a new tip
 #     would attest a different sha.
 #
 # The DISCLOSE_HOTFIX environment gates the "Push to RC Branch" app
-# credentials: required reviewers approve each run, and the environment's
+# credentials: required reviewers (DRE / Infra) approve each run, and the environment's
 # deployment branch policy (master only) prevents dispatching a modified copy
 # of this workflow from an unreviewed branch.
 
@@ -189,7 +189,9 @@ jobs:
             exit 1
           fi
 
-          if ! git show "$COMMIT:.github/workflows/release-testing.yml" 2>/dev/null | grep -q attest-uploads; then
+          # Match the top-level job key at the jobs indent level so a comment,
+          # a needs: reference or a commented-out job doesn't count.
+          if ! git show "$COMMIT:.github/workflows/release-testing.yml" 2>/dev/null | grep -qE '^  attest-uploads:'; then
             echo "::warning::the tree of $COMMIT has no attest-uploads job in release-testing.yml: the triggered run cannot mint an attestation"
           fi
 
@@ -247,7 +249,10 @@ jobs:
 
           run_url=""
           for _ in $(seq 24); do
-            run_url="$(gh api "repos/dfinity/ic/actions/workflows/release-testing.yml/runs?head_sha=$COMMIT" \
+            # branch and event=push narrow the match: head_sha alone could
+            # select a run for another branch or a prior workflow_dispatch
+            # at the same commit.
+            run_url="$(gh api "repos/dfinity/ic/actions/workflows/release-testing.yml/runs?head_sha=$COMMIT&branch=$BRANCH&event=push" \
               --jq '.workflow_runs[0].html_url // empty' 2>/dev/null || true)"
             if [ -n "$run_url" ]; then
               break
@@ -264,7 +269,7 @@ jobs:
             echo "no-ops (byte-identical to what the private build published). An"
             echo "\"immutable file modified\" failure means the public rebuild"
             echo "differs from the deployed CDN bytes — an incident signal for the"
-            echo "security team; never retry around it and never delete or"
+            echo "infra team; never retry around it and never delete or"
             echo "overwrite CDN objects. Do not push further commits to the branch"
             echo "until its attest-uploads job is green."
           } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/disclose-hotfix.yml
+++ b/.github/workflows/disclose-hotfix.yml
@@ -1,5 +1,11 @@
 name: Disclose Hotfix
 
+# The environment's required reviewers approve the run BEFORE any step
+# executes, and GitHub shows workflow_dispatch inputs neither in the run list
+# nor in the approval dialog — the run title is the only surface telling the
+# reviewer WHAT they are approving, so it must carry the inputs.
+run-name: "Disclose ${{ inputs.branch }} @ ${{ inputs.commit }} (confirm=${{ inputs.confirm }})"
+
 # Publish ("disclose") a security hotfix that was built and deployed from the
 # private dfinity/ic-private repository: push its exact elected commit to this
 # repository as the same hotfix-* branch. The push triggers the Release


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow that **discloses** a security hotfix built and deployed from the private dfinity/ic-private repository: it pushes the exact elected commit to this repository as the same `hotfix-*` branch, authenticated as the **"Push to RC Branch"** GitHub App. The push triggers Release Testing, which re-builds the commit, re-uploads its artifacts (rclone `--checksum --immutable`: identical bytes ⇒ no-op, differing bytes ⇒ hard failure) and mints the build-provenance attestation that release workflows and the mainnet-revisions updater verify CDN downloads against (attestation stack: #11323 → #11324 → #11325 → #11326).

Runs of this workflow have to be approved by either DRE or Infra.

### Flow

1. **Validate inputs** before touching any credential: `confirm` checkbox must be ticked (boolean `required: true` does not enforce this, same pattern as ci-kickoff-manual.yml), branch must match `hotfix-<suffix>` of `[A-Za-z0-9._-]+` (`/` excluded: branch protections and triggers match `hotfix-*` with fnmatch, where `*` does not cross `/`), commit must be a full 40-hex sha.
2. **Mint an app installation token** for `dfinity/ic` + `dfinity/ic-private` (same action pin as schedule-rc.yml).
3. **Validate remote state** via `ls-remote` only: the ic-private branch must exist with its tip **exactly** at the requested commit; on dfinity/ic the branch must be absent (proceed), already at the commit (succeed as a no-op) or anything else (fail loudly — never move an existing branch).
4. **Checkout dfinity/ic\@master**, fetch the branch from ic-private, re-check the tip (closes the validate→fetch race), reject non-commit objects, warn if the tree lacks the `attest-uploads` job (the run then can't mint an attestation).
5. **Push create-only**: `--force-with-lease="refs/heads/<branch>:"` (empty expected value = the ref must not exist, so the push can create but never move/fast-forward); a concurrent creation at the same commit is treated as a benign race; post-verify with `ls-remote`.
6. **Report** in the step summary: outcome, the triggered Release Testing run URL, and the operational reminders (uploads must be rclone no-ops; "immutable file modified" = incident signal for the infra team, never retry around it or touch CDN objects; no further pushes to the branch until `attest-uploads` is green).

### Why the tip must be exact

The attestation binds to the branch tip that Release Testing builds. A descendant or different commit would attest the wrong sha — hence exact-tip validation, the create-only lease, and the per-branch `concurrency` group (queued re-runs re-validate and converge to no-op/conflict instead of racing).

### Environment / prerequisites

- The **`DISCLOSE_HOTFIX`** environment exists (2026-08-27) with required reviewers (dfinity/dre + dfinity/infra), a master-only deployment branch policy (a Write user dispatching a modified copy of this workflow from a side branch cannot reach the credentials) and environment-scoped copies of the app credentials. It is separate from `PUSH_TO_RC_BRANCH` because required reviewers there would leave schedule-rc's nightly cron hanging.
- **Org-admin prerequisite done (2026-08-27)**: the "Push to RC Branch" app has access to `dfinity/ic-private` (Contents: read).
- In ic-private the synced workflow copy stays inert (`if: github.repository == 'dfinity/ic'`).

### Validation

- The exact `run` blocks (extracted from the YAML) were replayed against scratch bare repos: happy path creates the ref at exactly the commit; re-run is a no-op; existing-at-different-commit (including an ancestor — the silent-fast-forward case) is rejected both by the precheck and independently by the lease; private-tip-moved-after-validation aborts at the `FETCH_HEAD` re-check; benign/hostile create races behave as designed; `public-hotfix-x`, `hotfix-a/b`, `hotfix-a..b`, short shas and an unchecked `confirm` all fail input validation. 24/24 passed.
- `actionlint` (1.7.12) and shellcheck clean.
- Post-merge drill (after the attestation stack lands): disclose a scratch `hotfix-attest-drill-*` branch from ic-private at a post-stack commit; confirm push → Release Testing → rclone no-ops → `attest-uploads` mints; re-dispatch with identical inputs (no-op) and with a different commit (conflict failure); delete the branch.

### Operator usage

Actions UI → Disclose Hotfix → branch + commit + confirm, or:

```
gh workflow run disclose-hotfix.yml -R dfinity/ic -f branch=hotfix-... -f commit=<40-hex> -f confirm=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
