### PR TITLE
feat(cketh): enqueue the sweep a signed batch has become

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -590,6 +590,23 @@ type SignedAuthorization = record {
     s : blob;
 };
 
+// One deposit a sweep moves: the address the funds sit at, the account they are
+// credited to, the attestation binding the two, and the delegation letting the
+// sweeper's code run there.
+type AuthorizedSweepItem = record {
+    deposit : text;
+    owner : principal;
+    subaccount : opt blob;
+    // The attestation signed by the deposit address itself.
+    attestation_y_parity : bool;
+    // 32-byte signature components.
+    attestation_r : blob;
+    attestation_s : blob;
+    // The delegation installed on the way, absent if the address is already
+    // delegated.
+    authorization : opt SignedAuthorization;
+};
+
 // A sweep transaction the minter has created but not yet signed: a transaction,
 // plus the delegations it installs on the way. With none it is sent as a plain
 // EIP-1559 (0x02) transaction, and otherwise as an EIP-7702 (0x04) one.
@@ -664,14 +681,12 @@ type Event = record {
         AcceptedSweepRequest : record {
             sweep_id : nat;
             destination : text;
-            amount : nat;
-            // Transaction call data (the delegate sweep call).
-            data : blob;
+            // The single ERC-20 contract this sweep moves.
+            token : text;
+            // The deposits the sweep moves, one per account.
+            items : vec AuthorizedSweepItem;
             max_transaction_fee : nat;
             created_at : nat64;
-            // Delegations the sweep installs on the way, empty if every address
-            // it touches is already delegated.
-            authorizations : vec SignedAuthorization;
         };
         CreatedSweeperTransaction : record {
             sweep_id : nat;

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -578,16 +578,22 @@ type UnsignedTransaction = record {
     access_list : vec record { address : text; storage_keys : vec blob };
 };
 
+// A secp256k1 signature: the two 32-byte components and the parity recovering
+// the signing key from them.
+type TransactionSignature = record {
+    y_parity : bool;
+    // 32-byte signature components.
+    r : blob;
+    s : blob;
+};
+
 // An EIP-7702 authorization tuple: a deposit address' signed consent to delegate
 // its code to `delegate`, signed by the address itself.
 type SignedAuthorization = record {
     chain_id : nat;
     delegate : text;
     nonce : nat;
-    y_parity : bool;
-    // 32-byte signature components.
-    r : blob;
-    s : blob;
+    signature : TransactionSignature;
 };
 
 // One deposit a sweep moves: the address the funds sit at, the account they are
@@ -598,10 +604,7 @@ type AuthorizedSweepItem = record {
     owner : principal;
     subaccount : opt blob;
     // The attestation signed by the deposit address itself.
-    attestation_y_parity : bool;
-    // 32-byte signature components.
-    attestation_r : blob;
-    attestation_s : blob;
+    attestation : TransactionSignature;
     // The delegation installed on the way, absent if the address is already
     // delegated.
     authorization : opt SignedAuthorization;
@@ -801,10 +804,8 @@ type Event = record {
             deposit_helper : text;
             owner : principal;
             subaccount : opt blob;
-            y_parity : bool;
-            // 32-byte signature components.
-            r : blob;
-            s : blob;
+            // The attestation signed by the deposit address itself.
+            attestation : TransactionSignature;
         };
         AuthorizedDepositAddress : record {
             owner : principal;

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -450,6 +450,17 @@ pub mod events {
         pub access_list: Vec<AccessListItem>,
     }
 
+    /// A secp256k1 signature: the two 32-byte components and the parity recovering the signing
+    /// key from them.
+    #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+    pub struct TransactionSignature {
+        pub y_parity: bool,
+        /// 32-byte signature component.
+        pub r: ByteBuf,
+        /// 32-byte signature component.
+        pub s: ByteBuf,
+    }
+
     /// An [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) authorization tuple: a deposit
     /// address' signed consent to delegate its code to `delegate`, signed by the address itself.
     #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -457,11 +468,7 @@ pub mod events {
         pub chain_id: Nat,
         pub delegate: String,
         pub nonce: Nat,
-        pub y_parity: bool,
-        /// 32-byte signature component.
-        pub r: ByteBuf,
-        /// 32-byte signature component.
-        pub s: ByteBuf,
+        pub signature: TransactionSignature,
     }
 
     /// One deposit a sweep moves: the address the funds sit at, the account they are credited to,
@@ -472,11 +479,7 @@ pub mod events {
         pub owner: Principal,
         pub subaccount: Option<ByteBuf>,
         /// The attestation signed by the deposit address itself.
-        pub attestation_y_parity: bool,
-        /// 32-byte signature component.
-        pub attestation_r: ByteBuf,
-        /// 32-byte signature component.
-        pub attestation_s: ByteBuf,
+        pub attestation: TransactionSignature,
         /// The delegation installed on the way, absent if the address is already delegated.
         pub authorization: Option<SignedAuthorization>,
     }
@@ -584,11 +587,8 @@ pub mod events {
             deposit_helper: String,
             owner: Principal,
             subaccount: Option<ByteBuf>,
-            y_parity: bool,
-            /// 32-byte signature component.
-            r: ByteBuf,
-            /// 32-byte signature component.
-            s: ByteBuf,
+            /// The attestation signed by the deposit address itself.
+            attestation: TransactionSignature,
         },
         AuthorizedDepositAddress {
             owner: Principal,

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -464,6 +464,23 @@ pub mod events {
         pub s: ByteBuf,
     }
 
+    /// One deposit a sweep moves: the address the funds sit at, the account they are credited to,
+    /// the attestation binding the two, and the delegation letting the sweeper's code run there.
+    #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+    pub struct AuthorizedSweepItem {
+        pub deposit: String,
+        pub owner: Principal,
+        pub subaccount: Option<ByteBuf>,
+        /// The attestation signed by the deposit address itself.
+        pub attestation_y_parity: bool,
+        /// 32-byte signature component.
+        pub attestation_r: ByteBuf,
+        /// 32-byte signature component.
+        pub attestation_s: ByteBuf,
+        /// The delegation installed on the way, absent if the address is already delegated.
+        pub authorization: Option<SignedAuthorization>,
+    }
+
     /// A sweep transaction the minter has created but not yet signed: a transaction, plus the
     /// delegations it installs on the way. With none it is sent as a plain EIP-1559 (`0x02`)
     /// transaction, and otherwise as an EIP-7702 (`0x04`) one.
@@ -581,14 +598,12 @@ pub mod events {
         AcceptedSweepRequest {
             sweep_id: Nat,
             destination: String,
-            amount: Nat,
-            /// Transaction call data (the delegate sweep call).
-            data: ByteBuf,
+            /// The single ERC-20 contract this sweep moves.
+            token: String,
+            /// The deposits the sweep moves, one per account.
+            items: Vec<AuthorizedSweepItem>,
             max_transaction_fee: Nat,
             created_at: u64,
-            /// Delegations the sweep installs on the way, empty if every address it touches is
-            /// already delegated.
-            authorizations: Vec<SignedAuthorization>,
         },
         CreatedSweeperTransaction {
             sweep_id: Nat,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -34,8 +34,8 @@ use ic_cketh_minter::state::audit::{Event, EventType, process_event};
 use ic_cketh_minter::state::automatic_deposits::DepositRequest;
 use ic_cketh_minter::state::eth_logs_scraping::{LogScrapingId, LogScrapingInfo};
 use ic_cketh_minter::state::transactions::{
-    Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
-    ReimbursementRequest, SweepRequest,
+    AuthorizedSweepItem, Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed,
+    ReimbursementIndex, ReimbursementRequest, SweepRequest,
 };
 use ic_cketh_minter::state::{
     STATE, State, lazy_call_ecdsa_public_key, mutate_state, read_state, transactions,
@@ -728,7 +728,8 @@ async fn get_canister_status() -> ic_cdk_management_canister::CanisterStatusResu
 #[query]
 fn get_events(arg: GetEventsArg) -> GetEventsResult {
     use ic_cketh_minter::endpoints::events::{
-        AccessListItem, ReimbursementIndex as CandidReimbursementIndex,
+        AccessListItem, AuthorizedSweepItem as CandidAuthorizedSweepItem,
+        ReimbursementIndex as CandidReimbursementIndex,
         SignedAuthorization as CandidSignedAuthorization,
         TransactionReceipt as CandidTransactionReceipt,
         TransactionStatus as CandidTransactionStatus, UnsignedSweeperTransaction,
@@ -800,6 +801,30 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
             transaction: map_unsigned_transaction(tx),
             authorization_list: map_authorizations(tx.authorizations()),
         }
+    }
+
+    fn map_authorized_sweep_items(items: &[AuthorizedSweepItem]) -> Vec<CandidAuthorizedSweepItem> {
+        items
+            .iter()
+            .map(
+                |AuthorizedSweepItem {
+                     item,
+                     authorization,
+                 }| CandidAuthorizedSweepItem {
+                    deposit: item.deposit.as_address().to_string(),
+                    owner: item.account.owner,
+                    subaccount: item.account.subaccount.map(ByteBuf::from),
+                    attestation_y_parity: item.attestation.signature_y_parity,
+                    attestation_r: ByteBuf::from(item.attestation.r.to_be_bytes()),
+                    attestation_s: ByteBuf::from(item.attestation.s.to_be_bytes()),
+                    authorization: authorization.as_ref().map(|authorization| {
+                        map_authorizations(std::slice::from_ref(authorization))
+                            .pop()
+                            .expect("BUG: one authorization in, one out")
+                    }),
+                },
+            )
+            .collect()
     }
 
     fn map_authorizations(
@@ -1012,19 +1037,17 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                 EventType::AcceptedSweepRequest(SweepRequest {
                     id,
                     destination,
-                    amount,
-                    data,
+                    token,
+                    items,
                     max_transaction_fee,
                     created_at,
-                    authorizations,
                 }) => EP::AcceptedSweepRequest {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
-                    amount: amount.into(),
-                    data: ByteBuf::from(data),
+                    token: token.to_string(),
+                    items: map_authorized_sweep_items(&items),
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,
-                    authorizations: map_authorizations(&authorizations),
                 },
                 EventType::CreatedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -732,11 +732,14 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
         ReimbursementIndex as CandidReimbursementIndex,
         SignedAuthorization as CandidSignedAuthorization,
         TransactionReceipt as CandidTransactionReceipt,
+        TransactionSignature as CandidTransactionSignature,
         TransactionStatus as CandidTransactionStatus, UnsignedSweeperTransaction,
         UnsignedTransaction,
     };
     use ic_cketh_minter::eth_rpc_client::responses::TransactionReceipt;
-    use ic_cketh_minter::tx::{SignableTransaction, SignedAuthorization, SweepTransaction};
+    use ic_cketh_minter::tx::{
+        SignableTransaction, SignedAuthorization, SweepTransaction, TransactionSignature,
+    };
     use serde_bytes::ByteBuf;
 
     const MAX_EVENTS_PER_RESPONSE: u64 = 100;
@@ -803,6 +806,14 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
         }
     }
 
+    fn map_signature(signature: &TransactionSignature) -> CandidTransactionSignature {
+        CandidTransactionSignature {
+            y_parity: signature.signature_y_parity,
+            r: ByteBuf::from(signature.r.to_be_bytes()),
+            s: ByteBuf::from(signature.s.to_be_bytes()),
+        }
+    }
+
     fn map_authorized_sweep_items(items: &[AuthorizedSweepItem]) -> Vec<CandidAuthorizedSweepItem> {
         items
             .iter()
@@ -814,9 +825,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                     deposit: item.deposit.as_address().to_string(),
                     owner: item.account.owner,
                     subaccount: item.account.subaccount.map(ByteBuf::from),
-                    attestation_y_parity: item.attestation.signature_y_parity,
-                    attestation_r: ByteBuf::from(item.attestation.r.to_be_bytes()),
-                    attestation_s: ByteBuf::from(item.attestation.s.to_be_bytes()),
+                    attestation: map_signature(&item.attestation),
                     authorization: authorization.as_ref().map(|authorization| {
                         map_authorizations(std::slice::from_ref(authorization))
                             .pop()
@@ -836,9 +845,11 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                 chain_id: authorization.chain_id.into(),
                 delegate: authorization.delegate.to_string(),
                 nonce: authorization.nonce.into(),
-                y_parity: authorization.y_parity,
-                r: ByteBuf::from(authorization.r.to_be_bytes()),
-                s: ByteBuf::from(authorization.s.to_be_bytes()),
+                signature: CandidTransactionSignature {
+                    y_parity: authorization.y_parity,
+                    r: ByteBuf::from(authorization.r.to_be_bytes()),
+                    s: ByteBuf::from(authorization.s.to_be_bytes()),
+                },
             })
             .collect()
     }
@@ -1019,9 +1030,7 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                         deposit_helper: request.deposit_helper().to_string(),
                         owner: account.owner,
                         subaccount: account.subaccount.map(ByteBuf::from),
-                        y_parity: signature.signature_y_parity,
-                        r: ByteBuf::from(signature.r.to_be_bytes()),
-                        s: ByteBuf::from(signature.s.to_be_bytes()),
+                        attestation: map_signature(&signature),
                     }
                 }
                 EventType::AuthorizedDepositAddress { request, signature } => {

--- a/rs/ethereum/cketh/minter/src/management/mod.rs
+++ b/rs/ethereum/cketh/minter/src/management/mod.rs
@@ -15,6 +15,14 @@ pub struct CallError {
 }
 
 impl CallError {
+    /// An error from calling `method`, which failed for `reason`.
+    pub fn new(method: impl Into<String>, reason: Reason) -> Self {
+        Self {
+            method: method.into(),
+            reason,
+        }
+    }
+
     /// Returns the name of the method that resulted in this error.
     pub fn method(&self) -> &str {
         &self.method

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -121,6 +121,11 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
         }
         EventType::AcceptedSweepRequest(request) => {
             state.next_sweep_id = request.id.next();
+            state.automatic_deposits.record_sweep_scheduled(
+                request.id,
+                request.token,
+                request.items.iter().map(|item| item.item.account),
+            );
             state
                 .automatic_deposits
                 .record_sweep_request(request.clone());

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -3,7 +3,8 @@ use crate::checked_amount::CheckedAmountOf;
 use crate::deposit_address::DepositAddress;
 use crate::endpoints::events::{
     AuthorizedSweepItem as CandidAuthorizedSweepItem, Event as CandidEvent, EventPayload,
-    SignedAuthorization as CandidSignedAuthorization, UnsignedSweeperTransaction,
+    SignedAuthorization as CandidSignedAuthorization,
+    TransactionSignature as CandidTransactionSignature, UnsignedSweeperTransaction,
     UnsignedTransaction,
 };
 use crate::erc20::CkErc20Token;
@@ -292,13 +293,21 @@ impl GetEventsFile {
             )
         }
 
-        fn map_authorized_sweep_items(
-            items: Vec<CandidAuthorizedSweepItem>,
-        ) -> Vec<AuthorizedSweepItem> {
-            fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
+        fn map_candid_signature(signature: CandidTransactionSignature) -> TransactionSignature {
+            fn component(bytes: &[u8]) -> ethnum::u256 {
                 ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
             }
 
+            TransactionSignature {
+                signature_y_parity: signature.y_parity,
+                r: component(&signature.r),
+                s: component(&signature.s),
+            }
+        }
+
+        fn map_authorized_sweep_items(
+            items: Vec<CandidAuthorizedSweepItem>,
+        ) -> Vec<AuthorizedSweepItem> {
             items
                 .into_iter()
                 .map(|item| AuthorizedSweepItem {
@@ -310,11 +319,7 @@ impl GetEventsFile {
                                 .subaccount
                                 .map(|s| <[u8; 32]>::try_from(s.as_ref()).unwrap()),
                         },
-                        attestation: TransactionSignature {
-                            signature_y_parity: item.attestation_y_parity,
-                            r: map_signature_component(&item.attestation_r),
-                            s: map_signature_component(&item.attestation_s),
-                        },
+                        attestation: map_candid_signature(item.attestation),
                     },
                     authorization: item.authorization.map(|authorization| {
                         map_authorizations(vec![authorization])
@@ -328,19 +333,18 @@ impl GetEventsFile {
         fn map_authorizations(
             authorizations: Vec<CandidSignedAuthorization>,
         ) -> Vec<SignedAuthorization> {
-            fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
-                ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
-            }
-
             authorizations
                 .into_iter()
-                .map(|authorization| SignedAuthorization {
-                    chain_id: authorization.chain_id.0.to_u64().unwrap(),
-                    delegate: authorization.delegate.parse().unwrap(),
-                    nonce: authorization.nonce.try_into().unwrap(),
-                    y_parity: authorization.y_parity,
-                    r: map_signature_component(&authorization.r),
-                    s: map_signature_component(&authorization.s),
+                .map(|authorization| {
+                    let signature = map_candid_signature(authorization.signature);
+                    SignedAuthorization {
+                        chain_id: authorization.chain_id.0.to_u64().unwrap(),
+                        delegate: authorization.delegate.parse().unwrap(),
+                        nonce: authorization.nonce.try_into().unwrap(),
+                        y_parity: signature.signature_y_parity,
+                        r: signature.r,
+                        s: signature.s,
+                    }
                 })
                 .collect()
         }
@@ -471,9 +475,7 @@ impl GetEventsFile {
                     deposit_helper,
                     owner,
                     subaccount,
-                    y_parity,
-                    r,
-                    s,
+                    attestation,
                 } => ET::AttestedDepositAddress {
                     request: AttestationRequest::new(
                         chain_id.0.to_u64().unwrap(),
@@ -485,11 +487,7 @@ impl GetEventsFile {
                             }),
                         },
                     ),
-                    signature: TransactionSignature {
-                        signature_y_parity: y_parity,
-                        r: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(r.as_slice()).unwrap()),
-                        s: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(s.as_slice()).unwrap()),
-                    },
+                    signature: map_candid_signature(attestation),
                 },
                 EventPayload::AuthorizedDepositAddress {
                     owner,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -1,8 +1,10 @@
 use crate::attestation::AttestationRequest;
 use crate::checked_amount::CheckedAmountOf;
+use crate::deposit_address::DepositAddress;
 use crate::endpoints::events::{
-    Event as CandidEvent, EventPayload, SignedAuthorization as CandidSignedAuthorization,
-    UnsignedSweeperTransaction, UnsignedTransaction,
+    AuthorizedSweepItem as CandidAuthorizedSweepItem, Event as CandidEvent, EventPayload,
+    SignedAuthorization as CandidSignedAuthorization, UnsignedSweeperTransaction,
+    UnsignedTransaction,
 };
 use crate::erc20::CkErc20Token;
 use crate::eth_logs::{LedgerSubaccount, ReceivedErc20Event, ReceivedEthEvent};
@@ -11,9 +13,10 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::Wei;
 use crate::state::audit::{Event, replay_events_internal};
 use crate::state::transactions::{
-    Erc20WithdrawalRequest, Reimbursed, ReimbursementIndex, ReimbursementRequest, SweepId,
-    SweepRequest,
+    AuthorizedSweepItem, Erc20WithdrawalRequest, Reimbursed, ReimbursementIndex,
+    ReimbursementRequest, SweepId, SweepRequest,
 };
+use crate::sweeper_contract::SweepItem;
 use crate::timed_sized_map::Timestamp;
 use crate::tx::{
     AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
@@ -289,6 +292,39 @@ impl GetEventsFile {
             )
         }
 
+        fn map_authorized_sweep_items(
+            items: Vec<CandidAuthorizedSweepItem>,
+        ) -> Vec<AuthorizedSweepItem> {
+            fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
+                ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
+            }
+
+            items
+                .into_iter()
+                .map(|item| AuthorizedSweepItem {
+                    item: SweepItem {
+                        deposit: DepositAddress::new(item.deposit.parse().unwrap()),
+                        account: Account {
+                            owner: item.owner,
+                            subaccount: item
+                                .subaccount
+                                .map(|s| <[u8; 32]>::try_from(s.as_ref()).unwrap()),
+                        },
+                        attestation: TransactionSignature {
+                            signature_y_parity: item.attestation_y_parity,
+                            r: map_signature_component(&item.attestation_r),
+                            s: map_signature_component(&item.attestation_s),
+                        },
+                    },
+                    authorization: item.authorization.map(|authorization| {
+                        map_authorizations(vec![authorization])
+                            .pop()
+                            .expect("BUG: one authorization in, one out")
+                    }),
+                })
+                .collect()
+        }
+
         fn map_authorizations(
             authorizations: Vec<CandidSignedAuthorization>,
         ) -> Vec<SignedAuthorization> {
@@ -486,19 +522,17 @@ impl GetEventsFile {
                 EventPayload::AcceptedSweepRequest {
                     sweep_id,
                     destination,
-                    amount,
-                    data,
+                    token,
+                    items,
                     max_transaction_fee,
                     created_at,
-                    authorizations,
                 } => ET::AcceptedSweepRequest(SweepRequest {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
-                    amount: amount.try_into().unwrap(),
-                    data: data.into_vec(),
+                    token: token.parse().unwrap(),
+                    items: map_authorized_sweep_items(items),
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,
-                    authorizations: map_authorizations(authorizations),
                 }),
                 EventPayload::CreatedSweeperTransaction {
                     sweep_id,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -419,6 +419,7 @@ impl AutomaticDeposits {
                 last_scanned_block: deposit.last_scanned_block,
                 scan_count: deposit.scan_count,
                 scanned_balance: deposit.scanned_balance,
+                swept_by: None,
             },
         );
         assert!(
@@ -505,12 +506,16 @@ impl AutomaticDeposits {
             })
     }
 
+    /// The queued deposits a sweep could take next, batched by token, skipping those a sweep
+    /// already holds: taking them twice would move a balance the minter has already accounted for.
     pub fn requests_batch(
         &self,
         requested_batch_size: usize,
     ) -> BTreeMap<Address, Vec<SweepTarget>> {
         let mut batches = BTreeMap::new();
-        for (deposit_request, sweep_entry) in &self.sweep {
+        for (deposit_request, sweep_entry) in
+            self.sweep.iter().filter(|(_, entry)| entry.is_sweepable())
+        {
             let batch: &mut Vec<_> = batches.entry(deposit_request.token).or_default();
             if batch.len() < requested_batch_size {
                 batch.push(SweepTarget {
@@ -520,6 +525,33 @@ impl AutomaticDeposits {
             }
         }
         batches
+    }
+
+    /// Record that `sweep_id` took these accounts' deposits of `token`: each leaves the pool of
+    /// sweepable entries until the sweep is done with it.
+    ///
+    /// # Panics
+    ///
+    /// If a deposit is not queued, or another sweep already took it. Either means the queue no
+    /// longer describes which sweep owns which funds.
+    pub fn record_sweep_scheduled(
+        &mut self,
+        sweep_id: SweepId,
+        token: Address,
+        accounts: impl IntoIterator<Item = Account>,
+    ) {
+        for account in accounts {
+            let request = DepositRequest::new(account, token);
+            let entry = self
+                .sweep
+                .get_mut(&request)
+                .unwrap_or_else(|| panic!("BUG: {request:?} is not queued for sweeping"));
+            assert_eq!(
+                entry.swept_by, None,
+                "BUG: {request:?} was already taken by another sweep"
+            );
+            entry.swept_by = Some(sweep_id);
+        }
     }
 }
 
@@ -605,6 +637,17 @@ struct SweepEntry {
     scan_count: u32,
     /// The balance read for the token at `last_scanned_block`.
     scanned_balance: Erc20Value,
+    /// The sweep holding these funds, if one does. The entry stays queued while a sweep has it,
+    /// rather than leaving on being taken: until that sweep settles, this is the only record of
+    /// which balance sits at which address, and a failed sweep has to be able to say so.
+    swept_by: Option<SweepId>,
+}
+
+impl SweepEntry {
+    /// Whether a sweep could take these funds, i.e. no sweep already holds them.
+    fn is_sweepable(&self) -> bool {
+        self.swept_by.is_none()
+    }
 }
 
 /// The watchlist value held against one [`DepositRequest`]: the deposit address derived for its

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -216,7 +216,7 @@ impl AutomaticDeposits {
             if receipt.status == TransactionStatus::Failure {
                 log!(
                     INFO,
-                    "[record_finalized_sweep_transaction]: DROPPING {request:?} from the sweep                      queue: {id:?} failed and the minter does not retry. Its {:?} stays at {}, and                      reaching it again needs the pair armed afresh.",
+                    "[record_finalized_sweep_transaction]: DROPPING {request:?} from the sweep queue: {id:?} failed and the minter does not retry. Its {:?} stays at {}, and reaching it again needs the pair armed afresh.",
                     entry.scanned_balance,
                     entry.address
                 );

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -5,7 +5,8 @@ use crate::attestation::AttestationRequest;
 use crate::deposit_address::DepositAddress;
 use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, DetectedDeposit};
 use crate::eth_rpc::Hash;
-use crate::eth_rpc_client::responses::TransactionReceipt;
+use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::logs::INFO;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionCount, TransactionNonce};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
 use crate::state::transactions::{
@@ -15,6 +16,7 @@ use crate::timed_sized_map::{Entry, InsertError, TimedSizedMap, Timestamp};
 use crate::tx::{
     AuthorizationRequest, Finalized, GasFeeEstimate, Signed, SweepTransaction, TransactionSignature,
 };
+use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
@@ -177,13 +179,50 @@ impl AutomaticDeposits {
             .record_resubmit_transaction(new_tx)
     }
 
+    /// Finalize `id`'s transaction and release the deposits it held, whichever way it went: they
+    /// leave the queue on success because the funds moved, and on failure because the minter does
+    /// not retry them.
+    ///
+    /// # Panics
+    ///
+    /// If the sweep has no processed request, or a deposit it named is not queued or is held by
+    /// another sweep. Each means the queue has stopped describing which sweep owns which funds.
     pub fn record_finalized_sweep_transaction(
         &mut self,
         id: SweepId,
         receipt: &TransactionReceipt,
     ) -> Finalized<SweepTransaction> {
-        self.sweeper_transactions
-            .record_finalized_transaction(id, receipt)
+        let finalized = self
+            .sweeper_transactions
+            .record_finalized_transaction(id, receipt);
+        let request = self
+            .sweeper_transactions
+            .get_processed_request(&id)
+            .expect("BUG: missing sweep request");
+        let token = request.token;
+        let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
+
+        for account in accounts {
+            let request = DepositRequest::new(account, token);
+            let entry = self
+                .sweep
+                .remove(&request)
+                .unwrap_or_else(|| panic!("BUG: {request:?} is not queued for sweeping"));
+            assert_eq!(
+                entry.swept_by,
+                Some(id),
+                "BUG: {request:?} is not held by sweep {id:?}"
+            );
+            if receipt.status == TransactionStatus::Failure {
+                log!(
+                    INFO,
+                    "[record_finalized_sweep_transaction]: DROPPING {request:?} from the sweep                      queue: {id:?} failed and the minter does not retry. Its {:?} stays at {}, and                      reaching it again needs the pair armed afresh.",
+                    entry.scanned_balance,
+                    entry.address
+                );
+            }
+        }
+        finalized
     }
 
     /// Equality as replay defines it: the sweeper pipeline reorders its queue without recording an

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -10,7 +10,6 @@ use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, Erc20Value, Wei, WeiPerGas};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
 use crate::state::transactions::{AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest};
-use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
 use crate::sweeper_contract::SweepItem;
 use crate::test_fixtures::{deposit_address, usdc, usdt};
 use crate::timed_sized_map::{Entry, Timestamp};
@@ -839,7 +838,7 @@ fn finalize_sweep(
                 base_fee_per_gas: WeiPerGas::new(10),
                 max_priority_fee_per_gas: WeiPerGas::new(1),
             },
-            SWEEP_TRANSACTION_GAS_LIMIT,
+            request.gas_limit(),
             EthereumNetwork::Sepolia,
         )
         .expect("BUG: the fixture allowance covers the fixture fee");

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -4,11 +4,17 @@ use super::{
 };
 use crate::deposit_address::DepositAddress;
 use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, DetectedDeposit};
-use crate::numeric::{BlockNumber, Erc20Value};
+use crate::eth_rpc::Hash;
+use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::lifecycle::EthereumNetwork;
+use crate::numeric::{BlockNumber, Erc20Value, Wei, WeiPerGas};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::SweepId;
+use crate::state::transactions::{AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest};
+use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
+use crate::sweeper_contract::SweepItem;
 use crate::test_fixtures::{deposit_address, usdc, usdt};
 use crate::timed_sized_map::{Entry, Timestamp};
+use crate::tx::{GasFeeEstimate, SignableTransaction, Signed, TransactionSignature};
 use candid::{Nat, Principal};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -765,6 +771,122 @@ fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
     let mut deposits = queued(&[(account(0), usdc())]);
 
     deposits.record_sweep_scheduled(SweepId(1), usdt(), [account(0)]);
+}
+
+#[test]
+fn should_release_a_deposit_once_its_sweep_succeeds() {
+    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
+    let request = sweep_request(SweepId(0), usdc(), &[account(0)]);
+    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+
+    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+
+    // The swept pair is gone from the queue; the untouched one is still offered.
+    assert_eq!(deposits.sweep_len(), 1);
+    assert_eq!(
+        accounts_in(&deposits.requests_batch(10), usdc()),
+        vec![account(1)]
+    );
+}
+
+#[test]
+fn should_drop_a_deposit_once_its_sweep_fails() {
+    let mut deposits = queued(&[(account(0), usdc())]);
+    let request = sweep_request(SweepId(0), usdc(), &[account(0)]);
+    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+
+    finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
+
+    // A reverted sweep moved nothing, but the minter does not retry: the pair leaves the queue and
+    // has to be armed afresh.
+    assert_eq!(deposits.sweep_len(), 0);
+    assert!(deposits.requests_batch(10).is_empty());
+}
+
+#[test]
+fn should_release_every_account_a_sweep_held() {
+    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
+    let request = sweep_request(SweepId(0), usdc(), &[account(0), account(1)]);
+    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0), account(1)]);
+
+    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+
+    assert_eq!(deposits.sweep_len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "is not queued for sweeping")]
+fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
+    let mut deposits = queued(&[(account(0), usdc())]);
+    let request = sweep_request(SweepId(0), usdc(), &[account(0), account(1)]);
+    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+
+    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+}
+
+/// Drives `request` through the sweeper pipeline to a receipt of `status`.
+fn finalize_sweep(
+    deposits: &mut AutomaticDeposits,
+    request: SweepRequest,
+    status: TransactionStatus,
+) {
+    let id = request.id;
+    deposits.record_sweep_request(request.clone());
+    let transaction = request
+        .create_transaction(
+            deposits.next_sweeper_transaction_nonce(),
+            GasFeeEstimate {
+                base_fee_per_gas: WeiPerGas::new(10),
+                max_priority_fee_per_gas: WeiPerGas::new(1),
+            },
+            SWEEP_TRANSACTION_GAS_LIMIT,
+            EthereumNetwork::Sepolia,
+        )
+        .expect("BUG: the fixture allowance covers the fixture fee");
+    deposits.record_created_sweep_transaction(id, transaction.clone());
+    let signed = Signed::from((
+        transaction,
+        TransactionSignature {
+            signature_y_parity: false,
+            r: Default::default(),
+            s: Default::default(),
+        },
+    ));
+    let receipt = TransactionReceipt {
+        block_hash: Hash([0x11; 32]),
+        block_number: BlockNumber::new(4_190_269),
+        effective_gas_price: signed.transaction().max_fee_per_gas(),
+        gas_used: signed.transaction().gas_limit(),
+        status,
+        transaction_hash: signed.hash(),
+    };
+    deposits.record_signed_sweep_transaction(signed);
+    deposits.record_finalized_sweep_transaction(id, &receipt);
+}
+
+fn sweep_request(id: SweepId, token: Address, accounts: &[Account]) -> SweepRequest {
+    SweepRequest {
+        id,
+        destination: Address::new([0x5e; 20]),
+        token,
+        items: accounts
+            .iter()
+            .map(|account| AuthorizedSweepItem {
+                item: SweepItem {
+                    deposit: deposit_address(account),
+                    account: *account,
+                    attestation: TransactionSignature {
+                        signature_y_parity: false,
+                        r: Default::default(),
+                        s: Default::default(),
+                    },
+                },
+                authorization: None,
+            })
+            .collect(),
+        max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
+        created_at: 0,
+    }
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -7,13 +7,14 @@ use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, D
 use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
 use crate::lifecycle::EthereumNetwork;
-use crate::numeric::{BlockNumber, Erc20Value, Wei, WeiPerGas};
+use crate::numeric::{BlockNumber, Erc20Value};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::{AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest};
-use crate::sweeper_contract::SweepItem;
-use crate::test_fixtures::{deposit_address, usdc, usdt};
+use crate::state::transactions::{PipelineRequest, SweepId, SweepRequest};
+use crate::test_fixtures::{
+    deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, usdc, usdt,
+};
 use crate::timed_sized_map::{Entry, Timestamp};
-use crate::tx::{GasFeeEstimate, SignableTransaction, Signed, TransactionSignature};
+use crate::tx::{SignableTransaction, Signed, TransactionSignature};
 use candid::{Nat, Principal};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -772,15 +773,15 @@ fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
     deposits.record_sweep_scheduled(SweepId(1), usdt(), [account(0)]);
 }
 
-#[test]
-fn should_release_a_deposit_once_its_sweep_succeeds() {
-    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
-    let request = sweep_request(SweepId(0), usdc(), &[account(0)]);
-    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+#[tokio::test]
+async fn should_release_a_deposit_once_its_sweep_succeeds() {
+    let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    queue(&mut deposits, &[(account(1), usdc())]);
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Success);
 
-    // The swept pair is gone from the queue; the untouched one is still offered.
+    // The swept pair is gone from the queue; the pair queued after the sweep was decided is still
+    // offered.
     assert_eq!(deposits.sweep_len(), 1);
     assert_eq!(
         accounts_in(&deposits.requests_batch(10), usdc()),
@@ -788,11 +789,9 @@ fn should_release_a_deposit_once_its_sweep_succeeds() {
     );
 }
 
-#[test]
-fn should_drop_a_deposit_once_its_sweep_fails() {
-    let mut deposits = queued(&[(account(0), usdc())]);
-    let request = sweep_request(SweepId(0), usdc(), &[account(0)]);
-    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+#[tokio::test]
+async fn should_drop_a_deposit_once_its_sweep_fails() {
+    let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
 
@@ -802,46 +801,46 @@ fn should_drop_a_deposit_once_its_sweep_fails() {
     assert!(deposits.requests_batch(10).is_empty());
 }
 
-#[test]
-fn should_release_every_account_a_sweep_held() {
-    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
-    let request = sweep_request(SweepId(0), usdc(), &[account(0), account(1)]);
-    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0), account(1)]);
+#[tokio::test]
+async fn should_release_every_account_a_sweep_held() {
+    let (mut deposits, request) =
+        deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Success);
 
     assert_eq!(deposits.sweep_len(), 0);
 }
 
-#[test]
+/// The mismatch this test finalizes cannot come out of `create_pending_sweeper_requests`, which
+/// schedules exactly the deposits its request names. Hence the request the production code built
+/// for both accounts is replayed against a queue that never held the second one.
+#[tokio::test]
 #[should_panic(expected = "is not queued for sweeping")]
-fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
+async fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
+    let (_, request) =
+        deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
     let mut deposits = queued(&[(account(0), usdc())]);
-    let request = sweep_request(SweepId(0), usdc(), &[account(0), account(1)]);
     deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+    deposits.record_sweep_request(request.clone());
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Success);
 }
 
-/// Drives `request` through the sweeper pipeline to a receipt of `status`.
+/// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.
 fn finalize_sweep(
     deposits: &mut AutomaticDeposits,
     request: SweepRequest,
     status: TransactionStatus,
 ) {
     let id = request.id;
-    deposits.record_sweep_request(request.clone());
     let transaction = request
         .create_transaction(
             deposits.next_sweeper_transaction_nonce(),
-            GasFeeEstimate {
-                base_fee_per_gas: WeiPerGas::new(10),
-                max_priority_fee_per_gas: WeiPerGas::new(1),
-            },
+            gas_fee_estimate(),
             request.gas_limit(),
             EthereumNetwork::Sepolia,
         )
-        .expect("BUG: the fixture allowance covers the fixture fee");
+        .expect("BUG: the fixture prices the request with the estimate it creates with");
     deposits.record_created_sweep_transaction(id, transaction.clone());
     let signed = Signed::from((
         transaction,
@@ -863,34 +862,15 @@ fn finalize_sweep(
     deposits.record_finalized_sweep_transaction(id, &receipt);
 }
 
-fn sweep_request(id: SweepId, token: Address, accounts: &[Account]) -> SweepRequest {
-    SweepRequest {
-        id,
-        destination: Address::new([0x5e; 20]),
-        token,
-        items: accounts
-            .iter()
-            .map(|account| AuthorizedSweepItem {
-                item: SweepItem {
-                    deposit: deposit_address(account),
-                    account: *account,
-                    attestation: TransactionSignature {
-                        signature_y_parity: false,
-                        r: Default::default(),
-                        s: Default::default(),
-                    },
-                },
-                authorization: None,
-            })
-            .collect(),
-        max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
-        created_at: 0,
-    }
-}
-
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.
 fn queued(pairs: &[(Account, Address)]) -> AutomaticDeposits {
     let mut deposits = AutomaticDeposits::default();
+    queue(&mut deposits, pairs);
+    assert_eq!(deposits.sweep_len(), pairs.len());
+    deposits
+}
+
+fn queue(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {
     for (account, token) in pairs {
         deposits
             .watch_deposit(ts(0), *account, *token, deposit_address(account))
@@ -903,8 +883,6 @@ fn queued(pairs: &[(Account, Address)]) -> AutomaticDeposits {
             3,
         ));
     }
-    assert_eq!(deposits.sweep_len(), pairs.len());
-    deposits
 }
 
 fn accounts_in(batches: &BTreeMap<Address, Vec<SweepTarget>>, token: Address) -> Vec<Account> {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1,16 +1,18 @@
 use super::{
     AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, DepositRequest, MAX_ACTIVE_DEPOSITS,
-    MAX_TOKENS_PER_ACCOUNT, SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry,
+    MAX_TOKENS_PER_ACCOUNT, SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry, SweepTarget,
 };
 use crate::deposit_address::DepositAddress;
 use crate::endpoints::{DepositErc20Error, DepositErc20Response, DepositStatus, DetectedDeposit};
 use crate::numeric::{BlockNumber, Erc20Value};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
+use crate::state::transactions::SweepId;
 use crate::test_fixtures::{deposit_address, usdc, usdt};
 use crate::timed_sized_map::{Entry, Timestamp};
 use candid::{Nat, Principal};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeMap;
 
 #[test]
 fn should_watch_a_pair_for_the_scan_window() {
@@ -701,6 +703,96 @@ fn automatic_deposit(
     }
 }
 
+#[test]
+fn should_batch_queued_deposits_by_token() {
+    let deposits = queued(&[
+        (account(0), usdc()),
+        (account(1), usdc()),
+        (account(2), usdt()),
+    ]);
+
+    let batches = deposits.requests_batch(10);
+
+    assert_eq!(
+        batches.keys().copied().collect::<Vec<_>>(),
+        vec![usdc(), usdt()]
+    );
+    assert_eq!(accounts_in(&batches, usdc()), vec![account(0), account(1)]);
+    assert_eq!(accounts_in(&batches, usdt()), vec![account(2)]);
+
+    // Nothing has taken them, so batching again offers the same deposits.
+    let again = deposits.requests_batch(10);
+    assert_eq!(accounts_in(&again, usdc()), vec![account(0), account(1)]);
+    assert_eq!(accounts_in(&again, usdt()), vec![account(2)]);
+}
+
+#[test]
+fn should_stop_offering_a_deposit_a_sweep_has_taken() {
+    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
+
+    deposits.record_sweep_scheduled(SweepId(7), usdc(), [account(0)]);
+
+    let batches = deposits.requests_batch(10);
+    assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
+
+    // The taken deposit is still queued: only a settled sweep removes it.
+    assert_eq!(deposits.sweep_len(), 2);
+}
+
+#[test]
+fn should_offer_nothing_once_every_deposit_is_taken() {
+    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdt())]);
+
+    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), usdt(), [account(1)]);
+
+    assert!(deposits.requests_batch(10).is_empty());
+    assert_eq!(deposits.sweep_len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "was already taken by another sweep")]
+fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
+    let mut deposits = queued(&[(account(0), usdc())]);
+
+    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), usdc(), [account(0)]);
+}
+
+#[test]
+#[should_panic(expected = "is not queued for sweeping")]
+fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
+    let mut deposits = queued(&[(account(0), usdc())]);
+
+    deposits.record_sweep_scheduled(SweepId(1), usdt(), [account(0)]);
+}
+
+/// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.
+fn queued(pairs: &[(Account, Address)]) -> AutomaticDeposits {
+    let mut deposits = AutomaticDeposits::default();
+    for (account, token) in pairs {
+        deposits
+            .watch_deposit(ts(0), *account, *token, deposit_address(account))
+            .unwrap();
+        deposits.record_automatic_deposit_received(&automatic_deposit(
+            *account,
+            *token,
+            10,
+            BlockNumber::new(900),
+            3,
+        ));
+    }
+    assert_eq!(deposits.sweep_len(), pairs.len());
+    deposits
+}
+
+fn accounts_in(batches: &BTreeMap<Address, Vec<SweepTarget>>, token: Address) -> Vec<Account> {
+    batches
+        .get(&token)
+        .map(|targets| targets.iter().map(|target| target.account()).collect())
+        .unwrap_or_default()
+}
+
 fn sweep_entry(
     address: DepositAddress,
     last_scanned_block: BlockNumber,
@@ -712,6 +804,7 @@ fn sweep_entry(
         last_scanned_block,
         scan_count,
         scanned_balance: Erc20Value::new(scanned_balance),
+        swept_by: None,
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -13,7 +13,7 @@ use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::logs::INFO;
 use crate::map::MultiKeyMap;
 use crate::numeric::{
-    CkTokenAmount, Erc20Value, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
+    CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
     TransactionNonce, Wei,
 };
 use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
@@ -265,7 +265,72 @@ pub struct AuthorizedSweepItem {
     pub authorization: Option<SignedAuthorization>,
 }
 
+/// This and the constants below are derived from the EVM's own costs rather than from the ~42'000
+/// per deposit measured for a batch of 20, which does not record how many distinct tokens that
+/// batch covered and so cannot separate the work that grows with the pairs from the work that grows
+/// with the transfers. Each is deliberately generous: unspent gas is refunded, whereas an
+/// underestimate wastes the whole transaction.
+const SWEEP_BASE_GAS: GasAmount = GasAmount::new(60_000);
+
+/// Gas each `balanceOf` the delegate makes costs. `sweepErc20Batch` hands the whole token array to
+/// every item and `sweepErc20` loops over it, so a sweep pays one balance check per
+/// `(address, token)` pair whether or not the pair holds anything — and therefore at least one per
+/// address, which is where that address' calldata, `ecrecover` and delegated call are accounted
+/// for. A cold `balanceOf` is ~5'000 (2'600 account access, 2'100 cold slot, call overhead) and the
+/// per-address dispatch ~10'000.
+const SWEEP_GAS_PER_BALANCE_CHECK: GasAmount = GasAmount::new(15_000);
+
+/// Gas moving one pair costs beyond its balance check: the `approve` (a 20'000 slot write), the
+/// helper's `depositErc20` and the `transferFrom` it makes (two slot writes and two logs), ~55'000
+/// in the worst case, doubled.
+///
+/// Budgeted for every pair the batch touches rather than only for the deposits the queue named:
+/// `sweepErc20` moves whatever balance it finds, and a deposit address accumulates residue — a pair
+/// armed but not yet scanned, a pair whose watchlist window closed before the funds arrived, a token
+/// the sender was never asked for. A pair therefore costs a balance check and, on top of it,
+/// possibly a transfer.
+const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
+
+/// Gas one EIP-7702 authorization costs: 12'500 (`PER_AUTH_BASE_COST`) plus the 25'000
+/// (`PER_EMPTY_ACCOUNT_COST`) a deposit EOA pays, its account holding no ETH and no code yet.
+///
+/// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
+/// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
+/// matches — still pays `PER_AUTH_BASE_COST`, and pays no `PER_EMPTY_ACCOUNT_COST` because such an
+/// account exists, so this is the worst case either way.
+const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
+
+pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
+    let addresses = u64::try_from(
+        items
+            .iter()
+            .map(|authorized| authorized.item.deposit)
+            .collect::<BTreeSet<_>>()
+            .len(),
+    )
+    .unwrap_or(u64::MAX);
+    [
+        SWEEP_GAS_PER_BALANCE_CHECK,
+        SWEEP_GAS_PER_TRANSFER,
+        SWEEP_GAS_PER_AUTHORIZATION,
+    ]
+    .into_iter()
+    .fold(SWEEP_BASE_GAS, |total, gas_per_address| {
+        total
+            .checked_add(
+                gas_per_address
+                    .checked_mul(addresses)
+                    .unwrap_or(GasAmount::MAX),
+            )
+            .unwrap_or(GasAmount::MAX)
+    })
+}
+
 impl SweepRequest {
+    pub fn gas_limit(&self) -> GasAmount {
+        sweep_gas_limit(&self.items)
+    }
+
     /// The delegate's batch call, naming every deposit address this sweep walks and the single
     /// token it moves.
     pub fn call_data(&self) -> Vec<u8> {

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -291,13 +291,14 @@ const SWEEP_GAS_PER_BALANCE_CHECK: GasAmount = GasAmount::new(15_000);
 /// possibly a transfer.
 const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 
-/// Gas one EIP-7702 authorization costs: 12'500 (`PER_AUTH_BASE_COST`) plus the 25'000
-/// (`PER_EMPTY_ACCOUNT_COST`) a deposit EOA pays, its account holding no ETH and no code yet.
+/// Gas one EIP-7702 authorization costs: 25'000 (`PER_EMPTY_ACCOUNT_COST`) charged upfront for
+/// every tuple, before any of them is looked at.
 ///
 /// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
 /// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
-/// matches — still pays `PER_AUTH_BASE_COST`, and pays no `PER_EMPTY_ACCOUNT_COST` because such an
-/// account exists, so this is the worst case either way.
+/// matches — is charged the same 25'000 and refunded 12'500 for an authority the state trie
+/// already holds. That refund lands after execution and so cannot shrink the limit the transaction
+/// had to declare, leaving 25'000 the figure to budget either way. Rounded up as its siblings are.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -16,6 +16,7 @@ use crate::numeric::{
     CkTokenAmount, Erc20Value, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
     TransactionNonce, Wei,
 };
+use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
 use crate::tx::{
     Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
     Resubmittable, SignableTransaction, Signed, SignedAuthorization,
@@ -216,36 +217,72 @@ impl SweepId {
 /// sequence — the request type of the sweeper [`TransactionPipeline`]. It carries no ckETH burn
 /// and is never reimbursed.
 ///
-/// The sweep-queue-driven construction of the delegate call data is a follow-up.
+/// Like [`WithdrawalRequest`], this says *what* to sweep, not how the transaction carrying it
+/// looks: the nonce, the gas price and the call data are the pipeline's to decide in
+/// [`PipelineRequest::create_transaction`].
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub struct SweepRequest {
     /// This sweep's identity (the pipeline's alternate map key).
     #[n(0)]
     pub id: SweepId,
     /// Address the sweep transaction is sent to: the sweeper contract, whose batch entry point
-    /// sweeps every delegated deposit address named in `data`.
+    /// sweeps every delegated deposit address the sweep names.
     #[n(1)]
     pub destination: Address,
-    /// ETH value moved by the transaction (zero for an ERC-20 sweep, which moves tokens via calldata).
+    /// The single ERC-20 this sweep moves. One token per sweep: the delegate applies the token
+    /// list to every item it walks, so a sweep mixing tokens would check balances that cannot be
+    /// there. Holding it as one address rather than a list is what makes that an invariant of the
+    /// request instead of a property of how the batch happened to be picked.
     #[n(2)]
-    pub amount: Wei,
-    /// Transaction call data: the sweeper contract's batch call, naming the deposit addresses to
-    /// sweep, the IC account each is credited to, and the tokens to move. Its size is bounded by
-    /// the number of deposits the enqueuing side puts in one batch, which is where that limit
-    /// lives.
+    pub token: Address,
+    /// The deposits this sweep moves, one per account. A deposit address is derived per account,
+    /// so an account has one address, one attestation and one authorization however many tokens
+    /// it has queued.
     #[n(3)]
-    pub data: Vec<u8>,
+    pub items: Vec<AuthorizedSweepItem>,
     /// Ceiling on the transaction fee, used as the resubmission fee cap.
     #[n(4)]
     pub max_transaction_fee: Wei,
     /// The IC time at which the sweep was decided.
     #[n(5)]
     pub created_at: u64,
-    /// Delegations to install on the way, one signed by each deposit address the sweep touches
-    /// that is not yet delegated to the sweeper contract. Empty once they all are, and a sweep
-    /// with none is a plain EIP-1559 transaction.
-    #[n(6)]
-    pub authorizations: Vec<SignedAuthorization>,
+}
+
+/// A sweep item together with the delegation that lets the delegate code run at its address.
+///
+/// The two travel together but land in different parts of the transaction: the item is call data,
+/// the authorization is a transaction field. Pairing them here is what stops the two lists from
+/// drifting out of order against the account they describe.
+///
+/// The delegation is absent for an address already delegated to the sweeper contract, which needs
+/// no tuple to install one again. A sweep all of whose items are delegated carries no
+/// authorization at all, and is sent as a plain EIP-1559 transaction.
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
+pub struct AuthorizedSweepItem {
+    #[n(0)]
+    pub item: SweepItem,
+    #[n(1)]
+    pub authorization: Option<SignedAuthorization>,
+}
+
+impl SweepRequest {
+    /// The delegate's batch call, naming every deposit address this sweep walks and the single
+    /// token it moves.
+    pub fn call_data(&self) -> Vec<u8> {
+        let items: Vec<_> = self.items.iter().map(|item| item.item.clone()).collect();
+        encode_sweep_erc20_batch(&items, &[self.token])
+    }
+
+    /// The delegations the sweep installs on the way, one per deposit address it still has to
+    /// delegate. Signed for nonce zero, so a tuple whose delegation is already installed is
+    /// skipped rather than sinking the sweep. Empty once every address the sweep touches is
+    /// delegated, which is what makes it a plain EIP-1559 transaction.
+    pub fn authorizations(&self) -> Vec<SignedAuthorization> {
+        self.items
+            .iter()
+            .filter_map(|item| item.authorization.clone())
+            .collect()
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Decode, Encode)]

--- a/rs/ethereum/cketh/minter/src/state/transactions/request.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/request.rs
@@ -215,17 +215,17 @@ impl PipelineRequest for SweepRequest {
         );
         assert_eq!(
             transaction.amount(),
-            &self.amount,
-            "BUG: sweep transaction amount should equal the request amount"
+            &Wei::ZERO,
+            "BUG: an ERC-20 sweep moves its tokens through call data, not as value"
         );
         assert_eq!(
             transaction.data(),
-            self.data,
+            self.call_data(),
             "BUG: sweep transaction should carry the request's call data"
         );
         assert_eq!(
             transaction.authorizations(),
-            self.authorizations.as_slice(),
+            self.authorizations().as_slice(),
             "BUG: sweep transaction should install exactly the request's delegations"
         );
     }
@@ -268,11 +268,11 @@ impl PipelineRequest for SweepRequest {
                 max_fee_per_gas,
                 gas_limit,
                 destination: self.destination,
-                amount: self.amount,
-                data: self.data.clone(),
+                amount: Wei::ZERO,
+                data: self.call_data(),
                 access_list: Default::default(),
             },
-            self.authorizations.clone(),
+            self.authorizations(),
         ))
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2969,42 +2969,68 @@ pub mod arbitrary {
 
 mod sweep_lane {
     use super::{gas_fee_estimate, sign_transaction, transaction_receipt};
+    use crate::deposit_address::DepositAddress;
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
     use crate::numeric::{TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
-        CreateSweepTransactionError, PipelineRequest, ResubmitTransactionError, SweepId,
-        SweepRequest, TransactionPipeline,
+        AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest,
+        ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline,
     };
     use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
+    use crate::sweeper_contract::SweepItem;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
-        SignableTransaction, SignedAuthorization, SweepTransaction,
+        SignableTransaction, SignedAuthorization, SweepTransaction, TransactionSignature,
     };
     use assert_matches::assert_matches;
+    use candid::Principal;
     use ethnum::u256;
     use ic_ethereum_types::Address;
+    use icrc_ledger_types::icrc1::account::Account;
 
     const EIP1559_TX_ID: u8 = 2;
     const SET_CODE_TX_ID: u8 = 4;
 
+    /// A sweep of two deposit addresses, both already delegated to the sweeper contract and so
+    /// carrying no authorization.
     fn sweep_request(id: u64) -> SweepRequest {
         SweepRequest {
             id: SweepId(id),
             destination: Address::new([id as u8; 20]),
-            amount: Wei::ZERO,
-            data: vec![0xaa, 0xbb, 0xcc],
+            token: Address::new([0xc0; 20]),
+            items: vec![sweep_item(1, None), sweep_item(2, None)],
             max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
             created_at: 1_620_328_630_000_000_000,
-            authorizations: vec![],
         }
     }
 
     /// A sweep of two deposit addresses that are not yet delegated to the sweeper contract.
     fn delegating_sweep_request(id: u64) -> SweepRequest {
         SweepRequest {
-            authorizations: vec![authorization(1), authorization(2)],
+            items: vec![
+                sweep_item(1, Some(authorization(1))),
+                sweep_item(2, Some(authorization(2))),
+            ],
             ..sweep_request(id)
+        }
+    }
+
+    fn sweep_item(seed: u8, authorization: Option<SignedAuthorization>) -> AuthorizedSweepItem {
+        AuthorizedSweepItem {
+            item: SweepItem {
+                deposit: DepositAddress::new(Address::new([seed; 20])),
+                account: Account {
+                    owner: Principal::management_canister(),
+                    subaccount: Some([seed; 32]),
+                },
+                attestation: TransactionSignature {
+                    signature_y_parity: false,
+                    r: u256::from(seed),
+                    s: u256::from(seed),
+                },
+            },
+            authorization,
         }
     }
 
@@ -3063,37 +3089,40 @@ mod sweep_lane {
         );
         assert_eq!(tx.destination(), &sweep_request(0).destination);
         assert_eq!(tx.amount(), &Wei::ZERO);
-        assert_eq!(tx.data(), sweep_request(0).data);
+        assert_eq!(tx.data(), sweep_request(0).call_data());
     }
 
     #[test]
     fn should_sweep_with_the_transaction_type_the_delegations_to_install_call_for() {
         struct Case {
             scenario: &'static str,
-            authorizations: Vec<SignedAuthorization>,
+            items: Vec<AuthorizedSweepItem>,
             expected_transaction_type: u8,
         }
 
         for case in [
             Case {
                 scenario: "every swept address already delegated",
-                authorizations: vec![],
+                items: vec![sweep_item(1, None), sweep_item(2, None)],
                 expected_transaction_type: EIP1559_TX_ID,
             },
             Case {
                 scenario: "one swept address still to delegate",
-                authorizations: vec![authorization(1)],
+                items: vec![sweep_item(1, Some(authorization(1))), sweep_item(2, None)],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
             Case {
                 scenario: "two swept addresses still to delegate",
-                authorizations: vec![authorization(1), authorization(2)],
+                items: vec![
+                    sweep_item(1, Some(authorization(1))),
+                    sweep_item(2, Some(authorization(2))),
+                ],
                 expected_transaction_type: SET_CODE_TX_ID,
             },
         ] {
             let context = case.scenario;
             let request = SweepRequest {
-                authorizations: case.authorizations,
+                items: case.items,
                 ..sweep_request(0)
             };
             let mut pipeline = sweeper_pipeline();
@@ -3108,12 +3137,12 @@ mod sweep_lane {
             );
             assert_eq!(
                 tx.authorizations(),
-                request.authorizations.as_slice(),
+                request.authorizations().as_slice(),
                 "{context}"
             );
             assert_eq!(tx.destination(), &request.destination, "{context}");
-            assert_eq!(tx.amount(), &request.amount, "{context}");
-            assert_eq!(tx.data(), request.data, "{context}");
+            assert_eq!(tx.amount(), &Wei::ZERO, "{context}");
+            assert_eq!(tx.data(), request.call_data(), "{context}");
             assert_eq!(tx.nonce(), TransactionNonce::ZERO, "{context}");
         }
     }
@@ -3134,7 +3163,7 @@ mod sweep_lane {
         };
         assert_eq!(id, &SweepId(0));
         assert_eq!(bumped.transaction_type(), SET_CODE_TX_ID);
-        assert_eq!(bumped.authorizations(), request.authorizations.as_slice());
+        assert_eq!(bumped.authorizations(), request.authorizations().as_slice());
         assert!(bumped.max_priority_fee_per_gas() > created.max_priority_fee_per_gas());
         assert_eq!(bumped.max_fee_per_gas(), created.max_fee_per_gas());
     }
@@ -3168,7 +3197,7 @@ mod sweep_lane {
         assert_eq!(finalized.transaction_hash(), &signed.hash());
         assert_eq!(
             finalized.transaction().authorizations(),
-            delegating_sweep_request(0).authorizations.as_slice()
+            delegating_sweep_request(0).authorizations().as_slice()
         );
     }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2972,12 +2972,14 @@ mod sweep_lane {
     use crate::deposit_address::DepositAddress;
     use crate::eth_rpc_client::responses::TransactionStatus;
     use crate::lifecycle::EthereumNetwork;
+    use crate::numeric::GasAmount;
     use crate::numeric::{TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
         AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest,
         ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline,
     };
-    use crate::sweep::SWEEP_TRANSACTION_GAS_LIMIT;
+
+    const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
     use crate::sweeper_contract::SweepItem;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2976,7 +2976,7 @@ mod sweep_lane {
     use crate::numeric::{TransactionCount, TransactionNonce, Wei, WeiPerGas};
     use crate::state::transactions::{
         AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest,
-        ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline,
+        ResubmitTransactionError, SweepId, SweepRequest, TransactionPipeline, sweep_gas_limit,
     };
 
     const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
@@ -3074,6 +3074,41 @@ mod sweep_lane {
             .expect("BUG: the fixture allowance covers the fixture fee");
         pipeline.record_created_transaction(id, tx);
         pipeline.created_tx.get_alt(&id).unwrap().as_ref().clone()
+    }
+
+    #[test]
+    fn should_scale_the_sweep_gas_limit_with_the_distinct_addresses_walked() {
+        const MEASURED_TEN_DEPOSIT_SWEEP_GAS: u128 = 609_431;
+
+        let items_for = |addresses: u8| -> Vec<AuthorizedSweepItem> {
+            (1..=addresses).map(|seed| sweep_item(seed, None)).collect()
+        };
+
+        assert_eq!(sweep_gas_limit(&items_for(1)), GasAmount::new(225_000));
+        assert_eq!(sweep_gas_limit(&items_for(10)), GasAmount::new(1_710_000));
+        assert!(sweep_gas_limit(&items_for(10)) > GasAmount::new(MEASURED_TEN_DEPOSIT_SWEEP_GAS));
+
+        let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
+        assert_eq!(
+            sweep_gas_limit(&one_address_ten_times),
+            sweep_gas_limit(&items_for(1))
+        );
+    }
+
+    #[test]
+    fn should_price_and_create_a_sweep_transaction_with_the_same_gas_limit() {
+        let request = delegating_sweep_request(1);
+        let transaction = request
+            .create_transaction(
+                TransactionNonce::ZERO,
+                gas_fee_estimate(),
+                request.gas_limit(),
+                EthereumNetwork::Sepolia,
+            )
+            .expect("BUG: the fixture allowance covers the fixture fee");
+
+        assert_eq!(request.gas_limit(), sweep_gas_limit(&request.items));
+        assert_eq!(transaction.gas_limit(), sweep_gas_limit(&request.items));
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     deposit_address::sweeper_derivation_path,
     guard::TimerGuard,
     logs::{DEBUG, INFO},
-    numeric::{GasAmount, TransactionCount},
+    numeric::TransactionCount,
     runtime::CanisterRuntime,
     state::{
         State, TaskType,
@@ -27,6 +27,7 @@ use crate::{
         mutate_state, read_state,
         transactions::{
             AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepRequest,
+            sweep_gas_limit,
         },
     },
     time::TimeProvider,
@@ -40,10 +41,6 @@ use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use std::collections::BTreeSet;
-
-/// Gas limit of a sweep transaction. A fixed, conservative bound; a per-request estimate arrives
-/// with the real delegate sweep call.
-pub(crate) const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
@@ -155,15 +152,16 @@ fn enqueue_sweep<R: CanisterRuntime>(
             return;
         }
 
+        let max_transaction_fee = gas_fee_estimate
+            .clone()
+            .to_price(sweep_gas_limit(&items))
+            .max_transaction_fee();
         let request = SweepRequest {
             id: s.next_sweep_id,
             destination,
             token,
             items,
-            max_transaction_fee: gas_fee_estimate
-                .clone()
-                .to_price(SWEEP_TRANSACTION_GAS_LIMIT)
-                .max_transaction_fee(),
+            max_transaction_fee,
             created_at: runtime.time(),
         };
         process_event(s, EventType::AcceptedSweepRequest(request), runtime);
@@ -377,7 +375,7 @@ fn create_transactions_batch<T: TimeProvider>(
         match request.create_transaction(
             nonce,
             gas_fee_estimate.clone(),
-            SWEEP_TRANSACTION_GAS_LIMIT,
+            request.gas_limit(),
             ethereum_network,
         ) {
             Ok(transaction) => {

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -126,6 +126,9 @@ fn enqueue_sweep<R: CanisterRuntime>(
             return;
         };
 
+        assert_eq!(targets.len(), attestation_requests.len());
+        assert_eq!(targets.len(), authorization_requests.len());
+
         let items: Vec<_> = targets
             .iter()
             .zip(attestation_requests)

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -13,6 +13,7 @@
 mod tests;
 
 use crate::attestation::{AttestationRequest, sign_attestation};
+use crate::sweeper_contract::SweepItem;
 use crate::{
     deposit_address::sweeper_derivation_path,
     guard::TimerGuard,
@@ -22,8 +23,11 @@ use crate::{
     state::{
         State, TaskType,
         audit::{EventType, process_event},
+        automatic_deposits::SweepTarget,
         mutate_state, read_state,
-        transactions::{CreateSweepTransactionError, PipelineRequest},
+        transactions::{
+            AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepRequest,
+        },
     },
     time::TimeProvider,
     tx::{AuthorizationRequest, GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
@@ -74,7 +78,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     }
 
-    let Some(_gas_fee_estimate) = lazy_refresh_gas_fee_estimate(runtime).await else {
+    let Some(gas_fee_estimate) = lazy_refresh_gas_fee_estimate(runtime).await else {
         log!(
             INFO,
             "[create_pending_sweeper_requests]: SKIPPING: failed retrieving gas fee estimate"
@@ -82,7 +86,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     };
 
-    for (_token, targets) in batch_per_token {
+    for (token, targets) in batch_per_token {
         let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
             log!(
                 DEBUG,
@@ -100,7 +104,70 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         };
         sign_attestations_batch(attestation_requests, runtime).await;
         sign_authorizations_batch(authorization_requests, runtime).await;
+        enqueue_sweep(token, &targets, &gas_fee_estimate, runtime);
     }
+}
+
+/// Enqueues one sweep of `token` from the targets both signing passes covered, so the pipeline can
+/// price, sign and send it.
+///
+/// A target whose attestation or authorization is missing is left out rather than swept: its
+/// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
+/// delegate it with. It stays queued, and the next tick tries it again.
+fn enqueue_sweep<R: CanisterRuntime>(
+    token: Address,
+    targets: &[SweepTarget],
+    gas_fee_estimate: &GasFeeEstimate,
+    runtime: &R,
+) {
+    mutate_state(|s| {
+        let (Some(attestation_requests), Some(authorization_requests), Some(destination)) = (
+            s.attestation_requests(targets),
+            s.authorization_requests(targets),
+            s.sweeper_contract_address,
+        ) else {
+            return;
+        };
+
+        let items: Vec<_> = targets
+            .iter()
+            .zip(attestation_requests)
+            .zip(authorization_requests)
+            .filter_map(|((target, attestation_request), authorization_request)| {
+                let attestation = s.automatic_deposits.attestation(&attestation_request)?;
+                let authorization = s.automatic_deposits.authorization(&authorization_request)?;
+                Some(AuthorizedSweepItem {
+                    item: SweepItem {
+                        deposit: target.address(),
+                        account: target.account(),
+                        attestation: attestation.clone(),
+                    },
+                    authorization: Some(authorization_request.signed_with(authorization.clone())),
+                })
+            })
+            .collect();
+
+        if items.is_empty() {
+            log!(
+                INFO,
+                "[create_pending_sweeper_requests]: SKIPPING {token}: none of its queued deposits could be signed for"
+            );
+            return;
+        }
+
+        let request = SweepRequest {
+            id: s.next_sweep_id,
+            destination,
+            token,
+            items,
+            max_transaction_fee: gas_fee_estimate
+                .clone()
+                .to_price(SWEEP_TRANSACTION_GAS_LIMIT)
+                .max_transaction_fee(),
+            created_at: runtime.time(),
+        };
+        process_event(s, EventType::AcceptedSweepRequest(request), runtime);
+    });
 }
 
 async fn sign_attestations_batch<R: CanisterRuntime>(

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,16 +1,17 @@
 use crate::attestation::AttestationRequest;
 use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
-use crate::management::CallError;
-use crate::numeric::{BlockNumber, TransactionNonce, WeiPerGas};
+use crate::management::{CallError, Reason};
+use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
+use crate::state::transactions::{SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
 use crate::sweep::create_pending_sweeper_requests;
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
-    account, automatic_deposit, deposit_address, init_state, initial_state,
+    account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
     state_with_deposit_helper, usdc, usdt,
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
@@ -151,12 +152,138 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     assert!(first.is_some());
 
     mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+    // The first sweep took the account's USDC, so give the second pass its USDT to batch. Same
+    // account, hence the same authorization but for the delegate, which is what must miss.
+    queue_deposit(&account(), &usdt());
 
     create_pending_sweeper_requests(&runtime).await;
     let second = stored_authorization(ANOTHER_SWEEPER_CONTRACT);
     assert!(second.is_some());
     assert_ne!(first, second);
     assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
+}
+
+#[tokio::test]
+async fn should_enqueue_one_sweep_per_token() {
+    init_state(state_ready_to_sign(&[
+        (account(), usdc()),
+        (another_account(), usdc()),
+        (account(), usdt()),
+    ]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    let enqueued = pending_sweeps();
+    assert_eq!(
+        enqueued.iter().map(|r| r.token).collect::<Vec<_>>(),
+        vec![usdc(), usdt()]
+    );
+    assert_eq!(
+        enqueued.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![SweepId(0), SweepId(1)]
+    );
+
+    let usdc_sweep = &enqueued[0];
+    assert_eq!(
+        usdc_sweep
+            .items
+            .iter()
+            .map(|i| i.item.account)
+            .collect::<Vec<_>>(),
+        vec![account(), another_account()]
+    );
+    assert_eq!(usdc_sweep.destination, SWEEPER_CONTRACT);
+    assert_eq!(usdc_sweep.created_at, NOW);
+    assert!(usdc_sweep.max_transaction_fee > Wei::ZERO);
+}
+
+#[tokio::test]
+async fn should_carry_the_signed_attestation_and_authorization_of_every_swept_account() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    let enqueued = pending_sweeps();
+    let [sweep] = enqueued.as_slice() else {
+        panic!("BUG: expected exactly one sweep, got {enqueued:?}");
+    };
+    let [item] = sweep.items.as_slice() else {
+        panic!("BUG: expected exactly one item, got {:?}", sweep.items);
+    };
+    assert_eq!(item.item.deposit, deposit_address(&account()));
+    assert_eq!(
+        item.item.attestation,
+        expected_signature(&attestation_request(account()))
+    );
+    assert_eq!(
+        item.authorization,
+        read_state(|s| s
+            .automatic_deposits
+            .authorization(&authorization_request(SWEEPER_CONTRACT))
+            .map(
+                |signature| authorization_request(SWEEPER_CONTRACT).signed_with(signature.clone())
+            ))
+    );
+}
+
+#[tokio::test]
+async fn should_not_offer_an_enqueued_deposit_to_a_second_sweep() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+    assert_eq!(pending_sweeps().len(), 1);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(pending_sweeps().len(), 1);
+}
+
+#[tokio::test]
+async fn should_leave_out_a_deposit_whose_attestation_could_not_be_signed() {
+    init_state(state_ready_to_sign(&[
+        (account(), usdc()),
+        (another_account(), usdc()),
+    ]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    let unsignable = attestation_request(another_account()).digest().0;
+    runtime
+        .expect_sign_with_ecdsa()
+        .withf(move |_, _, message_hash| *message_hash == unsignable)
+        .returning(|_, _, _| Err(CallError::new("sign_with_ecdsa", Reason::OutOfCycles)));
+    expect_signing(&mut runtime);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    let enqueued = pending_sweeps();
+    let [sweep] = enqueued.as_slice() else {
+        panic!("BUG: expected exactly one sweep, got {enqueued:?}");
+    };
+    assert_eq!(
+        sweep
+            .items
+            .iter()
+            .map(|item| item.item.account)
+            .collect::<Vec<_>>(),
+        vec![account()],
+        "the account whose attestation failed must not be swept"
+    );
+
+    // It stays queued, so a later tick can try it again.
+    assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 2);
+}
+
+fn pending_sweeps() -> Vec<SweepRequest> {
+    read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
 }
 
 /// Expects `times` signatures over the authorization tuple every deposit address delegates with:
@@ -248,19 +375,24 @@ fn state_ready_to_sign(deposits: &[(Account, Address)]) -> State {
         },
     ));
     for (account, token) in deposits {
-        apply_state_transition(
-            &mut state,
-            &EventType::AutomaticDepositReceived(AutomaticDeposit {
-                owner: account.owner,
-                subaccount: account.subaccount,
-                address: deposit_address(account),
-                erc20_contract_address: *token,
-                ..automatic_deposit()
-            }),
-        );
+        apply_state_transition(&mut state, &deposit_received(account, token));
     }
     assert_eq!(state.automatic_deposits.sweep_len(), deposits.len());
     state
+}
+
+fn queue_deposit(account: &Account, token: &Address) {
+    mutate_state(|s| apply_state_transition(s, &deposit_received(account, token)));
+}
+
+fn deposit_received(account: &Account, token: &Address) -> EventType {
+    EventType::AutomaticDepositReceived(AutomaticDeposit {
+        owner: account.owner,
+        subaccount: account.subaccount,
+        address: deposit_address(account),
+        erc20_contract_address: *token,
+        ..automatic_deposit()
+    })
 }
 
 fn attestation_request(account: Account) -> AttestationRequest {

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
@@ -12,6 +12,7 @@ use crate::eth_logs::encode_principal;
 use crate::tx::TransactionSignature;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
+use minicbor::{Decode, Encode};
 
 /// First 4 bytes of
 /// keccak256("sweepErc20Batch((address,bytes32,bytes32,bytes32,bytes32,uint8)[],address[])").
@@ -25,10 +26,13 @@ const WORD: usize = 32;
 
 /// One deposit address in a batch sweep: the address, the IC account its balance is credited to,
 /// and that account's attestation, signed by the address' own key.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
 pub struct SweepItem {
+    #[n(0)]
     pub deposit: DepositAddress,
+    #[n(1)]
     pub account: Account,
+    #[n(2)]
     pub attestation: TransactionSignature,
 }
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -1,17 +1,22 @@
 use crate::EVM_RPC_ID_STAGING;
+use crate::attestation::AttestationRequest;
 use crate::deposit_address::DepositAddress;
 use crate::eth_logs::LedgerSubaccount;
 use crate::lifecycle::init::InitArg;
-use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, Wei};
-use crate::state::State;
+use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas};
+use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::EthWithdrawalRequest;
-use crate::tx::TransactionSignature;
+use crate::state::transactions::{EthWithdrawalRequest, SweepRequest};
+use crate::state::{State, read_state};
+use crate::sweep::create_pending_sweeper_requests;
+use crate::tx::{AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use candid::{Nat, Principal};
 use ethnum::u256;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeSet;
 
 pub fn expect_panic_with_message<F: FnOnce() -> R, R: std::fmt::Debug>(
     f: F,
@@ -128,6 +133,84 @@ pub fn automatic_deposit() -> AutomaticDeposit {
         last_scanned_block: BlockNumber::new(1_000),
         scan_count: 1,
         scanned_balance: Erc20Value::from(1_000_000_u64),
+    }
+}
+
+/// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs, all taken by the
+/// one sweep [`create_pending_sweeper_requests`] enqueued for them, returned along with that
+/// request. The deposits, attestations and authorizations the enqueue pairs up arrive through the
+/// event log, so the sweep is assembled by the production path without the runtime signing
+/// anything.
+pub async fn deposits_with_enqueued_sweep(
+    pairs: &[(Account, Address)],
+) -> (AutomaticDeposits, SweepRequest) {
+    const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
+
+    let mut state = state_with_deposit_helper(deposit_helper());
+    state.sweeper_contract_address = Some(sweeper_contract());
+    state.last_transaction_price_estimate = Some((SWEEP_DECIDED_AT, gas_fee_estimate()));
+    let chain_id = state.ethereum_network.chain_id();
+    for (account, token) in pairs {
+        apply_state_transition(
+            &mut state,
+            &EventType::AutomaticDepositReceived(AutomaticDeposit {
+                owner: account.owner,
+                subaccount: account.subaccount,
+                address: deposit_address(account),
+                erc20_contract_address: *token,
+                ..automatic_deposit()
+            }),
+        );
+    }
+    for account in pairs
+        .iter()
+        .map(|(account, _token)| *account)
+        .collect::<BTreeSet<_>>()
+    {
+        apply_state_transition(
+            &mut state,
+            &EventType::AttestedDepositAddress {
+                request: AttestationRequest::new(chain_id, deposit_helper(), account),
+                signature: transaction_signature(),
+            },
+        );
+        apply_state_transition(
+            &mut state,
+            &EventType::AuthorizedDepositAddress {
+                request: AuthorizationRequest::new(
+                    account,
+                    chain_id,
+                    sweeper_contract(),
+                    TransactionNonce::ZERO,
+                ),
+                signature: transaction_signature(),
+            },
+        );
+    }
+    init_state(state);
+    let mut runtime = mock::MockCanisterRuntime::new();
+    runtime.expect_time().return_const(SWEEP_DECIDED_AT);
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    read_state(|s| {
+        let [request] =
+            <[SweepRequest; 1]>::try_from(s.automatic_deposits.sweep_requests_batch(usize::MAX))
+                .expect("BUG: expected the pairs to become exactly one sweep");
+        (s.automatic_deposits.clone(), request)
+    })
+}
+
+pub fn sweeper_contract() -> Address {
+    Address::new([0x5e; 20])
+}
+
+/// The estimate every sweep fixture prices and creates with, so a fixture sweep's transaction fee
+/// always fits the cap its request was priced against.
+pub fn gas_fee_estimate() -> GasFeeEstimate {
+    GasFeeEstimate {
+        base_fee_per_gas: WeiPerGas::new(10),
+        max_priority_fee_per_gas: WeiPerGas::new(1),
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -60,6 +60,14 @@ pub fn account() -> Account {
     }
 }
 
+/// A second account, for tests that need two deposit addresses in one sweep.
+pub fn another_account() -> Account {
+    Account {
+        owner: Principal::from_slice(&[5, 6, 7, 8]),
+        subaccount: Some([43_u8; 32]),
+    }
+}
+
 /// The deposit helper whose events name the account an address credits.
 pub fn deposit_helper() -> Address {
     "0x2D39863d30716aaf2B7fFFd85Dd03Dda2BFC2E38"

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -10,8 +10,9 @@ use ic_cketh_minter::endpoints::events::{
     Event as CandidEvent, EventSource as CandidEventSource, GetEventsResult,
     ReimbursementIndex as CandidReimbursementIndex,
     SignedAuthorization as CandidSignedAuthorization,
-    TransactionReceipt as CandidTransactionReceipt, TransactionStatus as CandidTransactionStatus,
-    UnsignedSweeperTransaction, UnsignedTransaction,
+    TransactionReceipt as CandidTransactionReceipt,
+    TransactionSignature as CandidTransactionSignature,
+    TransactionStatus as CandidTransactionStatus, UnsignedSweeperTransaction, UnsignedTransaction,
 };
 use ic_cketh_minter::erc20::CkErc20Token;
 use ic_cketh_minter::eth_logs::{
@@ -237,20 +238,31 @@ fn map_unsigned_sweeper_transaction(tx: UnsignedSweeperTransaction) -> SweepTran
     )
 }
 
-fn map_authorizations(authorizations: Vec<CandidSignedAuthorization>) -> Vec<SignedAuthorization> {
-    fn map_signature_component(bytes: &[u8]) -> ethnum::u256 {
+fn map_candid_signature(signature: CandidTransactionSignature) -> TransactionSignature {
+    fn component(bytes: &[u8]) -> ethnum::u256 {
         ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(bytes).unwrap())
     }
 
+    TransactionSignature {
+        signature_y_parity: signature.y_parity,
+        r: component(&signature.r),
+        s: component(&signature.s),
+    }
+}
+
+fn map_authorizations(authorizations: Vec<CandidSignedAuthorization>) -> Vec<SignedAuthorization> {
     authorizations
         .into_iter()
-        .map(|authorization| SignedAuthorization {
-            chain_id: authorization.chain_id.0.to_u64().unwrap(),
-            delegate: authorization.delegate.parse().unwrap(),
-            nonce: authorization.nonce.try_into().unwrap(),
-            y_parity: authorization.y_parity,
-            r: map_signature_component(&authorization.r),
-            s: map_signature_component(&authorization.s),
+        .map(|authorization| {
+            let signature = map_candid_signature(authorization.signature);
+            SignedAuthorization {
+                chain_id: authorization.chain_id.0.to_u64().unwrap(),
+                delegate: authorization.delegate.parse().unwrap(),
+                nonce: authorization.nonce.try_into().unwrap(),
+                y_parity: signature.signature_y_parity,
+                r: signature.r,
+                s: signature.s,
+            }
         })
         .collect()
 }
@@ -267,15 +279,7 @@ fn map_authorized_sweep_items(items: Vec<CandidAuthorizedSweepItem>) -> Vec<Auth
                         .subaccount
                         .map(|s| <[u8; 32]>::try_from(s.as_ref()).unwrap()),
                 },
-                attestation: TransactionSignature {
-                    signature_y_parity: item.attestation_y_parity,
-                    r: ethnum::u256::from_be_bytes(
-                        <[u8; 32]>::try_from(item.attestation_r.as_ref()).unwrap(),
-                    ),
-                    s: ethnum::u256::from_be_bytes(
-                        <[u8; 32]>::try_from(item.attestation_s.as_ref()).unwrap(),
-                    ),
-                },
+                attestation: map_candid_signature(item.attestation),
             },
             authorization: item.authorization.map(|authorization| {
                 map_authorizations(vec![authorization])
@@ -415,9 +419,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                 deposit_helper,
                 owner,
                 subaccount,
-                y_parity,
-                r,
-                s,
+                attestation,
             } => ET::AttestedDepositAddress {
                 request: AttestationRequest::new(
                     chain_id.0.to_u64().unwrap(),
@@ -429,11 +431,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                         }),
                     },
                 ),
-                signature: TransactionSignature {
-                    signature_y_parity: y_parity,
-                    r: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(r.as_slice()).unwrap()),
-                    s: ethnum::u256::from_be_bytes(<[u8; 32]>::try_from(s.as_slice()).unwrap()),
-                },
+                signature: map_candid_signature(attestation),
             },
             EventPayload::AuthorizedDepositAddress {
                 owner,

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -4,9 +4,11 @@ use flate2::bufread::GzEncoder;
 use flate2::read::GzDecoder;
 use ic_cketh_minter::attestation::AttestationRequest;
 use ic_cketh_minter::checked_amount::CheckedAmountOf;
+use ic_cketh_minter::deposit_address::DepositAddress;
 use ic_cketh_minter::endpoints::events::{
-    AccessListItem as CandidAccessListItem, Event as CandidEvent, EventSource as CandidEventSource,
-    GetEventsResult, ReimbursementIndex as CandidReimbursementIndex,
+    AccessListItem as CandidAccessListItem, AuthorizedSweepItem as CandidAuthorizedSweepItem,
+    Event as CandidEvent, EventSource as CandidEventSource, GetEventsResult,
+    ReimbursementIndex as CandidReimbursementIndex,
     SignedAuthorization as CandidSignedAuthorization,
     TransactionReceipt as CandidTransactionReceipt, TransactionStatus as CandidTransactionStatus,
     UnsignedSweeperTransaction, UnsignedTransaction,
@@ -20,9 +22,10 @@ use ic_cketh_minter::lifecycle::EthereumNetwork;
 use ic_cketh_minter::state::audit::EventType as ET;
 use ic_cketh_minter::state::event::Event;
 use ic_cketh_minter::state::transactions::{
-    Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
-    ReimbursementRequest, SweepId, SweepRequest,
+    AuthorizedSweepItem, Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed,
+    ReimbursementIndex, ReimbursementRequest, SweepId, SweepRequest,
 };
+use ic_cketh_minter::sweeper_contract::SweepItem;
 use ic_cketh_minter::timed_sized_map::Timestamp;
 use ic_cketh_minter::tx::{
     AccessList, AccessListItem, AuthorizationRequest, DelegatingSweep, Eip1559TransactionRequest,
@@ -252,6 +255,37 @@ fn map_authorizations(authorizations: Vec<CandidSignedAuthorization>) -> Vec<Sig
         .collect()
 }
 
+fn map_authorized_sweep_items(items: Vec<CandidAuthorizedSweepItem>) -> Vec<AuthorizedSweepItem> {
+    items
+        .into_iter()
+        .map(|item| AuthorizedSweepItem {
+            item: SweepItem {
+                deposit: DepositAddress::new(item.deposit.parse().unwrap()),
+                account: Account {
+                    owner: item.owner,
+                    subaccount: item
+                        .subaccount
+                        .map(|s| <[u8; 32]>::try_from(s.as_ref()).unwrap()),
+                },
+                attestation: TransactionSignature {
+                    signature_y_parity: item.attestation_y_parity,
+                    r: ethnum::u256::from_be_bytes(
+                        <[u8; 32]>::try_from(item.attestation_r.as_ref()).unwrap(),
+                    ),
+                    s: ethnum::u256::from_be_bytes(
+                        <[u8; 32]>::try_from(item.attestation_s.as_ref()).unwrap(),
+                    ),
+                },
+            },
+            authorization: item.authorization.map(|authorization| {
+                map_authorizations(vec![authorization])
+                    .pop()
+                    .expect("BUG: one authorization in, one out")
+            }),
+        })
+        .collect()
+}
+
 fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
     use ic_cketh_minter::endpoints::events::EventPayload;
 
@@ -432,19 +466,17 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
             EventPayload::AcceptedSweepRequest {
                 sweep_id,
                 destination,
-                amount,
-                data,
+                token,
+                items,
                 max_transaction_fee,
                 created_at,
-                authorizations,
             } => ET::AcceptedSweepRequest(SweepRequest {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
-                amount: amount.try_into().unwrap(),
-                data: data.into_vec(),
+                token: token.parse().unwrap(),
+                items: map_authorized_sweep_items(items),
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,
-                authorizations: map_authorizations(authorizations),
             }),
             EventPayload::CreatedSweeperTransaction {
                 sweep_id,


### PR DESCRIPTION
`create_pending_sweeper_requests` signed a batch's attestations and its authorizations and then discarded both — the signatures reached stable memory, but nothing was ever asked to move the funds. This closes that gap, and fixes an asymmetry between the two transaction pipelines on the way.

**A sweep request now says what to sweep, not what its transaction looks like.** `WithdrawalTransactions` starts from a `WithdrawalRequest` that carries no Ethereum detail — the nonce, the gas price and even the ERC-20 call data are the pipeline's to decide. `SweepRequest` arrived pre-baked with its destination, value and ABI-encoded delegate call, leaving the pipeline only a nonce to fill in. It now names the single token it moves and, per account, the deposit address, the account credited, the attestation binding the two, and the delegation to install; the call data and the zero value are derived in `create_transaction`. `SweepTransaction` is once again the only Ethereum-shaped type in play.

The delegation is optional, so an address already delegated needs no tuple and a sweep of none is sent as a plain EIP-1559 transaction rather than a type-`0x04` one. `max_transaction_fee` stays on the request, as on `Erc20WithdrawalRequest`, because the resubmission strategy caps a fee bump against it.

**A queued deposit is no longer offered to two sweeps.** Batching only peeked at the sweep queue, so the deposits one tick took were still there for the next tick to take again — two sweeps moving a balance the minter has already accounted for once. A queued deposit now records the sweep holding it, and batching skips those. The entry stays queued until the sweep settles: while it is in flight this is the only record of which balance sits at which address, and a sweep that fails has to be able to say so. Releasing entries on success or failure comes with the code that sends them.

**Then the batch is enqueued**, one sweep per token, with its id minted as the event is recorded so two tokens batched in the same tick cannot claim the same one. A target missing either signature is left out rather than swept — without an attestation the sweep cannot prove the address credits the account, without an authorization it cannot delegate the address — and stays queued for the next tick.

**A sweep is priced for the work its delegate does.** Every sweep carried a flat 100'000 gas whatever it moved, which sits below the intrinsic cost of its own EIP-7702 authorizations as soon as it names more than a few addresses: a ten-deposit batch was accepted into the mempool and could never be included. The limit now grows with the addresses the sweep walks — a balance check, a transfer and an authorization each, over a fixed base — and `max_transaction_fee` is priced off the same figure, so a sweep is never created against a cap its own gas limit exceeds.

**Why `CI_OVERRIDE_DIDC_CHECK`.** The didc check requires the new Candid interface to be a subtype of the released one, and reshaping a record inside the `Event` variant `get_events` returns never is: `AcceptedSweepRequest` trades `amount`, `data` and `authorizations` for `token` and `items`, and `SignedAuthorization` and `AttestedDepositAddress` fold their loose `y_parity`/`r`/`s` fields into a `TransactionSignature`. Overriding is safe because every reshaped event belongs to the unreleased sweeper pipeline: no released minter has ever emitted one, so no stored log entry or client decodes the old shape.


