### PR TITLE
feat: add sender match condition

### DIFF
--- a/rs/boundary_node/ic_boundary/src/cli.rs
+++ b/rs/boundary_node/ic_boundary/src/cli.rs
@@ -281,7 +281,7 @@ pub struct RateLimiting {
     /// File is re-read periodically (see below) and new rules are applied if the changes are detected.
     ///
     /// Expecting YAML list with objects that have at least one of
-    /// (canister_id, subnet_id, methods_regex, request_types, limit) fields.
+    /// (canister_id, subnet_id, sender_id, methods_regex, request_types, limit) fields.
     ///
     /// Example:
     /// - canister_id: aaaaa-aa
@@ -292,6 +292,9 @@ pub struct RateLimiting {
     /// - subnet_id: aaaaaa-aa
     ///   canister_id: aaaaa-aa
     ///   methods_regex: ^baz$
+    ///   limit: block
+    ///
+    /// - sender_id: 2vxsx-fae
     ///   limit: block
     #[clap(env, long)]
     pub rate_limit_generic_file: Option<PathBuf>,

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
@@ -160,6 +160,7 @@ mod test {
                             rule_raw: Some(indoc! {"
                                 canister_id: aaaaa-aa
                                 subnet_id: 3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe
+                                sender_id: 2vxsx-fae
                                 methods_regex: ^foo|bar$
                                 limit: block
                             "}.into()),
@@ -259,6 +260,7 @@ mod test {
                     subnet_id: Some(principal!(
                         "3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"
                     )),
+                    sender_id: Some(principal!("2vxsx-fae")),
                     methods_regex: Some(Regex::new("^foo|bar$").unwrap()),
                     request_types: None,
                     ip_prefix_group: None,
@@ -270,6 +272,7 @@ mod test {
                     subnet_id: Some(principal!(
                         "3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"
                     )),
+                    sender_id: None,
                     methods_regex: Some(Regex::new("^baz|bax$").unwrap()),
                     request_types: None,
                     ip_prefix_group: None,
@@ -279,6 +282,7 @@ mod test {
                 RateLimitRule {
                     canister_id: Some(principal!("aaaaa-aa")),
                     subnet_id: None,
+                    sender_id: None,
                     methods_regex: Some(Regex::new("^foo|bax$").unwrap()),
                     request_types: None,
                     ip_prefix_group: None,

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -77,6 +77,7 @@ enum Decision {
 pub struct Context<'a> {
     subnet_id: Principal,
     canister_id: Option<Principal>,
+    sender: Option<Principal>,
     method: Option<&'a str>,
     request_type: RequestType,
     ip: IpAddr,
@@ -112,6 +113,13 @@ impl Bucket {
         if let Some(v) = self.rule.canister_id {
             // If we have a canister id - compare it, otherwise ignore this rule
             if ctx.canister_id? != v {
+                return None;
+            }
+        }
+
+        if let Some(v) = self.rule.sender_id {
+            // If we have a sender id - compare it, otherwise ignore this rule
+            if ctx.sender? != v {
                 return None;
             }
         }
@@ -477,6 +485,7 @@ pub async fn middleware(
     let ctx = Context {
         subnet_id: subnet.id,
         canister_id: canister_id.map(|x| x.get().into()),
+        sender: ctx.sender,
         method: ctx.method_name.as_deref(),
         request_type: ctx.request_type,
         ip: conn_info.remote_addr.ip(),
@@ -537,13 +546,25 @@ mod test {
         let id1 = principal!("aaaaa-aa");
         let id2 = principal!("5s2ji-faaaa-aaaaa-qaaaq-cai");
         let id3 = principal!("qoctq-giaaa-aaaaa-aaaea-cai");
+        let id4 = principal!("ryjl3-tyaaa-aaaaa-aaaba-cai");
 
         let subnet_id =
             principal!("3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe");
         let subnet_id2 =
             principal!("6pbhf-qzpdk-kuqbr-pklfa-5ehhf-jfjps-zsj6q-57nrl-kzhpd-mu7hc-vae");
 
+        // Senders used by the sender-based rules below
+        let sender_blocked = principal!("2vxsx-fae");
+        let sender_limited = principal!("sqjm4-qahae-aq");
+
         let rules = indoc! {"
+        - sender_id: 2vxsx-fae
+          limit: block
+
+        - sender_id: sqjm4-qahae-aq
+          canister_id: 5s2ji-faaaa-aaaaa-qaaaq-cai
+          limit: 2/1h
+
         - canister_id: pawub-syaaa-aaaam-qb7zq-cai
           limit: block
 
@@ -595,7 +616,7 @@ mod test {
             &Registry::new(),
         ));
         assert!(limiter.refresh().await.is_ok());
-        assert_eq!(limiter.active_rules.load().len(), 7);
+        assert_eq!(limiter.active_rules.load().len(), 9);
 
         // Check id1 limiting with any method
         // 10 pass
@@ -603,6 +624,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -617,6 +639,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -661,6 +684,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id0),
                     method: None,
                     request_type: RequestType::QueryV2,
@@ -675,6 +699,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: None,
                     method: None,
                     request_type: RequestType::QueryV2,
@@ -689,6 +714,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id0),
                     method: None,
                     request_type: RequestType::QueryV2,
@@ -701,6 +727,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id0),
                     method: None,
                     request_type: RequestType::QueryV2,
@@ -716,6 +743,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -730,6 +758,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -746,6 +775,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id: subnet_id2,
+                    sender: None,
                     canister_id: Some(id2),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -760,6 +790,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id: subnet_id2,
+                    sender: None,
                     canister_id: Some(id2),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -773,6 +804,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id: subnet_id2,
+                    sender: None,
                     canister_id: Some(id2),
                     method: Some("lol"),
                     request_type: RequestType::QueryV2,
@@ -785,6 +817,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id: subnet_id2,
+                    sender: None,
                     canister_id: Some(id2),
                     method: Some("rofl"),
                     request_type: RequestType::QueryV2,
@@ -799,6 +832,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id2),
                     method: Some("baz"),
                     request_type: RequestType::QueryV2,
@@ -814,6 +848,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: Some("rofl"),
                     request_type: RequestType::CallV2,
@@ -827,6 +862,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: Some("bar"),
                     request_type: RequestType::CallV2,
@@ -842,6 +878,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: Some("baz"),
                     request_type: RequestType::QueryV2,
@@ -855,6 +892,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: Some("zob"),
                     request_type: RequestType::QueryV2,
@@ -871,6 +909,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: None,
                     request_type: RequestType::ReadStateV2,
@@ -884,6 +923,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: None,
                     request_type: RequestType::ReadStateV2,
@@ -898,6 +938,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: None,
                     request_type: RequestType::ReadStateV2,
@@ -911,12 +952,74 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id3),
                     method: None,
                     request_type: RequestType::ReadStateV2,
                     ip: ip2,
                 }),
                 Decision::Limit
+            );
+        }
+
+        // Check sender-based rules.
+        // sender_blocked matches the sender-only block rule (before any canister
+        // rule), so it is blocked regardless of canister/method.
+        for _ in 0..100 {
+            assert_eq!(
+                limiter.evaluate(Context {
+                    subnet_id,
+                    sender: Some(sender_blocked),
+                    canister_id: Some(id2),
+                    method: Some("foo"),
+                    request_type: RequestType::QueryV2,
+                    ip: ip1,
+                }),
+                Decision::Block
+            );
+        }
+
+        // sender_limited is limited to 2/1h on id2 (5s2ji): 2 pass, then limited
+        for _ in 0..2 {
+            assert_eq!(
+                limiter.evaluate(Context {
+                    subnet_id,
+                    sender: Some(sender_limited),
+                    canister_id: Some(id2),
+                    method: Some("foo"),
+                    request_type: RequestType::QueryV2,
+                    ip: ip1,
+                }),
+                Decision::Pass
+            );
+        }
+        for _ in 0..100 {
+            assert_eq!(
+                limiter.evaluate(Context {
+                    subnet_id,
+                    sender: Some(sender_limited),
+                    canister_id: Some(id2),
+                    method: Some("foo"),
+                    request_type: RequestType::QueryV2,
+                    ip: ip1,
+                }),
+                Decision::Limit
+            );
+        }
+
+        // The sender+canister rule is scoped: the same sender on a canister with no
+        // matching rule always passes
+        for _ in 0..100 {
+            assert_eq!(
+                limiter.evaluate(Context {
+                    subnet_id,
+                    sender: Some(sender_limited),
+                    canister_id: Some(id4),
+                    method: Some("foo"),
+                    request_type: RequestType::QueryV2,
+                    ip: ip1,
+                }),
+                Decision::Pass
             );
         }
 
@@ -928,6 +1031,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -942,6 +1046,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -959,6 +1064,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -973,6 +1079,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -989,6 +1096,7 @@ mod test {
         assert_eq!(
             limiter.evaluate(Context {
                 subnet_id,
+                sender: None,
                 canister_id: Some(id1),
                 method: Some("foo"),
                 request_type: RequestType::QueryV2,
@@ -1002,6 +1110,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -1021,6 +1130,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -1035,6 +1145,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,
@@ -1054,6 +1165,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("foo"),
                     request_type: RequestType::QueryV2,
@@ -1068,6 +1180,7 @@ mod test {
             assert_eq!(
                 limiter.evaluate(Context {
                     subnet_id,
+                    sender: None,
                     canister_id: Some(id1),
                     method: Some("bar"),
                     request_type: RequestType::QueryV2,

--- a/rs/boundary_node/rate_limits/api/src/schema_versions/v1.rs
+++ b/rs/boundary_node/rate_limits/api/src/schema_versions/v1.rs
@@ -153,6 +153,7 @@ impl std::fmt::Display for IpPrefixes {
 pub struct RateLimitRule {
     pub canister_id: Option<Principal>,
     pub subnet_id: Option<Principal>,
+    pub sender_id: Option<Principal>,
     #[serde(default, with = "serde_regex")]
     pub methods_regex: Option<Regex>,
     pub ip: Option<IpNet>,
@@ -169,6 +170,7 @@ impl PartialEq for RateLimitRule {
             && self.request_types == other.request_types
             && self.canister_id == other.canister_id
             && self.subnet_id == other.subnet_id
+            && self.sender_id == other.sender_id
             && self.ip == other.ip
             && self.ip_prefix_group == other.ip_prefix_group
             && self.limit == other.limit
@@ -191,6 +193,7 @@ impl<'de> Deserialize<'de> for RateLimitRule {
 
         if this.canister_id.is_none()
             && this.subnet_id.is_none()
+            && this.sender_id.is_none()
             && this.methods_regex.is_none()
             && this.request_types.is_none()
             && this.ip.is_none()
@@ -217,9 +220,10 @@ impl std::fmt::Display for RateLimitRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CanisterID: {}, SubnetID: {}, Request Types: {:?}, Methods: {}, IP: {}, IP Prefix: {}, Limit: {}",
+            "CanisterID: {}, SubnetID: {}, SenderID: {}, Request Types: {:?}, Methods: {}, IP: {}, IP Prefix: {}, Limit: {}",
             format_option(&self.canister_id),
             format_option(&self.subnet_id),
+            format_option(&self.sender_id),
             self.request_types,
             format_option(&self.methods_regex),
             format_option(&self.ip),
@@ -300,6 +304,7 @@ mod test {
             RateLimitRule {
                 canister_id: Some(Principal::from_text("aaaaa-aa").unwrap()),
                 subnet_id: None,
+                sender_id: None,
                 methods_regex: Some(Regex::new("^.*$").unwrap()),
                 request_types: None,
                 ip: Some(IpNet::new_assert(
@@ -414,6 +419,13 @@ mod test {
             - call_v2
             - call_v3
           limit: pass
+
+        - sender_id: 2vxsx-fae
+          limit: block
+
+        - canister_id: aaaaa-aa
+          sender_id: 2vxsx-fae
+          limit: 100/1s
           "};
 
         let rules: Vec<RateLimitRule> = serde_yaml::from_str(rules).unwrap();
@@ -423,6 +435,7 @@ mod test {
             vec![
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("aaaaa-aa").unwrap()),
                     request_types: None,
                     methods_regex: Some(Regex::new("^.*$").unwrap()),
@@ -435,6 +448,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: None,
                     methods_regex: Some(Regex::new("^(foo|bar)$").unwrap()),
@@ -449,6 +463,7 @@ mod test {
                         )
                         .unwrap()
                     ),
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: None,
                     methods_regex: None,
@@ -458,6 +473,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: None,
                     methods_regex: Some(Regex::new("^(foo|bar)$").unwrap()),
@@ -467,6 +483,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: Some(vec![RequestType::QueryV2]),
                     methods_regex: Some(Regex::new("^(foo|bar)$").unwrap()),
@@ -476,6 +493,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: Some(vec![RequestType::QueryV2, RequestType::CallV3]),
                     methods_regex: None,
@@ -485,12 +503,35 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: Some(vec![RequestType::CallV2, RequestType::CallV3]),
                     methods_regex: None,
                     ip: None,
                     ip_prefix_group: None,
                     limit: Action::Pass,
+                },
+                // A rule with only a sender_id is valid (sender_id is a filtering condition)
+                RateLimitRule {
+                    subnet_id: None,
+                    sender_id: Some(Principal::from_text("2vxsx-fae").unwrap()),
+                    canister_id: None,
+                    request_types: None,
+                    methods_regex: None,
+                    ip: None,
+                    ip_prefix_group: None,
+                    limit: Action::Block,
+                },
+                // sender_id combines with other conditions
+                RateLimitRule {
+                    subnet_id: None,
+                    sender_id: Some(Principal::from_text("2vxsx-fae").unwrap()),
+                    canister_id: Some(Principal::from_text("aaaaa-aa").unwrap()),
+                    request_types: None,
+                    methods_regex: None,
+                    ip: None,
+                    ip_prefix_group: None,
+                    limit: Action::Limit(100, Duration::from_secs(1)),
                 },
             ],
         );
@@ -590,6 +631,7 @@ mod test {
             vec![
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: Some(vec![RequestType::CallV2]),
                     methods_regex: None,
@@ -599,6 +641,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("5s2ji-faaaa-aaaaa-qaaaq-cai").unwrap()),
                     request_types: Some(vec![RequestType::CallV3]),
                     methods_regex: None,
@@ -608,6 +651,7 @@ mod test {
                 },
                 RateLimitRule {
                     subnet_id: None,
+                    sender_id: None,
                     canister_id: Some(Principal::from_text("aaaaa-aa").unwrap()),
                     request_types: Some(vec![RequestType::CallV2, RequestType::CallV3]),
                     methods_regex: None,


### PR DESCRIPTION
ic-boundary has a built-in generic rate-limiter that takes as input rules consisting of match conditions and an action. The match conditions allow to specify on which requests the rules should apply: so far, canister ID, subnet ID, request type, method name, source IP address are covered. 

This PR adds the sender ID to the match conditions. 