### PR TITLE
feat: Record in-progress ingress messages after a subnet merge

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -39,13 +39,15 @@ use ic_replicated_state::{
 };
 use ic_types::batch::{Batch, BatchContent, BatchSummary};
 use ic_types::crypto::{KeyPurpose, threshold_sig::ThresholdSigPublicKey};
+use ic_types::ingress::IngressStatus;
 use ic_types::malicious_flags::MaliciousFlags;
+use ic_types::messages::MessageId;
 use ic_types::registry::RegistryClientError;
 use ic_types::state_manager::StateManagerError;
 use ic_types::xnet::{StreamHeader, StreamIndex};
 use ic_types::{
-    ExecutionRound, Height, NodeId, PrincipalId, PrincipalIdBlobParseError, RegistryVersion,
-    SubnetId, Time,
+    ExecutionRound, Height, NodeId, NumBytes, PrincipalId, PrincipalIdBlobParseError,
+    RegistryVersion, SubnetId, Time,
 };
 use ic_types_cycles::CanisterCyclesCostSchedule;
 use ic_utils_thread::JoinOnDrop;
@@ -133,6 +135,8 @@ pub const CRITICAL_ERROR_NON_INCREASING_BATCH_TIME: &str = "mr_non_increasing_ba
 pub const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
 pub const CRITICAL_ERROR_ILLEGAL_ENGINE_MESSAGE: &str = "mr_illegal_engine_message";
 const CRITICAL_ERROR_ILLEGAL_NON_EMPTY_SUBNET_ADMINS: &str = "mr_illegal_non_empty_subnet_admins";
+const CRITICAL_ERROR_UNEXPECTED_INGRESS_STATUS_AFTER_MERGE: &str =
+    "mr_unexpected_ingress_status_after_merge";
 
 /// Records the timestamp when all messages before the given index (down to the
 /// previous `MessageTime`) were first added to / learned about in a stream.
@@ -355,6 +359,10 @@ pub(crate) struct MessageRoutingMetrics {
     pub critical_error_engine_message: IntCounter,
     /// Critical error: a non-rental subnet has a non-empty subnet admins list.
     critical_error_illegal_non_empty_subnet_admins: IntCounter,
+    /// Critical error: an in-progress ingress message had an ingress history entry
+    /// with a status other than `Processing` in the first round after a subnet
+    /// merge.
+    critical_error_unexpected_ingress_status_after_merge: IntCounter,
 
     /// Metrics for query stats aggregator
     pub query_stats_metrics: QueryStatsAggregatorMetrics,
@@ -503,6 +511,8 @@ impl MessageRoutingMetrics {
                 .error_counter(CRITICAL_ERROR_ILLEGAL_ENGINE_MESSAGE),
             critical_error_illegal_non_empty_subnet_admins: metrics_registry
                 .error_counter(CRITICAL_ERROR_ILLEGAL_NON_EMPTY_SUBNET_ADMINS),
+            critical_error_unexpected_ingress_status_after_merge: metrics_registry
+                .error_counter(CRITICAL_ERROR_UNEXPECTED_INGRESS_STATUS_AFTER_MERGE),
 
             query_stats_metrics: QueryStatsAggregatorMetrics::new(metrics_registry),
 
@@ -540,6 +550,23 @@ impl MessageRoutingMetrics {
             batch_height,
             state_time,
             batch_time
+        );
+    }
+
+    pub fn observe_unexpected_ingress_status_after_merge(
+        &self,
+        log: &ReplicaLogger,
+        message_id: &MessageId,
+        status: &IngressStatus,
+    ) {
+        self.critical_error_unexpected_ingress_status_after_merge
+            .inc();
+        warn!(
+            log,
+            "{}: In-progress ingress message {} has unexpected status {} after a subnet merge.",
+            CRITICAL_ERROR_UNEXPECTED_INGRESS_STATUS_AFTER_MERGE,
+            message_id,
+            status.as_str()
         );
     }
 
@@ -594,6 +621,9 @@ struct BatchProcessorImpl<RegistryClient_: RegistryClient> {
     registry_reader: RegistryReader<RegistryClient_>,
     metrics: MessageRoutingMetrics,
     log: ReplicaLogger,
+    /// Soft limit on the memory footprint of the ingress history; used when
+    /// recording in-progress ingress messages after a subnet merge.
+    ingress_history_memory_capacity: NumBytes,
     #[allow(dead_code)]
     malicious_flags: MaliciousFlags,
 }
@@ -704,6 +734,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             metrics.clone(),
         ));
 
+        let ingress_history_memory_capacity = hypervisor_config.ingress_history_memory_capacity;
         let registry_reader = RegistryReader::new(
             registry,
             hypervisor_config.bitcoin,
@@ -717,6 +748,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             registry_reader,
             metrics,
             log,
+            ingress_history_memory_capacity,
             malicious_flags,
         }
     }
@@ -1420,6 +1452,23 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
                 .with_label_values(&[&split_from.to_string()])
                 .set(batch.batch_number.get() as i64);
             state.metadata.subnet_split_from = None;
+        }
+        // If this is the first round after a subnet merge, reset the merge
+        // marker and record all in-progress ingress messages (i.e. all not yet
+        // responded ingress-induced canister call contexts) in the ingress history.
+        if state.metadata.subnet_merged {
+            info!(
+                self.log,
+                "State has resulted from a subnet merge, recording in-progress ingress messages"
+            );
+            state.after_merge(
+                self.ingress_history_memory_capacity,
+                |message_id, status| {
+                    self.metrics.observe_unexpected_ingress_status_after_merge(
+                        &self.log, message_id, status,
+                    )
+                },
+            );
         }
         load_state_timer.observe_duration();
 

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1462,6 +1462,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
                 "State has resulted from a subnet merge, recording in-progress ingress messages"
             );
             state.after_merge(
+                batch.time,
                 self.ingress_history_memory_capacity,
                 |message_id, status| {
                     self.metrics.observe_unexpected_ingress_status_after_merge(

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1453,13 +1453,12 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
                 .set(batch.batch_number.get() as i64);
             state.metadata.subnet_split_from = None;
         }
-        // If this is the first round after a subnet merge, reset the merge
-        // marker and record all in-progress ingress messages (i.e. all not yet
-        // responded ingress-induced canister call contexts) in the ingress history.
+        // If this is the first round after a subnet merge, make the necessary
+        // adjustments to the state (see `ReplicatedState::after_merge()`).
         if state.metadata.subnet_merged {
             info!(
                 self.log,
-                "State has resulted from a subnet merge, recording in-progress ingress messages"
+                "State has resulted from a subnet merge, making post-merge state adjustments"
             );
             state.after_merge(
                 batch.time,

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -678,6 +678,8 @@ fn make_batch_processor<RegistryClient_: RegistryClient + 'static>(
         ),
         metrics: metrics.clone(),
         log,
+        ingress_history_memory_capacity: HypervisorConfig::default()
+            .ingress_history_memory_capacity,
         malicious_flags: MaliciousFlags::default(),
     };
     (batch_processor, metrics, state_manager, registry_settings)
@@ -2416,6 +2418,71 @@ fn process_batch_resets_split_marker() {
         // The subnet split marker was reset.
         let latest_state = state_manager.get_latest_state().take();
         assert_eq!(None, latest_state.metadata.subnet_split_from);
+    });
+}
+
+#[test]
+fn process_batch_resets_merge_marker() {
+    with_test_replica_logger(|log| {
+        use Integrity::*;
+
+        let own_subnet_id = subnet_test_id(13);
+        let nns_subnet_id = subnet_test_id(42);
+
+        let own_transcript = dummy_transcript_for_tests_with_params(
+            vec![node_test_id(123)], // committee
+            NiDkgTag::HighThreshold, // dkg_tag
+            2,                       // threshold
+            3,                       // registry_version
+        );
+
+        let fixture = RegistryFixture::new();
+        fixture
+            .write_test_records(&TestRecords {
+                subnet_ids: Valid([own_subnet_id]),
+                subnet_records: [Valid(&SubnetRecord::default())],
+                ni_dkg_transcripts: [Valid(Some(&own_transcript))],
+                nns_subnet_id: Valid(nns_subnet_id),
+                chain_key_enabled_subnets: &BTreeMap::default(),
+                provisional_whitelist: Valid(&ProvisionalWhitelist::All),
+                routing_table: Valid(&RoutingTable::new()),
+                canister_migrations: Valid(&CanisterMigrations::new()),
+                node_public_keys: &BTreeMap::default(),
+                api_boundary_node_records: &BTreeMap::default(),
+                node_records: &BTreeMap::default(),
+            })
+            .unwrap();
+
+        // Reading from the registry must succeed for fully specified records.
+        let (batch_processor, _metrics, state_manager, _registry_settings) =
+            make_batch_processor(fixture.registry.clone(), log);
+        let (mut height, mut state) = state_manager.take_tip();
+        state.metadata.own_subnet_id = own_subnet_id;
+        state.metadata.subnet_merged = true;
+        height.inc_assign();
+        state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
+
+        batch_processor.process_batch(Batch {
+            batch_number: height.increment(),
+            batch_summary: None,
+            content: BatchContent::Data {
+                batch_messages: BatchMessages::default(),
+                consensus_responses: Vec::new(),
+                canister_http_spent: Default::default(),
+                chain_key_data: Default::default(),
+                requires_full_state_hash: false,
+            },
+            randomness: Randomness::new([123; 32]),
+            registry_version: fixture.registry.get_latest_version(),
+            time: Time::from_nanos_since_unix_epoch(1),
+            blockmaker_metrics: BlockmakerMetrics::new_for_test(),
+            replica_version: test_replica_version(),
+        });
+
+        // The subnet merge marker was reset. (Which only happens in `after_merge()`,
+        // whose behavior is covered by the `ic-replicated-state` unit tests.)
+        let latest_state = state_manager.get_latest_state().take();
+        assert!(!latest_state.metadata.subnet_merged);
     });
 }
 

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -2392,14 +2392,13 @@ fn process_batch_resets_split_marker() {
         // Reading from the registry must succeed for fully specified records.
         let (batch_processor, _metrics, state_manager, _registry_settings) =
             make_batch_processor(fixture.registry.clone(), log);
-        let (mut height, mut state) = state_manager.take_tip();
+        let (_, mut state) = state_manager.take_tip();
         state.metadata.own_subnet_id = own_subnet_id;
         state.metadata.subnet_split_from = Some(other_subnet_id);
-        height.inc_assign();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
 
         batch_processor.process_batch(Batch {
-            batch_number: height.increment(),
+            batch_number: state_manager.tip_height().increment(),
             batch_summary: None,
             content: BatchContent::Data {
                 batch_messages: BatchMessages::default(),
@@ -2456,14 +2455,13 @@ fn process_batch_resets_merge_marker() {
         // Reading from the registry must succeed for fully specified records.
         let (batch_processor, _metrics, state_manager, _registry_settings) =
             make_batch_processor(fixture.registry.clone(), log);
-        let (mut height, mut state) = state_manager.take_tip();
+        let (_, mut state) = state_manager.take_tip();
         state.metadata.own_subnet_id = own_subnet_id;
         state.metadata.subnet_merged = true;
-        height.inc_assign();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
 
         batch_processor.process_batch(Batch {
-            batch_number: height.increment(),
+            batch_number: state_manager.tip_height().increment(),
             batch_summary: None,
             content: BatchContent::Data {
                 batch_messages: BatchMessages::default(),

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1,7 +1,7 @@
 use crate::canister_state::queues::{
     CanisterInput, CanisterQueuesLoopDetector, refunds::RefundPool,
 };
-use crate::canister_state::system_state::{CanisterOutputQueuesIterator, push_input};
+use crate::canister_state::system_state::{CallOrigin, CanisterOutputQueuesIterator, push_input};
 use crate::metadata_state::subnet_call_context_manager::{
     PreSignatureStash, ReshareChainKeyContext, SignWithThresholdContext,
 };
@@ -30,7 +30,7 @@ use ic_types::{
     CanisterId, NumBytes, SubnetId, Time,
     batch::{ConsensusResponse, RawQueryStats},
     consensus::idkg::IDkgMasterPublicKeyId,
-    ingress::IngressStatus,
+    ingress::{IngressState, IngressStatus},
     messages::{
         CallbackId, Ingress, MessageId, Refund, RequestOrResponse, Response, SubnetMessage,
     },
@@ -1611,6 +1611,85 @@ impl ReplicatedState {
 
         // Reset query stats after subnet split.
         *epoch_query_stats = RawQueryStats::default();
+    }
+
+    /// Makes adjustments to the replicated state during the first round after a
+    /// subnet merge: resets the "subnet was merged" marker and records all
+    /// not yet responded ingress-induced call contexts as `Processing` in the
+    /// ingress history.
+    ///
+    /// The ingress history of the merged subnet does not necessarily cover the
+    /// in-progress ingress messages of all merged subnets, so the corresponding
+    /// entries are (re)created here, ensuring that every in-progress ingress
+    /// message can be tracked to completion.
+    ///
+    /// Only call contexts of canisters are considered; subnet call contexts are
+    /// ignored, as subnet merging ensures that the subnets being merged have no
+    /// in-progress subnet call contexts.
+    ///
+    /// A message that already has an ingress history entry is left alone; its
+    /// status is expected to be `Processing`, anything else is reported via
+    /// `on_unexpected_ingress_status()` (as it indicates a bug).
+    pub fn after_merge(
+        &mut self,
+        ingress_memory_capacity: NumBytes,
+        on_unexpected_ingress_status: impl Fn(&MessageId, &IngressStatus),
+    ) {
+        assert!(
+            self.metadata.subnet_merged,
+            "Not a state resulting from a subnet merge"
+        );
+        self.metadata.subnet_merged = false;
+
+        let time = self.time();
+        let ingress_statuses = self
+            .canisters_iter()
+            .flat_map(|canister_state| {
+                let receiver = canister_state.canister_id().get();
+                canister_state
+                    .system_state
+                    .call_context_manager()
+                    .into_iter()
+                    .flat_map(|ccm| ccm.call_contexts().values())
+                    .filter(|call_context| !call_context.has_responded())
+                    .filter_map(move |call_context| match call_context.call_origin() {
+                        CallOrigin::Ingress(user_id, message_id, _) => Some((
+                            message_id.clone(),
+                            IngressStatus::Known {
+                                receiver,
+                                user_id: *user_id,
+                                time,
+                                state: IngressState::Processing,
+                            },
+                        )),
+                        CallOrigin::CanisterUpdate(..)
+                        | CallOrigin::Query(..)
+                        | CallOrigin::CanisterQuery(..)
+                        | CallOrigin::SystemTask => None,
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        for (message_id, status) in ingress_statuses {
+            match self.metadata.ingress_history.get(&message_id).cloned() {
+                // No entry yet, record the in-progress ingress message.
+                None => {
+                    self.set_ingress_status(message_id, status, ingress_memory_capacity, |_| {});
+                }
+
+                // Already recorded as `Processing`, nothing to do.
+                Some(IngressStatus::Known {
+                    state: IngressState::Processing,
+                    ..
+                }) => {}
+
+                // Any other status indicates a bug, report it. The existing entry is
+                // preserved, as overwriting a terminal status would be worse.
+                Some(unexpected_status) => {
+                    on_unexpected_ingress_status(&message_id, &unexpected_status)
+                }
+            }
+        }
     }
 
     /// Splits the replicated state during a special DSM round, retaining only the

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1614,13 +1614,23 @@ impl ReplicatedState {
     }
 
     /// Makes adjustments to the replicated state during the first round after a
-    /// subnet merge: resets the "subnet was merged" marker and records all
-    /// not yet responded ingress-induced call contexts as `Processing` in the
-    /// ingress history.
+    /// subnet merge:
+    ///
+    ///  * Resets the "subnet was merged" marker.
+    ///  * Updates canisters' input schedules, based on `self.canister_states`.
+    ///  * Records all not yet responded ingress-induced call contexts as
+    ///    `Processing` in the ingress history.
+    ///
+    /// Canisters hosted by the other merged subnets used to be remote and are now
+    /// local, so their input queues may sit in the wrong input schedule. As with a
+    /// subnet split, the schedules are explicitly re-partitioned, because a queue
+    /// in the wrong schedule is only corrected once it becomes empty (which is not
+    /// guaranteed to ever happen).
     ///
     /// The ingress history of the merged subnet does not necessarily cover the
     /// in-progress ingress messages of all merged subnets, so the corresponding
-    /// entries are (re)created here, ensuring that every in-progress ingress
+    /// entries are (re)created here (timestamped with `batch_time`, the time of
+    /// the batch being processed), ensuring that every in-progress ingress
     /// message can be tracked to completion.
     ///
     /// Only call contexts of canisters are considered; subnet call contexts are
@@ -1632,18 +1642,46 @@ impl ReplicatedState {
     /// `on_unexpected_ingress_status()` (as it indicates a bug).
     pub fn after_merge(
         &mut self,
+        batch_time: Time,
         ingress_memory_capacity: NumBytes,
         on_unexpected_ingress_status: impl Fn(&MessageId, &IngressStatus),
     ) {
+        // Destructure `self` in order for the compiler to enforce an explicit decision
+        // whenever new fields are added.
+        //
+        // (!) DO NOT USE THE ".." WILDCARD, THIS SERVES THE SAME FUNCTION AS A `match`!
+        let Self {
+            canister_states,
+            metadata,
+            subnet_queues: _,
+            consensus_queue: _,
+            refunds: _,
+            epoch_query_stats: _,
+        } = self;
+
         assert!(
-            self.metadata.subnet_merged,
+            metadata.subnet_merged,
             "Not a state resulting from a subnet merge"
         );
-        self.metadata.subnet_merged = false;
+        metadata.subnet_merged = false;
 
-        let time = self.time();
-        let ingress_statuses = self
-            .canisters_iter()
+        // Adjust `CanisterQueues::(local|remote)_subnet_input_schedule` based on which
+        // canisters are present in `canister_states`.
+        let local_canister_ids = canister_states.all_keys().cloned().collect::<Vec<_>>();
+        for canister_id in local_canister_ids.iter() {
+            let mut canister_state = canister_states.remove(canister_id).unwrap();
+            if canister_state.has_input() {
+                Arc::make_mut(&mut canister_state)
+                    .system_state
+                    .split_input_schedules(canister_id, canister_states);
+            }
+            canister_states.insert(canister_state);
+        }
+
+        // Record all not yet responded ingress-induced call contexts as `Processing`
+        // in the ingress history.
+        let ingress_statuses = canister_states
+            .all_values()
             .flat_map(|canister_state| {
                 let receiver = canister_state.canister_id().get();
                 canister_state
@@ -1658,7 +1696,7 @@ impl ReplicatedState {
                             IngressStatus::Known {
                                 receiver,
                                 user_id: *user_id,
-                                time,
+                                time: batch_time,
                                 state: IngressState::Processing,
                             },
                         )),
@@ -1671,10 +1709,16 @@ impl ReplicatedState {
             .collect::<Vec<_>>();
 
         for (message_id, status) in ingress_statuses {
-            match self.metadata.ingress_history.get(&message_id).cloned() {
+            match metadata.ingress_history.get(&message_id) {
                 // No entry yet, record the in-progress ingress message.
                 None => {
-                    self.set_ingress_status(message_id, status, ingress_memory_capacity, |_| {});
+                    metadata.ingress_history.insert(
+                        message_id,
+                        status,
+                        batch_time,
+                        ingress_memory_capacity,
+                        |_| {},
+                    );
                 }
 
                 // Already recorded as `Processing`, nothing to do.
@@ -1686,7 +1730,7 @@ impl ReplicatedState {
                 // Any other status indicates a bug, report it. The existing entry is
                 // preserved, as overwriting a terminal status would be worse.
                 Some(unexpected_status) => {
-                    on_unexpected_ingress_status(&message_id, &unexpected_status)
+                    on_unexpected_ingress_status(&message_id, unexpected_status)
                 }
             }
         }

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1582,16 +1582,7 @@ impl ReplicatedState {
 
         // Adjust `CanisterQueues::(local|remote)_subnet_input_schedule` based on which
         // canisters are present in `canister_states`.
-        let local_canister_ids = canister_states.all_keys().cloned().collect::<Vec<_>>();
-        for canister_id in local_canister_ids.iter() {
-            let mut canister_state = canister_states.remove(canister_id).unwrap();
-            if canister_state.has_input() {
-                Arc::make_mut(&mut canister_state)
-                    .system_state
-                    .split_input_schedules(canister_id, canister_states);
-            }
-            canister_states.insert(canister_state);
-        }
+        repartition_input_schedules(canister_states);
 
         // Drop in-progress management calls being executed by canisters on subnet B
         // (`own_subnet_id != split_from`). The corresponding calls will be rejected on
@@ -1667,16 +1658,7 @@ impl ReplicatedState {
 
         // Adjust `CanisterQueues::(local|remote)_subnet_input_schedule` based on which
         // canisters are present in `canister_states`.
-        let local_canister_ids = canister_states.all_keys().cloned().collect::<Vec<_>>();
-        for canister_id in local_canister_ids.iter() {
-            let mut canister_state = canister_states.remove(canister_id).unwrap();
-            if canister_state.has_input() {
-                Arc::make_mut(&mut canister_state)
-                    .system_state
-                    .split_input_schedules(canister_id, canister_states);
-            }
-            canister_states.insert(canister_state);
-        }
+        repartition_input_schedules(canister_states);
 
         // Record all not yet responded ingress-induced call contexts as `Processing`
         // in the ingress history.
@@ -1829,16 +1811,7 @@ impl ReplicatedState {
 
         // Adjust `CanisterQueues::(local|remote)_subnet_input_schedule` based on which
         // canisters are present in `canister_states`.
-        let local_canister_ids = canister_states.all_keys().cloned().collect::<Vec<_>>();
-        for canister_id in local_canister_ids.iter() {
-            let mut canister_state = canister_states.remove(canister_id).unwrap();
-            if canister_state.has_input() {
-                Arc::make_mut(&mut canister_state)
-                    .system_state
-                    .split_input_schedules(canister_id, &canister_states);
-            }
-            canister_states.insert(canister_state);
-        }
+        repartition_input_schedules(&mut canister_states);
 
         // On *subnet B*:
         if subnet_id != metadata.own_subnet_id {
@@ -1945,6 +1918,25 @@ impl ReplicatedState {
             balance_before, balance_after,
             "Cycles lost or duplicated: before = {balance_before}, after = {balance_after}",
         );
+    }
+}
+
+/// Re-partitions the local and remote sender schedules of all canisters in
+/// `canister_states`, based on which canisters are present in `canister_states`.
+///
+/// For use whenever the set of canisters hosted by the subnet changes, i.e. after
+/// a subnet split or a subnet merge. See
+/// [`CanisterQueues::split_input_schedules`] for why this must be done eagerly.
+fn repartition_input_schedules(canister_states: &mut CanisterStates) {
+    let local_canister_ids = canister_states.all_keys().cloned().collect::<Vec<_>>();
+    for canister_id in local_canister_ids.iter() {
+        let mut canister_state = canister_states.remove(canister_id).unwrap();
+        if canister_state.has_input() {
+            Arc::make_mut(&mut canister_state)
+                .system_state
+                .split_input_schedules(canister_id, canister_states);
+        }
+        canister_states.insert(canister_state);
     }
 }
 

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -12,8 +12,9 @@ use ic_management_canister_types_private::{
 use ic_registry_routing_table::{CANISTER_IDS_PER_SUBNET, CanisterIdRange, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
-    CanisterQueues, CanisterState, ExecutionTask, IngressHistoryState, InputSource, OutputRequest,
-    RefundPool, ReplicatedState, SchedulerState, StateError, SystemMetadata, SystemState,
+    CallContext, CallOrigin, CanisterQueues, CanisterState, ExecutionTask, IngressHistoryState,
+    InputSource, OutputRequest, RefundPool, ReplicatedState, SchedulerState, StateError,
+    SystemMetadata, SystemState,
     canister_state::{
         canister_snapshots::{CanisterSnapshot, CanisterSnapshots},
         execution_state::{CustomSection, CustomSectionType, WasmMetadata},
@@ -41,8 +42,8 @@ use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
 use ic_types::batch::RawQueryStats;
 use ic_types::ingress::{IngressState, IngressStatus};
 use ic_types::messages::{
-    CallbackId, CanisterCall, CanisterMessage, MAX_RESPONSE_COUNT_BYTES, Payload, Refund,
-    RejectContext, Request, RequestOrResponse, Response, SubnetMessage,
+    CallbackId, CanisterCall, CanisterMessage, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload,
+    Refund, RejectContext, Request, RequestMetadata, RequestOrResponse, Response, SubnetMessage,
 };
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::xnet::StreamIndex;
@@ -53,6 +54,7 @@ use ic_types_cycles::{
 };
 use maplit::btreemap;
 use proptest::prelude::*;
+use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::mem::size_of;
 use std::sync::Arc;
@@ -1446,6 +1448,146 @@ fn online_split() {
 
     // Everything else should be unchanged.
     assert_eq!(expected, state_b);
+}
+
+#[test]
+fn after_merge() {
+    const CANISTER_1: CanisterId = CanisterId::from_u64(1);
+    const CANISTER_2: CanisterId = CanisterId::from_u64(2);
+    const CANISTERS: [CanisterId; 2] = [CANISTER_1, CANISTER_2];
+
+    // A time different from the state time (`UNIX_EPOCH`), so that pre-existing
+    // ingress history entries can be told apart from newly recorded ones.
+    let before = Time::from_nanos_since_unix_epoch(13);
+
+    // Makes a not yet responded call context with the given origin.
+    fn open_call_context(call_origin: CallOrigin) -> CallContext {
+        CallContext::new(
+            call_origin,
+            false, // responded
+            false, // deleted
+            Cycles::zero(),
+            UNIX_EPOCH,
+            RequestMetadata::for_new_call_tree(UNIX_EPOCH),
+            None,
+        )
+    }
+
+    // Makes an ingress call origin for the given message.
+    fn ingress_origin(message: u64) -> CallOrigin {
+        CallOrigin::Ingress(
+            user_test_id(message),
+            message_test_id(message),
+            "update".into(),
+        )
+    }
+
+    // Makes an ingress status with the given receiver, message and state.
+    let ingress_status = |receiver: CanisterId, message: u64, time, state| IngressStatus::Known {
+        receiver: receiver.get(),
+        user_id: user_test_id(message),
+        time,
+        state,
+    };
+
+    let mut fixture = ReplicatedStateFixture::with_canisters(&CANISTERS);
+
+    // An in-progress ingress message to `CANISTER_1`, with no ingress history entry.
+    let canister_1 = fixture.state.canister_state_make_mut(&CANISTER_1).unwrap();
+    canister_1
+        .system_state
+        .with_call_context(open_call_context(ingress_origin(1)));
+    // An ingress message that was already responded to; and an in-progress canister
+    // update call. Neither should be recorded in the ingress history.
+    canister_1.system_state.with_call_context(CallContext::new(
+        ingress_origin(2),
+        true,  // responded
+        false, // deleted
+        Cycles::zero(),
+        UNIX_EPOCH,
+        RequestMetadata::for_new_call_tree(UNIX_EPOCH),
+        None,
+    ));
+    canister_1
+        .system_state
+        .with_call_context(open_call_context(CallOrigin::CanisterUpdate(
+            CANISTER_2,
+            CallbackId::from(3),
+            NO_DEADLINE,
+            "update".into(),
+        )));
+
+    // Three in-progress ingress messages to `CANISTER_2`: one with no ingress
+    // history entry; one already recorded as `Processing`; and one recorded with an
+    // unexpected status.
+    let canister_2 = fixture.state.canister_state_make_mut(&CANISTER_2).unwrap();
+    for message in [4, 5, 6] {
+        canister_2
+            .system_state
+            .with_call_context(open_call_context(ingress_origin(message)));
+    }
+    let processing_5 = ingress_status(CANISTER_2, 5, before, IngressState::Processing);
+    let received_6 = ingress_status(CANISTER_2, 6, before, IngressState::Received);
+    for (message, status) in [(5, processing_5.clone()), (6, received_6.clone())] {
+        fixture.state.metadata.ingress_history.insert(
+            message_test_id(message),
+            status,
+            before,
+            NumBytes::from(u64::MAX),
+            |_| {},
+        );
+    }
+
+    let mut state = fixture.state;
+    state.metadata.subnet_merged = true;
+
+    let unexpected_statuses = RefCell::new(Vec::new());
+    state.after_merge(NumBytes::from(u64::MAX), |message_id, status| {
+        unexpected_statuses
+            .borrow_mut()
+            .push((message_id.clone(), status.clone()));
+    });
+
+    // The merge marker was reset.
+    assert!(!state.metadata.subnet_merged);
+
+    // Only the `Received` entry of message 6 was reported as unexpected.
+    assert_eq!(
+        vec![(message_test_id(6), received_6.clone())],
+        unexpected_statuses.into_inner()
+    );
+
+    // Messages 1 and 4 were recorded as `Processing` at the state time; the existing
+    // entries of messages 5 and 6 were left alone; and nothing else was recorded.
+    let expected = BTreeMap::from([
+        (
+            message_test_id(1),
+            ingress_status(CANISTER_1, 1, UNIX_EPOCH, IngressState::Processing),
+        ),
+        (
+            message_test_id(4),
+            ingress_status(CANISTER_2, 4, UNIX_EPOCH, IngressState::Processing),
+        ),
+        (message_test_id(5), processing_5),
+        (message_test_id(6), received_6),
+    ]);
+    assert_eq!(
+        expected,
+        state
+            .metadata
+            .ingress_history
+            .statuses()
+            .map(|(message_id, status)| (message_id.clone(), status.clone()))
+            .collect::<BTreeMap<_, _>>()
+    );
+}
+
+#[test]
+#[should_panic(expected = "Not a state resulting from a subnet merge")]
+fn after_merge_without_merge_marker() {
+    ReplicatedStateFixture::new()
+        .state
+        .after_merge(NumBytes::from(u64::MAX), |_, _| {});
 }
 
 #[test]

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1454,11 +1454,14 @@ fn online_split() {
 fn after_merge() {
     const CANISTER_1: CanisterId = CanisterId::from_u64(1);
     const CANISTER_2: CanisterId = CanisterId::from_u64(2);
-    const CANISTERS: [CanisterId; 2] = [CANISTER_1, CANISTER_2];
 
     // A time different from the state time (`UNIX_EPOCH`), so that pre-existing
     // ingress history entries can be told apart from newly recorded ones.
     let before = Time::from_nanos_since_unix_epoch(13);
+    // The time of the batch being processed. Different from both the state time
+    // and `before`, to ensure that newly recorded entries are timestamped with the
+    // batch time (as opposed to the time of the state resulting from the merge).
+    let batch_time = Time::from_nanos_since_unix_epoch(42);
 
     // Makes a not yet responded call context with the given origin.
     fn open_call_context(call_origin: CallOrigin) -> CallContext {
@@ -1490,7 +1493,37 @@ fn after_merge() {
         state,
     };
 
-    let mut fixture = ReplicatedStateFixture::with_canisters(&CANISTERS);
+    // Start off with `CANISTER_1` only, as `CANISTER_2` was hosted by another subnet
+    // before the merge.
+    let mut fixture = ReplicatedStateFixture::with_canisters(&[CANISTER_1]);
+
+    // An input from `CANISTER_2` to `CANISTER_1`, enqueued while `CANISTER_2` was
+    // still remote, so it landed in `CANISTER_1`'s remote sender schedule.
+    assert!(
+        fixture
+            .push_input(
+                RequestBuilder::default()
+                    .sender(CANISTER_2)
+                    .receiver(CANISTER_1)
+                    .build()
+                    .into(),
+            )
+            .unwrap()
+    );
+    assert!(fixture.local_subnet_input_schedule(&CANISTER_1).is_empty());
+    assert_eq!(
+        &VecDeque::from(vec![CANISTER_2]),
+        fixture.remote_subnet_input_schedule(&CANISTER_1)
+    );
+
+    // `CANISTER_2` is now hosted by the merged subnet.
+    let canister_2_fixture = ReplicatedStateFixture::with_canisters(&[CANISTER_2]);
+    let canister_2_state = canister_2_fixture
+        .state
+        .canister_state(&CANISTER_2)
+        .unwrap()
+        .clone();
+    fixture.state.put_canister_state(canister_2_state);
 
     // An in-progress ingress message to `CANISTER_1`, with no ingress history entry.
     let canister_1 = fixture.state.canister_state_make_mut(&CANISTER_1).unwrap();
@@ -1542,14 +1575,31 @@ fn after_merge() {
     state.metadata.subnet_merged = true;
 
     let unexpected_statuses = RefCell::new(Vec::new());
-    state.after_merge(NumBytes::from(u64::MAX), |message_id, status| {
-        unexpected_statuses
-            .borrow_mut()
-            .push((message_id.clone(), status.clone()));
-    });
+    state.after_merge(
+        batch_time,
+        NumBytes::from(u64::MAX),
+        |message_id, status| {
+            unexpected_statuses
+                .borrow_mut()
+                .push((message_id.clone(), status.clone()));
+        },
+    );
 
     // The merge marker was reset.
     assert!(!state.metadata.subnet_merged);
+
+    // And `CANISTER_2` was moved from `CANISTER_1`'s remote to its local sender
+    // schedule, now that both canisters are hosted by the same subnet.
+    let queues = state
+        .canister_state(&CANISTER_1)
+        .unwrap()
+        .system_state
+        .queues();
+    assert_eq!(
+        &VecDeque::from(vec![CANISTER_2]),
+        queues.local_sender_schedule()
+    );
+    assert!(queues.remote_sender_schedule().is_empty());
 
     // Only the `Received` entry of message 6 was reported as unexpected.
     assert_eq!(
@@ -1557,16 +1607,16 @@ fn after_merge() {
         unexpected_statuses.into_inner()
     );
 
-    // Messages 1 and 4 were recorded as `Processing` at the state time; the existing
+    // Messages 1 and 4 were recorded as `Processing` at the batch time; the existing
     // entries of messages 5 and 6 were left alone; and nothing else was recorded.
     let expected = BTreeMap::from([
         (
             message_test_id(1),
-            ingress_status(CANISTER_1, 1, UNIX_EPOCH, IngressState::Processing),
+            ingress_status(CANISTER_1, 1, batch_time, IngressState::Processing),
         ),
         (
             message_test_id(4),
-            ingress_status(CANISTER_2, 4, UNIX_EPOCH, IngressState::Processing),
+            ingress_status(CANISTER_2, 4, batch_time, IngressState::Processing),
         ),
         (message_test_id(5), processing_5),
         (message_test_id(6), received_6),
@@ -1585,9 +1635,11 @@ fn after_merge() {
 #[test]
 #[should_panic(expected = "Not a state resulting from a subnet merge")]
 fn after_merge_without_merge_marker() {
-    ReplicatedStateFixture::new()
-        .state
-        .after_merge(NumBytes::from(u64::MAX), |_, _| {});
+    ReplicatedStateFixture::new().state.after_merge(
+        UNIX_EPOCH,
+        NumBytes::from(u64::MAX),
+        |_, _| {},
+    );
 }
 
 #[test]


### PR DESCRIPTION
If the `subnet_merged` marker is set, `process_batch()` now resets it and calls `ReplicatedState::after_merge()`, which makes the following adjustments during the first round after a subnet merge:

* **Records in-progress ingress messages.** All not yet responded ingress-induced canister call contexts are recorded as `Processing` in the ingress history, so that the corresponding ingress messages can be tracked to completion. The entries are timestamped with the time of the batch being processed (`after_merge()` runs before `batch_time` is updated during round execution, so the state time would still be that of the state resulting from the merge).

  Subnet call contexts are ignored, as subnet merging ensures that the subnets being merged have no in-progress subnet call contexts.

  A message that already has an ingress history entry is left alone. Its status is expected to be `Processing`; anything else raises the new `mr_unexpected_ingress_status_after_merge` critical error.

* **Re-partitions canisters' input schedules,** exactly as `after_split()` does. Canisters hosted by the other merged subnets were remote before the merge and are local now, so their input queues may sit in the wrong input schedule; and a misplaced queue is only corrected once it becomes empty, which is not guaranteed to ever happen.

Drive-by cleanups:

* Extract `repartition_input_schedules()`: the input schedule loop was duplicated across `split()`, `after_split()` and `after_merge()`.
* Simplify the height handling in `process_batch_resets_(split|merge)_marker`, which kept a local copy of the height in sync with the `FakeStateManager` instead of just reading it back off the state manager.
