### PR TITLE
fix: fetch mtools from mirrors.kernel.org first

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -874,8 +874,11 @@ http_archive(
     sha256 = "10cd1111da87bf2400a380c1639a6cba8bfb937a24f9c51f5f88d393ae5f6f76",
     strip_prefix = "mtools-4.0.49",
     urls = [
-        "https://ftp.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz",
+        # mirrors.kernel.org first: ftp.gnu.org and ftpmirror.gnu.org have a
+        # history of outages that broke CI (e.g. 2026-08-28).
+        "https://mirrors.kernel.org/gnu/mtools/mtools-4.0.49.tar.gz",
         "https://ftpmirror.gnu.org/mtools/mtools-4.0.49.tar.gz",
+        "https://ftp.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz",
     ],
 )
 


### PR DESCRIPTION
## Problem

GNU's download infrastructure has been down since ~2026-08-28 00:00 UTC, and every **CI Main / Build IC** job since then fails to fetch the `@mtools` external repo (first seen in run 33131446914 at 01:03Z; e.g. #11360, #11364, #11365):

```
WARNING: Download from https://ftp.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz failed: class java.io.IOException Connect timed out
WARNING: Download from https://ftpmirror.gnu.org/mtools/mtools-4.0.49.tar.gz failed: class java.io.IOException GET returned 502 Bad Gateway
ERROR: no such package '@@+http_archive+mtools//': ...
```

`ftp.gnu.org` is hard-down (TCP connect timeout on every attempt) and the `ftpmirror.gnu.org` redirector itself intermittently returns 502 (4 out of 8 probes) — so reordering the two existing URLs would not reliably fix CI. Since `bazel-remote` no longer has the blob cached, the fetch falls back to these URLs and fails. `@mtools` is on the IC-OS image build path (`vfat_image`/`fat32_image`) and a runtime dep of every `uvm_config_image`-using system test, so this blocks most of CI.

## Fix

Add `mirrors.kernel.org` as the primary URL and demote the two GNU hosts to fallbacks. The kernel.org mirror is fast and reliable (full download in ~2s vs ~27s via ftpmirror when it works at all) and serves a byte-identical tarball matching the pinned `sha256`, so this is risk-free. Precedent: #11134 (pigz via macports mirror when zlib.net was down).

## Verification

- Downloaded the tarball from both `mirrors.kernel.org` and `ftpmirror.gnu.org`: both are 569054 bytes with sha256 `10cd1111da87bf2400a380c1639a6cba8bfb937a24f9c51f5f88d393ae5f6f76`, matching the pin.
- `bazel build //... --nobuild` passes (full workspace loads/analyzes).
- `bazel run //:buildifier` clean.
- `bazel fetch --config=local --repository_cache= --force @mtools//...` succeeds with no download warnings, i.e. bazel's own downloader fetched from the new primary URL and the hash verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)