### PR TITLE
fix(PocketIC): prune the ingress pool

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -792,6 +792,25 @@ impl PocketIngressPool {
             },
         );
     }
+
+    /// Removes the ingress messages that were just included in a block, along
+    /// with any messages whose ingress expiry has passed (those can never be
+    /// included in a block anymore).
+    ///
+    /// Without this the pool is never pruned and retains every ingress message
+    /// ever submitted -- including its payload -- for the lifetime of the
+    /// instance.
+    fn remove_inducted_and_expired(&mut self, inducted: &[SignedIngress], now: Time) {
+        for m in inducted {
+            self.validated
+                .remove(&IngressMessageId::new(m.expiry_time(), m.id()));
+        }
+        // Keys are ordered by `(expiry_time, message_id)`, so everything strictly
+        // below this bound has already expired.
+        let expiry_bound =
+            IngressMessageId::new(now, MessageId::from([0; EXPECTED_MESSAGE_ID_LENGTH]));
+        self.validated = self.validated.split_off(&expiry_bound);
+    }
 }
 
 pub trait Subnets: Send + Sync {
@@ -1932,7 +1951,13 @@ impl StateMachine {
         // used by the function `Self::execute_payload` of the `StateMachine`.
         let xnet_payload = batch_payload.xnet.clone();
         let ingress = &batch_payload.ingress;
-        let ingress_messages = ingress.clone().try_into().unwrap();
+        let ingress_messages: Vec<SignedIngress> = ingress.clone().try_into().unwrap();
+        // Prune the ingress pool, mirroring what is done for the canister HTTP
+        // pool (`RemoveValidated`) and the query stats builder (`purge`) below.
+        self.ingress_pool
+            .write()
+            .unwrap()
+            .remove_inducted_and_expired(&ingress_messages, validation_context.time);
         let (http_responses, http_spent, _) =
             CanisterHttpPayloadBuilderImpl::into_messages(&batch_payload.canister_http);
         let inducted: Vec<_> = http_responses

--- a/rs/state_machine_tests/src/tests.rs
+++ b/rs/state_machine_tests/src/tests.rs
@@ -333,3 +333,57 @@ fn public_derivation_path() {
         "03fda02786d72d691d807a10a3de60522b664472ec2f06a704cc34ebe2fc26724c"
     );
 }
+
+#[test]
+fn pocket_ingress_pool_prunes_inducted_and_expired_messages() {
+    use ic_test_utilities_types::{ids::node_test_id, messages::SignedIngressBuilder};
+    use ic_types::{artifact::IngressMessageId, messages::SignedIngress, time::UNIX_EPOCH};
+    use std::time::Duration;
+
+    let now = UNIX_EPOCH + Duration::from_secs(100);
+    let msg = |expiry_secs: u64, nonce: u64| -> SignedIngress {
+        SignedIngressBuilder::new()
+            .nonce(nonce)
+            .expiry_time(UNIX_EPOCH + Duration::from_secs(expiry_secs))
+            .build()
+    };
+
+    // Expired: the ingress selector only considers the expiry range
+    // `[context.time, context.time + MAX_INGRESS_TTL]` and `StateMachine` time is
+    // monotone, so this can never be selected again and must be pruned.
+    let expired = msg(99, 1);
+    // The `split_off` boundary is non-inclusive, so a message expiring exactly at
+    // `now` is still selectable and must be retained.
+    let boundary = msg(100, 2);
+    // Neither expired nor included in a block: must be retained.
+    let future = msg(110, 3);
+    // Included in the block being assembled: must be pruned.
+    let inducted = msg(120, 4);
+
+    let mut pool = super::PocketIngressPool::new();
+    for m in [&expired, &boundary, &future, &inducted] {
+        pool.push(m.clone(), now, node_test_id(0));
+    }
+    assert_eq!(pool.validated.len(), 4);
+
+    pool.remove_inducted_and_expired(std::slice::from_ref(&inducted), now);
+
+    let retained = |m: &SignedIngress| pool.validated.contains_key(&IngressMessageId::from(m));
+    assert!(
+        !retained(&expired),
+        "a message expiring before `now` must be pruned"
+    );
+    assert!(
+        !retained(&inducted),
+        "a message included in a block must be pruned"
+    );
+    assert!(
+        retained(&boundary),
+        "`expiry == now` is the non-inclusive boundary and must be retained"
+    );
+    assert!(
+        retained(&future),
+        "an unexpired message not included in a block must be retained"
+    );
+    assert_eq!(pool.validated.len(), 2);
+}


### PR DESCRIPTION
## Problem

`PocketIngressPool` only ever inserts: `push` (`self.validated.insert`) is the *sole* mutation of its `BTreeMap` in the whole file. There is no `remove`, no `purge_below` and no expiry-based GC, unlike the replica's `IngressPoolImpl`, which has all three (`rs/artifact_pool/src/ingress_pool.rs`).

So every ingress message ever submitted to a PocketIC instance is retained, with its payload, for the lifetime of the process. And each `SignedIngress` holds the payload twice -- the decoded `signed.content.arg` and the re-serialized `binary: SignedRequestBytes` -- with the CBOR copy landing in a `Vec` grown by doubling, i.e. up to 2x the bytes it needs.

The result is roughly 2.7 bytes of RSS retained per byte of ingress payload, growing without bound. Uploading 800 MiB to an asset canister on an otherwise idle instance grows the server from 362 MiB to 2575 MiB, linearly, at ~240 MiB per 100 MiB uploaded, with no sign of levelling off.

## Fix

Prune the ingress pool where the block payload is assembled, mirroring what that same function already does for the canister HTTP pool (`CanisterHttpChangeAction::RemoveValidated`) and the query stats builder (`purge`): drop the messages that just made it into a block, and drop those whose ingress expiry has passed.

Purging below `validation_context.time` matches the replica, which issues `PurgeBelowExpiry(consensus_time)` (`rs/ingress_manager/src/ingress_handler.rs`), and uses the same non-inclusive `split_off` boundary as `purge_below`. The ingress selector only considers `[context.time, context.time + MAX_INGRESS_TTL]` and `StateMachine` time is monotone, so nothing removed here could ever be selected again. Removing inducted messages is safe because re-inclusion is prevented by ingress history (`IngressHistorySet`), not by pool contents, and ingress status polling reads ingress history too -- so there is no API-visible change.

Same workload, 800 MiB uploaded, before -> after:

| assets | uploaded | before | after |
|-------:|---------:|-------:|------:|
|      0 |        0 |   362M |  360M |
|      2 |    200M  |  1096M |  656M |
|      4 |    400M  |  1611M |  709M |
|      6 |    600M  |  2112M |  767M |
|      8 |    800M  |  2575M |  781M |

Growth drops from +2213 MiB (linear) to +421 MiB (converging: the last three assets cost +26, +7 and +7 MiB), i.e. 3.3x less RSS at 800 MiB and a gap that widens with every further message.