### PR TITLE
feat(sns): Add upgrade options for dapp canisters.

### DIFF
--- a/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
+++ b/rs/nervous_system/integration_tests/tests/upgrade_sns_controlled_canister_with_large_wasm.rs
@@ -194,6 +194,7 @@ async fn upgrade_sns_controlled_canister_with_large_wasm() {
         canister_upgrade_arg,
         mode,
         chunked_canister_wasm,
+        canister_upgrade_options: _,
     }) = action
     else {
         panic!("unexpected proposal action {action:?}");

--- a/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
+++ b/rs/sns/cli/src/upgrade_sns_controlled_canister.rs
@@ -482,6 +482,8 @@ pub async fn exec<C: CallCanisters>(
                     store_canister_id: Some(store_canister_id.get()),
                     chunk_hashes_list,
                 }),
+                // TODO: Add support for upgrade options to SNS CLI.
+                canister_upgrade_options: None,
             },
         )),
     };

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -392,6 +392,24 @@ pub struct UpgradeSnsControlledCanister {
     /// If the entire WASM does not fit into the 2 MiB ingress limit, then `new_canister_wasm` should be
     /// an empty, and this field should be set instead.
     pub chunked_canister_wasm: Option<ChunkedCanisterWasm>,
+    /// Options that only apply when mode is upgrade.
+    pub canister_upgrade_options: Option<upgrade_sns_controlled_canister::CanisterUpgradeOptions>,
+}
+/// Nested message and enum types in `UpgradeSnsControlledCanister`.
+pub mod upgrade_sns_controlled_canister {
+    #[derive(candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+    pub struct CanisterUpgradeOptions {
+        /// Whether to skip the canister's pre_upgrade hook. This would generally be
+        /// used in emergencies. See the corresponding field in the Management
+        /// canister API.
+        pub skip_pre_upgrade: Option<bool>,
+        /// Whether to retain (keep) or drop (replace) the canister's Wasm main
+        /// memory across the upgrade. If the old WASM had a custom section named
+        /// "icp:private enhanced-orthogonal-persistence", then this must be set
+        /// (otherwise, the Management canister will block the upgrade). If keep is
+        /// used here, then the new WASM must also have the same custom section.
+        pub wasm_memory_persistence: Option<i32>,
+    }
 }
 /// A proposal to transfer SNS treasury funds to (optionally a Subaccount of) the
 /// target principal.

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -906,8 +906,14 @@ type ChunkedCanisterWasm = record {
   chunk_hashes_list : vec blob;
 };
 
+type CanisterUpgradeOptions = record {
+  skip_pre_upgrade : opt bool;
+  wasm_memory_persistence : opt int32;
+};
+
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : blob;
+  canister_upgrade_options : opt CanisterUpgradeOptions;
   chunked_canister_wasm : opt ChunkedCanisterWasm;
   mode : opt int32;
   canister_id : opt principal;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -351,6 +351,20 @@ message ChunkedCanisterWasm {
 // A proposal function that upgrades a canister that is controlled by the
 // SNS Governance canister.
 message UpgradeSnsControlledCanister {
+  message CanisterUpgradeOptions {
+    // Whether to skip the canister's pre_upgrade hook. This would generally be
+    // used in emergencies. See the corresponding field in the Management
+    // canister API.
+    optional bool skip_pre_upgrade = 1;
+
+    // Whether to retain (keep) or drop (replace) the canister's Wasm main
+    // memory across the upgrade. If the old WASM had a custom section named
+    // "icp:private enhanced-orthogonal-persistence", then this must be set
+    // (otherwise, the Management canister will block the upgrade). If keep is
+    // used here, then the new WASM must also have the same custom section.
+    optional types.v1.WasmMemoryPersistence wasm_memory_persistence = 2;
+  }
+
   // The id of the canister that is upgraded.
   ic_base_types.pb.v1.PrincipalId canister_id = 1;
   // The new wasm module that the canister is upgraded to.
@@ -362,6 +376,8 @@ message UpgradeSnsControlledCanister {
   // If the entire WASM does not fit into the 2 MiB ingress limit, then `new_canister_wasm` should be
   // empty, and this field should be set instead.
   optional ChunkedCanisterWasm chunked_canister_wasm = 5;
+  // Options that only apply when mode is upgrade.
+  optional CanisterUpgradeOptions canister_upgrade_options = 6;
 }
 
 // A proposal to transfer SNS treasury funds to (optionally a Subaccount of) the

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -560,6 +560,9 @@ impl ValidatedRegisterExtension {
                     wasm,
                     init_blob,
                     CanisterInstallMode::Install,
+                    // Upgrade options. Since we are using install mode here, we
+                    // are supposed to not pass Some, only None.
+                    None,
                 )
                 .await?;
 
@@ -1230,6 +1233,7 @@ impl ValidatedUpgradeExtension {
                 wasm,
                 arg_bytes,
                 CanisterInstallMode::Upgrade,
+                None, // upgrade options
             )
             .await?;
 

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -489,6 +489,42 @@ pub struct UpgradeSnsControlledCanister {
     /// empty, and this field should be set instead.
     #[prost(message, optional, tag = "5")]
     pub chunked_canister_wasm: ::core::option::Option<ChunkedCanisterWasm>,
+    /// Options that only apply when mode is upgrade.
+    #[prost(message, optional, tag = "6")]
+    pub canister_upgrade_options:
+        ::core::option::Option<upgrade_sns_controlled_canister::CanisterUpgradeOptions>,
+}
+/// Nested message and enum types in `UpgradeSnsControlledCanister`.
+pub mod upgrade_sns_controlled_canister {
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        Hash,
+        ::prost::Message,
+    )]
+    pub struct CanisterUpgradeOptions {
+        /// Whether to skip the canister's pre_upgrade hook. This would generally be
+        /// used in emergencies. See the corresponding field in the Management
+        /// canister API.
+        #[prost(bool, optional, tag = "1")]
+        pub skip_pre_upgrade: ::core::option::Option<bool>,
+        /// Whether to retain (keep) or drop (replace) the canister's Wasm main
+        /// memory across the upgrade. If the old WASM had a custom section named
+        /// "icp:private enhanced-orthogonal-persistence", then this must be set
+        /// (otherwise, the Management canister will block the upgrade). If keep is
+        /// used here, then the new WASM must also have the same custom section.
+        #[prost(
+            enumeration = "::ic_protobuf::types::v1::WasmMemoryPersistence",
+            optional,
+            tag = "2"
+        )]
+        pub wasm_memory_persistence: ::core::option::Option<i32>,
+    }
 }
 /// A proposal to transfer SNS treasury funds to (optionally a Subaccount of) the
 /// target principal.

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -113,7 +113,6 @@ use ic_nervous_system_lock::acquire;
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nervous_system_timestamp::format_timestamp_for_humans;
 use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
-use ic_protobuf::types::v1::CanisterInstallMode as CanisterInstallModeProto;
 use ic_protobuf::types::v1::WasmMemoryPersistence as WasmMemoryPersistenceProto;
 use ic_sns_governance_proposal_criticality::ProposalCriticality;
 use ic_sns_governance_token_valuation::Valuation;
@@ -2678,7 +2677,12 @@ impl Governance {
             ));
         }
 
-        let mode = upgrade.mode_or_upgrade() as i32;
+        let mode = upgrade.mode_or_upgrade();
+        let mode = CanisterInstallMode::try_from(mode)?;
+
+        let canister_upgrade_options =
+            valid_canister_upgrade_options(mode, upgrade.canister_upgrade_options)
+                .map_err(|err| GovernanceError::new_with_message(ErrorType::InvalidCommand, err))?;
 
         let wasm = Wasm::try_from(&upgrade)
             .map_err(|err| GovernanceError::new_with_message(ErrorType::InvalidCommand, err))?;
@@ -2689,7 +2693,8 @@ impl Governance {
             upgrade
                 .canister_upgrade_arg
                 .unwrap_or_else(|| Encode!().unwrap()),
-            CanisterInstallMode::try_from(CanisterInstallModeProto::try_from(mode)?)?,
+            mode,
+            canister_upgrade_options,
         )
         .await
     }
@@ -2700,6 +2705,7 @@ impl Governance {
         wasm: Wasm,
         arg: Vec<u8>,
         mode: CanisterInstallMode,
+        canister_upgrade_options: Option<CanisterUpgradeOptions>,
     ) -> Result<(), GovernanceError> {
         // Serialize upgrade.
         let payload = {
@@ -2710,7 +2716,7 @@ impl Governance {
             // For more details, please refer to the comments above the (definition of the)
             // stop_before_installing field in ChangeCanisterRequest.
             let stop_before_installing = true;
-            let mode = CanisterInstallModeV2::from(mode);
+            let mode = assemble_mode(mode, canister_upgrade_options);
 
             let mut change_canister_arg =
                 ChangeCanisterRequest::new(stop_before_installing, mode, canister_id)
@@ -2886,6 +2892,11 @@ impl Governance {
                     Wasm::Bytes(target_wasm.clone()),
                     Encode!().unwrap(),
                     CanisterInstallMode::Upgrade,
+                    // upgrade options. skip_pre_upgrade would be dangerous, and
+                    // wasm_memory_persistence is not needed either, because no
+                    // SNS framework canister is written in Motoko (as of
+                    // August, 2026).
+                    None,
                 )
                 .await?;
             }
@@ -2953,6 +2964,11 @@ impl Governance {
                     Wasm::Bytes(target_wasm.clone()),
                     Encode!().unwrap(),
                     CanisterInstallMode::Upgrade,
+                    // upgrade options. skip_pre_upgrade would be dangerous, and
+                    // wasm_memory_persistence is not needed either, because no
+                    // SNS framework canister is written in Motoko (as of
+                    // August, 2026).
+                    None,
                 )
                 .await?;
             }
@@ -3155,6 +3171,7 @@ impl Governance {
             Wasm::Bytes(ledger_wasm),
             ledger_upgrade_arg,
             CanisterInstallMode::Upgrade,
+            None, // upgrade options
         )
         .await?;
 

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -70,7 +70,7 @@ use crate::{
             proposal::Action,
             proposal_data::ActionAuxiliary as ActionAuxiliaryPb,
             transfer_sns_treasury_funds::TransferFrom,
-            upgrade_journal_entry, valuation,
+            upgrade_journal_entry, upgrade_sns_controlled_canister, valuation,
         },
     },
     proposal::{
@@ -97,7 +97,7 @@ use ic_canister_profiler::SpanStats;
 use ic_ledger_core::Tokens;
 use ic_management_canister_types_private::{
     CanisterChangeDetails, CanisterInfoRequest, CanisterInfoResponse, CanisterInstallMode,
-    CanisterInstallModeV2,
+    CanisterInstallModeV2, CanisterUpgradeOptions, WasmMemoryPersistence,
 };
 use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_clients::ledger_client::ICRC1Ledger;
@@ -114,6 +114,7 @@ use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nervous_system_timestamp::format_timestamp_for_humans;
 use ic_nns_constants::LEDGER_CANISTER_ID as NNS_LEDGER_CANISTER_ID;
 use ic_protobuf::types::v1::CanisterInstallMode as CanisterInstallModeProto;
+use ic_protobuf::types::v1::WasmMemoryPersistence as WasmMemoryPersistenceProto;
 use ic_sns_governance_proposal_criticality::ProposalCriticality;
 use ic_sns_governance_token_valuation::Valuation;
 use icp_ledger::DEFAULT_TRANSFER_FEE as NNS_DEFAULT_TRANSFER_FEE;
@@ -6577,6 +6578,75 @@ impl TimeWarp {
             timestamp_s - ((-self.delta_s) as u64)
         }
     }
+}
+
+/// Combines the arguments into the Mode type required by Root (and the
+/// Management canister).
+///
+/// If mode is not Upgrade, then canister_upgrade_options does not affect the
+/// return value (but in non-release builds, this panics via debug_assert).
+fn assemble_mode(
+    mode: CanisterInstallMode,
+    canister_upgrade_options: Option<CanisterUpgradeOptions>,
+) -> CanisterInstallModeV2 {
+    match mode {
+        CanisterInstallMode::Upgrade => CanisterInstallModeV2::Upgrade(canister_upgrade_options),
+        mode => {
+            // This checks that the caller is calling us correctly. This only
+            // happens in non-release builds. In production,
+            // canister_upgrade_options is ignored when it is Some.
+            debug_assert_eq!(canister_upgrade_options, None);
+            CanisterInstallModeV2::from(mode)
+        }
+    }
+}
+
+/// Converts canister_upgrade_options into the type required by SNS Root.
+///
+/// Returns Err in the following cases:
+///
+/// 1. mode is not Upgrade.
+/// 2. wasm_memory_persistence is not one of the allowed values:
+///    a. Keep
+///    b. Replace
+///    c. None
+pub(crate) fn valid_canister_upgrade_options(
+    mode: CanisterInstallMode,
+    canister_upgrade_options: Option<upgrade_sns_controlled_canister::CanisterUpgradeOptions>,
+) -> Result<Option<CanisterUpgradeOptions>, String> {
+    let Some(canister_upgrade_options) = canister_upgrade_options else {
+        return Ok(None);
+    };
+
+    if mode != CanisterInstallMode::Upgrade {
+        return Err("canister_upgrade_options can only be set when mode is upgrade".to_string());
+    }
+
+    let upgrade_sns_controlled_canister::CanisterUpgradeOptions {
+        skip_pre_upgrade,
+        wasm_memory_persistence,
+    } = canister_upgrade_options;
+
+    let wasm_memory_persistence = match wasm_memory_persistence {
+        None => None,
+        Some(code) => Some(convert_i32_to_wasm_memory_persistence(code)?),
+    };
+
+    Ok(Some(CanisterUpgradeOptions {
+        skip_pre_upgrade,
+        wasm_memory_persistence,
+    }))
+}
+
+/// Converts from integer code to the enum type required by the Root canister
+/// (and the Management canister).
+///
+/// Ok values are Keep and Replace.
+fn convert_i32_to_wasm_memory_persistence(code: i32) -> Result<WasmMemoryPersistence, String> {
+    let new_error = || format!("Unrecognized wasm_memory_persistence code: {code}");
+
+    let result = WasmMemoryPersistenceProto::try_from(code).map_err(|_| new_error())?;
+    WasmMemoryPersistence::try_from(result).map_err(|_| new_error())
 }
 
 fn get_neuron_id_from_manage_neuron(

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -2,17 +2,15 @@
 //! here, so that Bazel does not recompile the whole production crate each time the tests are run.
 //! The name of this file is indeed too generic; feel free to factor specific tests out into
 //! more appropriate locations, or create new file modules for them, whatever makes more sense.
+use super::*;
 use crate::{
     extensions::{ExtensionSpec, ExtensionType, ExtensionVersion},
-    governance::{
-        test_helpers::{
-            A_MOTION_PROPOSAL, A_NEURON, A_NEURON_ID, A_NEURON_PRINCIPAL_ID, DoNothingLedger,
-            TEST_ARCHIVES_CANISTER_IDS, TEST_DAPP_CANISTER_IDS, TEST_GOVERNANCE_CANISTER_ID,
-            TEST_INDEX_CANISTER_ID, TEST_LEDGER_CANISTER_ID, TEST_ROOT_CANISTER_ID,
-            TEST_SWAP_CANISTER_ID, basic_governance_proto, canister_status_for_test,
-            canister_status_from_management_canister_for_test,
-        },
-        *,
+    governance::test_helpers::{
+        A_MOTION_PROPOSAL, A_NEURON, A_NEURON_ID, A_NEURON_PRINCIPAL_ID, DoNothingLedger,
+        TEST_ARCHIVES_CANISTER_IDS, TEST_DAPP_CANISTER_IDS, TEST_GOVERNANCE_CANISTER_ID,
+        TEST_INDEX_CANISTER_ID, TEST_LEDGER_CANISTER_ID, TEST_ROOT_CANISTER_ID,
+        TEST_SWAP_CANISTER_ID, basic_governance_proto, canister_status_for_test,
+        canister_status_from_management_canister_for_test,
     },
     pb::v1::{
         Account as AccountProto, Motion, NervousSystemFunction, NeuronPermissionType, ProposalData,

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -53,6 +53,7 @@ use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_OWNER_PRINCIPAL, TEST_USER1_KEYPAIR,
 };
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
+use ic_protobuf::types::v1::CanisterInstallMode as CanisterInstallModeProto;
 use ic_sns_governance_api::pb::v1::topics::Topic;
 use ic_sns_governance_token_valuation::{Token, ValuationFactors};
 use ic_sns_test_utils::itest_helpers::UserInfo;
@@ -3049,6 +3050,7 @@ fn test_sns_controlled_canister_upgrade_only_upgrades_dapp_canisters() {
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: None,
+            canister_upgrade_options: None,
         });
 
         // Upgrade Proposal

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -3164,6 +3164,95 @@ fn test_sns_controlled_canister_upgrade_only_upgrades_dapp_canisters() {
 }
 
 #[test]
+fn test_canister_upgrade_options_rejected_when_mode_is_not_upgrade() {
+    // Step 1: Prepare the world.
+    let install = CanisterInstallMode::Install;
+    let canister_upgrade_options = Some(upgrade_sns_controlled_canister::CanisterUpgradeOptions {
+        wasm_memory_persistence: Some(WasmMemoryPersistenceProto::Keep as i32),
+        skip_pre_upgrade: None,
+    });
+
+    // Step 2: Run the code under test.
+    let result = valid_canister_upgrade_options(install, canister_upgrade_options);
+
+    // Step 3: Inspect result(s).
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("canister_upgrade_options") && err.contains("mode is upgrade"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn test_canister_upgrade_options_rejected_when_wasm_memory_persistence_unspecified() {
+    // Step 1: Prepare the world.
+    let upgrade = CanisterInstallMode::Upgrade;
+    let canister_upgrade_options = Some(upgrade_sns_controlled_canister::CanisterUpgradeOptions {
+        // 0/Unspecified is not allowed here.
+        wasm_memory_persistence: Some(WasmMemoryPersistenceProto::Unspecified as i32),
+        skip_pre_upgrade: None,
+    });
+
+    // Step 2: Run the code under test.
+    let result = valid_canister_upgrade_options(upgrade, canister_upgrade_options);
+
+    // Step 3: Inspect result(s).
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("Unrecognized") && err.contains("wasm_memory_persistence"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn test_canister_upgrade_options_accepted_when_mode_is_upgrade() {
+    // Step 1: Prepare the world.
+    let upgrade = CanisterInstallMode::Upgrade;
+    let canister_upgrade_options = Some(upgrade_sns_controlled_canister::CanisterUpgradeOptions {
+        wasm_memory_persistence: Some(WasmMemoryPersistenceProto::Keep as i32),
+        skip_pre_upgrade: Some(true),
+    });
+
+    // Step 2: Run the code under test.
+    let canister_upgrade_options =
+        valid_canister_upgrade_options(upgrade, canister_upgrade_options).unwrap();
+    let root_mode = assemble_mode(upgrade, canister_upgrade_options);
+
+    // Step 3: Inspect result(s).
+    assert_eq!(
+        root_mode,
+        CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
+            skip_pre_upgrade: Some(true),
+            wasm_memory_persistence: Some(WasmMemoryPersistence::Keep),
+        })),
+    );
+}
+
+#[test]
+fn test_canister_upgrade_options_accepted_when_wasm_memory_persistence_is_replace() {
+    // Step 1: Prepare the world.
+    let upgrade = CanisterInstallMode::Upgrade;
+    let canister_upgrade_options = Some(upgrade_sns_controlled_canister::CanisterUpgradeOptions {
+        wasm_memory_persistence: Some(WasmMemoryPersistenceProto::Replace as i32),
+        skip_pre_upgrade: Some(false),
+    });
+
+    // Step 2: Run the code under test.
+    let canister_upgrade_options =
+        valid_canister_upgrade_options(upgrade, canister_upgrade_options).unwrap();
+    let root_mode = assemble_mode(upgrade, canister_upgrade_options);
+
+    // Step 3: Inspect result(s).
+    assert_eq!(
+        root_mode,
+        CanisterInstallModeV2::Upgrade(Some(CanisterUpgradeOptions {
+            skip_pre_upgrade: Some(false),
+            wasm_memory_persistence: Some(WasmMemoryPersistence::Replace),
+        })),
+    );
+}
+
+#[test]
 fn test_allow_canister_upgrades_while_motion_proposal_execution_is_in_progress() {
     // Step 1: Prepare the world.
     use ProposalDecisionStatus as Status;

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -399,6 +399,31 @@ impl From<pb::UpgradeSnsControlledCanister> for pb_api::UpgradeSnsControlledCani
             chunked_canister_wasm: item
                 .chunked_canister_wasm
                 .map(pb_api::ChunkedCanisterWasm::from),
+            canister_upgrade_options: item
+                .canister_upgrade_options
+                .map(pb_api::upgrade_sns_controlled_canister::CanisterUpgradeOptions::from),
+        }
+    }
+}
+
+impl From<pb::upgrade_sns_controlled_canister::CanisterUpgradeOptions>
+    for pb_api::upgrade_sns_controlled_canister::CanisterUpgradeOptions
+{
+    fn from(item: pb::upgrade_sns_controlled_canister::CanisterUpgradeOptions) -> Self {
+        Self {
+            skip_pre_upgrade: item.skip_pre_upgrade,
+            wasm_memory_persistence: item.wasm_memory_persistence,
+        }
+    }
+}
+
+impl From<pb_api::upgrade_sns_controlled_canister::CanisterUpgradeOptions>
+    for pb::upgrade_sns_controlled_canister::CanisterUpgradeOptions
+{
+    fn from(item: pb_api::upgrade_sns_controlled_canister::CanisterUpgradeOptions) -> Self {
+        Self {
+            skip_pre_upgrade: item.skip_pre_upgrade,
+            wasm_memory_persistence: item.wasm_memory_persistence,
         }
     }
 }
@@ -433,6 +458,9 @@ impl From<pb_api::UpgradeSnsControlledCanister> for pb::UpgradeSnsControlledCani
             chunked_canister_wasm: item
                 .chunked_canister_wasm
                 .map(pb::ChunkedCanisterWasm::from),
+            canister_upgrade_options: item
+                .canister_upgrade_options
+                .map(pb::upgrade_sns_controlled_canister::CanisterUpgradeOptions::from),
         }
     }
 }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     governance::{
         NERVOUS_SYSTEM_FUNCTION_DELETION_MARKER, TREASURY_SUBACCOUNT_NONCE, bytes_to_subaccount,
-        log_prefix,
+        log_prefix, valid_canister_upgrade_options,
     },
     logs::{ERROR, INFO},
     pb::v1::{
@@ -40,6 +40,7 @@ use candid::Principal;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
 use ic_crypto_sha2::Sha256;
+use ic_management_canister_types_private::CanisterInstallMode as RootCanisterInstallMode;
 use ic_nervous_system_common::{
     DEFAULT_TRANSFER_FEE, E8, ONE_DAY_SECONDS, denominations_to_tokens, i2d,
     ledger::compute_distribution_subaccount_bytes, ledger_validation,
@@ -1053,6 +1054,7 @@ async fn validate_and_render_upgrade_sns_controlled_canister(
         canister_id,
         canister_upgrade_arg,
         mode,
+        canister_upgrade_options,
         // The WASM-related fields are extracted separately.
         chunked_canister_wasm: _,
         new_canister_wasm: _,
@@ -1066,6 +1068,21 @@ async fn validate_and_render_upgrade_sns_controlled_canister(
     }
     // Assume mode is the default if it is not set
     let mode = upgrade.mode_or_upgrade();
+
+    // Inspect canister_upgrade_options.
+    match RootCanisterInstallMode::try_from(mode) {
+        Err(err) => {
+            // This would happen if mode was originally 0, Unspecified. Of
+            // course, if canister_upgrade_options is Some, that's also wrong
+            // here, but moot, so we do not add to defects for that.
+            defects.push(format!("Invalid mode: {err}"));
+        }
+        Ok(mode) => {
+            if let Err(err) = valid_canister_upgrade_options(mode, *canister_upgrade_options) {
+                defects.push(err);
+            }
+        }
+    }
 
     // Inspect canister_id.
     let canister_id = match validate_required_field("canister_id", canister_id) {

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -3072,6 +3072,7 @@ mod tests {
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: None,
+            canister_upgrade_options: None,
         };
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
         let text = validate_and_render_upgrade_sns_controlled_canister(
@@ -3113,6 +3114,7 @@ No upgrade argument."#
                 store_canister_id: Some(canister_test_id(111).get()),
                 chunk_hashes_list: vec![vec![1, 1, 1], vec![2, 2, 2], vec![3, 3, 3]],
             }),
+            canister_upgrade_options: None,
         };
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
         let text = validate_and_render_upgrade_sns_controlled_canister(
@@ -3160,6 +3162,7 @@ No upgrade argument."#
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: Some(chunked_canister_wasm.clone()),
+            canister_upgrade_options: None,
         };
 
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
@@ -3196,6 +3199,7 @@ No upgrade argument."#
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: Some(chunked_canister_wasm.clone()),
+            canister_upgrade_options: None,
         };
 
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
@@ -3234,6 +3238,7 @@ No upgrade argument."#
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: Some(chunked_canister_wasm.clone()),
+            canister_upgrade_options: None,
         };
 
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
@@ -3268,6 +3273,7 @@ No upgrade argument."#
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: Some(chunked_canister_wasm.clone()),
+            canister_upgrade_options: None,
         };
 
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
@@ -3297,6 +3303,7 @@ No upgrade argument."#
             canister_upgrade_arg: Some(vec![10, 20, 30, 40, 50, 60, 70, 80]),
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: None,
+            canister_upgrade_options: None,
         };
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
         let text = validate_and_render_upgrade_sns_controlled_canister(
@@ -3334,6 +3341,7 @@ Upgrade argument with 8 bytes and SHA256 `0a141e28323c4650`."#
             canister_upgrade_arg: None,
             mode: Some(100), // 100 is not a valid mode
             chunked_canister_wasm: None,
+            canister_upgrade_options: None,
         };
         let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
         let text = validate_and_render_upgrade_sns_controlled_canister(
@@ -3353,6 +3361,7 @@ Upgrade argument with 8 bytes and SHA256 `0a141e28323c4650`."#
             canister_upgrade_arg: None,
             mode: Some(CanisterInstallModeProto::Upgrade.into()),
             chunked_canister_wasm: None,
+            canister_upgrade_options: None,
         };
         let result = validate_and_render_upgrade_sns_controlled_canister(
             &upgrade,
@@ -5459,6 +5468,7 @@ Payload rendering here"#
                         canister_upgrade_arg: Some(vec![4, 5, 6, 7]),
                         mode: Some(1),
                         chunked_canister_wasm: None,
+                        canister_upgrade_options: None,
                     },
                 )),
                 ..Default::default()
@@ -5480,6 +5490,7 @@ Payload rendering here"#
                             canister_upgrade_arg: Some(vec![4, 5, 6, 7]),
                             mode: Some(1),
                             chunked_canister_wasm: None,
+                            canister_upgrade_options: None,
                         },
                     )),
                     ..Default::default()

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -30,6 +30,7 @@ use crate::{
             MintSnsTokensActionAuxiliary, TransferSnsTreasuryFundsActionAuxiliary,
         },
         transfer_sns_treasury_funds::TransferFrom,
+        upgrade_sns_controlled_canister::CanisterUpgradeOptions,
     },
     sns_upgrade::{UpgradeSnsParams, get_proposal_id_that_added_wasm, get_upgrade_params},
     treasury::assess_treasury_balance,
@@ -48,6 +49,7 @@ use ic_nervous_system_common::{
 use ic_nervous_system_proto::pb::v1::Percentage;
 use ic_nervous_system_timestamp::format_timestamp_for_humans;
 use ic_protobuf::types::v1::CanisterInstallMode;
+use ic_protobuf::types::v1::WasmMemoryPersistence as WasmMemoryPersistenceProto;
 use ic_sns_governance_api::{format_full_hash, pb::v1 as pb_api};
 use ic_sns_governance_proposals_amount_total_limit::{
     // TODO(NNS1-2982): Uncomment. mint_sns_tokens_7_day_total_upper_bound_tokens,
@@ -1042,6 +1044,40 @@ impl TokenProposalAction for MintSnsTokens {
     }
 }
 
+/// Renders the "## Upgrade options" section (including its own leading blank
+/// lines and heading), so that voters can tell whether the proposal includes
+/// skip_pre_upgrade and/or wasm_memory_persistence.
+///
+/// Returns "" (i.e. no section at all) when there is nothing to say.
+fn render_canister_upgrade_options_section(
+    canister_upgrade_options: &Option<CanisterUpgradeOptions>,
+) -> String {
+    let Some(CanisterUpgradeOptions {
+        skip_pre_upgrade,
+        wasm_memory_persistence,
+    }) = canister_upgrade_options
+    else {
+        return "".to_string();
+    };
+
+    let skip_pre_upgrade: bool = skip_pre_upgrade.unwrap_or_default();
+
+    let wasm_memory_persistence = match wasm_memory_persistence {
+        None => "Unspecified".to_string(),
+        Some(code) => match WasmMemoryPersistenceProto::try_from(*code) {
+            Ok(value) => format!("{value:?}"),
+            // This is unreachable because of validation performed by the caller.
+            Err(_) => format!("Unrecognized({code})"),
+        },
+    };
+
+    format!(
+        "\n\n## Upgrade options\n\n\
+         skip_pre_upgrade: {skip_pre_upgrade}\n\
+         wasm_memory_persistence: {wasm_memory_persistence}"
+    )
+}
+
 /// Validates and renders a proposal with action UpgradeSnsControlledCanister.
 async fn validate_and_render_upgrade_sns_controlled_canister(
     upgrade: &UpgradeSnsControlledCanister,
@@ -1150,6 +1186,8 @@ async fn validate_and_render_upgrade_sns_controlled_canister(
         })
         .unwrap_or_else(|| "No upgrade argument.".to_string());
 
+    let upgrade_options_section = render_canister_upgrade_options_section(canister_upgrade_options);
+
     Ok(format!(
         r"# Proposal to Upgrade an SNS Controlled Canister
 
@@ -1159,7 +1197,7 @@ async fn validate_and_render_upgrade_sns_controlled_canister(
 
 {wasm_info}
 
-## Mode: {mode:?}
+## Mode: {mode:?}{upgrade_options_section}
 
 ## Argument info
 
@@ -3094,6 +3132,57 @@ mod tests {
 Embedded module with 8 bytes and SHA256 `93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476`.
 
 ## Mode: Upgrade
+
+## Argument info
+
+No upgrade argument."#
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn render_upgrade_sns_controlled_canister_proposal_with_upgrade_options() {
+        let upgrade = UpgradeSnsControlledCanister {
+            // The point of this test is to make sure that this gets reflected
+            // in the description of the proposal.
+            canister_upgrade_options: Some(CanisterUpgradeOptions {
+                skip_pre_upgrade: Some(true),
+                wasm_memory_persistence: Some(WasmMemoryPersistenceProto::Keep as i32),
+            }),
+
+            // Similar to other test(s).
+            canister_id: Some(basic_canister_id()),
+            new_canister_wasm: vec![0, 0x61, 0x73, 0x6D, 1, 0, 0, 0],
+            canister_upgrade_arg: None,
+            mode: Some(CanisterInstallModeProto::Upgrade.into()),
+            chunked_canister_wasm: None,
+        };
+        let env = setup_for_upgrade_sns_controlled_canister_tests(&upgrade);
+
+        let text = validate_and_render_upgrade_sns_controlled_canister(
+            &upgrade,
+            &env,
+            canister_test_id(55),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            text,
+            r#"# Proposal to Upgrade an SNS Controlled Canister
+
+## Target canister: xbgkv-fyaaa-aaaaa-aaava-cai
+
+## Wasm info
+
+Embedded module with 8 bytes and SHA256 `93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476`.
+
+## Mode: Upgrade
+
+## Upgrade options
+
+skip_pre_upgrade: true
+wasm_memory_persistence: Keep
 
 ## Argument info
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1864,6 +1864,7 @@ impl UpgradeSnsControlledCanister {
                 .map(|blob| summarize_blob_field(blob)),
             mode: self.mode,
             chunked_canister_wasm: self.chunked_canister_wasm.clone(),
+            canister_upgrade_options: self.canister_upgrade_options,
         }
     }
 
@@ -1875,6 +1876,7 @@ impl UpgradeSnsControlledCanister {
             mode: self.mode,
             new_canister_wasm: Vec::new(),
             chunked_canister_wasm: self.chunked_canister_wasm.clone(),
+            canister_upgrade_options: self.canister_upgrade_options,
         }
     }
 }

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,10 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added support for upgrade options to `UpgradeSnsControlledCanister` proposals.
+  In particular, added `wasm_memory_persistence` and `skip_pre_upgrade`. The
+  former is of particular interest to Motoko canisters.
+
 ## Changed
 
 ## Deprecated

--- a/rs/sns/integration_tests/src/upgrade_canister.rs
+++ b/rs/sns/integration_tests/src/upgrade_canister.rs
@@ -137,6 +137,7 @@ fn test_upgrade_canister_proposal_is_successful() {
                 // mode: None corresponds to CanisterInstallModeProto::Upgrade
                 mode: None,
                 chunked_canister_wasm: None,
+                canister_upgrade_options: None,
             },
         )),
         ..Default::default()
@@ -264,6 +265,7 @@ fn test_upgrade_canister_proposal_reinstall() {
                     canister_upgrade_arg: Some(wasm().build()),
                     mode: Some(CanisterInstallModeProto::Reinstall.into()),
                     chunked_canister_wasm: None,
+                    canister_upgrade_options: None,
                 },
             )),
             ..Default::default()
@@ -418,6 +420,7 @@ fn test_upgrade_canister_proposal_execution_fail() {
                     canister_upgrade_arg: None,
                     mode: Some(CanisterInstallModeProto::Upgrade.into()),
                     chunked_canister_wasm: None,
+                    canister_upgrade_options: None,
                 },
             )),
             ..Default::default()
@@ -522,6 +525,7 @@ fn test_upgrade_canister_proposal_too_large() {
                 // mode: None corresponds to CanisterInstallModeProto::Upgrade
                 mode: None,
                 chunked_canister_wasm: None,
+                canister_upgrade_options: None,
             },
         )),
         ..Default::default()
@@ -644,6 +648,7 @@ fn test_upgrade_after_state_shrink() {
                     canister_upgrade_arg: None,
                     mode: Some(CanisterInstallModeProto::Upgrade.into()),
                     chunked_canister_wasm: None,
+                    canister_upgrade_options: None,
                 },
             )),
             ..Default::default()

--- a/rs/sns/testing/src/sns.rs
+++ b/rs/sns/testing/src/sns.rs
@@ -512,6 +512,7 @@ pub async fn propose_sns_controlled_canister_upgrade<C: CallCanisters + Progress
                     canister_upgrade_arg: upgrade_arg,
                     mode: Some(CanisterInstallMode::Upgrade as i32),
                     chunked_canister_wasm: None,
+                    canister_upgrade_options: None,
                 },
             )),
         },


### PR DESCRIPTION
SNS root already supported this from when we added support to NNS. This just adds support to SNS Governance.

In particular, the following are added:

- wasm_memory_persistence - This is the more interesting one, because it allows SNSs to have canisters written in Motoko. More precisely, the allows them to take advantage of Enhanced Orthogonal Persistence.
- skip_pre_upgrade - This could be useful in an emergency, which will hopefully never happen 🤞

This is tested in another (not yet merged PR): https://github.com/dfinity/ic/pull/11379