### PR TITLE
docs(nns): Added more info about skip_pre_upgrade.

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -2590,7 +2590,6 @@ pub mod install_code {
         candid::Deserialize,
         serde::Serialize,
         Clone,
-        Copy,
         Debug,
         PartialEq,
         Eq,
@@ -2598,7 +2597,9 @@ pub mod install_code {
         Default,
     )]
     pub struct CanisterUpgradeOptions {
-        /// Whether to skip the canister's pre_upgrade hook.
+        /// Whether to skip the canister's pre_upgrade hook. This would generally be
+        /// used in emergencies. See the corresponding field in the Management
+        /// canister API.
         pub skip_pre_upgrade: Option<bool>,
         /// Whether to retain (keep) or drop (replace) the canister's Wasm main
         /// memory across the upgrade. When the previous WASM had a custom

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1938,7 +1938,9 @@ message InstallCode {
   optional bytes arg_hash = 7;
 
   message CanisterUpgradeOptions {
-    // Whether to skip the canister's pre_upgrade hook.
+    // Whether to skip the canister's pre_upgrade hook. This would generally be
+    // used in emergencies. See the corresponding field in the Management
+    // canister API.
     optional bool skip_pre_upgrade = 1;
 
     // Whether to retain (keep) or drop (replace) the canister's Wasm main

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2859,7 +2859,9 @@ pub mod install_code {
         ::prost::Message,
     )]
     pub struct CanisterUpgradeOptions {
-        /// Whether to skip the canister's pre_upgrade hook.
+        /// Whether to skip the canister's pre_upgrade hook. This would generally be
+        /// used in emergencies. See the corresponding field in the Management
+        /// canister API.
         #[prost(bool, optional, tag = "1")]
         pub skip_pre_upgrade: ::core::option::Option<bool>,
         /// Whether to retain (keep) or drop (replace) the canister's Wasm main

--- a/rs/nns/nns.bzl
+++ b/rs/nns/nns.bzl
@@ -21,7 +21,7 @@ but other things could be added here later.
 CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = {
     "cycles-minting-canister.wasm.gz": 6,
     "genesis-token-canister.wasm.gz": 3,
-    "governance-canister.wasm.gz": 24,
+    "governance-canister.wasm.gz": 25,
     "governance-canister_test.wasm.gz": 26,
     "registry-canister.wasm.gz": 17,
     "root-canister.wasm.gz": 6,


### PR DESCRIPTION
Also, removed derivation of `Copy` from `CanisterUpgradeOptions`, because we might add a Vec or similar field there later.