### PR TITLE
docs(governance): Changelogs for 2026-08-28 upgrade proposals

### DIFF
--- a/rs/nns/cmc/CHANGELOG.md
+++ b/rs/nns/cmc/CHANGELOG.md
@@ -20,7 +20,7 @@ This just keeps code in production fresh. No new features or fixes.
 
 # 2026-07-17: Proposal 142938
 
-https://dashboard.internetcomputer.org/proposal/142938
+http://dashboard.internetcomputer.org/proposal/142938
 
 Just a maintenance release, i.e. no new features or fixes. This upgrade just
 makes sure that the code we have in production is not too far behind what's in
@@ -79,7 +79,7 @@ piling up in for the next "real" upgrade.
 
 # 2025-10-17: Proposal 138993
 
-https://dashboard.internetcomputer.org/proposal/138993
+http://dashboard.internetcomputer.org/proposal/138993
 
 ## Added
 

--- a/rs/nns/cmc/CHANGELOG.md
+++ b/rs/nns/cmc/CHANGELOG.md
@@ -11,6 +11,13 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2026-08-28: Proposal 143738
+
+http://dashboard.internetcomputer.org/proposal/143738
+
+This just keeps code in production fresh. No new features or fixes.
+
+
 # 2026-07-17: Proposal 142938
 
 https://dashboard.internetcomputer.org/proposal/142938

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -189,7 +189,7 @@ http://dashboard.internetcomputer.org/proposal/142453
 
 # 2026-06-12 : Proposal 142265
 
-https://dashboard.internetcomputer.org/proposal/142265
+http://dashboard.internetcomputer.org/proposal/142265
 
 ## Changed
 
@@ -204,7 +204,7 @@ https://dashboard.internetcomputer.org/proposal/142265
 
 # 2026-06-05: Proposal 142129
 
-https://dashboard.internetcomputer.org/proposal/142129
+http://dashboard.internetcomputer.org/proposal/142129
 
 ## Added
 
@@ -501,7 +501,7 @@ http://dashboard.internetcomputer.org/proposal/139085
 
 # 2025-10-17: Proposal 138992
 
-https://dashboard.internetcomputer.org/proposal/138992
+http://dashboard.internetcomputer.org/proposal/138992
 
 ## Changed
 
@@ -569,7 +569,7 @@ http://dashboard.internetcomputer.org/proposal/137917
 
 # 2025-07-18: Proposal 137500
 
-https://dashboard.internetcomputer.org/proposal/137500
+http://dashboard.internetcomputer.org/proposal/137500
 
 Back fill some node records with reward type.
 
@@ -595,7 +595,7 @@ http://dashboard.internetcomputer.org/proposal/137254
 
 # 2025-06-20: Proposal 137081
 
-https://dashboard.internetcomputer.org/proposal/137081
+http://dashboard.internetcomputer.org/proposal/137081
 
 ### Changed
 
@@ -667,7 +667,7 @@ http://dashboard.internetcomputer.org/proposal/136581
 
 # 2025-05-02: Proposal 136428
 
-https://dashboard.internetcomputer.org/proposal/136428
+http://dashboard.internetcomputer.org/proposal/136428
 
 No behavior changes. When there are large registry records, then, the new code
 here will behave differently (per [this forum post]), but there is currently no
@@ -686,13 +686,13 @@ http://dashboard.internetcomputer.org/proposal/136371
 
 # 2025-03-28: Proposal 136007
 
-https://dashboard.internetcomputer.org/proposal/136007
+http://dashboard.internetcomputer.org/proposal/136007
 
 This is a maintenance upgrade.
 
 # 2025-03-21: Proposal 135934
 
-https://dashboard.internetcomputer.org/proposal/135934
+http://dashboard.internetcomputer.org/proposal/135934
 
 No "real" behavior changes. This is just a maintenance upgrade.
 
@@ -700,7 +700,7 @@ Technically, there is a new get_chunk method, but it does not actually do anythi
 
 # 2025-02-13: Proposal 135300
 
-https://dashboard.internetcomputer.org/proposal/135300
+http://dashboard.internetcomputer.org/proposal/135300
 
 ## Fixed
 

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -11,6 +11,18 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2026-08-28: Proposal 143737
+
+http://dashboard.internetcomputer.org/proposal/143737
+
+## Added
+
+* `cooling_down` field in `SubnetRecord`, settable via `UpdateSubnetRecord` proposals. See
+  `ic_replicated_state::SubnetTopology::cooling_down` for the exact semantics. The field must not
+  be set on mainnet before the replica version rejecting ingress messages to cooling down subnets
+  has been rolled out to all subnets.
+
+
 # 2026-08-21: Proposal 143659
 
 http://dashboard.internetcomputer.org/proposal/143659

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -7,7 +7,7 @@ on the process that this file is part of, see
 
 # Next Upgrade Proposal
 
-## Added=
+## Added
 
 * A subnet-split request will now fail if a concurrent call modified the `StandardEngineReplicaVersionRecord`
   while the fresh key material was being generated for the splitting subnet.

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,11 +9,6 @@ on the process that this file is part of, see
 
 ## Added
 
-* `cooling_down` field in `SubnetRecord`, settable via `UpdateSubnetRecord` proposals. See
-  `ic_replicated_state::SubnetTopology::cooling_down` for the exact semantics. The field must not
-  be set on mainnet before the replica version rejecting ingress messages to cooling down subnets
-  has been rolled out to all subnets.
-
 ## Changed
 
 ## Deprecated

--- a/rs/sns/root/CHANGELOG.md
+++ b/rs/sns/root/CHANGELOG.md
@@ -11,6 +11,23 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2026-08-28: Proposal 143739
+
+http://dashboard.internetcomputer.org/proposal/143739
+
+Besides features and fixes, this freshens the code again, since it has been a
+while since we updated this.
+
+###  Added
+
+- Support for `snapshot_visibility` in `ManageDappCanisterSettingsRequest`.
+
+- Support for upgrade options. The one of greatest interest is
+  wasm_memory_persistence, which is needed for modern Motoko canisters that use
+  Enhanced Orthogonal Persistence.
+
+
+
 # 2025-11-28: Proposal 139577
 
 http://dashboard.internetcomputer.org/proposal/139577

--- a/rs/sns/root/unreleased_changelog.md
+++ b/rs/sns/root/unreleased_changelog.md
@@ -9,12 +9,6 @@ on the process that this file is part of, see
 
 ## Added
 
-- Support for `snapshot_visibility` in `ManageDappCanisterSettingsRequest`.
-
-- Support for upgrade options. The one of greatest interest is
-  wasm_memory_persistence, which is needed for modern Motoko canisters that use
-  Enhanced Orthogonal Persistence.
-
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
Proposals:

* NNS
    * [Registry 143737][reg]
    * [Cycles Minting 143738][cmc]
* SNS
    * [Root 143739][sns-root]

[reg]: https://dashboard.internetcomputer.org/proposal/143737
[cmc]: https://dashboard.internetcomputer.org/proposal/143738
[sns-root]: https://dashboard.internetcomputer.org/proposal/143739

Also, homogenized proposal URLs. Most were using http, so I changed to that.