### PR TITLE
chore(replay): remove unused `RestoreFromBackup2Cmd` struct

### DIFF
--- a/rs/replay/src/cmd.rs
+++ b/rs/replay/src/cmd.rs
@@ -132,18 +132,6 @@ pub struct RestoreFromBackupCmd {
 }
 
 #[derive(Clone, Parser)]
-pub struct RestoreFromBackup2Cmd {
-    /// Registry local store path
-    pub registry_local_store_path: PathBuf,
-    /// Backup spool path
-    pub backup_spool_path: PathBuf,
-    /// The replica version to be restored
-    pub replica_version: String,
-    /// Height from which the restoration should happen
-    pub start_height: u64,
-}
-
-#[derive(Clone, Parser)]
 pub struct AddRegistryContentCmd {
     /// Path to a directory containing one file for each registry version to be
     /// inserted as initial content into the registry.


### PR DESCRIPTION
The associated `RestoreFromBackup2` subcommand was removed in https://github.com/dfinity/ic/commit/11ea46473e0e6b484ff224381a5d84ae21d4130b, and this removes the now-unused struct that the subcommand used to deserialize CLI args into.