### PR TITLE
chore: deduplicate test-strategy crate

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e531f700af05e625c7c906ab208a0419f635c3db0421f1cebf7fd5c5ae874b46",
+  "checksum": "46fa585d9d126d7755a96f3eb31c92d29410378db6c3d1424d19da222e5e0925",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -18493,6 +18493,66 @@
       ],
       "license_file": "LICENSE-Apache"
     },
+    "derive-ex 0.1.8": {
+      "name": "derive-ex",
+      "version": "0.1.8",
+      "package_url": "https://github.com/frozenlib/derive-ex",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/derive-ex/0.1.8/download",
+          "sha256": "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "derive_ex",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "derive_ex",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.106",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.47",
+              "target": "quote"
+            },
+            {
+              "id": "structmeta 0.3.0",
+              "target": "structmeta"
+            },
+            {
+              "id": "syn 2.0.119",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.8"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
     "derive-new 0.7.0": {
       "name": "derive-new",
       "version": "0.7.0",
@@ -21147,7 +21207,7 @@
               "target": "strum_macros"
             },
             {
-              "id": "test-strategy 0.3.1",
+              "id": "test-strategy 0.4.5",
               "target": "test_strategy"
             }
           ],
@@ -70657,71 +70717,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "structmeta 0.2.0": {
-      "name": "structmeta",
-      "version": "0.2.0",
-      "package_url": "https://github.com/frozenlib/structmeta",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/structmeta/0.2.0/download",
-          "sha256": "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "structmeta",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "structmeta",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.119",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "structmeta-derive 0.2.0",
-              "target": "structmeta_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "structmeta 0.3.0": {
       "name": "structmeta",
       "version": "0.3.0",
@@ -70779,62 +70774,6 @@
           "selects": {}
         },
         "version": "0.3.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "structmeta-derive 0.2.0": {
-      "name": "structmeta-derive",
-      "version": "0.2.0",
-      "package_url": "https://github.com/frozenlib/structmeta",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/structmeta-derive/0.2.0/download",
-          "sha256": "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "structmeta_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "structmeta_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.47",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.119",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -73521,14 +73460,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "test-strategy 0.3.1": {
+    "test-strategy 0.4.5": {
       "name": "test-strategy",
-      "version": "0.3.1",
+      "version": "0.4.5",
       "package_url": "https://github.com/frozenlib/test-strategy",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/test-strategy/0.3.1/download",
-          "sha256": "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+          "url": "https://static.crates.io/crates/test-strategy/0.4.5/download",
+          "sha256": "8f7fd1eb9efb36942b85a290c4201d317980fe09bc88d34dd48aaaae03075c6a"
         }
       },
       "targets": [
@@ -73561,7 +73500,7 @@
               "target": "quote"
             },
             {
-              "id": "structmeta 0.2.0",
+              "id": "structmeta 0.3.0",
               "target": "structmeta"
             },
             {
@@ -73572,7 +73511,16 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.1"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "derive-ex 0.1.8",
+              "target": "derive_ex"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.4.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -92236,7 +92184,7 @@
     "tar 0.4.46",
     "tarpc 0.37.0",
     "tempfile 3.23.0",
-    "test-strategy 0.3.1",
+    "test-strategy 0.4.5",
     "textplots 0.8.4",
     "thiserror 2.0.18",
     "thousands 0.2.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3074,6 +3074,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-ex"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8734,7 +8746,7 @@ dependencies = [
  "quote",
  "regex",
  "regex-syntax 0.8.11",
- "structmeta 0.3.0",
+ "structmeta",
  "syn 2.0.119",
 ]
 
@@ -11789,36 +11801,13 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive 0.2.0",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "structmeta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta-derive 0.3.0",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2",
- "quote",
+ "structmeta-derive",
  "syn 2.0.119",
 ]
 
@@ -12252,13 +12241,14 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-strategy"
-version = "0.3.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+checksum = "8f7fd1eb9efb36942b85a290c4201d317980fe09bc88d34dd48aaaae03075c6a"
 dependencies = [
+ "derive-ex",
  "proc-macro2",
  "quote",
- "structmeta 0.2.0",
+ "structmeta",
  "syn 2.0.119",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,7 +3534,7 @@ checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta 0.3.0",
+ "structmeta",
  "syn 2.0.117",
 ]
 
@@ -7008,7 +7008,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -7027,7 +7027,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "scoped_threadpool",
- "test-strategy 0.4.5",
+ "test-strategy",
  "thiserror 2.0.18",
 ]
 
@@ -7341,7 +7341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "test-strategy 0.4.5",
+ "test-strategy",
  "tokio",
 ]
 
@@ -8877,7 +8877,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "test-strategy 0.4.5",
+ "test-strategy",
  "thiserror 2.0.18",
 ]
 
@@ -8890,7 +8890,7 @@ dependencies = [
  "ic-crypto-tree-hash",
  "proptest",
  "rand 0.8.6",
- "test-strategy 0.4.5",
+ "test-strategy",
  "thiserror 2.0.18",
 ]
 
@@ -9339,7 +9339,7 @@ dependencies = [
  "slog",
  "strum 0.26.3",
  "tempfile",
- "test-strategy 0.3.1",
+ "test-strategy",
  "tokio",
  "tower",
  "tracing",
@@ -10096,7 +10096,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_bytes",
- "test-strategy 0.4.5",
+ "test-strategy",
  "thiserror 2.0.18",
 ]
 
@@ -10206,7 +10206,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_bytes",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -10249,7 +10249,7 @@ dependencies = [
  "num-traits",
  "proptest",
  "serde",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -10264,7 +10264,7 @@ dependencies = [
  "num-traits",
  "proptest",
  "serde",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -10909,7 +10909,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "slog",
- "test-strategy 0.3.1",
+ "test-strategy",
  "tracing",
 ]
 
@@ -13328,7 +13328,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -13429,7 +13429,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -14233,7 +14233,7 @@ dependencies = [
  "prost",
  "scoped_threadpool",
  "slog",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -14310,7 +14310,7 @@ dependencies = [
  "slog",
  "slog-term",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
  "tokio",
  "tokio-util",
  "tower",
@@ -14377,7 +14377,7 @@ dependencies = [
  "slog",
  "strum 0.26.3",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
  "tokio",
  "tree-deserializer",
  "uuid",
@@ -15555,7 +15555,7 @@ dependencies = [
  "reqwest",
  "slog",
  "tempfile",
- "test-strategy 0.4.5",
+ "test-strategy",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -17738,7 +17738,7 @@ dependencies = [
  "messaging-test-utils",
  "proptest",
  "serde",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]
@@ -23014,36 +23014,13 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive 0.2.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "structmeta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta-derive 0.3.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2",
- "quote",
+ "structmeta-derive",
  "syn 2.0.117",
 ]
 
@@ -23437,18 +23414,6 @@ dependencies = [
 
 [[package]]
 name = "test-strategy"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta 0.2.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "test-strategy"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f7fd1eb9efb36942b85a290c4201d317980fe09bc88d34dd48aaaae03075c6a"
@@ -23456,7 +23421,7 @@ dependencies = [
  "derive-ex",
  "proc-macro2",
  "quote",
- "structmeta 0.3.0",
+ "structmeta",
  "syn 2.0.117",
 ]
 
@@ -24255,7 +24220,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "serde",
- "test-strategy 0.4.5",
+ "test-strategy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -946,6 +946,7 @@ sys-mount = "3.0"
 sysinfo = "0.37"
 tar = "0.4.39"
 tempfile = "3.20"
+test-strategy = "0.4.0"
 textplots = "^0.8"
 # DO NOT upgrade to >=2.0.19 as it pulls in syn 3 whereas the rest of the
 # codebase uses syn 2.

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1736,7 +1736,7 @@ crate.spec(
 )
 crate.spec(
     package = "test-strategy",
-    version = "^0.3.1",
+    version = "^0.4.0",
 )
 crate.spec(
     package = "textplots",

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -86,7 +86,7 @@ proptest = { workspace = true }
 regex-lite = { workspace = true }
 rstest = { workspace = true }
 serde_bytes = { workspace = true }
-test-strategy = "0.3.1"
+test-strategy = "0.4.0"
 wat = { workspace = true }
 wirm = { workspace = true }
 

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -86,7 +86,7 @@ proptest = { workspace = true }
 regex-lite = { workspace = true }
 rstest = { workspace = true }
 serde_bytes = { workspace = true }
-test-strategy = "0.4.0"
+test-strategy = { workspace = true }
 wat = { workspace = true }
 wirm = { workspace = true }
 

--- a/rs/messaging/Cargo.toml
+++ b/rs/messaging/Cargo.toml
@@ -68,7 +68,7 @@ pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-test-strategy = "0.3.1"
+test-strategy = "0.4.0"
 
 [features]
 default = []

--- a/rs/messaging/Cargo.toml
+++ b/rs/messaging/Cargo.toml
@@ -68,7 +68,7 @@ pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-test-strategy = "0.4.0"
+test-strategy = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
This streamlines the versions of `test-strategy` used, collapsing them to a single crate.