### PR TITLE
feat: release PocketIC v16.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19532,7 +19532,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "backon",
  "base64 0.13.1",
@@ -19595,7 +19595,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic-server"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "aide",
  "askama",

--- a/mainnet-routing-table.json
+++ b/mainnet-routing-table.json
@@ -435,66 +435,10 @@
   ],
   [
     {
-      "start": "lfwl7-zyaaa-aaaat-aaaaa-cai",
-      "end": "xoqru-kqaaa-aaaat-p777q-cai"
-    },
-    "mkbc3-fzim5-s5pye-pbnzo-uj5yv-raphe-ceecn-ejd6g-5poxm-dzuot-iae"
-  ],
-  [
-    {
-      "start": "hggcq-ziaaa-aaaat-qaaaa-cai",
-      "end": "3nay3-kaaaa-aaaat-7777q-cai"
-    },
-    "xok3w-cnepj-fg6aa-cjitt-uoxod-4ddsy-nc7dq-zwudz-o6jar-rzstb-gqe"
-  ],
-  [
-    {
       "start": "og4hq-oaaaa-aaaau-aaaaa-cai",
       "end": "sn253-5iaaa-aaaau-p777q-cai"
     },
     "c4isl-65rwf-emhk5-5ta5m-ngl73-rgrl3-tcc56-2hkja-4erqd-iivmy-7ae"
-  ],
-  [
-    {
-      "start": "cfmo7-oqaaa-aaaau-qaaaa-cai",
-      "end": "6okuu-5yaaa-aaaau-7777q-cai"
-    },
-    "vcpt7-niq42-6snup-7kcgy-cndz6-srq6n-h6vwi-oswri-a3guc-v5ssd-5qe"
-  ],
-  [
-    {
-      "start": "wb4vo-paaaa-aaaav-aaaaa-cai",
-      "end": "kk2pf-4iaaa-aaaav-p777q-cai"
-    },
-    "xlkub-3thlm-uha3c-hqmfw-qykp5-6rldi-hpfxy-nwyxy-w6bbk-tpg5h-vqe"
-  ],
-  [
-    {
-      "start": "2cm4b-pqaaa-aaaav-qaaaa-cai",
-      "end": "gjkgk-4yaaa-aaaav-7777q-cai"
-    },
-    "kp5jj-kpgmn-f4ohx-uqot6-wtbbr-lmtqv-kpkaf-gcksv-snkwm-43kmy-iae"
-  ],
-  [
-    {
-      "start": "fffsa-4iaaa-aaaaw-aaaaa-cai",
-      "end": "zodil-paaaa-aaaaw-p777q-cai"
-    },
-    "6excn-doq5g-bmrxd-3774i-hjnn2-3ovbo-xjwz7-3yozt-fsbzx-bethy-bae"
-  ],
-  [
-    {
-      "start": "jgv3p-4yaaa-aaaaw-qaaaa-cai",
-      "end": "vntbe-pqaaa-aaaaw-7777q-cai"
-    },
-    "rtvil-s5u5d-jbj7o-prlhw-bzlr5-3j5kn-2iu7a-jq2hl-avkhn-w7oa7-6ae"
-  ],
-  [
-    {
-      "start": "5cfa6-5iaaa-aaaax-aaaaa-cai",
-      "end": "bjd2v-oaaaa-aaaax-p777q-cai"
-    },
-    "2zs4v-uoqha-xsuun-lveyr-i4ktc-5y3ju-aysud-niobd-gxnqa-ctqem-hae"
   ],
   [
     {
@@ -540,52 +484,10 @@
   ],
   [
     {
-      "start": "eplnz-uaaaa-aaaa7-aaaaa-cai",
-      "end": "yenxs-hiaaa-aaaa7-p777q-cai"
-    },
-    "eibym-ivfhk-djg4s-deka3-nn636-nhuph-ick7x-wyj4w-uvseb-vr23o-gae"
-  ],
-  [
-    {
       "start": "im3ew-uqaaa-aaaa7-qaaaa-cai",
       "end": "uh565-hyaaa-aaaa7-7777q-cai"
     },
     "sz537-xjj7n-swzh6-fvrkl-5diqq-usb44-33lwg-dpas7-qj4mg-dc6pd-nqe"
-  ],
-  [
-    {
-      "start": "cydsx-nyaaa-aaaba-aaaaa-cai",
-      "end": "6tfi4-6qaaa-aaaba-p777q-cai"
-    },
-    "kmtcz-qzmmp-7notg-anaxm-k3lqq-ydlry-cfavr-6fc2t-necnx-erwvl-kqe"
-  ],
-  [
-    {
-      "start": "o3t3y-niaaa-aaaba-qaaaa-cai",
-      "end": "sqvbt-6aaaa-aaaba-7777q-cai"
-    },
-    "vrkjh-6nhwg-ri7h3-5rcug-nn2fd-z66p5-fucrt-qkyfd-dui7l-l7m73-wae"
-  ],
-  [
-    {
-      "start": "27daj-myaaa-aaabb-aaaaa-cai",
-      "end": "guf2c-7qaaa-aaabb-p777q-cai"
-    },
-    "t3joh-zsbty-6wt6u-dbfqq-zj73a-jqv2q-x6y2i-jbvkc-fvziy-y3fgh-fae"
-  ],
-  [
-    {
-      "start": "w4tjg-miaaa-aaabb-qaaaa-cai",
-      "end": "kxvtn-7aaaa-aaabb-7777q-cai"
-    },
-    "rzejw-zy4bh-odqim-fqv5y-u62g7-cgf5e-uwojq-l6xbe-nsiu2-4kutf-3ae"
-  ],
-  [
-    {
-      "start": "j32hh-7qaaa-aaabc-aaaaa-cai",
-      "end": "vq45m-myaaa-aaabc-p777q-cai"
-    },
-    "eno7l-b2l4p-zsik7-5uy76-cx6pj-4d4gb-qg37u-kohn3-jbz7e-vpdlo-hae"
   ],
   [
     {
@@ -603,45 +505,10 @@
   ],
   [
     {
-      "start": "57k4w-6aaaa-aaabd-qaaaa-cai",
-      "end": "bumg5-niaaa-aaabd-7777q-cai"
-    },
-    "aguy2-wjdps-3lmqn-ydpxq-tgbld-3ixks-p5hbi-5wjgw-4jku5-xocll-wqe"
-  ],
-  [
-    {
       "start": "u7qzw-jiaaa-aaabe-aaaaa-cai",
       "end": "iuwd5-2aaaa-aaabe-p777q-cai"
     },
     "hxiqp-fzqcb-xo5k5-zmqoo-cndlf-ku2mu-hegjf-pi7zk-vajmy-jlyeh-oqe"
-  ],
-  [
-    {
-      "start": "myqli-iiaaa-aaabf-aaaaa-cai",
-      "end": "qtwrd-3aaaa-aaabf-p777q-cai"
-    },
-    "eta2y-unqt3-ynnlb-ywllk-3cmrm-ra6zq-wdhe5-3ozv7-uxodv-psngc-yqe"
-  ],
-  [
-    {
-      "start": "a3ach-iyaaa-aaabf-qaaaa-cai",
-      "end": "4qgym-3qaaa-aaabf-7777q-cai"
-    },
-    "sd2ht-sbgu7-wxvge-6iiqq-qjgsy-2oluv-lzgqs-7mcca-i4m5e-lqfbo-3qe"
-  ],
-  [
-    {
-      "start": "74jmg-3aaaa-aaabg-aaaaa-cai",
-      "end": "dxpwn-iiaaa-aaabg-p777q-cai"
-    },
-    "6fxer-zgg7s-dn7m5-rvjd2-xoo53-tqxw5-y2lr4-54j35-u7kej-af7hd-6qe"
-  ],
-  [
-    {
-      "start": "t7zfj-3qaaa-aaabg-qaaaa-cai",
-      "end": "pu77c-iyaaa-aaabg-7777q-cai"
-    },
-    "qdsyr-ii53r-lflhb-6ycfd-lskjs-iztcj-w2am3-jm27i-qxzka-4yavy-jqe"
   ],
   [
     {
@@ -656,5 +523,117 @@
       "end": "xt7n4-jyaaa-aaabh-7777q-cai"
     },
     "kindg-7ygma-4ms3x-gkn7w-ya6lx-ws37e-j37rr-qk3fi-vm34u-vkeae-lae"
+  ],
+  [
+    {
+      "start": "4vedp-wiaaa-aaabk-qaaaa-cai",
+      "end": "a6cze-faaaa-aaabk-7777q-cai"
+    },
+    "56zwx-qdnrz-4jqvu-p4ml2-w6x53-zqtn7-jr7lh-tkszd-bse7l-7igyk-nqe"
+  ],
+  [
+    {
+      "start": "hmxr2-pqaaa-aaabq-qaaaa-cai",
+      "end": "3hrlr-4yaaa-aaabq-7777q-cai"
+    },
+    "x4jtx-5dnbo-v3exa-vzamo-teufh-qsiit-txx4g-mi76n-ckrfl-oc5a6-nae"
+  ],
+  [
+    {
+      "start": "am6nf-5iaaa-aaabs-aaaaa-cai",
+      "end": "4hyxo-oaaaa-aaabs-p777q-cai"
+    },
+    "ayp5v-3dl6f-nyidr-exauc-fedy6-mlyzt-tcnnh-2v4mk-efzok-igawf-5qe"
+  ],
+  [
+    {
+      "start": "uiowu-4yaaa-aaabt-qaaaa-cai",
+      "end": "idim7-pqaaa-aaabt-7777q-cai"
+    },
+    "ofuqa-xjv25-cuj2z-qdbn2-q6cmx-6egdh-xhoq5-gsr6j-cfx4p-sqmst-xae"
+  ],
+  [
+    {
+      "start": "fpubk-kqaaa-aaabv-aaaaa-cai",
+      "end": "zes3b-zyaaa-aaabv-p777q-cai"
+    },
+    "n7ps4-t6z2t-5kbzc-ihlom-3v5q2-fj7zc-efo5c-5v42u-otnav-hc2yh-nqe"
+  ],
+  [
+    {
+      "start": "scjvs-giaaa-aaaby-aaaaa-cai",
+      "end": "ojppz-vaaaa-aaaby-p777q-cai"
+    },
+    "pgabo-5xn4c-jmdgm-mdh7s-uzht6-x4bt6-la4lz-6qtf2-vlwm5-n2kla-iqe"
+  ],
+  [
+    {
+      "start": "kfjhm-hiaaa-aaabz-aaaaa-cai",
+      "end": "wop5h-uaaaa-aaabz-p777q-cai"
+    },
+    "uw5ql-smzbi-sadfn-urdoy-irsne-27mwo-qbzpb-3oinv-yxour-533bx-fae"
+  ],
+  [
+    {
+      "start": "ggzod-hyaaa-aaabz-qaaaa-cai",
+      "end": "2n7ui-uqaaa-aaabz-7777q-cai"
+    },
+    "ni3q3-vfklb-7uflk-treef-uzfdn-oerzk-lne6x-h5gl2-jsozx-arfyc-nae"
+  ],
+  [
+    {
+      "start": "zbqac-uaaaa-aaab2-aaaaa-cai",
+      "end": "fkw2j-hiaaa-aaab2-p777q-cai"
+    },
+    "qqlrz-ozqld-4wrig-5d7ds-zkxq2-j2zva-gnfif-spvmw-viukw-kgpxr-5qe"
+  ],
+  [
+    {
+      "start": "vcajn-uqaaa-aaab2-qaaaa-cai",
+      "end": "jjgtg-hyaaa-aaab2-7777q-cai"
+    },
+    "xw2uf-pqkmq-s4wa5-qqtto-ncpft-ujwx3-6cm6q-hepym-uvfuj-rnlie-hae"
+  ],
+  [
+    {
+      "start": "bgqs4-vaaaa-aaab3-aaaaa-cai",
+      "end": "5nwix-giaaa-aaab3-p777q-cai"
+    },
+    "cqsln-s2lnn-v3vws-3ckkh-rkv2d-ancbx-3dmb3-jxnrk-u6o3n-fpjbt-7qe"
+  ],
+  [
+    {
+      "start": "nfa3t-vqaaa-aaab3-qaaaa-cai",
+      "end": "rogby-gyaaa-aaab3-7777q-cai"
+    },
+    "ltzr2-lddhj-7ec46-yzmyk-tpvnu-bby75-2ntqk-rh76t-5fs7i-pl7gh-tae"
+  ],
+  [
+    {
+      "start": "ef26t-cyaaa-aaab4-aaaaa-cai",
+      "end": "yo4ey-rqaaa-aaab4-p777q-cai"
+    },
+    "wxtxj-psrmy-ngtvg-7bhh4-qmwin-g23r6-eee6o-4v3tn-of54o-4jgg2-wqe"
+  ],
+  [
+    {
+      "start": "igkx4-ciaaa-aaab4-qaaaa-cai",
+      "end": "unmnx-raaaa-aaab4-7777q-cai"
+    },
+    "xyqdd-6h5as-7olew-2hbqt-us5ig-5stj2-h5h27-gwmtq-2n5hh-vjjgf-oqe"
+  ],
+  [
+    {
+      "start": "4c2mn-dyaaa-aaab5-aaaaa-cai",
+      "end": "aj4wg-qqaaa-aaab5-p777q-cai"
+    },
+    "vx5bf-wwwjp-uyetc-6hdoc-prf4q-c5gfz-6nzr5-hnwm3-a634r-noiw5-dqe"
+  ],
+  [
+    {
+      "start": "qbkfc-diaaa-aaab5-qaaaa-cai",
+      "end": "mkm7j-qaaaa-aaab5-7777q-cai"
+    },
+    "pjjzy-5umsy-egk2r-xvirw-2ati7-fmuff-73hc4-p4w6l-lybhf-j6fxa-yqe"
   ]
 ]

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = { workspace = true }
 candid = { workspace = true }
 ic-http-types = { version = "0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }
-pocket-ic = { version = "15.0.0", path = "../../packages/pocket-ic", optional = true }
+pocket-ic = { version = "16.0.0", path = "../../packages/pocket-ic", optional = true }
 regex = { workspace = true }
 
 [features]

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -9,7 +9,7 @@ rust_library(
     proc_macro_deps = [
         "@crate_index//:strum_macros",
     ],
-    version = "15.0.0",
+    version = "16.0.0",
     deps = [
         # Keep sorted.
         "@crate_index//:backon",

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## 16.0.0 - 2026-08-31
+
 ### Added
 - Added the `SubnetCoolingDown` variant to the `ErrorCode` enum: ingress messages addressed to a subnet that is "cooling down" are rejected with this error code.
+- Added the `CanisterStatusAccessDenied` variant to the `ErrorCode` enum: a call to the `canister_status` endpoint of the management canister is rejected with this error code if the caller is not allowed to access the canister status according to the `status_visibility` canister setting.
 
 ### Changed
 - The functions `PocketIc::auto_progress`, `PocketIc::make_live`, and their variants only return

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic"
-version = "15.0.0"
+version = "16.0.0"
 license = "Apache-2.0"
 description = "PocketIC: A Canister Smart Contract Testing Platform"
 repository = "https://github.com/dfinity/ic"

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -104,11 +104,11 @@ pub mod nonblocking;
 
 const POCKET_IC_SERVER_NAME: &str = "pocket-ic-server";
 
-const MIN_SERVER_VERSION: &str = "15.0.0";
-const MAX_SERVER_VERSION: &str = "16";
+const MIN_SERVER_VERSION: &str = "16.0.0";
+const MAX_SERVER_VERSION: &str = "17";
 
 /// Public to facilitate downloading the PocketIC server.
-pub const LATEST_SERVER_VERSION: &str = "15.0.0";
+pub const LATEST_SERVER_VERSION: &str = "16.0.0";
 
 // the default timeout of a PocketIC operation
 const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;
@@ -2529,25 +2529,25 @@ mod test {
                 .contains("Unexpected PocketIC server version")
         );
         assert!(
-            check_pocketic_server_version("pocket-ic 15.0.0")
+            check_pocketic_server_version("pocket-ic 16.0.0")
                 .unwrap_err()
                 .contains("Unexpected PocketIC server version")
         );
         assert!(
-            check_pocketic_server_version("pocket-ic-server 15 0 0")
+            check_pocketic_server_version("pocket-ic-server 16 0 0")
                 .unwrap_err()
                 .contains("Failed to parse PocketIC server version")
         );
         assert!(
-            check_pocketic_server_version("pocket-ic-server 14.0.0")
+            check_pocketic_server_version("pocket-ic-server 15.0.0")
                 .unwrap_err()
                 .contains("Incompatible PocketIC server version")
         );
-        check_pocketic_server_version("pocket-ic-server 15.0.0").unwrap();
-        check_pocketic_server_version("pocket-ic-server 15.0.1").unwrap();
-        check_pocketic_server_version("pocket-ic-server 15.1.0").unwrap();
+        check_pocketic_server_version("pocket-ic-server 16.0.0").unwrap();
+        check_pocketic_server_version("pocket-ic-server 16.0.1").unwrap();
+        check_pocketic_server_version("pocket-ic-server 16.1.0").unwrap();
         assert!(
-            check_pocketic_server_version("pocket-ic-server 16.0.0")
+            check_pocketic_server_version("pocket-ic-server 17.0.0")
                 .unwrap_err()
                 .contains("Incompatible PocketIC server version")
         );

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -274,7 +274,7 @@ MAINNET_NNS_CANISTER_ENV = {
             "@crate_index//:async-trait",
         ],
         rustc_env = EXTERNAL_CANISTER_ENV | nns_canister_env,
-        version = "15.0.0",
+        version = "16.0.0",
         deps = LIB_DEPENDENCIES + [":build_script"],
     )
     for (name_suffix, nns_canister_data, nns_canister_env) in [

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## 16.0.0 - 2026-08-31
+
 ### Changed
 - The endpoint `/instances/<instance_id>/auto_progress` (and creating an instance with automatic progress enabled)
   only returns after the certified time of the PocketIC instance has been updated for the first time.

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic-server"
-version = "15.0.0"
+version = "16.0.0"
 edition.workspace = true
 
 [dependencies]

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -65,7 +65,7 @@ static MAINNET_ROUTING_TABLE: &[u8] = include_bytes!(env!("MAINNET_ROUTING_TABLE
 
 #[derive(Parser)]
 #[clap(name = "pocket-ic-server")]
-#[clap(version = "15.0.0")]
+#[clap(version = "16.0.0")]
 struct Args {
     /// The IP address to which the PocketIC server should bind (defaults to 127.0.0.1)
     #[clap(long, short)]


### PR DESCRIPTION
Bump the PocketIC library and server to 16.0.0 and cut the `Unreleased` sections of both changelogs into a `16.0.0 - 2026-08-31` section.

The library's supported server version range moves to `[16.0.0, 17)` and `LATEST_SERVER_VERSION` to `16.0.0`.

Also refresh `mainnet-routing-table.json` from the mainnet registry (version 63722). Every subnet that is actually part of the mainnet topology keeps exactly its previous canister ranges; the entries that disappear are pre-allocated ranges for subnet IDs that never became real subnets.