### PR TITLE
fix: deflake //rs/ethereum/cketh/minter:deposit_from_cex

### DIFF
--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -19,10 +19,15 @@
 //!
 //! Two consequences of a live instance are worth knowing before adding to this harness:
 //!
-//! * An ingress message may not be awaited by driving the instance with explicit `tick`s: the rounds
-//!   arrive on their own, and a tick-driven await runs out its round budget and reports the message
-//!   as unanswerable. `CkEthSetup`'s own `minter_address` and `stop_minter` do exactly that, which is
-//!   why this module fetches the address and upgrades the minter itself.
+//! * An ingress message whose completion depends on canister-http traffic must be *polled* for
+//!   ([`pocket_ic::PocketIc::ingress_status`]), never awaited. The client's blocking awaits —
+//!   `await_call`, and everything built on it: `update_call`, `stop_canister`, … — run as one
+//!   server-side operation that executes up to 100 rounds back to back, and while it holds the
+//!   instance the auto-progress loop cannot run `ProcessCanisterHttpInternal`, so no outcall is
+//!   dispatched or answered until the await has already failed. A call that completes on rounds
+//!   alone finishes well within the budget; one waiting on an outcall response never can.
+//!   `CkEthSetup`'s tick-driving `minter_address` and `stop_minter` are unusable here for the same
+//!   reason, which is why this module fetches the address and upgrades the minter itself.
 //! * Any loop waiting on a minter timer must poll a canister while it waits. The PocketIC server
 //!   shuts an idle instance down, which stops the minter's timers and looks exactly like a minter
 //!   bug.
@@ -583,24 +588,29 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
     ///
     /// The minter is stopped first, as any upgrade must be: upgrading a running canister leaves its
     /// in-flight HTTPS outcalls to resolve into fresh Wasm, which traps it with "CallFutureState for
-    /// in-flight calls" and corrupts its heap. Stopped through the client rather than through
-    /// `CkEthSetup::stop_minter`, which drives the instance with explicit `tick`s (see the module
-    /// documentation).
+    /// in-flight calls" and corrupts its heap.
     ///
-    /// Stopping also has to wait for those same outcalls first: a stop lands as an ingress the
-    /// server answers within a bounded burst of rounds, while the outcalls resolve on the
-    /// auto-progress loop's own pace — so a stop racing a busy minter can time out before the
-    /// calls it is waiting on come back.
+    /// The stop is submitted and then polled for, rather than awaited through the client's
+    /// `stop_canister` (see the module documentation): a stop only replies once every open call
+    /// context of the minter has closed, and when the stop lands while one of the minter's
+    /// timer-driven outcall chains is in flight, closing them takes the very canister-http
+    /// deliveries the blocking await prevents — so it deterministically burns its round budget
+    /// (which advances instance time by mere nanoseconds, so not even the 60-second outcall
+    /// timeout can fire inside it) and fails with `BadIngressMessage`. Nor can such a chain be
+    /// waited out beforehand: `get_canister_http()` lists only requests not yet handed to the
+    /// HTTP adapter, which auto-progress does within one ~100ms iteration, so on a live instance
+    /// a probe of it reads empty for virtually an outcall's whole lifetime — a stop gated on it
+    /// still races every chain. Polling the ingress status instead leaves the auto-progress loop
+    /// free to deliver the responses the stop is waiting on, however the stop lands.
     fn upgrade_minter_with(&self, arg: UpgradeArg) {
         let minter_id = self.minter_id();
+        let stop_message_id = self.cketh().submit_stop_minter();
         self.poll_until(
             AWAIT_DEADLINE,
-            |_| "the minter's in-flight HTTPS outcalls never resolved".to_string(),
-            |setup| setup.env().get_canister_http().is_empty().then_some(()),
-        );
-        self.env()
-            .stop_canister(minter_id, None)
-            .expect("stopping the minter must succeed");
+            |_| "the minter never stopped".to_string(),
+            |setup| setup.env().ingress_status(stop_message_id.clone()),
+        )
+        .expect("stopping the minter must succeed");
         self.env()
             .upgrade_canister(
                 minter_id,


### PR DESCRIPTION
## Problem

`//rs/ethereum/cketh/minter:deposit_from_cex` kept flaking after #11299: every flaky invocation on `master` and in the merge queue since then (10 invocations, Aug 26–31) shares one signature — `should_fund_the_sweeper_address_by_burning_cketh_from_the_fee_account` panics during setup, in `LiveSetup::new_funding → upgrade_minter_with → PocketIc::stop_canister`, with

```
BadIngressMessage("Failed to answer to ingress 0x… after 100 rounds.")
```

## Root cause

Stopping the minter through the client's `stop_canister` awaits via the server's `AwaitIngressMessage` — a **single blocking operation** that executes up to 100 rounds back to back (`rs/pocket_ic_server/src/pocket_ic.rs`, `max_rounds = 100`). Operations serialize per instance, so while it runs, the auto-progress loop spins on `Busy` and cannot run `ProcessCanisterHttpInternal` — the **only** code that dispatches live canister-http requests to the adapter and picks up their responses. And the await's own rounds advance instance time by ~1 ns each, so not even the 60-second outcall timeout can fire inside it.

A `stop_canister` only replies once every open call context of the target has closed. So if the stop lands while one of the minter's timer-driven outcall chains (log scrape, latest-block refresh) is in flight, closing those contexts requires the very canister-http deliveries the await is blocking — the await then **deterministically** burns its budget and the client panics. The failing CI logs confirm it: the last activity is always a scrape's `eth_getLogs` batch that never receives responses.

The harness' pre-stop drain gate (`poll_until(get_canister_http().is_empty())`) cannot close the race: `get_canister_http()` filters out requests already handed to the adapter (`canister_http.pending`, `rs/pocket_ic_server/src/pocket_ic.rs`), which auto-progress does within one ~100 ms iteration — on a live instance the probe reads empty for virtually an outcall's entire lifetime. The flake rate was simply the probability that a scrape chain was in flight at the moment the stop landed, which CI load (slower anvil round trips → longer chains) amplifies.

## Fix

`upgrade_minter_with` now submits the stop (`CkEthSetup::submit_stop_minter`) and polls its ingress status with the harness' usual deadline-plus-minter-logs failure path, instead of using the blocking await; the ineffective drain gate is dropped. Polling leaves the auto-progress loop free to deliver the responses the stop is waiting on, so the stop completes as soon as the in-flight chain drains, however the stop lands.

## Validation

- **Deterministic reproduction**: temporarily instrumenting the harness to wait until the minter is demonstrably mid-scrape (its `Scraping ETH logs in block range` log line, emitted right before the `eth_getLogs` call) and then stopping:
  - through the **old** blocking `stop_canister` → fails with the exact CI signature;
  - through the **new** polled stop → the stop completes and the funding test passes end to end.
- `cargo check -p ic-cketh-test-utils`, `cargo fmt`, `./ci/scripts/rust-lint.sh` — clean.
- Depth-2 bazel rdeps all pass: `integration_tests_tests/{ckerc20,cketh}_test`, `minter:lib_tests`, `test_utils:lib_tests`.
- `bazel test --runs_per_test=3 --jobs=3 //rs/ethereum/cketh/minter:deposit_from_cex` — 3/3 full-suite runs pass.

The remaining non-`master` failures in the query window predate #11299 or were in-development test code on feature branches; this was the only root cause left on `master`.

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)