### PR TITLE
chore: bump cached

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "46fa585d9d126d7755a96f3eb31c92d29410378db6c3d1424d19da222e5e0925",
+  "checksum": "c26bc66bc604ceac1faf476740635e4974b15014b69aca35d215116c07ef7666",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -10082,65 +10082,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cached 0.49.2": {
-      "name": "cached",
-      "version": "0.49.2",
-      "package_url": "https://github.com/jaemk/cached",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/cached/0.49.2/download",
-          "sha256": "f251fd1e72720ca07bf5d8e310f54a193fd053479a1f6342c6663ee4fa01cf96"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cached",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "cached",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "hashbrown 0.14.5",
-              "target": "hashbrown"
-            },
-            {
-              "id": "instant 0.1.12",
-              "target": "instant"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
-            },
-            {
-              "id": "thiserror 1.0.68",
-              "target": "thiserror"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.49.2"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "cached 0.54.0": {
       "name": "cached",
       "version": "0.54.0",
@@ -19813,7 +19754,7 @@
               "target": "bytes"
             },
             {
-              "id": "cached 0.49.2",
+              "id": "cached 0.56.0",
               "target": "cached"
             },
             {
@@ -91905,7 +91846,7 @@
     "byte-unit 4.0.19",
     "byteorder 1.5.0",
     "bytes 1.11.1",
-    "cached 0.49.2",
+    "cached 0.56.0",
     "canbench-rs 0.7.0",
     "candid 0.10.35",
     "candid_parser 0.1.4",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1690,18 +1690,6 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.49.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f251fd1e72720ca07bf5d8e310f54a193fd053479a1f6342c6663ee4fa01cf96"
-dependencies = [
- "hashbrown 0.14.5",
- "instant",
- "once_cell",
- "thiserror 1.0.68",
-]
-
-[[package]]
-name = "cached"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
@@ -3302,7 +3290,7 @@ dependencies = [
  "byte-unit",
  "byteorder",
  "bytes",
- "cached 0.49.2",
+ "cached 0.56.0",
  "canbench-rs",
  "candid",
  "candid_parser 0.1.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,18 +1757,6 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.49.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
-dependencies = [
- "hashbrown 0.14.5",
- "instant",
- "once_cell",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cached"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
@@ -8090,7 +8078,7 @@ dependencies = [
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
 dependencies = [
- "cached 0.49.3",
+ "cached 0.56.0",
  "criterion",
  "hex",
  "ic-crypto-test-utils-reproducible-rng",
@@ -8320,7 +8308,7 @@ name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
 dependencies = [
  "base64 0.13.1",
- "cached 0.49.3",
+ "cached 0.56.0",
  "criterion",
  "hex",
  "ic-crypto-internal-bls12-381-type",
@@ -16447,15 +16435,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -632,7 +632,7 @@ build-info-build = { git = "https://github.com/dfinity-lab/build-info", rev = "2
 by_address = "^1.1.0"
 byteorder = "^1.3.4"
 bytes = "1.9.0"
-cached = { version = "0.49", default-features = false }
+cached = { version = "0.56", default-features = false }
 canbench-rs = "0.7.0"
 candid = { version = "0.10.35" }
 candid_parser = { version = "0.1.2" }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -245,7 +245,7 @@ crate.spec(
 crate.spec(
     default_features = False,
     package = "cached",
-    version = "^0.49",
+    version = "^0.56",
 )
 crate.spec(
     package = "canbench-rs",


### PR DESCRIPTION
This aligns the crate we use in this repo with that of ic-agent (much more recent). This allows us to drop a duplicate version as well as some other deprecated crates.