### PR TITLE
feat(core): Limit accessed heap pages per message

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -116,9 +116,8 @@ const STABLE_MEMORY_ACCESSED_PAGE_LIMIT_QUERY: NumOsPages =
 // Maximum number of Wasm heap OS pages (4KiB) that a single message execution is
 // allowed to access, counting both reads and writes.
 //
-// This is intentionally an independent constant rather than being derived from
-// `MAX_WASM64_MEMORY_IN_BYTES`, so that raising the heap size ceiling does not
-// implicitly widen the per-message budget.
+// This is intentionally independent from `MAX_WASM64_MEMORY_IN_BYTES`, the maximum
+// heap size.
 const WASM_MEMORY_ACCESSED_PAGE_LIMIT: NumOsPages = NumOsPages::new(6 * GIB / (PAGE_SIZE as u64));
 
 /// The maximum size in bytes for an uncompressed Wasm module. This value is
@@ -154,7 +153,7 @@ pub enum MeteringType {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
-pub struct StableMemoryPageLimit {
+pub struct MemoryPageLimit {
     // Regular message (e.g., update) execution dirty/accessed page limit.
     pub message: NumOsPages,
     // Longer message (e.g., upgrade) execution dirty/accessed page limit.
@@ -210,16 +209,15 @@ pub struct Config {
 
     // Maximum number of stable memory pages that a single message execution
     // can access.
-    pub stable_memory_accessed_page_limit: StableMemoryPageLimit,
+    pub stable_memory_accessed_page_limit: MemoryPageLimit,
 
     /// Maximum number of Wasm heap pages that a single message execution can
-    /// access, counting both reads and writes. Dirty pages are a subset of
-    /// accessed pages, so this transitively bounds the per-message heap delta.
-    pub wasm_memory_accessed_page_limit: StableMemoryPageLimit,
+    /// access, counting both reads and writes.
+    pub wasm_memory_accessed_page_limit: MemoryPageLimit,
 
     /// Maximum number of stable memory dirty pages that a single message
     /// execution is allowed to produce.
-    pub stable_memory_dirty_page_limit: StableMemoryPageLimit,
+    pub stable_memory_dirty_page_limit: MemoryPageLimit,
 
     /// Sandbox process eviction ensures that the number of sandbox processes is
     /// always below this threshold.
@@ -282,17 +280,17 @@ impl Config {
             num_rayon_page_allocator_threads: DEFAULT_PAGE_ALLOCATOR_THREADS,
             feature_flags: FeatureFlags::const_default(),
             metering_type: MeteringType::New,
-            stable_memory_dirty_page_limit: StableMemoryPageLimit {
+            stable_memory_dirty_page_limit: MemoryPageLimit {
                 message: STABLE_MEMORY_DIRTY_PAGE_LIMIT_MESSAGE,
                 upgrade: STABLE_MEMORY_DIRTY_PAGE_LIMIT_UPGRADE,
                 query: STABLE_MEMORY_DIRTY_PAGE_LIMIT_QUERY,
             },
-            stable_memory_accessed_page_limit: StableMemoryPageLimit {
+            stable_memory_accessed_page_limit: MemoryPageLimit {
                 message: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_MESSAGE,
                 upgrade: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_UPGRADE,
                 query: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_QUERY,
             },
-            wasm_memory_accessed_page_limit: StableMemoryPageLimit {
+            wasm_memory_accessed_page_limit: MemoryPageLimit {
                 message: WASM_MEMORY_ACCESSED_PAGE_LIMIT,
                 upgrade: WASM_MEMORY_ACCESSED_PAGE_LIMIT,
                 query: WASM_MEMORY_ACCESSED_PAGE_LIMIT,

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -113,6 +113,14 @@ const STABLE_MEMORY_ACCESSED_PAGE_LIMIT_MESSAGE: NumOsPages =
 const STABLE_MEMORY_ACCESSED_PAGE_LIMIT_QUERY: NumOsPages =
     NumOsPages::new(GIB / (PAGE_SIZE as u64));
 
+// Maximum number of Wasm heap OS pages (4KiB) that a single message execution is
+// allowed to access, counting both reads and writes.
+//
+// This is intentionally an independent constant rather than being derived from
+// `MAX_WASM64_MEMORY_IN_BYTES`, so that raising the heap size ceiling does not
+// implicitly widen the per-message budget.
+const WASM_MEMORY_ACCESSED_PAGE_LIMIT: NumOsPages = NumOsPages::new(6 * GIB / (PAGE_SIZE as u64));
+
 /// The maximum size in bytes for an uncompressed Wasm module. This value is
 /// also used as the maximum size for the Wasm chunk store of each canister.
 pub const WASM_MAX_SIZE: NumBytes = NumBytes::new(100 * 1024 * 1024); // 100 MiB
@@ -204,6 +212,11 @@ pub struct Config {
     // can access.
     pub stable_memory_accessed_page_limit: StableMemoryPageLimit,
 
+    /// Maximum number of Wasm heap pages that a single message execution can
+    /// access, counting both reads and writes. Dirty pages are a subset of
+    /// accessed pages, so this transitively bounds the per-message heap delta.
+    pub wasm_memory_accessed_page_limit: StableMemoryPageLimit,
+
     /// Maximum number of stable memory dirty pages that a single message
     /// execution is allowed to produce.
     pub stable_memory_dirty_page_limit: StableMemoryPageLimit,
@@ -278,6 +291,11 @@ impl Config {
                 message: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_MESSAGE,
                 upgrade: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_UPGRADE,
                 query: STABLE_MEMORY_ACCESSED_PAGE_LIMIT_QUERY,
+            },
+            wasm_memory_accessed_page_limit: StableMemoryPageLimit {
+                message: WASM_MEMORY_ACCESSED_PAGE_LIMIT,
+                upgrade: WASM_MEMORY_ACCESSED_PAGE_LIMIT,
+                query: WASM_MEMORY_ACCESSED_PAGE_LIMIT,
             },
             max_sandbox_count: DEFAULT_MAX_SANDBOX_COUNT,
             max_sandbox_idle_time: DEFAULT_MAX_SANDBOX_IDLE_TIME,

--- a/rs/embedders/fuzz/src/imports.rs
+++ b/rs/embedders/fuzz/src/imports.rs
@@ -68,6 +68,7 @@ pub(crate) fn system_api_imports(config: EmbeddersConfig, is_wasm64: bool) -> Sy
             config.feature_flags,
             config.stable_memory_dirty_page_limit,
             config.stable_memory_accessed_page_limit,
+            config.wasm_memory_accessed_page_limit,
             WasmMemoryType::Wasm64,
         );
     } else {
@@ -76,6 +77,7 @@ pub(crate) fn system_api_imports(config: EmbeddersConfig, is_wasm64: bool) -> Sy
             config.feature_flags,
             config.stable_memory_dirty_page_limit,
             config.stable_memory_accessed_page_limit,
+            config.wasm_memory_accessed_page_limit,
             WasmMemoryType::Wasm32,
         );
     }

--- a/rs/embedders/src/lib.rs
+++ b/rs/embedders/src/lib.rs
@@ -89,6 +89,7 @@ pub(crate) enum InternalErrorCode {
     MemoryWriteLimitExceeded = 4,
     MemoryAccessLimitExceeded = 5,
     StableGrowFailed = 6,
+    HeapAccessLimitExceeded = 7,
 }
 
 impl InternalErrorCode {
@@ -104,6 +105,7 @@ impl InternalErrorCode {
                 Self::MemoryAccessLimitExceeded
             }
             code if code == Self::StableGrowFailed as i32 => Self::StableGrowFailed,
+            code if code == Self::HeapAccessLimitExceeded as i32 => Self::HeapAccessLimitExceeded,
             _ => Self::Unknown,
         }
     }

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -21,6 +21,12 @@
 //! counter overflows, the value of the counter is the initial value minus the
 //! sum of cost of all executed instructions.
 //!
+//! There is a second check at each reentrant block: Whether the current message
+//! has exceeded the maximum number of accessed heap pages. It does so by checking
+//! the injected global "canister pending_trap_code", which is written to by the
+//! deterministic memory tracker if the limit is exceeded. In that case, the execution
+//! is aborted by calling "internal_trap".
+//!
 //! In more details, first, it inserts up to five System API functions:
 //!
 //! ```wasm
@@ -35,8 +41,19 @@
 //! It then inserts (and exports) a global mutable counter:
 //! ```wasm
 //! (global (;0;) (mut i64) (i64.const 0))
-//! (export "canister counter_instructions" (global 0)))
+//! (export "canister counter_instructions" (global 0))
+//! (export "canister counter_dirty_pages" (global 1))
+//! (export "canister counter_accessed_pages" (global 2))
+//! (export "canister pending_trap_code" (global 3))
 //! ```
+//!
+//! The first counts instructions; the next two count dirty and accessed pages
+//! in the stable memory. The last holds an `InternalErrorCode` to be raised at
+//! the next reentrant basic block, or zero if no trap is pending. Unlike the
+//! counters it is an i32, so that its value can be passed straight to
+//! `internal_trap`, and it is excluded from the globals persisted in the
+//! execution state (see `get_exported_globals`), so it starts at zero on every
+//! instance.
 //!
 //! An additional function is also inserted to handle updates to the instruction
 //! counter for bulk memory instructions whose cost can only be determined at
@@ -73,21 +90,29 @@
 //! global.set 0
 //! ```
 //!
-//! and a decrementation with a counter overflow check at the beginning of every
-//! reentrant block (a function or a loop body):
+//! and a decrementation followed by a pending trap check and a counter overflow
+//! check at the beginning of every reentrant block (a function or a loop body):
 //!
 //! ```wasm
 //! global.get 0
 //! i64.const 8
 //! i64.sub
 //! global.set 0
+//! global.get 3
+//! if  ;; label = @1
+//!   global.get 3
+//!   call 3           # the `internal_trap` function
+//! end
 //! global.get 0
 //! i64.const 0
 //! i64.lt_s
 //! if  ;; label = @1
-//!   (call x)
+//!   call 0           # the `out_of_instructions` function
 //! end
 //! ```
+//!
+//! The pending trap code is checked before the instruction counter so
+//! that a memory limit violation traps before an out of instructions trap.
 //!
 //! Before every bulk memory operation, a call is made to the function which
 //! will decrement the instruction counter by the "size" argument of the bulk

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -717,9 +717,8 @@ const TABLE_STR: &str = "table";
 pub(crate) const INSTRUCTIONS_COUNTER_GLOBAL_NAME: &str = "canister counter_instructions";
 pub(crate) const DIRTY_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_dirty_pages";
 pub(crate) const ACCESSED_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_accessed_pages";
-/// Holds an `InternalErrorCode` to be raised at the next reentrant block start,
-/// or zero if no trap is pending. Written out of band by the memory tracker's
-/// signal handler, which cannot trap by itself.
+/// Holds an `InternalErrorCode` to be raised at the next reentrant block start, or zero if
+/// no trap is pending. Written by the memory tracker when the page limit is exceeded.
 pub(crate) const PENDING_TRAP_CODE_GLOBAL_NAME: &str = "canister pending_trap_code";
 const CANISTER_START_STR: &str = "canister_start";
 
@@ -961,9 +960,7 @@ fn export_additional_symbols<'a>(
     );
 
     // Push the pending trap code. It is an i32 so that its value can be passed
-    // straight to `internal_trap`, and it starts at zero (no trap pending) on
-    // every instance; see `get_exported_globals`, which keeps it out of the
-    // globals persisted in the execution state.
+    // straight to `internal_trap`, and it starts at zero (no trap pending).
     let pending_trap_code = *module.add_global(
         InitExpr::new(vec![InitInstr::Value(Value::I32(0))]),
         DataType::I32,
@@ -1365,12 +1362,7 @@ fn inject_metering(
                     },
                 ]);
                 if scope == Scope::ReentrantBlockStart {
-                    // Raise a trap requested out of band by the memory tracker.
-                    // `if` branches on a non-zero i32, so no explicit compare
-                    // against zero is needed. This is checked before the
-                    // out-of-instructions check so that a memory limit
-                    // violation deterministically wins over an instruction
-                    // counter underflow in the same block.
+                    // Trap if we accessed too many pages.
                     elems.extend([
                         GlobalGet {
                             global_index: injected_counters.pending_trap_code,
@@ -1386,6 +1378,7 @@ fn inject_metering(
                         },
                         End,
                     ]);
+                    // Trap if we are out of instructions.
                     elems.extend([
                         GlobalGet {
                             global_index: injected_counters.instructions_counter,

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -717,6 +717,10 @@ const TABLE_STR: &str = "table";
 pub(crate) const INSTRUCTIONS_COUNTER_GLOBAL_NAME: &str = "canister counter_instructions";
 pub(crate) const DIRTY_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_dirty_pages";
 pub(crate) const ACCESSED_PAGES_COUNTER_GLOBAL_NAME: &str = "canister counter_accessed_pages";
+/// Holds an `InternalErrorCode` to be raised at the next reentrant block start,
+/// or zero if no trap is pending. Written out of band by the memory tracker's
+/// signal handler, which cannot trap by itself.
+pub(crate) const PENDING_TRAP_CODE_GLOBAL_NAME: &str = "canister pending_trap_code";
 const CANISTER_START_STR: &str = "canister_start";
 
 /// There is one byte for each OS page in the memory.
@@ -797,6 +801,8 @@ pub(super) struct InjectedCounters {
     pub instructions_counter: u32,
     pub dirty_pages_counter: u32,
     pub accessed_pages_counter: u32,
+    /// Pending `InternalErrorCode`, or zero if no trap is pending.
+    pub pending_trap_code: u32,
     /// Function to decrement the instruction counter.
     pub decr_instruction_counter_fn: u32,
     /// Function to count clean pages.
@@ -950,6 +956,17 @@ fn export_additional_symbols<'a>(
     let accessed_pages_counter = *module.add_global(
         InitExpr::new(vec![InitInstr::Value(Value::I64(0))]),
         DataType::I64,
+        true,
+        false,
+    );
+
+    // Push the pending trap code. It is an i32 so that its value can be passed
+    // straight to `internal_trap`, and it starts at zero (no trap pending) on
+    // every instance; see `get_exported_globals`, which keeps it out of the
+    // globals persisted in the execution state.
+    let pending_trap_code = *module.add_global(
+        InitExpr::new(vec![InitInstr::Value(Value::I32(0))]),
+        DataType::I32,
         true,
         false,
     );
@@ -1125,6 +1142,11 @@ fn export_additional_symbols<'a>(
         accessed_pages_counter,
     );
 
+    debug_assert!(super::validation::RESERVED_SYMBOLS.contains(&PENDING_TRAP_CODE_GLOBAL_NAME));
+    module
+        .exports
+        .add_export_global(PENDING_TRAP_CODE_GLOBAL_NAME.to_string(), pending_trap_code);
+
     if let Some(index) = module.start.map(|s| s.0) {
         // push canister_start
         debug_assert!(super::validation::RESERVED_SYMBOLS.contains(&CANISTER_START_STR));
@@ -1138,6 +1160,7 @@ fn export_additional_symbols<'a>(
             instructions_counter,
             dirty_pages_counter,
             accessed_pages_counter,
+            pending_trap_code,
             decr_instruction_counter_fn: *decr_instruction_counter_fn_id,
             count_clean_pages_fn: *count_clean_pages_fn_id,
         },
@@ -1342,6 +1365,27 @@ fn inject_metering(
                     },
                 ]);
                 if scope == Scope::ReentrantBlockStart {
+                    // Raise a trap requested out of band by the memory tracker.
+                    // `if` branches on a non-zero i32, so no explicit compare
+                    // against zero is needed. This is checked before the
+                    // out-of-instructions check so that a memory limit
+                    // violation deterministically wins over an instruction
+                    // counter underflow in the same block.
+                    elems.extend([
+                        GlobalGet {
+                            global_index: injected_counters.pending_trap_code,
+                        },
+                        If {
+                            blockty: wirm::wasmparser::BlockType::Empty,
+                        },
+                        GlobalGet {
+                            global_index: injected_counters.pending_trap_code,
+                        },
+                        Call {
+                            function_index: injected_functions.internal_trap,
+                        },
+                        End,
+                    ]);
                     elems.extend([
                         GlobalGet {
                             global_index: injected_counters.instructions_counter,

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -21,8 +21,8 @@ use crate::wasmtime_embedder::{
 use crate::{
     MAX_WASM_STACK_SIZE, MIN_GUARD_REGION_SIZE,
     wasm_utils::instrumentation::{
-        ACCESSED_PAGES_COUNTER_GLOBAL_NAME, DIRTY_PAGES_COUNTER_GLOBAL_NAME, WasmMemoryType,
-        main_memory_type,
+        ACCESSED_PAGES_COUNTER_GLOBAL_NAME, DIRTY_PAGES_COUNTER_GLOBAL_NAME,
+        PENDING_TRAP_CODE_GLOBAL_NAME, WasmMemoryType, main_memory_type,
     },
 };
 use wirm::{
@@ -42,11 +42,12 @@ use crate::WASM_PAGE_SIZE;
 
 /// Symbols that are reserved and cannot be exported by canisters.
 #[doc(hidden)] // pub for usage in tests
-pub const RESERVED_SYMBOLS: [&str; 6] = [
+pub const RESERVED_SYMBOLS: [&str; 7] = [
     "canister counter_instructions",
     "canister_start",
     DIRTY_PAGES_COUNTER_GLOBAL_NAME,
     ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
+    PENDING_TRAP_CODE_GLOBAL_NAME,
     STABLE_MEMORY_NAME,
     STABLE_BYTEMAP_MEMORY_NAME,
 ];

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -166,9 +166,6 @@ fn get_exported_globals<T>(instance: &Instance, store: &mut Store<T>) -> Vec<was
     const TO_IGNORE: &[&str] = &[
         DIRTY_PAGES_COUNTER_GLOBAL_NAME,
         ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
-        // Kept out of the persisted globals so that adding it does not change
-        // the number of globals recorded in existing execution states, and so
-        // that every instance starts with no trap pending.
         PENDING_TRAP_CODE_GLOBAL_NAME,
     ];
 
@@ -669,7 +666,9 @@ impl WasmtimeEmbedder {
 
             Arc::new(SignalMutex::new(move |reason: AbortReason| {
                 let code = match reason {
-                    AbortReason::AccessLimitExceeded => InternalErrorCode::HeapAccessLimitExceeded,
+                    AbortReason::WasmPagesAccessLimitExceeded => {
+                        InternalErrorCode::HeapAccessLimitExceeded
+                    }
                 };
                 // SAFETY: Accessing the Store and Global from the signal handler.
                 unsafe {

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -656,11 +656,16 @@ impl WasmtimeEmbedder {
 
         // Create a closure that aborts the execution by recording a pending
         // trap code, which the instrumented Wasm raises at the next reentrant
-        // block start. Writing an integer keeps the signal handler free of
-        // allocation; the error message is built by `internal_trap`.
+        // block start. The error message is built by `internal_trap`.
         //
-        // SAFETY: as for `subtract_instruction_counter` above.
+        // SAFETY: We store a raw pointer to the Store and a copy of the Global.
+        // These remain valid for the lifetime of the WasmtimeInstance because:
+        // 1. The Store is pinned (heap-allocated) and owned by WasmtimeInstance
+        // 2. The Global is a lightweight handle that references data in the Store
+        // 3. The memory tracker (which holds this closure) is also owned by WasmtimeInstance
+        // 4. All are dropped together when WasmtimeInstance is dropped
         let abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>> = {
+            // StorePtr::new requires a Pin, enforcing that the store is pinned.
             let mut store_ptr = StorePtr::new(store.as_mut());
             let global_copy = pending_trap_code_global;
 
@@ -671,10 +676,9 @@ impl WasmtimeEmbedder {
                     }
                 };
                 // SAFETY: Accessing the Store and Global from the signal handler.
+                // Both pointers are guaranteed valid by the lifetime relationship described above.
                 unsafe {
                     let store_ref = store_ptr.get();
-                    // The first violation wins, so that the reported error
-                    // does not depend on how many faults follow it.
                     if let Val::I32(0) = global_copy.get(&mut *store_ref) {
                         let _ = global_copy.set(store_ref, Val::I32(code as i32));
                     }

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -31,16 +31,18 @@ use ic_types::{
 };
 use ic_wasm_types::{BinaryEncodedWasm, WasmEngineError};
 use memory_tracker::{
-    DeterministicMemoryTracker, DirtyPageTracking, MemoryLimits, signal_mutex::SignalMutex,
+    AbortReason, DeterministicMemoryTracker, DirtyPageTracking, MemoryLimits,
+    signal_mutex::SignalMutex,
 };
 use signal_stack::WasmtimeSignalStack;
 
 use crate::wasm_utils::instrumentation::{
     ACCESSED_PAGES_COUNTER_GLOBAL_NAME, DIRTY_PAGES_COUNTER_GLOBAL_NAME,
-    INSTRUCTIONS_COUNTER_GLOBAL_NAME, WasmMemoryType,
+    INSTRUCTIONS_COUNTER_GLOBAL_NAME, PENDING_TRAP_CODE_GLOBAL_NAME, WasmMemoryType,
 };
 use crate::{
-    serialized_module::SerializedModuleBytes, wasm_utils::validation::wasmtime_validation_config,
+    InternalErrorCode, serialized_module::SerializedModuleBytes,
+    wasm_utils::validation::wasmtime_validation_config,
 };
 
 use super::InstanceRunResult;
@@ -164,6 +166,10 @@ fn get_exported_globals<T>(instance: &Instance, store: &mut Store<T>) -> Vec<was
     const TO_IGNORE: &[&str] = &[
         DIRTY_PAGES_COUNTER_GLOBAL_NAME,
         ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
+        // Kept out of the persisted globals so that adding it does not change
+        // the number of globals recorded in existing execution states, and so
+        // that every instance starts with no trap pending.
+        PENDING_TRAP_CODE_GLOBAL_NAME,
     ];
 
     instance
@@ -314,6 +320,7 @@ impl WasmtimeEmbedder {
                     self.config.feature_flags,
                     self.config.stable_memory_dirty_page_limit,
                     self.config.stable_memory_accessed_page_limit,
+                    self.config.wasm_memory_accessed_page_limit,
                     main_memory_type,
                 );
             }
@@ -323,6 +330,7 @@ impl WasmtimeEmbedder {
                     self.config.feature_flags,
                     self.config.stable_memory_dirty_page_limit,
                     self.config.stable_memory_accessed_page_limit,
+                    self.config.wasm_memory_accessed_page_limit,
                     main_memory_type,
                 );
             }
@@ -446,32 +454,41 @@ impl WasmtimeEmbedder {
         };
 
         // Compute dirty page limit and access page limit based on the message type.
-        let (current_dirty_page_limit, current_accessed_limit) = match system_api {
-            Some(ref system_api) => (
-                system_api.get_page_limit(&self.config.stable_memory_dirty_page_limit),
-                system_api.get_page_limit(&self.config.stable_memory_accessed_page_limit),
-            ),
+        let (current_dirty_page_limit, current_accessed_limit, current_heap_accessed_limit) =
+            match system_api {
+                Some(ref system_api) => (
+                    system_api.get_page_limit(&self.config.stable_memory_dirty_page_limit),
+                    system_api.get_page_limit(&self.config.stable_memory_accessed_page_limit),
+                    system_api.get_page_limit(&self.config.wasm_memory_accessed_page_limit),
+                ),
 
-            // If system api is not present, then this function has been called from
-            // get_initial_globals_and_memory(). In this case, the number of
-            // dirty pages does not matter as the canister is not running.
-            None => (
-                self.config.stable_memory_dirty_page_limit.message,
-                self.config.stable_memory_accessed_page_limit.message,
-            ),
-        };
+                // If system api is not present, then this function has been called from
+                // get_initial_globals_and_memory(). In this case, the number of
+                // dirty pages does not matter as the canister is not running.
+                None => (
+                    self.config.stable_memory_dirty_page_limit.message,
+                    self.config.stable_memory_accessed_page_limit.message,
+                    self.config.wasm_memory_accessed_page_limit.message,
+                ),
+            };
 
-        let stable_memory_limits = MemoryLimits {
-            max_memory_size: self.config.max_stable_memory_size,
-            max_dirty_pages: current_dirty_page_limit,
-        };
         let max_heap_memory_size = self
             .config
             .max_wasm_memory_size
             .max(self.config.max_wasm64_memory_size);
+        let stable_memory_limits = MemoryLimits {
+            max_memory_size: self.config.max_stable_memory_size,
+            max_dirty_pages: current_dirty_page_limit,
+            // Stable memory accesses are limited by the bytemap counters in the
+            // Wasm-native system API implementation, not by the tracker.
+            max_accessed_pages: NumOsPages::new(
+                self.config.max_stable_memory_size.get() / PAGE_SIZE as u64,
+            ),
+        };
         let heap_memory_limits = MemoryLimits {
             max_memory_size: max_heap_memory_size,
             max_dirty_pages: NumOsPages::new(max_heap_memory_size.get() / PAGE_SIZE as u64),
+            max_accessed_pages: current_heap_accessed_limit,
         };
 
         let mut store = Store::new(
@@ -581,6 +598,12 @@ impl WasmtimeEmbedder {
             .set(&mut store, Val::I64(current_accessed_limit.get() as i64))
             .expect("Couldn't set dirty page counter global");
 
+        // The global is excluded from the persisted globals, so it is already
+        // zero (no trap pending) and only needs to be read out here.
+        let pending_trap_code_global = instance
+            .get_global(&mut store, PENDING_TRAP_CODE_GLOBAL_NAME)
+            .expect("Pending trap code global should have been added by instrumentation.");
+
         let mut memories = HashMap::new();
         for mem_info in self.list_memory_infos(modification_tracking, heap_memory, stable_memory) {
             let memory_limits = match mem_info.memory_type {
@@ -634,6 +657,32 @@ impl WasmtimeEmbedder {
             }
         };
 
+        // Create a closure that aborts the execution by recording a pending
+        // trap code, which the instrumented Wasm raises at the next reentrant
+        // block start. Writing an integer keeps the signal handler free of
+        // allocation; the error message is built by `internal_trap`.
+        //
+        // SAFETY: as for `subtract_instruction_counter` above.
+        let abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>> = {
+            let mut store_ptr = StorePtr::new(store.as_mut());
+            let global_copy = pending_trap_code_global;
+
+            Arc::new(SignalMutex::new(move |reason: AbortReason| {
+                let code = match reason {
+                    AbortReason::AccessLimitExceeded => InternalErrorCode::HeapAccessLimitExceeded,
+                };
+                // SAFETY: Accessing the Store and Global from the signal handler.
+                unsafe {
+                    let store_ref = store_ptr.get();
+                    // The first violation wins, so that the reported error
+                    // does not depend on how many faults follow it.
+                    if let Val::I32(0) = global_copy.get(&mut *store_ref) {
+                        let _ = global_copy.set(store_ref, Val::I32(code as i32));
+                    }
+                }
+            }))
+        };
+
         let signal_stack = WasmtimeSignalStack::new();
         let mut main_memory_type = WasmMemoryType::Wasm32;
         if let Some(mem) = instance.get_memory(&mut *store, WASM_HEAP_MEMORY_NAME)
@@ -648,6 +697,7 @@ impl WasmtimeEmbedder {
             self.log.clone(),
             self.config.page_overhead,
             subtract_instruction_counter,
+            abort_execution,
         );
 
         Ok(WasmtimeInstance {
@@ -801,6 +851,7 @@ fn sigsegv_memory_tracker<S>(
     log: ReplicaLogger,
     page_overhead: NumInstructions,
     subtract_instruction_counter: Arc<SignalMutex<dyn FnMut(u64) + Send>>,
+    abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>>,
 ) -> HashMap<CanisterMemoryType, Arc<SignalMutex<DeterministicMemoryTracker>>> {
     let mut tracked_memories = vec![];
     let mut result = HashMap::new();
@@ -842,6 +893,7 @@ fn sigsegv_memory_tracker<S>(
                     memory_limits,
                     page_overhead.get(),
                     subtract_instruction_counter.clone(),
+                    abort_execution.clone(),
                 )
                 .expect("failed to instantiate SIGSEGV memory tracker"),
             ))

--- a/rs/embedders/src/wasmtime_embedder/linker.rs
+++ b/rs/embedders/src/wasmtime_embedder/linker.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use ic_config::{
-    embedders::{FeatureFlags, StableMemoryPageLimit},
+    embedders::{FeatureFlags, MemoryPageLimit},
     flag_status::FlagStatus,
 };
 use ic_interfaces::execution_environment::{
@@ -234,9 +234,9 @@ pub fn syscalls<
 >(
     linker: &mut Linker<StoreData>,
     feature_flags: FeatureFlags,
-    stable_memory_dirty_page_limit: StableMemoryPageLimit,
-    stable_memory_access_page_limit: StableMemoryPageLimit,
-    wasm_memory_access_page_limit: StableMemoryPageLimit,
+    stable_memory_dirty_page_limit: MemoryPageLimit,
+    stable_memory_access_page_limit: MemoryPageLimit,
+    wasm_memory_access_page_limit: MemoryPageLimit,
     main_memory_type: WasmMemoryType,
 ) where
     <I as TryInto<usize>>::Error: std::fmt::Display,

--- a/rs/embedders/src/wasmtime_embedder/linker.rs
+++ b/rs/embedders/src/wasmtime_embedder/linker.rs
@@ -236,6 +236,7 @@ pub fn syscalls<
     feature_flags: FeatureFlags,
     stable_memory_dirty_page_limit: StableMemoryPageLimit,
     stable_memory_access_page_limit: StableMemoryPageLimit,
+    wasm_memory_access_page_limit: StableMemoryPageLimit,
     main_memory_type: WasmMemoryType,
 ) where
     <I as TryInto<usize>>::Error: std::fmt::Display,
@@ -1581,6 +1582,17 @@ pub fn syscalls<
                             stable_memory_access_page_limit.message.get()
                                 * (PAGE_SIZE as u64 / 1024),
                             stable_memory_access_page_limit.query.get() * (PAGE_SIZE as u64 / 1024),
+                        ))
+                    }
+                    InternalErrorCode::HeapAccessLimitExceeded => {
+                        HypervisorError::MemoryAccessLimitExceeded(format!(
+                            "Exceeded the limit for the number of \
+                            accessed pages in the heap in a single \
+                            execution: limit {} KB for regular messages, {} KB \
+                            for upgrade messages and {} KB for queries.",
+                            wasm_memory_access_page_limit.message.get() * (PAGE_SIZE as u64 / 1024),
+                            wasm_memory_access_page_limit.upgrade.get() * (PAGE_SIZE as u64 / 1024),
+                            wasm_memory_access_page_limit.query.get() * (PAGE_SIZE as u64 / 1024),
                         ))
                     }
                     InternalErrorCode::StableGrowFailed => HypervisorError::CalledTrap {

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, DecoderConfig, decode_one_with_config};
 use ic_base_types::{InternalAddress, PrincipalIdBlobParseError};
-use ic_config::embedders::{Config as EmbeddersConfig, StableMemoryPageLimit};
+use ic_config::embedders::{Config as EmbeddersConfig, MemoryPageLimit};
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_error_types::RejectCode;
 use ic_interfaces::execution_environment::{
@@ -1936,7 +1936,7 @@ impl SystemApiImpl {
 
     /// Based on the page limit object, returns the page limit for the current
     /// system API type. Can be called with the limit for dirty pages or accessed pages.
-    pub fn get_page_limit(&self, page_limit: &StableMemoryPageLimit) -> NumOsPages {
+    pub fn get_page_limit(&self, page_limit: &MemoryPageLimit) -> NumOsPages {
         match &self.api_type {
             // Longer-running messages make use of a different, possibly higher limit.
             ApiType::Init { .. } | ApiType::PreUpgrade { .. } => page_limit.upgrade,

--- a/rs/embedders/src/wasmtime_embedder/tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/tests.rs
@@ -150,6 +150,7 @@ fn test_wasmtime_system_api() {
         config.feature_flags,
         config.stable_memory_dirty_page_limit,
         config.stable_memory_accessed_page_limit,
+        config.wasm_memory_accessed_page_limit,
         crate::wasmtime_embedder::WasmMemoryType::Wasm32,
     );
     let instance = linker

--- a/rs/embedders/tests/snapshots/instrumentation__app.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__app.snap
@@ -23,6 +23,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "memory" (memory 0))
   (export "compute" (func $compute))
   (export "double" (func $double))
@@ -31,12 +32,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $compute (;5;) (type 0) (param i32) (result i32)
     (local i32 i32)
     global.get 0
     i64.const 19
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -66,6 +73,11 @@ expression: out
         i64.const 10
         i64.sub
         global.set 0
+        global.get 3
+        if ;; label = @3
+          global.get 3
+          call 3
+        end
         global.get 0
         i64.const 0
         i64.lt_s
@@ -87,6 +99,11 @@ expression: out
           i64.const 8
           i64.sub
           global.set 0
+          global.get 3
+          if ;; label = @4
+            global.get 3
+            call 3
+          end
           global.get 0
           i64.const 0
           i64.lt_s
@@ -128,6 +145,11 @@ expression: out
     i64.const 4
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__app2.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__app2.snap
@@ -21,6 +21,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "compute" (func $compute))
   (export "tenfold" (func $tenfold))
   (export "inc" (func $inc))
@@ -29,12 +30,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $compute (;5;) (type 0) (param i64) (result i64)
     (local i64)
     global.get 0
     i64.const 16
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -120,6 +127,11 @@ expression: out
     i64.const 4
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -135,6 +147,11 @@ expression: out
     i64.const 4
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__basic.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__basic.snap
@@ -21,17 +21,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "addTwo" (func $addTwo))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $addTwo (;5;) (type 0) (param i32 i32) (result i32)
     global.get 0
     i64.const 4
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__basic_import.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__basic_import.snap
@@ -23,17 +23,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "addTwo" (func $addTwo))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $addTwo (;6;) (type $a) (param i32 i32) (result i32)
     global.get 0
     i64.const 4
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__basic_import_call.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__basic_import_call.snap
@@ -22,17 +22,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "addTwo" (func $addTwo))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $addTwo (;6;) (type $a) (param i32 i32) (result i32)
     global.get 0
     i64.const 11
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__control_flow.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__control_flow.snap
@@ -24,6 +24,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "loop" (func 6))
   (export "countTo" (func 7))
   (export "if_then_else" (func 8))
@@ -33,12 +34,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func (;6;) (type 1)
     (local i64)
     global.get 0
     i64.const 3
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -53,6 +60,11 @@ expression: out
         i64.const 5
         i64.sub
         global.set 0
+        global.get 3
+        if ;; label = @3
+          global.get 3
+          call 4
+        end
         global.get 0
         i64.const 0
         i64.lt_s
@@ -83,6 +95,11 @@ expression: out
     i64.const 3
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -96,6 +113,11 @@ expression: out
       i64.const 15
       i64.sub
       global.set 0
+      global.get 3
+      if ;; label = @2
+        global.get 3
+        call 4
+      end
       global.get 0
       i64.const 0
       i64.lt_s
@@ -119,6 +141,11 @@ expression: out
     i64.const 6
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__element.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__element.snap
@@ -25,6 +25,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "Mt.call" (func 0))
   (export "call Mt.call" (func 8))
   (export "call" (func 9))
@@ -34,12 +35,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (elem (;0;) (i32.const 0) func 7 7 7 1 0)
   (func (;7;) (type 1) (result i64)
     global.get 0
     i64.const 2
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 5
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -53,6 +60,11 @@ expression: out
     i64.const 7
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 5
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -67,6 +79,11 @@ expression: out
     i64.const 12
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 5
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__export_mutable_globals.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__export_mutable_globals.snap
@@ -25,6 +25,7 @@ expression: out
   (global (;4;) (mut i64) i64.const 0)
   (global (;5;) (mut i64) i64.const 0)
   (global (;6;) (mut i64) i64.const 0)
+  (global (;7;) (mut i32) i32.const 0)
   (export "_g_0" (global 0))
   (export "_g_1" (global 1))
   (export "stable_memory" (memory 0))
@@ -33,6 +34,7 @@ expression: out
   (export "canister counter_instructions" (global 4))
   (export "canister counter_dirty_pages" (global 5))
   (export "canister counter_accessed_pages" (global 6))
+  (export "canister pending_trap_code" (global 7))
   (func (;5;) (type 5) (param i64) (result i64)
     (local i64)
     global.get 4

--- a/rs/embedders/tests/snapshots/instrumentation__fac.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__fac.snap
@@ -21,17 +21,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "fac" (func $fac))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $fac (;5;) (type 0) (param i64) (result i64)
     global.get 0
     i64.const 6
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__fizzbuzz.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__fizzbuzz.snap
@@ -24,6 +24,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "fizzbuzz" (func 6))
   (export "memory" (memory 0))
   (export "stable_memory" (memory 1))
@@ -31,12 +32,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func (;6;) (type 1) (param i32)
     (local i32 i32 i32)
     global.get 0
     i64.const 7
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 4
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -54,6 +61,11 @@ expression: out
       i64.const 15
       i64.sub
       global.set 0
+      global.get 3
+      if ;; label = @2
+        global.get 3
+        call 4
+      end
       global.get 0
       i64.const 0
       i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__memory_fill.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__memory_fill.snap
@@ -22,17 +22,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "memory" (memory 0))
   (export "stable_memory" (memory 1))
   (export "stable_bytemap_memory" (memory 2))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func (;5;) (type 0)
     global.get 0
     i64.const 104
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__memory_grow.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__memory_grow.snap
@@ -23,6 +23,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "memory" (memory 0))
   (export "grow" (func $grow))
   (export "stable_memory" (memory 1))
@@ -30,12 +31,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $grow (;5;) (type 0) (param i32) (result i32)
     (local i32 i32 i32)
     global.get 0
     i64.const 302
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__nested_ifs.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__nested_ifs.snap
@@ -21,17 +21,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "compute" (func $compute))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $compute (;5;) (type 0) (param i64) (result i64)
     global.get 0
     i64.const 7
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__recursive.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__recursive.snap
@@ -21,17 +21,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "fac" (func $fac))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $fac (;5;) (type 0) (param i64) (result i64)
     global.get 0
     i64.const 10
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__simple_loop.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__simple_loop.snap
@@ -22,6 +22,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "canister_update test" (func $test))
   (export "memory" (memory $memory))
   (export "stable_memory" (memory 1))
@@ -29,11 +30,17 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $test (;5;) (type 0)
     global.get 0
     i64.const 1
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -45,6 +52,11 @@ expression: out
       i64.const 2
       i64.sub
       global.set 0
+      global.get 3
+      if ;; label = @2
+        global.get 3
+        call 3
+      end
       global.get 0
       i64.const 0
       i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__start.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__start.snap
@@ -26,6 +26,7 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "e" (func 1))
   (export "table" (table 0))
   (export "memory" (memory 0))
@@ -34,12 +35,18 @@ expression: out
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (export "canister_start" (func $foo))
   (func $foo (;7;) (type 3)
     global.get 0
     i64.const 1
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 5
+    end
     global.get 0
     i64.const 0
     i64.lt_s
@@ -52,6 +59,11 @@ expression: out
     i64.const 3
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 5
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/snapshots/instrumentation__zero_cost_ops.snap
+++ b/rs/embedders/tests/snapshots/instrumentation__zero_cost_ops.snap
@@ -21,17 +21,24 @@ expression: out
   (global (;0;) (mut i64) i64.const 0)
   (global (;1;) (mut i64) i64.const 0)
   (global (;2;) (mut i64) i64.const 0)
+  (global (;3;) (mut i32) i32.const 0)
   (export "fac" (func $fac))
   (export "stable_memory" (memory 0))
   (export "stable_bytemap_memory" (memory 1))
   (export "canister counter_instructions" (global 0))
   (export "canister counter_dirty_pages" (global 1))
   (export "canister counter_accessed_pages" (global 2))
+  (export "canister pending_trap_code" (global 3))
   (func $fac (;5;) (type 0) (param i64) (result i64)
     global.get 0
     i64.const 6
     i64.sub
     global.set 0
+    global.get 3
+    if ;; label = @1
+      global.get 3
+      call 3
+    end
     global.get 0
     i64.const 0
     i64.lt_s

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use ic_config::{
-    embedders::{Config, StableMemoryPageLimit},
+    embedders::{Config, MemoryPageLimit},
     flag_status::FlagStatus,
 };
 use ic_embedders::{
@@ -723,7 +723,7 @@ fn stable_read_accessed_pages_allowance() {
     use HypervisorError::*;
 
     let config = Config {
-        stable_memory_accessed_page_limit: StableMemoryPageLimit {
+        stable_memory_accessed_page_limit: MemoryPageLimit {
             message: ic_types::NumOsPages::new(3),
             upgrade: ic_types::NumOsPages::new(3),
             query: ic_types::NumOsPages::new(3),
@@ -817,7 +817,7 @@ fn stable64_read_accessed_pages_allowance() {
     use HypervisorError::*;
 
     let config = Config {
-        stable_memory_accessed_page_limit: StableMemoryPageLimit {
+        stable_memory_accessed_page_limit: MemoryPageLimit {
             message: ic_types::NumOsPages::new(3),
             upgrade: ic_types::NumOsPages::new(3),
             query: ic_types::NumOsPages::new(3),

--- a/rs/execution_environment/src/execution/call_or_task/tests.rs
+++ b/rs/execution_environment/src/execution/call_or_task/tests.rs
@@ -18,7 +18,7 @@ use ic_universal_canister::{call_args, wasm};
 use more_asserts::assert_gt;
 use std::time::Duration;
 
-use ic_config::embedders::StableMemoryPageLimit;
+use ic_config::embedders::MemoryPageLimit;
 use ic_test_utilities_execution_environment::{
     ExecutionTest, ExecutionTestBuilder, check_ingress_status,
 };
@@ -120,7 +120,7 @@ fn with_update_and_replicated_query<F: Fn(&str)>(test: F) {
 #[test]
 fn can_write_to_each_page_in_stable_memory() {
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(10),
             message: NumOsPages::new(10),
             query: NumOsPages::new(10),
@@ -565,7 +565,7 @@ fn dirty_pages_cost_the_same_on_app_and_system_subnets() {
 fn hitting_page_delta_limit_fails_message() {
     let no_pages = 10;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(no_pages),
             message: NumOsPages::new(no_pages),
             query: NumOsPages::new(no_pages),
@@ -592,7 +592,7 @@ fn hitting_page_delta_limit_fails_message() {
 fn hitting_page_delta_limit_fails_message_system_subnet() {
     let no_pages = 10;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(no_pages),
             message: NumOsPages::new(no_pages),
             query: NumOsPages::new(no_pages),
@@ -622,7 +622,7 @@ fn hitting_page_delta_limit_fails_for_install_code() {
     // A large enough limit that will never be triggered.
     let no_pages_other_messages = no_pages_upgrade * 10_000_000;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(no_pages_upgrade),
             message: NumOsPages::new(no_pages_other_messages),
             query: NumOsPages::new(no_pages_other_messages),
@@ -654,7 +654,7 @@ fn hitting_page_delta_limit_fails_for_install_code() {
 fn hitting_page_delta_limit_fails_non_replicated_query() {
     let no_pages = 10;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(no_pages),
             message: NumOsPages::new(no_pages),
             query: NumOsPages::new(no_pages - 1),
@@ -678,7 +678,7 @@ fn hitting_page_delta_limit_fails_non_replicated_query() {
 fn hitting_page_delta_limit_fails_replicated_query() {
     let no_pages = 10;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+        .with_stable_memory_dirty_page_limit(MemoryPageLimit {
             upgrade: NumOsPages::new(no_pages),
             message: NumOsPages::new(no_pages),
             query: NumOsPages::new(no_pages - 1),
@@ -700,7 +700,7 @@ fn hitting_page_delta_limit_fails_replicated_query() {
 fn hitting_access_limit_fails_non_replicated_query() {
     let no_pages = 10;
     let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_access_limit(StableMemoryPageLimit {
+        .with_stable_memory_access_limit(MemoryPageLimit {
             message: NumOsPages::new(no_pages),
             upgrade: NumOsPages::new(no_pages),
             query: NumOsPages::new(no_pages - 1),
@@ -756,7 +756,7 @@ fn wat_touching_each_heap_page(export: &str, wasm_pages: u64) -> String {
     )
 }
 
-fn expected_heap_access_error(canister_id: CanisterId, limit: &StableMemoryPageLimit) -> String {
+fn expected_heap_access_error(canister_id: CanisterId, limit: &MemoryPageLimit) -> String {
     format!(
         "Error from Canister {canister_id}: Canister exceeded memory access \
         limits: Exceeded the limit for the number of accessed pages in the heap \
@@ -773,7 +773,7 @@ fn expected_heap_access_error(canister_id: CanisterId, limit: &StableMemoryPageL
 #[test]
 fn heap_access_at_the_limit_succeeds() {
     let wasm_pages = 4;
-    let limit = StableMemoryPageLimit {
+    let limit = MemoryPageLimit {
         message: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
         upgrade: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
         query: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
@@ -789,7 +789,7 @@ fn heap_access_at_the_limit_succeeds() {
 #[test]
 fn hitting_heap_access_limit_fails_message() {
     let limit_wasm_pages = 2;
-    let limit = StableMemoryPageLimit {
+    let limit = MemoryPageLimit {
         message: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
         upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
         query: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
@@ -812,7 +812,7 @@ fn hitting_heap_access_limit_fails_message() {
 fn hitting_heap_access_limit_commits_no_heap_delta() {
     let limit_wasm_pages = 2;
     let mut test = ExecutionTestBuilder::new()
-        .with_wasm_memory_access_limit(StableMemoryPageLimit {
+        .with_wasm_memory_access_limit(MemoryPageLimit {
             message: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
             upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
             // Large enough for the `read` query below to succeed.
@@ -836,7 +836,7 @@ fn hitting_heap_access_limit_fails_for_install_code() {
     let limit_wasm_pages = 2;
     // A large enough limit for the other message types that it never triggers.
     let other_messages_limit = limit_wasm_pages * OS_PAGES_PER_WASM_PAGE * 10_000;
-    let limit = StableMemoryPageLimit {
+    let limit = MemoryPageLimit {
         message: NumOsPages::new(other_messages_limit),
         upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
         query: NumOsPages::new(other_messages_limit),
@@ -860,7 +860,7 @@ fn hitting_heap_access_limit_fails_for_install_code() {
 fn hitting_heap_access_limit_fails_non_replicated_query() {
     let limit_wasm_pages = 2;
     let other_messages_limit = limit_wasm_pages * OS_PAGES_PER_WASM_PAGE * 10_000;
-    let limit = StableMemoryPageLimit {
+    let limit = MemoryPageLimit {
         message: NumOsPages::new(other_messages_limit),
         upgrade: NumOsPages::new(other_messages_limit),
         query: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),

--- a/rs/execution_environment/src/execution/call_or_task/tests.rs
+++ b/rs/execution_environment/src/execution/call_or_task/tests.rs
@@ -12,7 +12,7 @@ use ic_state_machine_tests::WasmResult;
 use ic_sys::PAGE_SIZE;
 use ic_types::ingress::IngressState;
 use ic_types::messages::{CallbackId, RequestMetadata};
-use ic_types::{NumBytes, NumInstructions, NumOsPages};
+use ic_types::{CanisterId, NumBytes, NumInstructions, NumOsPages};
 use ic_types_cycles::Cycles;
 use ic_universal_canister::{call_args, wasm};
 use more_asserts::assert_gt;
@@ -717,6 +717,165 @@ fn hitting_access_limit_fails_non_replicated_query() {
         number of accessed pages in the stable memory in a single message execution: limit {} KB for regular messages and \
          {} KB for queries.",
          no_pages * (PAGE_SIZE as u64 / 1024), (no_pages - 1) * (PAGE_SIZE as u64 / 1024))
+    );
+}
+
+/// The heap is tracked at Wasm page granularity, so one accessed Wasm page
+/// counts as this many OS pages.
+const OS_PAGES_PER_WASM_PAGE: u64 = WASM_PAGE_SIZE_IN_BYTES as u64 / PAGE_SIZE as u64;
+
+/// Writes one byte in each of the first `wasm_pages` Wasm pages of the heap,
+/// from the method exported as `export`. Also exports a `read` query replying
+/// with the first byte of the heap, to check what was committed.
+fn wat_touching_each_heap_page(export: &str, wasm_pages: u64) -> String {
+    let heap_pages = wasm_pages.max(1);
+    let memory_amount = wasm_pages * WASM_PAGE_SIZE_IN_BYTES as u64;
+    format!(
+        r#"
+        (module
+            (import "ic0" "msg_reply" (func $msg_reply))
+            (import "ic0" "msg_reply_data_append"
+                (func $msg_reply_data_append (param i32 i32))
+            )
+            (func (export "{export}") (local i32)
+                (local.set 0 (i32.const 0))
+                (loop $loop
+                    (i32.store8 (local.get 0) (i32.const 1))
+                    (local.set 0 (i32.add (local.get 0) (i32.const {wasm_page_size}))) (;increment by Wasm page size;)
+                    (br_if $loop (i32.lt_u (local.get 0) (i32.const {memory_amount})))
+                )
+                (call $msg_reply)
+            )
+            (func (export "canister_query read")
+                (call $msg_reply_data_append (i32.const 0) (i32.const 1))
+                (call $msg_reply)
+            )
+            (memory (export "memory") {heap_pages})
+        )"#,
+        wasm_page_size = WASM_PAGE_SIZE_IN_BYTES,
+    )
+}
+
+fn expected_heap_access_error(canister_id: CanisterId, limit: &StableMemoryPageLimit) -> String {
+    format!(
+        "Error from Canister {canister_id}: Canister exceeded memory access \
+        limits: Exceeded the limit for the number of accessed pages in the heap \
+        in a single execution: limit {} KB for regular messages, {} KB for \
+        upgrade messages and {} KB for queries.",
+        limit.message.get() * (PAGE_SIZE as u64 / 1024),
+        limit.upgrade.get() * (PAGE_SIZE as u64 / 1024),
+        limit.query.get() * (PAGE_SIZE as u64 / 1024),
+    )
+}
+
+/// Accessing exactly the limit must still succeed, which is what makes the
+/// default limit (the whole heap) a no-op for existing canisters.
+#[test]
+fn heap_access_at_the_limit_succeeds() {
+    let wasm_pages = 4;
+    let limit = StableMemoryPageLimit {
+        message: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
+        upgrade: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
+        query: NumOsPages::new(wasm_pages * OS_PAGES_PER_WASM_PAGE),
+    };
+    let mut test = ExecutionTestBuilder::new()
+        .with_wasm_memory_access_limit(limit)
+        .build();
+    let wat = wat_touching_each_heap_page("canister_update go", wasm_pages);
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    assert!(test.ingress(canister_id, "go", vec![]).is_ok());
+}
+
+#[test]
+fn hitting_heap_access_limit_fails_message() {
+    let limit_wasm_pages = 2;
+    let limit = StableMemoryPageLimit {
+        message: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+        upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+        query: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+    };
+    let mut test = ExecutionTestBuilder::new()
+        .with_wasm_memory_access_limit(limit)
+        .build();
+    let wat = wat_touching_each_heap_page("canister_update go", limit_wasm_pages + 2);
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    let result = test.ingress(canister_id, "go", vec![]).unwrap_err();
+    result.assert_contains(
+        ErrorCode::CanisterMemoryAccessLimitExceeded,
+        &expected_heap_access_error(canister_id, &limit),
+    );
+}
+
+/// A message aborted by the access limit must not commit any of the pages it
+/// dirtied before hitting the limit.
+#[test]
+fn hitting_heap_access_limit_commits_no_heap_delta() {
+    let limit_wasm_pages = 2;
+    let mut test = ExecutionTestBuilder::new()
+        .with_wasm_memory_access_limit(StableMemoryPageLimit {
+            message: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+            upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+            // Large enough for the `read` query below to succeed.
+            query: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE * 10_000),
+        })
+        .build();
+    let wat = wat_touching_each_heap_page("canister_update go", limit_wasm_pages + 2);
+    let canister_id = test.canister_from_wat(wat).unwrap();
+
+    // The update writes to the first heap page before hitting the limit.
+    test.ingress(canister_id, "go", vec![]).unwrap_err();
+
+    let result = test
+        .non_replicated_query(canister_id, "read", vec![])
+        .unwrap();
+    assert_eq!(result, WasmResult::Reply(vec![0]));
+}
+
+#[test]
+fn hitting_heap_access_limit_fails_for_install_code() {
+    let limit_wasm_pages = 2;
+    // A large enough limit for the other message types that it never triggers.
+    let other_messages_limit = limit_wasm_pages * OS_PAGES_PER_WASM_PAGE * 10_000;
+    let limit = StableMemoryPageLimit {
+        message: NumOsPages::new(other_messages_limit),
+        upgrade: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+        query: NumOsPages::new(other_messages_limit),
+    };
+    let mut test = ExecutionTestBuilder::new()
+        .with_wasm_memory_access_limit(limit)
+        .build();
+    let wat = wat_touching_each_heap_page("canister_init", limit_wasm_pages + 2);
+
+    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
+    let result = test
+        .install_canister(canister_id, wat::parse_str(wat).unwrap())
+        .unwrap_err();
+    result.assert_contains(
+        ErrorCode::CanisterMemoryAccessLimitExceeded,
+        &expected_heap_access_error(canister_id, &limit),
+    );
+}
+
+#[test]
+fn hitting_heap_access_limit_fails_non_replicated_query() {
+    let limit_wasm_pages = 2;
+    let other_messages_limit = limit_wasm_pages * OS_PAGES_PER_WASM_PAGE * 10_000;
+    let limit = StableMemoryPageLimit {
+        message: NumOsPages::new(other_messages_limit),
+        upgrade: NumOsPages::new(other_messages_limit),
+        query: NumOsPages::new(limit_wasm_pages * OS_PAGES_PER_WASM_PAGE),
+    };
+    let mut test = ExecutionTestBuilder::new()
+        .with_wasm_memory_access_limit(limit)
+        .build();
+    let wat = wat_touching_each_heap_page("canister_query go", limit_wasm_pages + 2);
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    let result = test
+        .non_replicated_query(canister_id, "go", vec![])
+        .unwrap_err();
+    result.assert_contains(
+        ErrorCode::CanisterMemoryAccessLimitExceeded,
+        &expected_heap_access_error(canister_id, &limit),
     );
 }
 

--- a/rs/execution_environment/src/history.rs
+++ b/rs/execution_environment/src/history.rs
@@ -408,8 +408,8 @@ fn dashboard_label_value_from(code: ErrorCode) -> &'static str {
         }
 
         CanisterMemoryAccessLimitExceeded => {
-            "Canister exceeded the limit for the number of modified stable memory pages \
-                for a single message execution"
+            "Canister exceeded the limit for the number of accessed or modified \
+                heap or stable memory pages for a single message execution"
         }
         QueryCallGraphTooDeep => "Query call graph contains too many nested calls",
         QueryCallGraphTotalInstructionLimitExceeded => {

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -494,8 +494,8 @@ impl AsErrorHelp for HypervisorError {
                 doc_link: doc_ref("slice-overrun"),
             },
             Self::MemoryAccessLimitExceeded(_) => ErrorHelp::UserError {
-                suggestion: "Try optimizing the use of stable memory so that individual \
-                messages don't need to access as much stable memory."
+                suggestion: "Try optimizing the use of memory so that individual \
+                messages don't need to access as much heap or stable memory."
                     .to_string(),
                 doc_link: doc_ref("memory-access-limit-exceeded"),
             },

--- a/rs/memory_tracker/benches/traps.rs
+++ b/rs/memory_tracker/benches/traps.rs
@@ -47,8 +47,10 @@ fn new_tracker(ptr: *mut c_void) -> DeterministicMemoryTracker {
         MemoryLimits {
             max_memory_size: NumBytes::new(WASM_PAGE_SIZE_IN_BYTES as u64),
             max_dirty_pages: NumOsPages::new((WASM_PAGE_SIZE_IN_BYTES / PAGE_SIZE) as u64),
+            max_accessed_pages: NumOsPages::new((WASM_PAGE_SIZE_IN_BYTES / PAGE_SIZE) as u64),
         },
         /* page_overhead */ 0,
+        Arc::new(SignalMutex::new(|_| {})),
         Arc::new(SignalMutex::new(|_| {})),
     )
     .unwrap()

--- a/rs/memory_tracker/src/deterministic.rs
+++ b/rs/memory_tracker/src/deterministic.rs
@@ -329,9 +329,8 @@ pub struct DeterministicMemoryTracker {
     pub metrics: MemoryTrackerMetrics,
     state: RefCell<DeterministicState>,
     page_overhead: u64,
+    max_accessable_os_pages_per_message: u64,
     subtract_instruction_counter: Arc<SignalMutex<dyn FnMut(u64) + Send>>,
-    /// Maximum number of OS pages a single message execution may access.
-    max_accessed_os_pages: u64,
     /// Aborts the current execution with the given trap reason. Called at most
     /// once per execution; the callee ignores repeated calls.
     abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>>,
@@ -341,7 +340,8 @@ pub struct DeterministicMemoryTracker {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum AbortReason {
     /// The execution accessed more pages than `MemoryLimits::max_accessed_pages`.
-    AccessLimitExceeded,
+    WasmPagesAccessLimitExceeded,
+    // might add a stable variant later.
 }
 
 impl DeterministicMemoryTracker {
@@ -365,13 +365,13 @@ impl DeterministicMemoryTracker {
         // Charge instructions.
         (self.subtract_instruction_counter.lock())(num_os_pages * self.page_overhead);
 
-        // Every dirty page is also counted as accessed, so this single check
-        // covers both reads and writes. The comparison is strict so that a
-        // message accessing exactly the whole limit still succeeds.
+        // If the number of accessed OS pages exceeds the limit, abort the execution by
+        // setting an exported Wasm global "pending_trap_code".
+        // The instrumentation will check it (at the next reentrant block) and trap.
         let accessed_os_pages =
             state.accessed_wasm_pages_count.get() as u64 * OS_PAGES_PER_WASM_PAGE;
-        if accessed_os_pages > self.max_accessed_os_pages {
-            (self.abort_execution.lock())(AbortReason::AccessLimitExceeded);
+        if accessed_os_pages > self.max_accessable_os_pages_per_message {
+            (self.abort_execution.lock())(AbortReason::WasmPagesAccessLimitExceeded);
         }
     }
 
@@ -522,8 +522,8 @@ impl DeterministicMemoryTracker {
             metrics: MemoryTrackerMetrics::default(),
             state: RefCell::new(state),
             page_overhead,
+            max_accessable_os_pages_per_message: memory_limits.max_accessed_pages.get(),
             subtract_instruction_counter,
-            max_accessed_os_pages: memory_limits.max_accessed_pages.get(),
             abort_execution,
         };
 

--- a/rs/memory_tracker/src/deterministic.rs
+++ b/rs/memory_tracker/src/deterministic.rs
@@ -79,6 +79,10 @@ use crate::checksum;
 #[cfg(feature = "sigsegv_handler_checksum")]
 use std::ops::BitXor;
 
+/// The number of OS pages in a Wasm page. Pages are accounted for a whole Wasm
+/// page at a time, so this is the granularity of the accessed page count.
+const OS_PAGES_PER_WASM_PAGE: u64 = (WASM_PAGE_SIZE_IN_BYTES / PAGE_SIZE) as u64;
+
 /// Metrics may vary due to non-deterministic signal delivery.
 #[derive(Default)]
 struct NonDeterministicMetrics {
@@ -182,6 +186,7 @@ impl DeterministicState {
         let MemoryLimits {
             max_memory_size,
             max_dirty_pages,
+            max_accessed_pages: _,
         } = memory_limits;
 
         let num_bytes = NumBytes::from_num_os_pages(num_os_pages);
@@ -325,6 +330,18 @@ pub struct DeterministicMemoryTracker {
     state: RefCell<DeterministicState>,
     page_overhead: u64,
     subtract_instruction_counter: Arc<SignalMutex<dyn FnMut(u64) + Send>>,
+    /// Maximum number of OS pages a single message execution may access.
+    max_accessed_os_pages: u64,
+    /// Aborts the current execution with the given trap reason. Called at most
+    /// once per execution; the callee ignores repeated calls.
+    abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>>,
+}
+
+/// The reason a memory tracker aborted the current execution.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum AbortReason {
+    /// The execution accessed more pages than `MemoryLimits::max_accessed_pages`.
+    AccessLimitExceeded,
 }
 
 impl DeterministicMemoryTracker {
@@ -347,6 +364,15 @@ impl DeterministicMemoryTracker {
 
         // Charge instructions.
         (self.subtract_instruction_counter.lock())(num_os_pages * self.page_overhead);
+
+        // Every dirty page is also counted as accessed, so this single check
+        // covers both reads and writes. The comparison is strict so that a
+        // message accessing exactly the whole limit still succeeds.
+        let accessed_os_pages =
+            state.accessed_wasm_pages_count.get() as u64 * OS_PAGES_PER_WASM_PAGE;
+        if accessed_os_pages > self.max_accessed_os_pages {
+            (self.abort_execution.lock())(AbortReason::AccessLimitExceeded);
+        }
     }
 
     /// Marks a Wasm page as dirty.
@@ -468,6 +494,7 @@ impl DeterministicMemoryTracker {
         memory_limits: MemoryLimits,
         page_overhead: u64,
         subtract_instruction_counter: Arc<SignalMutex<dyn FnMut(u64) + Send>>,
+        abort_execution: Arc<SignalMutex<dyn FnMut(AbortReason) + Send>>,
     ) -> nix::Result<Self>
     where
         Self: Sized,
@@ -496,6 +523,8 @@ impl DeterministicMemoryTracker {
             state: RefCell::new(state),
             page_overhead,
             subtract_instruction_counter,
+            max_accessed_os_pages: memory_limits.max_accessed_pages.get(),
+            abort_execution,
         };
 
         let mut instructions = tracker.page_map.get_base_memory_instructions();

--- a/rs/memory_tracker/src/lib.rs
+++ b/rs/memory_tracker/src/lib.rs
@@ -78,10 +78,10 @@ pub use deterministic::{AbortReason, DeterministicMemoryTracker};
 #[derive(Clone, Copy, Default)]
 pub struct MemoryLimits {
     pub max_memory_size: NumBytes,
-    /// Capacity hint for the list of dirty pages. Not enforced.
+    // Currently not enforced, because we limit accesses. Dirty pages are a subset of that.
     pub max_dirty_pages: NumOsPages,
-    /// Maximum number of pages a single message execution may access, counting
-    /// both reads and writes. Exceeding it aborts the execution.
+    /// Maximum number of pages a single message execution may access (read or write).
+    /// Exceeding it aborts the execution.
     pub max_accessed_pages: NumOsPages,
 }
 

--- a/rs/memory_tracker/src/lib.rs
+++ b/rs/memory_tracker/src/lib.rs
@@ -72,13 +72,17 @@ pub(crate) mod checksum {
     }
 }
 
-pub use deterministic::DeterministicMemoryTracker;
+pub use deterministic::{AbortReason, DeterministicMemoryTracker};
 
 /// Memory limits for the deterministic memory tracker.
 #[derive(Clone, Copy, Default)]
 pub struct MemoryLimits {
     pub max_memory_size: NumBytes,
+    /// Capacity hint for the list of dirty pages. Not enforced.
     pub max_dirty_pages: NumOsPages,
+    /// Maximum number of pages a single message execution may access, counting
+    /// both reads and writes. Exceeding it aborts the execution.
+    pub max_accessed_pages: NumOsPages,
 }
 
 /// Specifies whether the currently running message execution needs to know

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -45,6 +45,7 @@ fn setup(
 
 /// Like `setup`, but with an explicit per-message access limit. Also returns the
 /// list of abort reasons the tracker reported, in order.
+#[allow(clippy::type_complexity)]
 fn setup_with_access_limit(
     checkpoint_pages: usize,
     memory_pages: usize,

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -633,7 +633,7 @@ fn access_limit_exceeded_aborts_once(
     );
     assert_eq!(
         *aborts.lock().unwrap(),
-        vec![AbortReason::AccessLimitExceeded]
+        vec![AbortReason::WasmPagesAccessLimitExceeded]
     );
 
     // Faults after the violation report it again; the embedder keeps only the
@@ -646,8 +646,8 @@ fn access_limit_exceeded_aborts_once(
     assert_eq!(
         *aborts.lock().unwrap(),
         vec![
-            AbortReason::AccessLimitExceeded,
-            AbortReason::AccessLimitExceeded
+            AbortReason::WasmPagesAccessLimitExceeded,
+            AbortReason::WasmPagesAccessLimitExceeded
         ]
     );
 }

--- a/rs/memory_tracker/src/tests.rs
+++ b/rs/memory_tracker/src/tests.rs
@@ -17,7 +17,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    AccessKind, DeterministicMemoryTracker, DirtyPageTracking, MemoryLimits,
+    AbortReason, AccessKind, DeterministicMemoryTracker, DirtyPageTracking, MemoryLimits,
     conversions::OS_PAGES_IN_WASM_PAGE,
 };
 
@@ -32,6 +32,32 @@ fn setup(
     page_delta: Vec<PageIndex>,
     dirty_page_tracking: DirtyPageTracking,
 ) -> (DeterministicMemoryTracker, PageMap, *mut c_void, Vec<u8>) {
+    let (tracker, page_map, memory, vec, _aborts) = setup_with_access_limit(
+        checkpoint_pages,
+        memory_pages,
+        page_delta,
+        dirty_page_tracking,
+        // Effectively unlimited: the whole tracked region may be accessed.
+        NumOsPages::new(memory_pages as u64),
+    );
+    (tracker, page_map, memory, vec)
+}
+
+/// Like `setup`, but with an explicit per-message access limit. Also returns the
+/// list of abort reasons the tracker reported, in order.
+fn setup_with_access_limit(
+    checkpoint_pages: usize,
+    memory_pages: usize,
+    page_delta: Vec<PageIndex>,
+    dirty_page_tracking: DirtyPageTracking,
+    max_accessed_pages: NumOsPages,
+) -> (
+    DeterministicMemoryTracker,
+    PageMap,
+    *mut c_void,
+    Vec<u8>,
+    Arc<Mutex<Vec<AbortReason>>>,
+) {
     let mut vec = vec![0_u8; memory_pages * PAGE_SIZE];
     let tmpfile = tempfile::Builder::new().prefix("test").tempfile().unwrap();
     for page in 0..checkpoint_pages {
@@ -70,6 +96,9 @@ fn setup(
     }
     .as_ptr();
 
+    let aborts = Arc::new(Mutex::new(Vec::new()));
+    let recorded_aborts = Arc::clone(&aborts);
+
     let tracker = DeterministicMemoryTracker::new(
         memory,
         NumBytes::new((memory_pages * PAGE_SIZE) as u64),
@@ -79,13 +108,17 @@ fn setup(
         MemoryLimits {
             max_memory_size: NumBytes::new((memory_pages * PAGE_SIZE) as u64),
             max_dirty_pages: NumOsPages::new(memory_pages as u64),
+            max_accessed_pages,
         },
         /* page_overhead not relevant in these tests */ 1,
         Arc::new(SignalMutex::new(|_| {})),
+        Arc::new(SignalMutex::new(move |reason: AbortReason| {
+            recorded_aborts.lock().unwrap().push(reason);
+        })),
     )
     .unwrap();
 
-    (tracker, page_map, memory, vec)
+    (tracker, page_map, memory, vec, aborts)
 }
 
 fn with_setup<F>(
@@ -530,5 +563,91 @@ fn deterministic_memory_tracker_correctly_count_access_and_dirty_pages(
                 assert_eq!(tracker.take_dirty_pages().len(), 0);
             }
         },
+    );
+}
+
+/// Accessing exactly the limit must not abort: the default limit is the whole
+/// heap, so a message touching all of it has to keep working.
+#[rstest]
+fn access_limit_is_not_exceeded_at_the_limit(
+    #[values(DirtyPageTracking::Ignore, DirtyPageTracking::Track)]
+    dirty_page_tracking: DirtyPageTracking,
+    #[values(AccessKind::Read, AccessKind::Write)] access_kind: AccessKind,
+) {
+    let wasm_pages = 4;
+    let memory_pages = wasm_pages * OS_PAGES_IN_WASM_PAGE;
+    let (tracker, _page_map, _memory, _vec, aborts) = setup_with_access_limit(
+        0,
+        memory_pages,
+        vec![],
+        dirty_page_tracking,
+        NumOsPages::new(memory_pages as u64),
+    );
+
+    for wasm_page in 0..wasm_pages {
+        sigsegv(
+            &tracker,
+            PageIndex::new((wasm_page * OS_PAGES_IN_WASM_PAGE) as u64),
+            access_kind,
+        );
+    }
+
+    assert_eq!(tracker.num_accessed_pages(), memory_pages);
+    assert_eq!(*aborts.lock().unwrap(), vec![]);
+}
+
+/// Both reads and writes count towards the single access limit, and the
+/// violation is reported once, when the limit is first exceeded.
+#[rstest]
+fn access_limit_exceeded_aborts_once(
+    #[values(DirtyPageTracking::Ignore, DirtyPageTracking::Track)]
+    dirty_page_tracking: DirtyPageTracking,
+    #[values(AccessKind::Read, AccessKind::Write)] access_kind: AccessKind,
+) {
+    // Allow two Wasm pages worth of OS pages, then access four Wasm pages.
+    let allowed_wasm_pages = 2;
+    let wasm_pages = 4;
+    let memory_pages = wasm_pages * OS_PAGES_IN_WASM_PAGE;
+    let (tracker, _page_map, _memory, _vec, aborts) = setup_with_access_limit(
+        0,
+        memory_pages,
+        vec![],
+        dirty_page_tracking,
+        NumOsPages::new((allowed_wasm_pages * OS_PAGES_IN_WASM_PAGE) as u64),
+    );
+
+    for wasm_page in 0..allowed_wasm_pages {
+        sigsegv(
+            &tracker,
+            PageIndex::new((wasm_page * OS_PAGES_IN_WASM_PAGE) as u64),
+            access_kind,
+        );
+    }
+    assert_eq!(*aborts.lock().unwrap(), vec![]);
+
+    // The next Wasm page crosses the limit.
+    sigsegv(
+        &tracker,
+        PageIndex::new((allowed_wasm_pages * OS_PAGES_IN_WASM_PAGE) as u64),
+        access_kind,
+    );
+    assert_eq!(
+        *aborts.lock().unwrap(),
+        vec![AbortReason::AccessLimitExceeded]
+    );
+
+    // Faults after the violation report it again; the embedder keeps only the
+    // first one, so the reported error does not depend on how many follow.
+    sigsegv(
+        &tracker,
+        PageIndex::new(((allowed_wasm_pages + 1) * OS_PAGES_IN_WASM_PAGE) as u64),
+        access_kind,
+    );
+    assert_eq!(
+        *aborts.lock().unwrap(),
+        vec![
+            AbortReason::AccessLimitExceeded,
+            AbortReason::AccessLimitExceeded
+        ]
     );
 }

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_base_types::{NumBytes, NumSeconds, PrincipalId, SubnetId};
-use ic_config::embedders::{MeteringType, StableMemoryPageLimit};
+use ic_config::embedders::{MemoryPageLimit, MeteringType};
 use ic_config::{
     embedders::{Config as EmbeddersConfig, WASM_MAX_SIZE},
     execution_environment::Config,
@@ -2814,7 +2814,7 @@ impl ExecutionTestBuilder {
 
     pub fn with_stable_memory_dirty_page_limit(
         mut self,
-        stable_memory_dirty_page_limit: StableMemoryPageLimit,
+        stable_memory_dirty_page_limit: MemoryPageLimit,
     ) -> Self {
         self.execution_config
             .embedders_config
@@ -2825,7 +2825,7 @@ impl ExecutionTestBuilder {
 
     pub fn with_stable_memory_access_limit(
         mut self,
-        stable_memory_access_limit: StableMemoryPageLimit,
+        stable_memory_access_limit: MemoryPageLimit,
     ) -> Self {
         self.execution_config
             .embedders_config
@@ -2836,7 +2836,7 @@ impl ExecutionTestBuilder {
 
     pub fn with_wasm_memory_access_limit(
         mut self,
-        wasm_memory_access_limit: StableMemoryPageLimit,
+        wasm_memory_access_limit: MemoryPageLimit,
     ) -> Self {
         self.execution_config
             .embedders_config

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2834,6 +2834,17 @@ impl ExecutionTestBuilder {
         self
     }
 
+    pub fn with_wasm_memory_access_limit(
+        mut self,
+        wasm_memory_access_limit: StableMemoryPageLimit,
+    ) -> Self {
+        self.execution_config
+            .embedders_config
+            .wasm_memory_accessed_page_limit = wasm_memory_access_limit;
+
+        self
+    }
+
     pub fn with_max_canister_http_requests_in_flight(
         mut self,
         max_canister_http_requests_in_flight: usize,


### PR DESCRIPTION
This PR paves the way for large heaps! 

Currently, the heap is limited to 4GiB for 32bit canisters and 6GiB for 64bit canisters. We want to raise the limit for 64bit to much more, but the amount of heap that can be accessed in a single message has to remain small, because the nodes' RAM is limited. 

This PR uses the deterministic memory tracker stats to bound the number of memory pages accessible during a single message. The current limit is 6GiB, which is the full canister heap, so there is no behavioural change to the protocol. 
Later, we can raise the memory limit and keep this pages-per-message limit as is, such that the reasonable limits remain in place but the overall memory a canister can access is vastly bigger. 