### PR TITLE
feat(ledger-suite-orchestrator): forward ledger upgrade argument to managed ledgers

### DIFF
--- a/rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did
+++ b/rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did
@@ -49,6 +49,30 @@ type UpgradeArg = record {
    // Those ledger suites are *NOT* necessarily ckERC20 tokens.
    // This assumes that the orchestrator is a controller of all the canisters in the list.
    manage_ledger_suites: opt vec InstalledLedgerSuite;
+
+   // Upgrade argument forwarded to every managed ledger canister when upgrading it.
+   // Requires `ledger_compressed_wasm_hash` to be set, since ledger canisters are only
+   // upgraded when that field is present.
+   ledger_upgrade_arg: opt LedgerUpgradeArg;
+};
+
+// Subset of the ICRC1 ledger `UpgradeArgs` (see the ledger's Candid file) that the
+// orchestrator forwards to its managed ledger canisters.
+type LedgerUpgradeArg = record {
+    change_archive_options : opt ChangeArchiveOptions;
+};
+
+// Changes the parameters used to spawn and maintain archive canisters.
+// Same type as `ChangeArchiveOptions` in the ICRC1 ledger's Candid file.
+type ChangeArchiveOptions = record {
+    num_blocks_to_archive : opt nat64;
+    max_transactions_per_response : opt nat64;
+    trigger_threshold : opt nat64;
+    max_message_size_bytes : opt nat64;
+    cycles_for_archive_creation : opt nat64;
+    node_max_memory_size_bytes : opt nat64;
+    controller_id : opt principal;
+    more_controller_ids : opt vec principal;
 };
 
 type AddErc20Arg = record {

--- a/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
@@ -1,6 +1,7 @@
 use crate::scheduler::Erc20Token;
 use crate::state::{Canister, Canisters};
 use candid::{CandidType, Deserialize, Nat, Principal};
+use ic_icrc1_ledger::ChangeArchiveOptions;
 use std::fmt::{Display, Formatter};
 
 #[allow(clippy::large_enum_variant)]
@@ -26,6 +27,7 @@ pub struct UpgradeArg {
     pub archive_compressed_wasm_hash: Option<String>,
     pub cycles_management: Option<UpdateCyclesManagement>,
     pub manage_ledger_suites: Option<Vec<InstalledLedgerSuite>>,
+    pub ledger_upgrade_arg: Option<LedgerUpgradeArg>,
 }
 
 impl UpgradeArg {
@@ -33,6 +35,20 @@ impl UpgradeArg {
         self.ledger_compressed_wasm_hash.is_some()
             || self.index_compressed_wasm_hash.is_some()
             || self.archive_compressed_wasm_hash.is_some()
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
+pub struct LedgerUpgradeArg {
+    pub change_archive_options: Option<ChangeArchiveOptions>,
+}
+
+impl From<LedgerUpgradeArg> for ic_icrc1_ledger::UpgradeArgs {
+    fn from(arg: LedgerUpgradeArg) -> Self {
+        ic_icrc1_ledger::UpgradeArgs {
+            change_archive_options: arg.change_archive_options,
+            ..ic_icrc1_ledger::UpgradeArgs::default()
+        }
     }
 }
 

--- a/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/candid/mod.rs
@@ -45,8 +45,11 @@ pub struct LedgerUpgradeArg {
 
 impl From<LedgerUpgradeArg> for ic_icrc1_ledger::UpgradeArgs {
     fn from(arg: LedgerUpgradeArg) -> Self {
+        let LedgerUpgradeArg {
+            change_archive_options,
+        } = arg;
         ic_icrc1_ledger::UpgradeArgs {
-            change_archive_options: arg.change_archive_options,
+            change_archive_options,
             ..ic_icrc1_ledger::UpgradeArgs::default()
         }
     }

--- a/rs/ethereum/ledger-suite-orchestrator/src/management/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/management/mod.rs
@@ -1,6 +1,6 @@
 use crate::logs::DEBUG;
 use async_trait::async_trait;
-use candid::{CandidType, Encode, Principal};
+use candid::{CandidType, Principal};
 use ic_canister_log::log;
 use ic_cdk::call::{Call, CallFailed, OnewayError, RejectCode};
 use ic_cdk_management_canister::{
@@ -170,11 +170,12 @@ pub trait CanisterRuntime {
         arg: Vec<u8>,
     ) -> Result<(), CallError>;
 
-    /// Upgrade the given canister without any upgrade arguments.
+    /// Upgrade the given canister with the given upgrade arguments.
     async fn upgrade_canister(
         &self,
         canister_id: Principal,
         wasm_module: Vec<u8>,
+        arg: Vec<u8>,
     ) -> Result<(), CallError>;
 
     async fn canister_cycles(&self, canister_id: Principal) -> Result<u128, CallError>;
@@ -297,12 +298,13 @@ impl CanisterRuntime for IcCanisterRuntime {
         &self,
         canister_id: Principal,
         wasm_module: Vec<u8>,
+        arg: Vec<u8>,
     ) -> Result<(), CallError> {
         install_code(&InstallCodeArgs {
             mode: CanisterInstallMode::Upgrade(None),
             canister_id,
             wasm_module,
-            arg: Encode!(&()).unwrap(),
+            arg,
         })
         .await
         .map_err(|err| CallError {

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -366,11 +366,18 @@ impl UpgradeLedgerSuiteSubtask {
                 let canisters = read_state(|s| s.managed_canisters(token_id).cloned())
                     .ok_or(UpgradeLedgerSuiteError::TokenNotFound(token_id.clone()))?;
                 let canister_id = ensure_canister_is_installed(token_id, canisters.index)?;
-                upgrade_canister::<Index, _>(canister_id, compressed_wasm_hash, runtime).await
+                upgrade_canister::<Index, _>(
+                    canister_id,
+                    compressed_wasm_hash,
+                    encode_empty_arg(),
+                    runtime,
+                )
+                .await
             }
             UpgradeLedgerSuiteSubtask::UpgradeLedger {
                 token_id,
                 compressed_wasm_hash,
+                ledger_upgrade_arg,
             } => {
                 log!(
                     INFO,
@@ -381,7 +388,13 @@ impl UpgradeLedgerSuiteSubtask {
                 let canisters = read_state(|s| s.managed_canisters(token_id).cloned())
                     .ok_or(UpgradeLedgerSuiteError::TokenNotFound(token_id.clone()))?;
                 let canister_id = ensure_canister_is_installed(token_id, canisters.ledger)?;
-                upgrade_canister::<Ledger, _>(canister_id, compressed_wasm_hash, runtime).await
+                upgrade_canister::<Ledger, _>(
+                    canister_id,
+                    compressed_wasm_hash,
+                    ledger_upgrade_arg.clone().unwrap_or_else(encode_empty_arg),
+                    runtime,
+                )
+                .await
             }
             UpgradeLedgerSuiteSubtask::DiscoverArchives { token_id } => {
                 log!(INFO, "Discovering archive canister(s) for {:?}", token_id);
@@ -413,8 +426,13 @@ impl UpgradeLedgerSuiteSubtask {
                 );
                 //We expect usually 0 or 1 archive, so a simple sequential strategy is good enough.
                 for canister_id in archives {
-                    upgrade_canister::<Archive, _>(canister_id, compressed_wasm_hash, runtime)
-                        .await?;
+                    upgrade_canister::<Archive, _>(
+                        canister_id,
+                        compressed_wasm_hash,
+                        encode_empty_arg(),
+                        runtime,
+                    )
+                    .await?;
                 }
                 Ok(())
             }
@@ -1289,6 +1307,7 @@ fn ensure_canister_is_installed<T>(
 async fn upgrade_canister<T: StorableWasm, R: CanisterRuntime>(
     canister_id: Principal,
     wasm_hash: &WasmHash,
+    upgrade_arg: Vec<u8>,
     runtime: &R,
 ) -> Result<(), UpgradeLedgerSuiteError> {
     let wasm = match read_wasm_store(|s| wasm_store_try_get::<T>(s, wasm_hash)) {
@@ -1310,7 +1329,7 @@ async fn upgrade_canister<T: StorableWasm, R: CanisterRuntime>(
         wasm_hash
     );
     runtime
-        .upgrade_canister(canister_id, wasm.to_bytes())
+        .upgrade_canister(canister_id, wasm.to_bytes(), upgrade_arg)
         .await
         .map_err(UpgradeLedgerSuiteError::UpgradeCanisterError)?;
 

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -4,7 +4,9 @@ pub mod test_fixtures;
 #[cfg(test)]
 mod tests;
 
-use crate::candid::{AddCkErc20Token, AddErc20Arg, CyclesManagement, LedgerInitArg, UpgradeArg};
+use crate::candid::{
+    AddCkErc20Token, AddErc20Arg, CyclesManagement, LedgerInitArg, LedgerUpgradeArg, UpgradeArg,
+};
 use crate::logs::DEBUG;
 use crate::logs::INFO;
 use crate::management::IcCanisterRuntime;
@@ -24,7 +26,9 @@ use ic_base_types::PrincipalId;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use ic_icrc1_index_ng::{IndexArg, InitArg as IndexInitArg};
-use ic_icrc1_ledger::{ArchiveOptions, InitArgs as LedgerInitArgs, LedgerArgument};
+use ic_icrc1_ledger::{
+    ArchiveOptions, InitArgs as LedgerInitArgs, LedgerArgument, UpgradeArgs as LedgerUpgradeArgs,
+};
 use icrc_ledger_types::icrc3::archive::{GetArchivesArgs, GetArchivesResult};
 pub use metrics::encode_orchestrator_metrics;
 use metrics::observe_task_duration;
@@ -447,11 +451,13 @@ pub struct UpgradeOrchestratorArgs {
     ledger_compressed_wasm_hash: Option<WasmHash>,
     index_compressed_wasm_hash: Option<WasmHash>,
     archive_compressed_wasm_hash: Option<WasmHash>,
+    ledger_upgrade_arg: Option<Vec<u8>>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum InvalidUpgradeArgError {
     WasmHashError(WasmHashError),
+    LedgerUpgradeArgRequiresLedgerWasmHash,
 }
 
 impl UpgradeOrchestratorArgs {
@@ -470,10 +476,14 @@ impl UpgradeOrchestratorArgs {
             arg.archive_compressed_wasm_hash.as_deref(),
         )
         .map_err(InvalidUpgradeArgError::WasmHashError)?;
+        if arg.ledger_upgrade_arg.is_some() && ledger_compressed_wasm_hash.is_none() {
+            return Err(InvalidUpgradeArgError::LedgerUpgradeArgRequiresLedgerWasmHash);
+        }
         Ok(UpgradeOrchestratorArgs {
             ledger_compressed_wasm_hash,
             index_compressed_wasm_hash,
             archive_compressed_wasm_hash,
+            ledger_upgrade_arg: arg.ledger_upgrade_arg.map(encode_ledger_upgrade_arg),
         })
     }
 
@@ -500,10 +510,22 @@ impl UpgradeOrchestratorArgs {
     pub fn into_task(self, token_id: TokenId) -> UpgradeLedgerSuite {
         UpgradeLedgerSuite::builder(token_id)
             .ledger_wasm_hash(self.ledger_compressed_wasm_hash)
+            .ledger_upgrade_arg(self.ledger_upgrade_arg)
             .index_wasm_hash(self.index_compressed_wasm_hash)
             .archive_wasm_hash(self.archive_compressed_wasm_hash)
             .build()
     }
+}
+
+fn encode_ledger_upgrade_arg(arg: LedgerUpgradeArg) -> Vec<u8> {
+    Encode!(&Some(LedgerArgument::Upgrade(Some(
+        LedgerUpgradeArgs::from(arg)
+    ))))
+    .expect("BUG: failed to encode ledger upgrade argument")
+}
+
+fn encode_empty_arg() -> Vec<u8> {
+    Encode!(&()).expect("BUG: failed to encode empty upgrade argument")
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -233,6 +233,50 @@ pub struct UpgradeLedgerSuite {
 }
 
 impl UpgradeLedgerSuite {
+    fn builder(token_id: TokenId) -> UpgradeLedgerSuiteBuilder {
+        UpgradeLedgerSuiteBuilder::new(token_id)
+    }
+}
+
+struct UpgradeLedgerSuiteBuilder {
+    token_id: TokenId,
+    ledger_wasm_hash: Option<WasmHash>,
+    ledger_upgrade_arg: Option<Vec<u8>>,
+    index_wasm_hash: Option<WasmHash>,
+    archive_wasm_hash: Option<WasmHash>,
+}
+
+impl UpgradeLedgerSuiteBuilder {
+    fn new(token_id: TokenId) -> Self {
+        Self {
+            token_id,
+            ledger_wasm_hash: None,
+            ledger_upgrade_arg: None,
+            index_wasm_hash: None,
+            archive_wasm_hash: None,
+        }
+    }
+
+    fn ledger_wasm_hash<T: Into<Option<WasmHash>>>(mut self, ledger_wasm_hash: T) -> Self {
+        self.ledger_wasm_hash = ledger_wasm_hash.into();
+        self
+    }
+
+    fn ledger_upgrade_arg<T: Into<Option<Vec<u8>>>>(mut self, ledger_upgrade_arg: T) -> Self {
+        self.ledger_upgrade_arg = ledger_upgrade_arg.into();
+        self
+    }
+
+    fn index_wasm_hash<T: Into<Option<WasmHash>>>(mut self, index_wasm_hash: T) -> Self {
+        self.index_wasm_hash = index_wasm_hash.into();
+        self
+    }
+
+    fn archive_wasm_hash<T: Into<Option<WasmHash>>>(mut self, archive_wasm_hash: T) -> Self {
+        self.archive_wasm_hash = archive_wasm_hash.into();
+        self
+    }
+
     /// Create a new upgrade ledger suite task containing multiple subtasks
     /// depending on which canisters need to be upgraded. Due to the dependencies between the canisters of a ledger suite, e.g.,
     /// the index pulls transactions from the ledger, the order of the subtasks is important.
@@ -251,84 +295,34 @@ impl UpgradeLedgerSuite {
     /// However, this is deemed preferable to trying to do some kind of atomic upgrade,
     /// where the ledger would be stopped before upgrading the index, since this would result in 2 canisters being stopped at the same time,
     /// which could be more problematic, especially if for some unexpected reason the upgrade fails.
-    fn new(
-        token_id: TokenId,
-        ledger_compressed_wasm_hash: Option<WasmHash>,
-        index_compressed_wasm_hash: Option<WasmHash>,
-        archive_compressed_wasm_hash: Option<WasmHash>,
-    ) -> Self {
+    fn build(self) -> UpgradeLedgerSuite {
         let mut subtasks = Vec::new();
-        if let Some(index_compressed_wasm_hash) = index_compressed_wasm_hash {
+        if let Some(index_wasm_hash) = self.index_wasm_hash {
             subtasks.push(UpgradeLedgerSuiteSubtask::UpgradeIndex {
-                token_id: token_id.clone(),
-                compressed_wasm_hash: index_compressed_wasm_hash,
+                token_id: self.token_id.clone(),
+                compressed_wasm_hash: index_wasm_hash,
             });
         }
-        if let Some(ledger_compressed_wasm_hash) = ledger_compressed_wasm_hash {
+        if let Some(ledger_wasm_hash) = self.ledger_wasm_hash {
             subtasks.push(UpgradeLedgerSuiteSubtask::UpgradeLedger {
-                token_id: token_id.clone(),
-                compressed_wasm_hash: ledger_compressed_wasm_hash,
+                token_id: self.token_id.clone(),
+                compressed_wasm_hash: ledger_wasm_hash,
+                ledger_upgrade_arg: self.ledger_upgrade_arg,
             });
         }
-        if let Some(archive_compressed_wasm_hash) = archive_compressed_wasm_hash {
+        if let Some(archive_wasm_hash) = self.archive_wasm_hash {
             subtasks.push(UpgradeLedgerSuiteSubtask::DiscoverArchives {
-                token_id: token_id.clone(),
+                token_id: self.token_id.clone(),
             });
             subtasks.push(UpgradeLedgerSuiteSubtask::UpgradeArchives {
-                token_id: token_id.clone(),
-                compressed_wasm_hash: archive_compressed_wasm_hash,
+                token_id: self.token_id.clone(),
+                compressed_wasm_hash: archive_wasm_hash,
             });
         }
-        Self {
+        UpgradeLedgerSuite {
             subtasks,
             next_subtask_index: 0,
         }
-    }
-
-    fn builder(token_id: TokenId) -> UpgradeLedgerSuiteBuilder {
-        UpgradeLedgerSuiteBuilder::new(token_id)
-    }
-}
-
-struct UpgradeLedgerSuiteBuilder {
-    token_id: TokenId,
-    ledger_wasm_hash: Option<WasmHash>,
-    index_wasm_hash: Option<WasmHash>,
-    archive_wasm_hash: Option<WasmHash>,
-}
-
-impl UpgradeLedgerSuiteBuilder {
-    fn new(token_id: TokenId) -> Self {
-        Self {
-            token_id,
-            ledger_wasm_hash: None,
-            index_wasm_hash: None,
-            archive_wasm_hash: None,
-        }
-    }
-
-    fn ledger_wasm_hash<T: Into<Option<WasmHash>>>(mut self, ledger_wasm_hash: T) -> Self {
-        self.ledger_wasm_hash = ledger_wasm_hash.into();
-        self
-    }
-
-    fn index_wasm_hash<T: Into<Option<WasmHash>>>(mut self, index_wasm_hash: T) -> Self {
-        self.index_wasm_hash = index_wasm_hash.into();
-        self
-    }
-
-    fn archive_wasm_hash<T: Into<Option<WasmHash>>>(mut self, archive_wasm_hash: T) -> Self {
-        self.archive_wasm_hash = archive_wasm_hash.into();
-        self
-    }
-
-    fn build(self) -> UpgradeLedgerSuite {
-        UpgradeLedgerSuite::new(
-            self.token_id,
-            self.ledger_wasm_hash,
-            self.index_wasm_hash,
-            self.archive_wasm_hash,
-        )
     }
 }
 
@@ -341,6 +335,8 @@ pub enum UpgradeLedgerSuiteSubtask {
     UpgradeLedger {
         token_id: TokenId,
         compressed_wasm_hash: WasmHash,
+        #[serde(default)]
+        ledger_upgrade_arg: Option<Vec<u8>>,
     },
     DiscoverArchives {
         token_id: TokenId,

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -1752,11 +1752,10 @@ mod install_ledger_suite_args {
     use crate::scheduler::tests::{MINTER_PRINCIPAL, usdc_metadata};
     use crate::scheduler::{ChainId, Erc20Token, InstallLedgerSuiteArgs, InvalidAddErc20ArgError};
     use crate::state::test_fixtures::{expect_panic_with_message, new_state, new_state_from};
-    use crate::state::{GitCommitHash, IndexWasm, LedgerSuiteVersion, LedgerWasm, WasmHash};
+    use crate::state::{IndexWasm, LedgerSuiteVersion, LedgerWasm, WasmHash};
     use crate::storage::test_fixtures::{
-        embedded_ledger_suite_version, empty_task_queue, empty_wasm_store,
+        embedded_ledger_suite_version, empty_task_queue, wasm_store_with_icrc1_ledger_suite,
     };
-    use crate::storage::{WasmStore, record_icrc1_ledger_suite_wasms};
     use assert_matches::assert_matches;
     use candid::Nat;
     use proptest::collection::vec;
@@ -1949,17 +1948,203 @@ mod install_ledger_suite_args {
             },
         }
     }
+}
 
-    fn wasm_store_with_icrc1_ledger_suite() -> WasmStore {
-        let mut store = empty_wasm_store();
-        assert_eq!(
-            record_icrc1_ledger_suite_wasms(
-                &mut store,
-                1_620_328_630_000_000_000,
-                GitCommitHash::default(),
-            ),
-            Ok(embedded_ledger_suite_version())
+mod validate_upgrade_arg {
+    use crate::candid::{LedgerUpgradeArg, UpgradeArg};
+    use crate::scheduler::{InvalidUpgradeArgError, UpgradeOrchestratorArgs};
+    use crate::storage::test_fixtures::{
+        embedded_ledger_suite_version, wasm_store_with_icrc1_ledger_suite,
+    };
+    use assert_matches::assert_matches;
+    use candid::Decode;
+    use ic_icrc1_ledger::{ChangeArchiveOptions, LedgerArgument, UpgradeArgs as LedgerUpgradeArgs};
+
+    #[test]
+    fn should_error_when_ledger_upgrade_arg_without_ledger_wasm_hash() {
+        let wasm_store = wasm_store_with_icrc1_ledger_suite();
+        let arg = UpgradeArg {
+            ledger_upgrade_arg: Some(raise_trigger_threshold()),
+            ..Default::default()
+        };
+
+        assert_matches!(
+            UpgradeOrchestratorArgs::validate_upgrade_arg(&wasm_store, arg),
+            Err(InvalidUpgradeArgError::LedgerUpgradeArgRequiresLedgerWasmHash)
         );
-        store
+    }
+
+    #[test]
+    fn should_accept_ledger_upgrade_arg_with_ledger_wasm_hash() {
+        let wasm_store = wasm_store_with_icrc1_ledger_suite();
+        let arg = UpgradeArg {
+            ledger_compressed_wasm_hash: Some(embedded_ledger_wasm_hash()),
+            ledger_upgrade_arg: Some(raise_trigger_threshold()),
+            ..Default::default()
+        };
+
+        let validated_args =
+            UpgradeOrchestratorArgs::validate_upgrade_arg(&wasm_store, arg).unwrap();
+
+        assert!(validated_args.upgrade_ledger_suite());
+    }
+
+    #[test]
+    fn should_encode_ledger_upgrade_arg_as_ledger_argument() {
+        let wasm_store = wasm_store_with_icrc1_ledger_suite();
+        let change_archive_options = ChangeArchiveOptions {
+            trigger_threshold: Some(20_000),
+            ..Default::default()
+        };
+        let arg = UpgradeArg {
+            ledger_compressed_wasm_hash: Some(embedded_ledger_wasm_hash()),
+            ledger_upgrade_arg: Some(LedgerUpgradeArg {
+                change_archive_options: Some(change_archive_options.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let validated_args =
+            UpgradeOrchestratorArgs::validate_upgrade_arg(&wasm_store, arg).unwrap();
+
+        let encoded_arg = validated_args.ledger_upgrade_arg.unwrap();
+        assert_eq!(
+            Decode!(&encoded_arg, Option<LedgerArgument>).unwrap(),
+            Some(LedgerArgument::Upgrade(Some(LedgerUpgradeArgs {
+                change_archive_options: Some(change_archive_options),
+                ..Default::default()
+            })))
+        );
+    }
+
+    #[test]
+    fn should_have_no_encoded_arg_when_ledger_upgrade_arg_absent() {
+        let wasm_store = wasm_store_with_icrc1_ledger_suite();
+        let arg = UpgradeArg {
+            ledger_compressed_wasm_hash: Some(embedded_ledger_wasm_hash()),
+            ..Default::default()
+        };
+
+        let validated_args =
+            UpgradeOrchestratorArgs::validate_upgrade_arg(&wasm_store, arg).unwrap();
+
+        assert_eq!(validated_args.ledger_upgrade_arg, None);
+    }
+
+    fn raise_trigger_threshold() -> LedgerUpgradeArg {
+        LedgerUpgradeArg {
+            change_archive_options: Some(ChangeArchiveOptions {
+                trigger_threshold: Some(20_000),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn embedded_ledger_wasm_hash() -> String {
+        embedded_ledger_suite_version()
+            .ledger_compressed_wasm_hash
+            .to_string()
+    }
+}
+
+mod schema_upgrades {
+    use crate::scheduler::test_fixtures::usdc_token_id;
+    use crate::scheduler::{UpgradeLedgerSuite, UpgradeLedgerSuiteSubtask};
+    use crate::state::{TokenId, WasmHash, decode, encode};
+    use candid::Deserialize;
+    use serde::Serialize;
+
+    #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+    pub struct UpgradeLedgerSuitePreviousVersion {
+        subtasks: Vec<UpgradeLedgerSuiteSubtaskPreviousVersion>,
+        next_subtask_index: usize,
+    }
+
+    impl From<UpgradeLedgerSuite> for UpgradeLedgerSuitePreviousVersion {
+        fn from(value: UpgradeLedgerSuite) -> Self {
+            Self {
+                subtasks: value.subtasks.into_iter().map(Into::into).collect(),
+                next_subtask_index: value.next_subtask_index,
+            }
+        }
+    }
+
+    #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+    pub enum UpgradeLedgerSuiteSubtaskPreviousVersion {
+        UpgradeIndex {
+            token_id: TokenId,
+            compressed_wasm_hash: WasmHash,
+        },
+        UpgradeLedger {
+            token_id: TokenId,
+            compressed_wasm_hash: WasmHash,
+        },
+        DiscoverArchives {
+            token_id: TokenId,
+        },
+        UpgradeArchives {
+            token_id: TokenId,
+            compressed_wasm_hash: WasmHash,
+        },
+    }
+
+    impl From<UpgradeLedgerSuiteSubtask> for UpgradeLedgerSuiteSubtaskPreviousVersion {
+        fn from(value: UpgradeLedgerSuiteSubtask) -> Self {
+            match value {
+                UpgradeLedgerSuiteSubtask::UpgradeIndex {
+                    token_id,
+                    compressed_wasm_hash,
+                } => Self::UpgradeIndex {
+                    token_id,
+                    compressed_wasm_hash,
+                },
+                UpgradeLedgerSuiteSubtask::UpgradeLedger {
+                    token_id,
+                    compressed_wasm_hash,
+                    ledger_upgrade_arg: _,
+                } => Self::UpgradeLedger {
+                    token_id,
+                    compressed_wasm_hash,
+                },
+                UpgradeLedgerSuiteSubtask::DiscoverArchives { token_id } => {
+                    Self::DiscoverArchives { token_id }
+                }
+                UpgradeLedgerSuiteSubtask::UpgradeArchives {
+                    token_id,
+                    compressed_wasm_hash,
+                } => Self::UpgradeArchives {
+                    token_id,
+                    compressed_wasm_hash,
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn should_decode_upgrade_ledger_suite_task_from_previous_version() {
+        let task_before_upgrade: UpgradeLedgerSuitePreviousVersion =
+            UpgradeLedgerSuite::builder(usdc_token_id())
+                .ledger_wasm_hash(WasmHash::from([1_u8; 32]))
+                .index_wasm_hash(WasmHash::from([2_u8; 32]))
+                .archive_wasm_hash(WasmHash::from([3_u8; 32]))
+                .build()
+                .into();
+
+        let serialized_task_before_upgrade = encode(&task_before_upgrade);
+        let task_after_upgrade: UpgradeLedgerSuite =
+            decode(serialized_task_before_upgrade.as_slice());
+
+        assert_eq!(task_before_upgrade, task_after_upgrade.clone().into());
+        assert!(
+            task_after_upgrade
+                .subtasks
+                .iter()
+                .all(|subtask| match subtask {
+                    UpgradeLedgerSuiteSubtask::UpgradeLedger {
+                        ledger_upgrade_arg, ..
+                    } => ledger_upgrade_arg.is_none(),
+                    _ => true,
+                })
+        );
     }
 }

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -765,7 +765,8 @@ mod upgrade_ledger_suite {
             subtasks,
             vec![UpgradeLedger {
                 token_id: usdc_token_id(),
-                compressed_wasm_hash: ledger_wasm_hash.clone()
+                compressed_wasm_hash: ledger_wasm_hash.clone(),
+                ledger_upgrade_arg: None,
             },]
         );
 
@@ -795,7 +796,8 @@ mod upgrade_ledger_suite {
                 },
                 UpgradeLedger {
                     token_id: usdc_token_id(),
-                    compressed_wasm_hash: ledger_wasm_hash.clone()
+                    compressed_wasm_hash: ledger_wasm_hash.clone(),
+                    ledger_upgrade_arg: None,
                 },
             ]
         );
@@ -827,7 +829,8 @@ mod upgrade_ledger_suite {
             vec![
                 UpgradeLedger {
                     token_id: usdc_token_id(),
-                    compressed_wasm_hash: ledger_wasm_hash.clone()
+                    compressed_wasm_hash: ledger_wasm_hash.clone(),
+                    ledger_upgrade_arg: None,
                 },
                 DiscoverArchives {
                     token_id: usdc_token_id()
@@ -876,7 +879,8 @@ mod upgrade_ledger_suite {
                 },
                 UpgradeLedger {
                     token_id: usdc_token_id(),
-                    compressed_wasm_hash: ledger_wasm_hash.clone()
+                    compressed_wasm_hash: ledger_wasm_hash.clone(),
+                    ledger_upgrade_arg: None,
                 },
                 DiscoverArchives {
                     token_id: usdc_token_id()
@@ -887,6 +891,80 @@ mod upgrade_ledger_suite {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn should_attach_ledger_upgrade_arg_to_ledger_subtask_only() {
+        let ledger_wasm_hash = WasmHash::from([1_u8; 32]);
+        let index_wasm_hash = WasmHash::from([2_u8; 32]);
+        let archive_wasm_hash = WasmHash::from([3_u8; 32]);
+        let ledger_upgrade_arg = vec![4_u8, 5, 6];
+
+        let subtasks: Vec<_> = UpgradeLedgerSuite::builder(usdc_token_id())
+            .ledger_wasm_hash(ledger_wasm_hash.clone())
+            .ledger_upgrade_arg(ledger_upgrade_arg.clone())
+            .index_wasm_hash(index_wasm_hash.clone())
+            .archive_wasm_hash(archive_wasm_hash.clone())
+            .build()
+            .collect();
+
+        assert_eq!(
+            subtasks,
+            vec![
+                UpgradeIndex {
+                    token_id: usdc_token_id(),
+                    compressed_wasm_hash: index_wasm_hash
+                },
+                UpgradeLedger {
+                    token_id: usdc_token_id(),
+                    compressed_wasm_hash: ledger_wasm_hash,
+                    ledger_upgrade_arg: Some(ledger_upgrade_arg),
+                },
+                DiscoverArchives {
+                    token_id: usdc_token_id()
+                },
+                UpgradeArchives {
+                    token_id: usdc_token_id(),
+                    compressed_wasm_hash: archive_wasm_hash
+                }
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn should_upgrade_ledger_with_ledger_upgrade_arg() {
+        init_state();
+        let usdc = usdc();
+        let usdc_token_id = TokenId::from(usdc.clone());
+        mutate_state(|s| {
+            s.record_new_erc20_token(usdc.clone(), usdc_metadata());
+            s.record_created_canister::<Ledger>(&usdc, LEDGER_PRINCIPAL);
+            s.record_installed_canister::<Ledger>(&usdc, WasmHash::default());
+        });
+        let mut runtime = MockCanisterRuntime::new();
+        let ledger_upgrade_arg = vec![4_u8, 5, 6];
+        let task = Task::UpgradeLedgerSuite(
+            UpgradeLedgerSuite::builder(usdc_token_id)
+                .ledger_wasm_hash(read_ledger_wasm_hash())
+                .ledger_upgrade_arg(ledger_upgrade_arg.clone())
+                .build(),
+        );
+
+        expect_stop_canister(&mut runtime, LEDGER_PRINCIPAL, Ok(()));
+        expect_upgrade_canister(
+            &mut runtime,
+            LEDGER_PRINCIPAL,
+            LEDGER_BYTECODE.to_vec(),
+            ledger_upgrade_arg,
+            Ok(()),
+        );
+        expect_start_canister(&mut runtime, LEDGER_PRINCIPAL, Ok(()));
+        runtime.expect_time().return_const(0_u64);
+
+        let result = execute_now(task.clone(), &runtime).await;
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(task_queue_from_state(), vec![]);
     }
 
     #[test]

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -733,7 +733,7 @@ mod upgrade_ledger_suite {
     };
     use crate::scheduler::{
         Task, TaskError, UpgradeLedgerSuite, UpgradeLedgerSuiteError, UpgradeLedgerSuiteSubtask,
-        pop_if_ready,
+        encode_empty_arg, pop_if_ready,
     };
     use crate::state::{
         ARCHIVE_NODE_BYTECODE, CanisterUpgrade, INDEX_BYTECODE, Index, LEDGER_BYTECODE, Ledger,
@@ -1146,6 +1146,7 @@ mod upgrade_ledger_suite {
             &mut runtime,
             INDEX_PRINCIPAL,
             INDEX_BYTECODE.to_vec(),
+            encode_empty_arg(),
             Ok(()),
         );
         expect_start_canister(&mut runtime, INDEX_PRINCIPAL, Ok(()));
@@ -1165,6 +1166,7 @@ mod upgrade_ledger_suite {
             &mut runtime,
             LEDGER_PRINCIPAL,
             LEDGER_BYTECODE.to_vec(),
+            encode_empty_arg(),
             Ok(()),
         );
         expect_start_canister(&mut runtime, LEDGER_PRINCIPAL, Ok(()));
@@ -1209,6 +1211,7 @@ mod upgrade_ledger_suite {
             &mut runtime,
             INDEX_PRINCIPAL,
             INDEX_BYTECODE.to_vec(),
+            encode_empty_arg(),
             Ok(()),
         );
         expect_start_canister(&mut runtime, INDEX_PRINCIPAL, Ok(()));
@@ -1229,6 +1232,7 @@ mod upgrade_ledger_suite {
             &mut runtime,
             LEDGER_PRINCIPAL,
             LEDGER_BYTECODE.to_vec(),
+            encode_empty_arg(),
             Ok(()),
         );
         expect_start_canister(&mut runtime, LEDGER_PRINCIPAL, Ok(()));
@@ -1277,6 +1281,7 @@ mod upgrade_ledger_suite {
                 &mut runtime,
                 archive,
                 ARCHIVE_NODE_BYTECODE.to_vec(),
+                encode_empty_arg(),
                 Ok(()),
             );
             expect_start_canister(&mut runtime, archive, Ok(()));
@@ -1315,11 +1320,14 @@ mod upgrade_ledger_suite {
         runtime: &mut MockCanisterRuntime,
         canister_id: Principal,
         wasm_module: Vec<u8>,
+        upgrade_arg: Vec<u8>,
         mocked_result: Result<(), CallError>,
     ) {
         runtime
             .expect_upgrade_canister()
-            .withf(move |&id, module| id == canister_id && module == &wasm_module)
+            .withf(move |&id, module, arg| {
+                id == canister_id && module == &wasm_module && arg == &upgrade_arg
+            })
             .times(1)
             .return_const(mocked_result);
     }
@@ -1798,7 +1806,8 @@ mod mock {
             async fn upgrade_canister(
                 &self,
                 canister_id: Principal,
-                wasm_module:Vec<u8>,
+                wasm_module: Vec<u8>,
+                arg: Vec<u8>,
             ) -> Result<(), CallError>;
 
             async fn canister_cycles(

--- a/rs/ethereum/ledger-suite-orchestrator/src/state/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/state/mod.rs
@@ -504,13 +504,13 @@ impl Storable for ConfigState {
     const BOUND: Bound = Bound::Unbounded;
 }
 
-fn encode<S: ?Sized + serde::Serialize>(state: &S) -> Vec<u8> {
+pub(crate) fn encode<S: ?Sized + serde::Serialize>(state: &S) -> Vec<u8> {
     let mut buf = vec![];
     ciborium::ser::into_writer(state, &mut buf).expect("failed to encode state");
     buf
 }
 
-fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
+pub(crate) fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
     ciborium::de::from_reader(bytes)
         .unwrap_or_else(|e| panic!("failed to decode state bytes {}: {e}", hex::encode(bytes)))
 }

--- a/rs/ethereum/ledger-suite-orchestrator/src/storage/test_fixtures.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/storage/test_fixtures.rs
@@ -1,5 +1,7 @@
+use crate::state::GitCommitHash;
 use crate::storage::{
     ArchiveWasm, IndexWasm, LedgerSuiteVersion, LedgerWasm, TaskQueue, WasmStore,
+    record_icrc1_ledger_suite_wasms,
 };
 use ic_stable_structures::BTreeMap;
 use ic_stable_structures::DefaultMemoryImpl;
@@ -7,6 +9,20 @@ use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
 
 pub fn empty_wasm_store() -> WasmStore {
     WasmStore::init(MemoryManager::init(DefaultMemoryImpl::default()).get(MemoryId::new(0)))
+}
+
+pub fn wasm_store_with_icrc1_ledger_suite() -> WasmStore {
+    const RECORDING_TIMESTAMP_NS: u64 = 1_620_328_630_000_000_000;
+    let mut store = empty_wasm_store();
+    assert_eq!(
+        record_icrc1_ledger_suite_wasms(
+            &mut store,
+            RECORDING_TIMESTAMP_NS,
+            GitCommitHash::default(),
+        ),
+        Ok(embedded_ledger_suite_version())
+    );
+    store
 }
 
 pub fn empty_task_queue() -> TaskQueue {

--- a/rs/ethereum/ledger-suite-orchestrator/src/storage/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/storage/tests.rs
@@ -86,11 +86,11 @@ proptest! {
 }
 
 mod validate_wasm_hashes {
-    use crate::state::{GitCommitHash, WasmHash};
-    use crate::storage::test_fixtures::{embedded_ledger_suite_version, empty_wasm_store};
-    use crate::storage::{
-        WasmHashError, WasmStore, record_icrc1_ledger_suite_wasms, validate_wasm_hashes,
+    use crate::state::WasmHash;
+    use crate::storage::test_fixtures::{
+        embedded_ledger_suite_version, empty_wasm_store, wasm_store_with_icrc1_ledger_suite,
     };
+    use crate::storage::{WasmHashError, validate_wasm_hashes};
     use assert_matches::assert_matches;
     use proptest::array::uniform32;
     use proptest::prelude::any;
@@ -207,19 +207,6 @@ mod validate_wasm_hashes {
                 Some(archive_hash.parse().unwrap())
             ])
         );
-    }
-
-    fn wasm_store_with_icrc1_ledger_suite() -> WasmStore {
-        let mut store = empty_wasm_store();
-        assert_eq!(
-            record_icrc1_ledger_suite_wasms(
-                &mut store,
-                1_620_328_630_000_000_000,
-                GitCommitHash::default(),
-            ),
-            Ok(embedded_ledger_suite_version())
-        );
-        store
     }
 
     fn valid_wasm_hashes() -> (String, String, String) {

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/flow.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/flow.rs
@@ -46,6 +46,8 @@ impl AddErc20TokenFlow {
     }
 }
 
+pub const ARCHIVE_TRIGGER_THRESHOLD: usize = 10;
+
 pub struct ManagedCanistersAssert {
     pub setup: LedgerSuiteOrchestrator,
     pub canister_ids: ManagedCanisterIds,
@@ -78,8 +80,6 @@ impl ManagedCanistersAssert {
     }
 
     pub fn trigger_creation_of_archive(self) -> Self {
-        const ARCHIVE_TRIGGER_THRESHOLD: usize = 10;
-
         // The productive value for `trigger_threshold` is `2_000`,
         // which would require `2_000` transfers to trigger the creation of an archive.
         // We set this value to an artificially low number to speed up the test.
@@ -87,28 +87,17 @@ impl ManagedCanistersAssert {
             trigger_threshold: Some(ARCHIVE_TRIGGER_THRESHOLD),
             ..Default::default()
         });
+        self.trigger_creation_of_archive_by_transfers(ARCHIVE_TRIGGER_THRESHOLD)
+    }
+
+    pub fn trigger_creation_of_archive_by_transfers(self, number_of_transfers: usize) -> Self {
         let archive_ids_before: BTreeSet<_> = self
             .call_ledger_archives()
             .into_iter()
             .map(|info| info.canister_id)
             .collect();
 
-        for _i in 0..ARCHIVE_TRIGGER_THRESHOLD {
-            let from = MINTER_PRINCIPAL;
-            let to = Principal::management_canister();
-            self.call_ledger_icrc1_transfer(
-                from,
-                &TransferArg {
-                    from_subaccount: None,
-                    to: to.into(),
-                    fee: None,
-                    created_at_time: None,
-                    memo: None,
-                    amount: Nat::from(1_u8),
-                },
-            )
-            .expect("BUG: fail to make a transfer to trigger archive creation");
-        }
+        self.make_transfers(number_of_transfers);
 
         let archive_ids_after: BTreeSet<_> = self
             .call_ledger_archives()
@@ -129,6 +118,25 @@ impl ManagedCanistersAssert {
                 index: self.canister_ids.index,
                 archives: Vec::from_iter(archive_ids_after),
             },
+        }
+    }
+
+    pub fn make_transfers(&self, number_of_transfers: usize) {
+        for _i in 0..number_of_transfers {
+            let from = MINTER_PRINCIPAL;
+            let to = Principal::management_canister();
+            self.call_ledger_icrc1_transfer(
+                from,
+                &TransferArg {
+                    from_subaccount: None,
+                    to: to.into(),
+                    fee: None,
+                    created_at_time: None,
+                    memo: None,
+                    amount: Nat::from(1_u8),
+                },
+            )
+            .expect("BUG: fail to make a transfer");
         }
     }
 
@@ -283,7 +291,7 @@ impl ManagedCanistersAssert {
         .expect("failed to decode icrc3_get_blocks response")
     }
 
-    fn call_ledger_archives(&self) -> Vec<ArchiveInfo> {
+    pub fn call_ledger_archives(&self) -> Vec<ArchiveInfo> {
         Decode!(
             &self
                 .setup

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/mod.rs
@@ -100,6 +100,7 @@ impl LedgerSuiteOrchestrator {
                 archive_compressed_wasm_hash: None,
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         ))
     }
@@ -176,6 +177,7 @@ impl LedgerSuiteOrchestrator {
                 archive_compressed_wasm_hash: None,
                 cycles_management: None,
                 manage_ledger_suites: Some(manage_installed_canister),
+                ledger_upgrade_arg: None,
             },
         ))
     }

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -120,6 +120,7 @@ fn should_change_cycles_for_canister_creation() {
                     ..Default::default()
                 }),
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         ))
         .unwrap();
@@ -265,6 +266,7 @@ fn should_reject_upgrade_with_invalid_args() {
         archive_compressed_wasm_hash: None,
         cycles_management: None,
         manage_ledger_suites: None,
+        ledger_upgrade_arg: None,
     };
 
     test_upgrade_with_invalid_args(
@@ -549,6 +551,7 @@ fn should_not_change_ledger_suite_version_when_registering_embedded_wasms_a_seco
             archive_compressed_wasm_hash: None,
             cycles_management: None,
             manage_ledger_suites: None,
+            ledger_upgrade_arg: None,
         },
     );
 
@@ -663,6 +666,7 @@ mod upgrade {
                 archive_compressed_wasm_hash: None,
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         );
 
@@ -818,6 +822,7 @@ mod upgrade {
                 archive_compressed_wasm_hash: Some(embedded_archive_wasm_hash.to_string()),
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         );
         orchestrator.advance_time_for_upgrade();
@@ -914,6 +919,7 @@ mod upgrade {
                 archive_compressed_wasm_hash: Some(embedded_archive_wasm_hash.to_string()),
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         );
 
@@ -985,6 +991,7 @@ mod upgrade {
                 archive_compressed_wasm_hash: None,
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         );
 
@@ -1047,6 +1054,7 @@ mod upgrade {
                     archive_compressed_wasm_hash: None,
                     cycles_management: None,
                     manage_ledger_suites: None,
+                    ledger_upgrade_arg: None,
                 },
             );
 
@@ -1123,6 +1131,7 @@ mod upgrade {
                 archive_compressed_wasm_hash: Some(embedded_archive_wasm_hash.to_string()),
                 cycles_management: None,
                 manage_ledger_suites: None,
+                ledger_upgrade_arg: None,
             },
         );
 
@@ -1217,6 +1226,7 @@ mod upgrade {
                     index: index.clone(),
                     archives: None,
                 }]),
+                ledger_upgrade_arg: None,
             },
         );
 

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -2,11 +2,13 @@ use assert_matches::assert_matches;
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::PrincipalId;
 use ic_http_types::{HttpRequest, HttpResponse};
+use ic_icrc1_ledger::ChangeArchiveOptions;
 use ic_ledger_suite_orchestrator::candid::{
-    AddErc20Arg, CyclesManagement, LedgerInitArg, LedgerSuiteVersion, ManagedCanisterStatus,
-    ManagedCanisters, ManagedLedgerSuite, OrchestratorArg, OrchestratorInfo,
+    AddErc20Arg, CyclesManagement, LedgerInitArg, LedgerSuiteVersion, LedgerUpgradeArg,
+    ManagedCanisterStatus, ManagedCanisters, ManagedLedgerSuite, OrchestratorArg, OrchestratorInfo,
     UpdateCyclesManagement, UpgradeArg,
 };
+use ic_ledger_suite_orchestrator_test_utils::pocket_ic::flow::ARCHIVE_TRIGGER_THRESHOLD;
 use ic_ledger_suite_orchestrator_test_utils::pocket_ic::{LedgerSuiteOrchestrator, new_pocket_ic};
 use ic_ledger_suite_orchestrator_test_utils::{
     GIT_COMMIT_HASH_UPGRADE, MINTER_PRINCIPAL, NNS_ROOT_PRINCIPAL, cketh_installed_canisters,
@@ -299,6 +301,20 @@ fn should_reject_upgrade_with_invalid_args() {
                 cketh_installed_canisters(),
                 cketh_installed_canisters(), //erroneous duplicate entry
             ]),
+            ..valid_upgrade_arg.clone()
+        }),
+    );
+
+    test_upgrade_with_invalid_args(
+        &orchestrator,
+        &OrchestratorArg::UpgradeArg(UpgradeArg {
+            ledger_compressed_wasm_hash: None,
+            ledger_upgrade_arg: Some(LedgerUpgradeArg {
+                change_archive_options: Some(ChangeArchiveOptions {
+                    trigger_threshold: Some(20_000),
+                    ..Default::default()
+                }),
+            }),
             ..valid_upgrade_arg.clone()
         }),
     );
@@ -669,6 +685,81 @@ mod upgrade {
             );
             assert_eq!(status.status, CanisterStatusType::Running);
         }
+    }
+
+    #[test]
+    fn should_change_archive_options_of_ledger_without_spawned_archive() {
+        let orchestrator = LedgerSuiteOrchestrator::default().register_embedded_wasms();
+        let embedded_ledger_wasm_hash = orchestrator.embedded_ledger_wasm_hash.clone();
+        let managed_canisters = orchestrator
+            .add_erc20_token(usdc())
+            .expect_new_ledger_and_index_canisters();
+        assert!(managed_canisters.call_ledger_archives().is_empty());
+
+        let orchestrator = managed_canisters.setup.upgrade_ledger_suite_orchestrator(
+            ledger_suite_orchestrator_wasm(),
+            UpgradeArg {
+                git_commit_hash: Some(GIT_COMMIT_HASH_UPGRADE.to_string()),
+                ledger_compressed_wasm_hash: Some(embedded_ledger_wasm_hash.to_string()),
+                index_compressed_wasm_hash: None,
+                archive_compressed_wasm_hash: None,
+                cycles_management: None,
+                manage_ledger_suites: None,
+                ledger_upgrade_arg: Some(LedgerUpgradeArg {
+                    change_archive_options: Some(ChangeArchiveOptions {
+                        trigger_threshold: Some(ARCHIVE_TRIGGER_THRESHOLD),
+                        ..Default::default()
+                    }),
+                }),
+            },
+        );
+        orchestrator.advance_time_for_upgrade();
+
+        orchestrator
+            .assert_managed_canisters(&usdc_erc20_contract())
+            .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash)
+            .trigger_creation_of_archive_by_transfers(ARCHIVE_TRIGGER_THRESHOLD);
+    }
+
+    #[test]
+    fn should_stop_archiving_when_trigger_threshold_raised() {
+        const RAISED_TRIGGER_THRESHOLD: usize = 1_000_000;
+
+        let orchestrator = LedgerSuiteOrchestrator::default().register_embedded_wasms();
+        let embedded_ledger_wasm_hash = orchestrator.embedded_ledger_wasm_hash.clone();
+        let managed_canisters = orchestrator
+            .add_erc20_token(usdc())
+            .expect_new_ledger_and_index_canisters()
+            .trigger_creation_of_archive();
+        let archives_before = managed_canisters.call_ledger_archives();
+        assert!(!archives_before.is_empty());
+
+        let orchestrator = managed_canisters.setup.upgrade_ledger_suite_orchestrator(
+            ledger_suite_orchestrator_wasm(),
+            UpgradeArg {
+                git_commit_hash: Some(GIT_COMMIT_HASH_UPGRADE.to_string()),
+                ledger_compressed_wasm_hash: Some(embedded_ledger_wasm_hash.to_string()),
+                index_compressed_wasm_hash: None,
+                archive_compressed_wasm_hash: None,
+                cycles_management: None,
+                manage_ledger_suites: None,
+                ledger_upgrade_arg: Some(LedgerUpgradeArg {
+                    change_archive_options: Some(ChangeArchiveOptions {
+                        trigger_threshold: Some(RAISED_TRIGGER_THRESHOLD),
+                        num_blocks_to_archive: Some(RAISED_TRIGGER_THRESHOLD),
+                        ..Default::default()
+                    }),
+                }),
+            },
+        );
+        orchestrator.advance_time_for_upgrade();
+
+        let managed_canisters = orchestrator
+            .assert_managed_canisters(&usdc_erc20_contract())
+            .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash);
+        managed_canisters.make_transfers(10 * ARCHIVE_TRIGGER_THRESHOLD);
+
+        assert_eq!(managed_canisters.call_ledger_archives(), archives_before);
     }
 
     #[test]

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -750,7 +750,6 @@ mod upgrade {
                 ledger_upgrade_arg: Some(LedgerUpgradeArg {
                     change_archive_options: Some(ChangeArchiveOptions {
                         trigger_threshold: Some(RAISED_TRIGGER_THRESHOLD),
-                        num_blocks_to_archive: Some(RAISED_TRIGGER_THRESHOLD),
                         ..Default::default()
                     }),
                 }),

--- a/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/tests/tests.rs
@@ -760,9 +760,32 @@ mod upgrade {
         let managed_canisters = orchestrator
             .assert_managed_canisters(&usdc_erc20_contract())
             .assert_ledger_has_wasm_hash(&embedded_ledger_wasm_hash);
-        managed_canisters.make_transfers(10 * ARCHIVE_TRIGGER_THRESHOLD);
+        let log_length_before = managed_canisters
+            .call_ledger_icrc3_get_blocks(&Vec::new())
+            .log_length;
+        let number_of_transfers = 10 * ARCHIVE_TRIGGER_THRESHOLD;
+        managed_canisters.make_transfers(number_of_transfers);
 
         assert_eq!(managed_canisters.call_ledger_archives(), archives_before);
+        let new_blocks = managed_canisters.call_ledger_icrc3_get_blocks(&vec![GetBlocksRequest {
+            start: log_length_before.clone(),
+            length: Nat::from(number_of_transfers),
+        }]);
+        assert_eq!(
+            new_blocks.log_length,
+            log_length_before.clone() + Nat::from(number_of_transfers)
+        );
+        assert!(new_blocks.archived_blocks.is_empty());
+        assert_eq!(
+            new_blocks
+                .blocks
+                .iter()
+                .map(|block| block.id.clone())
+                .collect::<Vec<_>>(),
+            (0..number_of_transfers)
+                .map(|i| log_length_before.clone() + Nat::from(i))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

* Awaiting `archive_blocks` before replying makes archiving a commit point on the ledger transaction path. A trap there turns a committed transaction into a reject. The ck minters read that as "the mint did not happen" and retry, risking a double mint (DEFI-2967).
* The agreed stopgap is to disable archiving by raising the ledgers' `trigger_threshold` via an upgrade argument. This was already done for ckBTC via per-canister proposal 143757. The ckEVM ledger suites are only upgradable through the ledger suite orchestrator.

## What

* The orchestrator upgrade argument can now carry an optional ledger upgrade argument, currently limited to `change_archive_options`. It is forwarded to every managed ledger when the ledgers are upgraded.
* It requires the ledger wasm hash to be set in the same upgrade argument. Validation rejects it otherwise. The hash may be any registered version: the DEFI-2986 proposals will pass the currently-installed one, but the argument can also accompany a real version bump.
* Index and archive canisters keep the empty upgrade argument.
* Upgrade tasks persisted by the currently deployed orchestrator still deserialize.
* Integration tests cover stopping archiving via a raised threshold, a fresh suite without a spawned archive canister, and the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S568wBREAARUA9GvGP5JMP