### PR TITLE
fix: deflake should_flag_only_deposits_at_or_above_the_per_token_minimum

### DIFF
--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -123,8 +123,10 @@ const AWAIT_DEADLINE: Duration = Duration::from_secs(60);
 const SCAN_TICK: Duration = Duration::from_secs(BALANCE_SCAN_INTERVAL.as_secs() + 5);
 
 /// A budget, not a cost: one tick refreshes the latest block height the scan needs, the next scans;
-/// the spares cover a tick lost to an outcall the jump timed out.
-const SCAN_TICKS: u32 = 4;
+/// the spares cover a tick lost to an outcall the jump timed out, and the blocks the pair's
+/// block-based backoff gap demands before it is due again — up to 300 block-seconds (25 blocks)
+/// once an address has been scanned a few times, against the ~10 blocks each tick's settle mines.
+const SCAN_TICKS: u32 = 8;
 
 /// A budget, not a cost: the sweep path crosses the enqueue, send, and finalization timers, and
 /// driving stops the moment the expected transactions are on chain.
@@ -334,28 +336,47 @@ impl LiveSetup<CkErc20Setup> {
         }
     }
 
-    /// Waits until the minter's periodic balance scan has scanned `caller`'s deposit address —
-    /// observed through `deposit_erc20`'s own status — and returns that response. An address counts
-    /// as scanned once its status is `Scanning` with `scan_count >= 1` (a below-minimum address,
-    /// advanced in place) or `AwaitingSweep` (a funded address, detected and queued). Either proves
-    /// the `eth_call` against anvil succeeded and decoded, since a failing batch never advances or
-    /// queues an address. Buys balance-scan ticks rather than waiting the interval out, and panics
-    /// if no scan completes within [`SCAN_TICKS`] of them.
+    /// Waits until the minter's periodic balance scan has scanned `caller`'s deposit address *at a
+    /// block where its funding is visible* — observed through `deposit_erc20`'s own status — and
+    /// returns that response. An address counts as scanned once its status is `AwaitingSweep` (a
+    /// funded address, detected and queued — terminal by construction) or `Scanning` with
+    /// `scan_count >= 1` and a `last_scanned_block` at or past the chain head as of entry (a
+    /// below-minimum address, advanced in place). Either proves the `eth_call` against anvil
+    /// succeeded, decoded, and read the funded balance. Buys balance-scan ticks rather than waiting
+    /// the interval out, and panics if no such scan completes within [`SCAN_TICKS`] of them.
+    ///
+    /// The pinned-block requirement is what makes the wait sound: the scan reads every balance at
+    /// the minter's *cached* latest block height, refreshed on its own thirty-second timer — so a
+    /// scan can run after [`Self::credit_deposits`] funded the addresses and still read them at a
+    /// pre-funding block, bumping `scan_count` without having seen the funds. Accepting any
+    /// `scan_count >= 1` returned that transient verdict and made the caller's `AwaitingSweep`
+    /// assertion flaky; a scan pinned at or past the entry head (the funding is mined before a
+    /// test awaits its scan) cannot have missed the balance.
     pub fn await_scan(
         &self,
         caller: Principal,
         subaccount: [u8; 32],
         token: &Erc20Token,
     ) -> DepositErc20Response {
+        let funded_by = Nat::from(self.anvil.block_number());
         let mut scanned = None;
         self.drive_until_with(
             SCAN_TICK,
             SCAN_TICKS,
-            |_| "the deposit address was not scanned".to_string(),
+            |_| format!("the deposit address was not scanned at or past block {funded_by}"),
             |setup| {
                 let progress = setup.deposit_erc20(caller, subaccount, token);
                 let is_scanned = match &progress.status {
-                    DepositStatus::Scanning { scan_count, .. } => *scan_count >= 1,
+                    DepositStatus::Scanning {
+                        scan_count,
+                        last_scanned_block,
+                        ..
+                    } => {
+                        *scan_count >= 1
+                            && last_scanned_block
+                                .as_ref()
+                                .is_some_and(|block| *block >= funded_by)
+                    }
                     DepositStatus::AwaitingSweep(_) => true,
                 };
                 if is_scanned {


### PR DESCRIPTION
## Problem

`//rs/ethereum/cketh/minter:deposit_from_cex` kept flaking after #11383 (which removed the dominant stop-canister race). Both post-#11383 `master` flakes share one new signature: `should_flag_only_deposits_at_or_above_the_per_token_minimum` fails at its first assertion with

```
assertion failed: `Scanning { valid_until: …, last_scanned_block: Some(Nat(11)), scan_count: 1 }`
does not match `DepositStatus::AwaitingSweep(detected) if …`
```

right after `credit_deposits` funded the deposit addresses on anvil (its own balance assertions passed, so the funds were readable).

## Root cause

The minter's balance scan does not fetch a block number: it `eth_call`s at its **cached** `latest_block_height` (`rs/ethereum/cketh/minter/src/balance_scan/mod.rs`, pinned as `BlockTag::Number`), and that cache is refreshed **only** by the separate 30-second `REFRESH_LATEST_BLOCK_HEIGHT_INTERVAL` timer (`deposit.rs` is its sole writer; the log scrape writes a different field). So a scan firing after the harness mined the funding block can still read every balance at a pre-funding block: the call succeeds (the token code, set through `anvil_setCode`, is visible to historical `eth_call`s — mined transfers are not), finds nothing, and `record_scan` stores `scan_count = 1` with the stale `last_scanned_block`.

The failing logs show exactly this: an ETH log scrape covering blocks `1..=11` (head ≥ 11 pre-funding), the funding mined after it, then one balance scan — `scanned 3 (address, token) pair(s), found 0 candidate(s), 0 decode error(s), 0 call error(s)` — pinned at block 11.

The harness' `await_scan` accepted **any** `Scanning` status with `scan_count >= 1` as terminal, so it returned that transient verdict instead of driving on until a scan that could actually see the funds — and the test's `AwaitingSweep` assertion failed. (The next scan corrects the verdict within a couple of blocks; the predicate just never waited for it.)

## Fix

`await_scan` now snapshots the anvil chain head at entry (the funding is always mined by then — every caller funds through `credit_deposits` first) and counts an address as scanned only once its status is:

- `AwaitingSweep` — terminal by construction (a detection only results from a scan that read a balance at or above the minimum, and a queued pair never returns to `Scanning`), or
- `Scanning` with `scan_count >= 1` **and** `last_scanned_block` at or past that entry head — a scan pinned there cannot have missed the balance, so a below-minimum verdict is genuine.

`SCAN_TICKS` grows from 4 to 8 (a budget, not a cost — driving stops the moment the condition holds): the pair's block-based backoff can demand up to 300 block-seconds before it is due for the scan the new predicate waits for, against the ~10 blocks each tick's settle mines.

## Validation

- **Deterministic reproduction**: temporarily deploying the token code before registration (so a pre-funding scan completes, recording exactly the state the stale-cache race records — `scan_count = 1` at a block where the funding is invisible) and forcing one such scan:
  - old predicate → fails with the exact CI signature, deterministically;
  - fixed predicate → converges to `AwaitingSweep` and the test passes end to end.
- `cargo check`, `cargo fmt`, `./ci/scripts/rust-lint.sh` — clean.
- Depth-2 bazel rdeps all pass: `integration_tests_tests/{ckerc20,cketh}_test`, `minter:lib_tests`, `test_utils:lib_tests`.
- `bazel test --runs_per_test=3 --jobs=3 //rs/ethereum/cketh/minter:deposit_from_cex` — 3/3 full-suite runs pass.

The remaining non-success runs in the window since #11383 merged all ran on commits that predate it (branch/merge-queue checkouts from before the merge) and show the old, already-fixed stop-canister signature.

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)