### PR TITLE
fix: make vetKD key share signing backward compatible across replica versions

### DIFF
--- a/rs/crypto/src/vetkd/mod.rs
+++ b/rs/crypto/src/vetkd/mod.rs
@@ -31,9 +31,37 @@ use ic_types::crypto::vetkd::{
     VetKdKeyShareCombinationError, VetKdKeyShareCreationError, VetKdKeyShareVerificationError,
     VetKdKeyVerificationError,
 };
-use ic_types::crypto::{BasicSig, BasicSigOf};
+use ic_types::crypto::{BasicSig, BasicSigOf, CryptoError};
 use std::collections::BTreeMap;
 use std::fmt;
+
+/// Migration switch for the content signed by vetKD encrypted key shares
+/// (see https://github.com/dfinity/ic/pull/11333):
+///
+/// * `false` (phase 1, current): sign the legacy content (the encrypted key
+///   share alone), but accept both the legacy and the request-ID-binding
+///   content during verification. This is required for backward compatibility:
+///   replica versions released before #11333 verify only the legacy content,
+///   so signing the new content would make them permanently invalidate our
+///   shares (and vice versa) in mixed-version subnets, i.e. during every
+///   rolling upgrade of a vetKD-enabled subnet.
+/// * `true` (phase 2): sign the request-ID-binding
+///   [`VetKdEncryptedKeyShareSigningContent`], which prevents a malicious
+///   node from replaying another node's validly-signed share under a
+///   different request. Only flip this once *all* mainnet subnets run a
+///   phase-1 replica (one that verifies both contents).
+///
+/// Phase 3 (once no elected replica version signs the legacy content anymore):
+/// remove the legacy verification fallback, the legacy `Signable` impl of
+/// `VetKdEncryptedKeyShareContent`, and this constant.
+///
+/// Note that deferring the request-ID binding to phase 2 is not a security
+/// regression: it is the signing scheme vetKD launched with on mainnet, and a
+/// replayed share can never forge a key (the BLS key share itself binds the
+/// input, context, and transport key); it can merely slow down share
+/// combination, which a malicious node could equally achieve by signing
+/// garbage.
+const SIGN_REQUEST_ID_BINDING_CONTENT: bool = false;
 
 impl<C: CryptoServiceProvider, R: CryptoComponentRng> VetKdProtocol for CryptoComponentImpl<C, R> {
     #[allow(clippy::result_large_err)]
@@ -240,14 +268,21 @@ fn create_encrypted_key_share_internal(
         )
         .map_err(vetkd_key_share_creation_error_from_vault_error)?;
 
-    let node_signature = basic_sig::sign(
-        &VetKdEncryptedKeyShareSigningContent::new(&args, &encrypted_key_share),
-        vault,
-        metrics,
-    )
-    .map_err(VetKdKeyShareCreationError::KeyShareSigningError)?
-    .get()
-    .0;
+    let node_signature = if SIGN_REQUEST_ID_BINDING_CONTENT {
+        basic_sig::sign(
+            &VetKdEncryptedKeyShareSigningContent::new(&args, &encrypted_key_share),
+            vault,
+            metrics,
+        )
+        .map_err(VetKdKeyShareCreationError::KeyShareSigningError)?
+        .get()
+        .0
+    } else {
+        basic_sig::sign(&encrypted_key_share, vault, metrics)
+            .map_err(VetKdKeyShareCreationError::KeyShareSigningError)?
+            .get()
+            .0
+    };
 
     Ok(VetKdEncryptedKeyShare {
         encrypted_key_share,
@@ -296,18 +331,38 @@ fn verify_encrypted_key_share_internal<S: CspSigner>(
             )
         })?;
 
-    let signature = BasicSigOf::new(BasicSig(key_share.node_signature.clone()));
-    let signed_content =
-        VetKdEncryptedKeyShareSigningContent::new(args, &key_share.encrypted_key_share);
-    BasicSigVerifierInternal::verify_basic_sig(
+    match BasicSigVerifierInternal::verify_basic_sig(
         csp_signer,
         registry,
-        &signature,
-        &signed_content,
+        &BasicSigOf::new(BasicSig(key_share.node_signature.clone())),
+        &key_share.encrypted_key_share,
         signer,
         registry_version_from_store,
-    )
-    .map_err(VetKdKeyShareVerificationError::VerificationError)
+    ) {
+        Ok(()) => Ok(()),
+        // The signer may already sign the request-ID-binding content (see
+        // `SIGN_REQUEST_ID_BINDING_CONTENT`), so fall back to verifying that
+        // content. The fallback is limited to signature verification failures:
+        // all other errors (registry lookups, malformed keys or signatures,
+        // unsupported algorithms) do not depend on the signed bytes, so
+        // retrying with different bytes cannot succeed.
+        Err(legacy_err @ CryptoError::SignatureVerification { .. }) => {
+            let signed_content =
+                VetKdEncryptedKeyShareSigningContent::new(args, &key_share.encrypted_key_share);
+            BasicSigVerifierInternal::verify_basic_sig(
+                csp_signer,
+                registry,
+                &BasicSigOf::new(BasicSig(key_share.node_signature.clone())),
+                &signed_content,
+                signer,
+                registry_version_from_store,
+            )
+            // If both verifications fail, report the error for the legacy
+            // content since that is what phase-1 signers produce.
+            .map_err(|_| VetKdKeyShareVerificationError::VerificationError(legacy_err))
+        }
+        Err(e) => Err(VetKdKeyShareVerificationError::VerificationError(e)),
+    }
 }
 
 fn combine_encrypted_key_shares_internal<C: ThresholdSignatureCspClient>(

--- a/rs/crypto/tests/vetkd.rs
+++ b/rs/crypto/tests/vetkd.rs
@@ -6,6 +6,7 @@ use ic_crypto_test_utils_ni_dkg::{
 };
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_crypto_test_utils_vetkd::VetKdArgsOwned;
+use ic_interfaces::crypto::BasicSigner;
 use ic_interfaces::crypto::VetKdProtocol;
 use ic_interfaces::crypto::{LoadTranscriptResult, NiDkgAlgorithm};
 use ic_test_utilities_in_memory_logger::assertions::LogEntriesAssert;
@@ -16,6 +17,7 @@ use ic_types::crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTranscript};
 use ic_types::crypto::vetkd::VetKdEncryptedKey;
 use ic_types::crypto::vetkd::VetKdEncryptedKeyShare;
 use ic_types::crypto::vetkd::VetKdEncryptedKeyShareContent;
+use ic_types::crypto::vetkd::VetKdEncryptedKeyShareSigningContent;
 use ic_types::crypto::vetkd::VetKdKeyShareCombinationError;
 use ic_types::crypto::vetkd::VetKdKeyShareCreationError;
 use ic_types::crypto::vetkd::VetKdKeyShareVerificationError;
@@ -348,8 +350,12 @@ mod verify_key_share {
         }
     }
 
+    // PHASE-2(SIGN_REQUEST_ID_BINDING_CONTENT): once shares are signed over the
+    // request-ID-binding content, invert this test back to expecting a
+    // `VetKdKeyShareVerificationError::VerificationError` (and rename it to
+    // `should_err_if_request_id_altered`).
     #[test]
-    fn should_err_if_request_id_altered() {
+    fn should_currently_accept_shares_under_altered_request_id() {
         let mut rng = reproducible_rng();
         let server = VetKDTestServer::new(&mut rng);
         let client = VetKDTestClient::new(&mut rng, &server);
@@ -372,12 +378,72 @@ mod verify_key_share {
             let mut altered_args = vetkd_args.clone();
             altered_args.request_id = altered;
 
-            match server.verify_key_shares(&shares, &altered_args, &mut rng) {
-                Err(VetKdKeyShareVerificationError::VerificationError(_)) => { /* expected */ }
-                Ok(()) => panic!("Shares accepted under request id {altered:?}"),
-                Err(e) => panic!("Unexpected error {:?}", e),
-            }
+            // Shares are currently signed over the legacy content, which does
+            // not bind the request ID, so verification still succeeds.
+            server
+                .verify_key_shares(&shares, &altered_args, &mut rng)
+                .unwrap_or_else(|e| panic!("Shares rejected under request id {altered:?}: {e:?}"));
         }
+    }
+
+    /// Verification must accept shares signed over the legacy content (the
+    /// encrypted key share alone), independently of which content
+    /// `create_encrypted_key_share` signs: replica versions predating the
+    /// introduction of `VetKdEncryptedKeyShareSigningContent` produce such
+    /// shares, so this must keep succeeding until no elected replica version
+    /// signs the legacy content anymore (phase 3).
+    #[test]
+    fn should_verify_share_signed_over_legacy_content() {
+        let mut rng = reproducible_rng();
+        let server = VetKDTestServer::new(&mut rng);
+        let client = VetKDTestClient::new(&mut rng, &server);
+        let vetkd_args = client.create_args(&server.dkg_id);
+
+        let mut shares = server
+            .create_key_shares(&vetkd_args, &mut rng)
+            .expect("Share creation unexpectedly failed");
+
+        for (node_id, share) in shares.iter_mut() {
+            let signature = crypto_for(*node_id, &server.env.crypto_components)
+                .sign_basic(&share.encrypted_key_share)
+                .expect("failed to sign the legacy content");
+            share.node_signature = signature.get().0;
+        }
+
+        server
+            .verify_key_shares(&shares, &vetkd_args, &mut rng)
+            .expect("Shares signed over the legacy content should verify");
+    }
+
+    /// Verification must accept shares signed over the request-ID-binding
+    /// content: this is what phase-2 signers will produce (see
+    /// `SIGN_REQUEST_ID_BINDING_CONTENT` in `rs/crypto/src/vetkd/mod.rs`), so
+    /// this pins the verification fallback that makes the phase-2 flip safe.
+    #[test]
+    fn should_verify_share_signed_over_request_id_binding_content() {
+        let mut rng = reproducible_rng();
+        let server = VetKDTestServer::new(&mut rng);
+        let client = VetKDTestClient::new(&mut rng, &server);
+        let vetkd_args = client.create_args(&server.dkg_id);
+
+        let mut shares = server
+            .create_key_shares(&vetkd_args, &mut rng)
+            .expect("Share creation unexpectedly failed");
+
+        for (node_id, share) in shares.iter_mut() {
+            let content = VetKdEncryptedKeyShareSigningContent::new(
+                &vetkd_args.as_ref(),
+                &share.encrypted_key_share,
+            );
+            let signature = crypto_for(*node_id, &server.env.crypto_components)
+                .sign_basic(&content)
+                .expect("failed to sign the request-ID-binding content");
+            share.node_signature = signature.get().0;
+        }
+
+        server
+            .verify_key_shares(&shares, &vetkd_args, &mut rng)
+            .expect("Shares signed over the request-ID-binding content should verify");
     }
 
     #[test]

--- a/rs/types/types/src/crypto/sign.rs
+++ b/rs/types/types/src/crypto/sign.rs
@@ -11,7 +11,7 @@ use crate::consensus::{
 };
 use crate::crypto::SignedBytesWithoutDomainSeparator;
 use crate::crypto::canister_threshold_sig::idkg::{IDkgDealing, SignedIDkgDealing};
-use crate::crypto::vetkd::VetKdEncryptedKeyShareSigningContent;
+use crate::crypto::vetkd::{VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareSigningContent};
 use crate::messages::{
     Delegation, MessageId, QueryResponseHash, SenderInfoContent, WebAuthnEnvelope,
 };
@@ -80,6 +80,7 @@ mod private {
     impl SignatureDomainSeal for RandomTapeContent {}
     impl SignatureDomainSeal for SignableMock {}
     impl SignatureDomainSeal for QueryResponseHash {}
+    impl SignatureDomainSeal for VetKdEncryptedKeyShareContent {}
     impl SignatureDomainSeal for VetKdEncryptedKeyShareSigningContent<'_> {}
 }
 
@@ -200,6 +201,12 @@ impl SignatureDomain for RandomTapeContent {
 impl SignatureDomain for QueryResponseHash {
     fn domain(&self) -> Vec<u8> {
         domain_with_prepended_length(DomainSeparator::QueryResponse.as_str())
+    }
+}
+
+impl SignatureDomain for VetKdEncryptedKeyShareContent {
+    fn domain(&self) -> Vec<u8> {
+        domain_with_prepended_length(DomainSeparator::VetKdEncryptedKeyShareContent.as_str())
     }
 }
 


### PR DESCRIPTION
# Why

The `//rs/tests/consensus/upgrade` app-subnet upgrade/downgrade system tests became the most flaky tests in CI (up to ~7% of runs) starting 2026-08-27:

```
//rs/tests/consensus/upgrade:upgrade_downgrade_old_app_subnet_test_colocate          7/99 flaky
//rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_head_nns_colocate     7/98 flaky
//rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_colocate              4/98 flaky
... (plus the _local and remaining _head_nns/old variants)
```

## Root cause

#11333 (d9fd141cb4, merged 2026-08-27 11:42 UTC) changed the content that nodes sign for vetKD encrypted key shares — from the encrypted key share alone (“legacy content”) to `callback_id ‖ height ‖ encrypted key share` (`VetKdEncryptedKeyShareSigningContent`), under the same domain separator — and switched **both signing and verification at once**. Replica versions released before that commit (including all current mainnet GuestOS versions) sign and verify only the legacy content.

In any **mixed-version subnet** the two sides therefore permanently invalidate each other's vetKD key shares:

* new verifier + old signer → Ed25519 signature verification fails → `IDkgChangeAction::HandleInvalid`
* old verifier + new signer → same, and this side is immutable (it is already released)

Each `HandleInvalid` increments the replica metric `idkg_invalidated_artifacts`, which the system-test driver requires to be exactly 0, both in the post-test `assert_no_metrics_errors` check and in the mid-test `assert_no_critical_errors` check performed before every replica restart (`rs/tests/consensus/utils/src/upgrade.rs`).

The upgrade/downgrade app-subnet tests create exactly such mixed-version windows (mainnet ↔ branch, with a chain-key signing workload running throughout, and a “faulty” node that is restarted with a delay), so any vetKD share in flight during the 20–70 s reboot skew gets invalidated. Analysis of all 28 failed attempts of the last week: every single one shows only `Invalid IDKG artifact … VetKdKeyShare … Ed25519 signature could not be verified … A signature was invalid` warnings, all timestamped inside the version-skew windows, in both directions (18 runs tripped the post-test check on downgraded mainnet-version nodes, 10 runs tripped the mid-test check on freshly-upgraded branch-version nodes).

This is not only a test problem: on a mainnet rolling upgrade of a vetKD-enabled subnet, shares crossing the skew window are permanently invalidated on the other side, transiently impairing vetKD share combination until enough nodes run the same version.

## The fix: phased migration (phase 1)

Following the repo's established pattern for consensus-visible content changes (produce old + accept both → produce new → remove old; cf. CON-1441: #9829 → #10405 → #10504):

* **Sign the legacy content again** (`SIGN_REQUEST_ID_BINDING_CONTENT = false` in `rs/crypto/src/vetkd/mod.rs`) — so verifiers on already-released versions keep accepting our shares;
* **Verify the legacy content first, falling back to the request-ID-binding content** — so the shares of phase-2 signers will be accepted once the flip happens. The fallback only engages on `CryptoError::SignatureVerification` (any other error does not depend on the signed bytes) and costs at most one extra Ed25519 verification for shares that are actually invalid;
* Restore the legacy `SignatureDomain`/`SignatureDomainSeal` impls for `VetKdEncryptedKeyShareContent` in `rs/types/types/src/crypto/sign.rs`.

The rest of #11333 is untouched: the skip-malformed-shares combination logic is format-independent (it never looks at `node_signature`), and the `RequestId` plumbing through `VetKdArgs` is exactly what phase 2 needs.

**Phase 2** (later PR, once *all* mainnet subnets run a phase-1 replica): flip the const to `true` and re-invert `should_currently_accept_shares_under_altered_request_id`. **Phase 3** (once no elected version signs legacy anymore): remove the fallback, the legacy `Signable` impls, and the const. Both phases are documented on the const.

Note for reviewers: since nothing on mainnet has ever signed the new format, phase 1 is the last cheap opportunity to give `VetKdEncryptedKeyShareSigningContent` its **own domain separator** (currently it shares `DomainSeparator::VetKdEncryptedKeyShareContent` with the legacy content, leaving a theoretical — practically unexploitable — cross-format signature ambiguity). Deliberately left out here to keep the diff minimal; happy to add it in this PR if preferred.

Security note: continuing to sign the legacy content is byte-for-byte the scheme vetKD launched with on mainnet. The request-ID binding is hardening against a malicious subnet peer replaying an honest node's share under a different request (which cannot forge a key — the BLS share itself binds input/context/transport key — but wastes combination work); deferring it to phase 2 is not a regression.

## Test changes

* `should_err_if_request_id_altered` → inverted to `should_currently_accept_shares_under_altered_request_id` (legacy content does not bind the request id), with a PHASE-2 marker to invert it back;
* new `should_verify_share_signed_over_legacy_content`: pins legacy acceptance independently of what `create_encrypted_key_share` signs (protects the mixed-version window even after the phase-2 flip; removed in phase 3);
* new `should_verify_share_signed_over_request_id_binding_content`: pins the verification fallback, i.e. guarantees phase-2 signers will be accepted.

## Validation

* `cargo check --all-targets --all-features -p ic-types -p ic-crypto`, `cargo fmt`, `./ci/scripts/rust-lint.sh` — clean
* `bazel test //rs/crypto:integration_suite_tests/vetkd_test //rs/types/types:types_test //rs/crypto:crypto_test //rs/consensus/idkg:idkg_test` — pass
* `bazel test --runs_per_test=3 --jobs=3 //rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_colocate` — PASSED 3/3 (934s / 940s / 975s), i.e. the mainnet<->branch mixed-version windows no longer invalidate any shares
* full `rdeps` depth-2 test sweep (413 targets) — 410/412 pass; the 2 failures (`upgrade_canisters_with_golden_nns_state`, `golden_state_swap_upgrade_twice`) fail in <0.3s trying to download the golden state from `zh1-pyr07` (no SSH access from this machine) — environmental, unrelated

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md` (root-cause analysis of last week's flaky runs of `//rs/tests/consensus/upgrade:...`).

FYI @eichhorl (author of #11333)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
