### PR TITLE
fix: don't fail system-test runs when the Vector logging VM is unreachable

### DIFF
--- a/rs/tests/driver/src/driver/vector_logging_task.rs
+++ b/rs/tests/driver/src/driver/vector_logging_task.rs
@@ -21,7 +21,19 @@ pub(crate) fn vector_logging_task(group_ctx: GroupContext, start_time: DateTime<
     }
 
     let mut vector_vm = VectorVm::new().with_start_time(start_time);
-    vector_vm.start(&env).expect("Failed to start Vector VM");
+    // This task supervises the whole test plan, so failing (or panicking) here
+    // would fail the entire test run just because the log-shipping VM could
+    // not be provisioned. Finishing normally, in contrast, has no effect on
+    // the supervised tasks. Vector only ships logs to Elasticsearch, so
+    // continue without it and let the logs be fetched from the nodes directly
+    // if needed.
+    if let Err(e) = vector_vm.start(&env) {
+        warn!(
+            logger,
+            "Failed to start Vector VM: {:?}. Continuing the run without vector logging.", e
+        );
+        return;
+    }
 
     loop {
         if let Err(e) = vector_vm.sync_with_vector(&env) {

--- a/rs/tests/driver/src/driver/vector_vm.rs
+++ b/rs/tests/driver/src/driver/vector_vm.rs
@@ -5,6 +5,7 @@ use std::{
     path::Path,
 };
 
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 use slog::{Logger, debug, info, warn};
@@ -265,10 +266,14 @@ impl VectorVm {
             return Ok(());
         };
 
-        let deployed_vm = env.get_deployed_universal_vm("vector").unwrap();
+        // Return errors instead of panicking: this runs in the vector_logging
+        // task which supervises the whole test plan, so a panic here would fail
+        // the entire test run just because the log-shipping VM is unreachable.
+        // The caller (the loop in `vector_logging_task`) warns and retries.
+        let deployed_vm = env.get_deployed_universal_vm("vector")?;
         let session = deployed_vm
             .block_on_ssh_session()
-            .unwrap_or_else(|e| panic!("Failed to setup SSH session to vector because: {e:?}!",));
+            .context("Failed to setup SSH session to vector")?;
 
         std::fs::write(
             vector_local_dir.join("generated_config.json"),
@@ -309,7 +314,7 @@ docker run -d --name vector \
         "#,
                     ),
                 )
-                .unwrap();
+                .context("Failed to run vector container")?;
             self.container_running = true;
 
             emit_kibana_url_event(&log, &infra_group_name, &self.start_time);
@@ -317,7 +322,7 @@ docker run -d --name vector \
             info!(log, "Issuing command to reload vector configuration.");
             deployed_vm
                 .block_on_bash_script_from_session(&session, "docker kill --signal=HUP vector")
-                .unwrap();
+                .context("Failed to reload vector configuration")?;
         }
 
         info!(log, "Vector targets sync complete.");


### PR DESCRIPTION
# Why

In the flaky run of `//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test_head_nns_colocate` on 2026-09-01 18:13 UTC, the **only** failing task was `vector_logging`:

```
Task Test("vector_logging") failed due to: Failed to setup SSH session to vector because:
Func="get_ssh_session to 2602:fb2b:100:10:507d:1eff:fe86:8a29" timed out after 503s on attempt 63.
```

The Vector VM (a universal VM that only ships logs to Elasticsearch/Kibana — pure observability, no interaction with the system under test) was allocated by Farm but never became reachable over SSH. `VectorVm::sync_with_vector` then **panicked** (`rs/tests/driver/src/driver/vector_vm.rs:271`), and since the `vector_logging` task is composed as a supervisor of the whole test plan (`rs/tests/driver/src/driver/group.rs`), the panic SIGKILLed the actual test mid-upgrade and failed the run — even though the IC under test was perfectly healthy.

## Fix

Turn the panics/unwraps on the SSH/remote-command paths of `sync_with_vector` into propagated errors. The calling loop in `vector_logging_task` already warns and retries every 30 s on `Err` (that behavior was introduced for the sync path in ce616a312a), and `config_hash` is only updated after a fully successful sync, so a failed sync is naturally retried with the same config.

Also soften the remaining panic path, `VectorVm::start(...).expect(...)`, to warn-and-return: per the task-scheduler semantics (`action_graph.rs`), a supervisor task *finishing normally* has no effect on its supervised children — only a *failure* cancels them — so returning after a warn simply gives up vector logging for that run and lets the tests proceed. No retry of `start()` is attempted: Farm's HTTP layer already retries each call for up to 500 s internally, and re-running a partially-failed `start()` would re-issue `createVm` with the same VM name, which is not known to be idempotent.

No behavior change when the Vector VM works: all edits are on error paths only.

Trade-off: a genuine regression in Vector VM provisioning now surfaces as grep-able `Failed to start Vector VM` / `Failed to sync with vector vm` warnings instead of failing runs — consistent with how the other observability tasks (`logs_stream`, `log_consoles`, `metrics_sync`) already behave.

## Validation

* `cargo check --all-targets --all-features -p ic-system-test-driver`, `cargo fmt`, `./ci/scripts/rust-lint.sh` — clean
* bazel build of the direct rdeps of the two files — pass
* smoke: `//rs/tests/consensus/upgrade:upgrade_downgrade_unassigned_nodes_test_head_nns` PASSED in 177s on this branch, with "Spawned vector vm" and "Vector targets sync complete" present in the driver log (unchanged happy path); `//rs/tests/driver:unit_tests` and `//rs/tests/idx:test_e2e_scenarios` pass

Found while root-causing the `//rs/tests/consensus/upgrade:...` flakiness following `.claude/skills/fix-flaky-tests/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
