### PR TITLE
fix: deflake //rs/tests/consensus/upgrade:upgrade_downgrade_unassigned_nodes_test

### DIFF
--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -162,6 +162,7 @@ system_test_nns(
         "long_test",
     ],
     test_driver_target = ":upgrade_downgrade_unassigned_test_bin",
+    test_timeout = "eternal",
 )
 
 system_test_nns(
@@ -174,6 +175,7 @@ system_test_nns(
         "long_test",
     ],
     test_driver_target = ":upgrade_downgrade_unassigned_test_bin",
+    test_timeout = "eternal",
 )
 
 system_test_nns(

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -38,10 +38,10 @@ use slog::{Logger, info};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-const ALLOWED_FAILURES: usize = 1;
+pub const ALLOWED_FAILURES: usize = 1;
 
-pub const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(25 * 60);
-pub const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+pub const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_mins(35);
+pub const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_mins(30);
 
 pub fn elect_target_version(env: &TestEnv, nns_node: &IcNodeSnapshot) -> ReplicaVersion {
     let logger = env.logger();

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -1,11 +1,7 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use futures::future::join_all;
-use slog::Logger;
-use tokio::runtime::{Builder, Runtime};
-
 use ic_consensus_system_test_upgrade_common::{
+    ALLOWED_FAILURES, UP_DOWNGRADE_OVERALL_TIMEOUT, UP_DOWNGRADE_PER_TEST_TIMEOUT,
     elect_target_version, get_chain_key_canister_and_public_key, upgrade,
 };
 use ic_consensus_system_test_utils::rw_message::{
@@ -32,14 +28,14 @@ use ic_system_test_driver::generic_workload_engine::metrics::{
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::{MessageCanister, block_on, get_app_subnet_and_node};
 use ic_types::Height;
+use slog::Logger;
 use slog::info;
+use std::time::Duration;
+use tokio::runtime::{Builder, Runtime};
 
 const SCHNORR_MSG_SIZE_BYTES: usize = 32;
 const DKG_INTERVAL: u64 = 29;
-const ALLOWED_FAILURES: usize = 1;
-const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
-const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
-const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1;
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn setup(env: TestEnv) {

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
-
 use anyhow::Result;
-
-use ic_consensus_system_test_upgrade_common::{elect_target_version, upgrade};
+use ic_consensus_system_test_upgrade_common::{
+    ALLOWED_FAILURES, UP_DOWNGRADE_OVERALL_TIMEOUT, UP_DOWNGRADE_PER_TEST_TIMEOUT,
+    elect_target_version, upgrade,
+};
 use ic_consensus_system_test_utils::rw_message::{
     can_read_msg_with_retries, install_nns_and_check_progress,
 };
@@ -19,10 +19,7 @@ use ic_types::Height;
 use slog::info;
 
 const DKG_INTERVAL: u64 = 9;
-const ALLOWED_FAILURES: usize = 1;
-const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
-const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
-const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1;
 
 fn setup(env: TestEnv) {
     let subnet_under_test = Subnet::new(SubnetType::System)

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_unassigned_nodes_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_unassigned_nodes_test.rs
@@ -22,11 +22,11 @@ Success::
 
 end::catalog[] */
 
-use std::time::Duration;
-
 use anyhow::Result;
 use anyhow::bail;
-use ic_consensus_system_test_upgrade_common::elect_target_version;
+use ic_consensus_system_test_upgrade_common::{
+    UP_DOWNGRADE_OVERALL_TIMEOUT, UP_DOWNGRADE_PER_TEST_TIMEOUT, elect_target_version,
+};
 use ic_consensus_system_test_utils::{
     rw_message::install_nns_and_check_progress,
     upgrade::{deploy_guestos_to_all_unassigned_nodes, fetch_unassigned_node_version},
@@ -41,15 +41,6 @@ use ic_system_test_driver::{
 use ic_types::ReplicaVersion;
 use slog::Logger;
 use slog::info;
-
-// The test performs two sequential GuestOS upgrades of the unassigned node,
-// each of which is polled with a 600s retry budget (see
-// `upgrade_unassigned_nodes` below). The driver's default per-test timeout of
-// 10 minutes cannot even cover a single exhausted poll, so give the test an
-// explicit budget that covers its own worst case (2 x 600s polling + proposal
-// handling + slack), like its siblings in this package do.
-const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
-const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(25 * 60);
 
 fn setup(env: TestEnv) {
     InternetComputer::new()

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_unassigned_nodes_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_unassigned_nodes_test.rs
@@ -22,6 +22,8 @@ Success::
 
 end::catalog[] */
 
+use std::time::Duration;
+
 use anyhow::Result;
 use anyhow::bail;
 use ic_consensus_system_test_upgrade_common::elect_target_version;
@@ -39,6 +41,15 @@ use ic_system_test_driver::{
 use ic_types::ReplicaVersion;
 use slog::Logger;
 use slog::info;
+
+// The test performs two sequential GuestOS upgrades of the unassigned node,
+// each of which is polled with a 600s retry budget (see
+// `upgrade_unassigned_nodes` below). The driver's default per-test timeout of
+// 10 minutes cannot even cover a single exhausted poll, so give the test an
+// explicit budget that covers its own worst case (2 x 600s polling + proposal
+// handling + slack), like its siblings in this package do.
+const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(25 * 60);
 
 fn setup(env: TestEnv) {
     InternetComputer::new()
@@ -96,6 +107,8 @@ fn upgrade_downgrade_unassigned_nodes(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_overall_timeout(UP_DOWNGRADE_OVERALL_TIMEOUT)
+        .with_timeout_per_test(UP_DOWNGRADE_PER_TEST_TIMEOUT)
         .with_setup(setup)
         .add_test(systest!(upgrade_downgrade_unassigned_nodes))
         .execute_from_args()?;


### PR DESCRIPTION
This PR slightly rewrites the upgrade system tests code to reuse duplicated constants and sets the same timeout to all of them. In particular, `upgrade_downgrade_unassigned_nodes_test` now has the same timeout as its siblings `upgrade_downgrade_{app,nns}_subnet_test`. This deflakes the former as it was occasionally timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
👨 Revised by @pierugo-dfinity
