### PR TITLE
fix(guestos): allow systemd-resolved to connect to networkd's resolve-hook socket

### DIFF
--- a/ic-os/components/guestos/selinux/systemd-fixes/systemd-fixes.te
+++ b/ic-os/components/guestos/selinux/systemd-fixes/systemd-fixes.te
@@ -87,6 +87,14 @@ require_read_proc_sys_kernel(systemd_detect_virt_t)
 require_read_efivarfs_files(systemd_resolved_t)
 # it wants to read certificates
 miscfiles_read_generic_certs(systemd_resolved_t)
+# systemd-resolved connects to systemd-networkd's varlink "resolve hook"
+# socket (/run/systemd/resolve.hook/io.systemd.Network) to obtain per-link DNS
+# configuration. When this is denied, resolved logs "Failed to connect to
+# resolve.hook: Permission denied" and can end up without any DNS servers for
+# the lifetime of the boot ("Failed to start query: Permission denied" for
+# every lookup), which for example makes the orchestrator unable to download
+# GuestOS upgrade images.
+allow systemd_resolved_t systemd_networkd_t : unix_stream_socket { connectto };
 
 ###############################################################################
 # systemd-cryptsetup


### PR DESCRIPTION
# Why

While root-causing a flake of `//rs/tests/consensus/upgrade:upgrade_downgrade_unassigned_nodes_test_head_nns` (2026-08-28 17:40 UTC), the unassigned GuestOS node turned out to have **no working DNS for its entire ~11-minute life**:

* 443 × enforced SELinux denials in its journal:
  ```
  avc: denied { connectto } for comm="systemd-resolve" path="/run/systemd/resolve.hook/io.systemd.Network"
  scontext=...:systemd_resolved_t:... tcontext=...:systemd_networkd_t:... tclass=unix_stream_socket permissive=0
  ```
* 790 × `Failed to start query: Permission denied` from systemd-resolved — every DNS lookup failed;
* consequently, all 58 of the orchestrator's attempts to download the elected GuestOS upgrade image failed within ~2 ms (`error sending request`), zero bytes ever fetched, and the test timed out.

systemd-resolved connects to systemd-networkd's varlink "resolve hook" socket (`/run/systemd/resolve.hook/io.systemd.Network`) to obtain per-link DNS configuration. Our policy does not allow that `connectto`, so the denial fires on **every** boot (a single `Failed to connect to resolve.hook: Permission denied` appears in healthy boots too). Usually resolved still ends up with working DNS through other paths; nondeterministically — as in this run — it does not recover and the node is left without name resolution, with no self-healing for the rest of the boot. SSH/IP-based connectivity keeps working, which is why the node looks healthy to the test driver while every DNS-dependent operation (such as upgrade-image downloads) is dead.

## Fix

Allow the connection in the `systemd-fixes` policy module:

```
allow systemd_resolved_t systemd_networkd_t : unix_stream_socket { connectto };
```

(The sock-file write permission is evidently already granted — the denial fires on the final `connectto` check.)

## Validation

* `bazel build //ic-os/guestos/envs/dev:rootfs-tree.tar` — pass (this is the action that compiles the SELinux policy modules via the refpolicy devel Makefile, so it validates the new rule); `//ic-os/components:check_unused_components_test` — pass. (`dev_component_file_references_test` fails identically on unmodified master on this machine — a local `UnicodeDecodeError` reading the `open_rootfs_dev` binary — so it is left to CI.)

Found while root-causing the `//rs/tests/consensus/upgrade:...` flakiness following `.claude/skills/fix-flaky-tests/SKILL.md`. The tightened driver/bazel timeouts for the affected test are in #11412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
