### PR TITLE
fix: Adjust the response execution prepayment to the Wasm execution mode

### DIFF
--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -849,6 +849,85 @@ impl CyclesAccountManager {
         )
     }
 
+    /// Adjusts the cycles prepaid for the execution of a response so that they match
+    /// exactly the cycles required for executing the response in the given Wasm
+    /// execution mode.
+    ///
+    /// The cycles for a response execution are prepaid when the corresponding call
+    /// is performed, i.e., using the instruction costs of the Wasm execution mode
+    /// of the calling canister at that time. The canister might have been upgraded
+    /// to a different Wasm execution mode before the response arrives:
+    ///
+    /// - if the prepayment falls short of the requirement (the canister was upgraded
+    ///   to a more expensive Wasm execution mode), then the missing cycles are
+    ///   withdrawn from the canister's balance. No freezing threshold is applied:
+    ///   the canister already committed to executing the response when it performed
+    ///   the corresponding call;
+    /// - if the prepayment exceeds the requirement (the canister was upgraded to a
+    ///   cheaper Wasm execution mode), then the excess is refunded immediately.
+    ///
+    /// Matching the prepayment to the requirement lets the canister pay exactly for
+    /// the instructions it executed, at the instruction costs of the Wasm execution
+    /// mode it executed them in.
+    ///
+    /// Returns the prepayment matching the cycles required for executing the response
+    /// in the given Wasm execution mode, or a `CanisterOutOfCyclesError` if the
+    /// canister's balance does not cover the additional prepayment.
+    pub fn adjust_prepayment_for_response_execution(
+        &self,
+        system_state: &mut SystemState,
+        prepayment_for_response_execution: CompoundCycles<Instructions>,
+        subnet_cycles_config: CyclesAccountManagerSubnetConfig,
+        execution_mode: WasmExecutionMode,
+        reveal_top_up: bool,
+    ) -> Result<CompoundCycles<Instructions>, CanisterOutOfCyclesError> {
+        let required = self.prepayment_for_response_execution(subnet_cycles_config, execution_mode);
+        let prepaid = prepayment_for_response_execution;
+        if prepaid.real() < required.real() {
+            // No freezing threshold is applied, i.e., the threshold is zero.
+            self.consume_with_threshold_impl(
+                system_state,
+                required - prepaid,
+                Cycles::zero(),
+                reveal_top_up,
+            )?;
+            return Ok(required);
+        }
+        Ok(self.refund_excess_prepayment_for_response_execution(
+            system_state,
+            prepaid,
+            subnet_cycles_config,
+            execution_mode,
+        ))
+    }
+
+    /// Refunds the part of the cycles prepaid for the execution of a response that
+    /// exceeds the cycles required for executing the response in the given Wasm
+    /// execution mode and returns the remaining prepayment.
+    ///
+    /// Unlike `adjust_prepayment_for_response_execution`, which uses this function to
+    /// handle an excessive prepayment, this never withdraws cycles from the canister's
+    /// balance and hence it cannot fail. It is thus also used on its own for responses
+    /// whose callback is not executed at all, where topping up the prepayment would
+    /// be pointless because the additional cycles would be refunded right away.
+    pub fn refund_excess_prepayment_for_response_execution(
+        &self,
+        system_state: &mut SystemState,
+        prepayment_for_response_execution: CompoundCycles<Instructions>,
+        subnet_cycles_config: CyclesAccountManagerSubnetConfig,
+        execution_mode: WasmExecutionMode,
+    ) -> CompoundCycles<Instructions> {
+        let required = self.prepayment_for_response_execution(subnet_cycles_config, execution_mode);
+        if prepayment_for_response_execution.real() <= required.real() {
+            return prepayment_for_response_execution;
+        }
+        // The excess part of the prepayment is refunded in full and hence it does not
+        // contribute to the consumed cycles of the canister.
+        let excess = prepayment_for_response_execution - required;
+        system_state.refund_cycles(excess, excess);
+        required
+    }
+
     /// Returns the amount of cycles required for transmitting the largest
     /// response message.
     pub fn prepayment_for_response_transmission(

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -907,10 +907,8 @@ impl CyclesAccountManager {
     ///
     /// Unlike `adjust_prepayment_for_response_execution`, which uses this function to
     /// handle an excessive prepayment, this never withdraws cycles from the canister's
-    /// balance and hence it cannot fail. It is thus also used on its own for responses
-    /// whose callback is not executed at all, where topping up the prepayment would
-    /// be pointless because the additional cycles would be refunded right away.
-    pub fn refund_excess_prepayment_for_response_execution(
+    /// balance and hence it cannot fail.
+    fn refund_excess_prepayment_for_response_execution(
         &self,
         system_state: &mut SystemState,
         prepayment_for_response_execution: CompoundCycles<Instructions>,
@@ -926,6 +924,41 @@ impl CyclesAccountManager {
         let excess = prepayment_for_response_execution - required;
         system_state.refund_cycles(excess, excess);
         required
+    }
+
+    /// Settles the cycles prepaid for the execution of a response whose callback is
+    /// not executed at all: the canister is charged the fixed per-message execution
+    /// fee and the rest of the prepayment is refunded to it.
+    ///
+    /// Since no instructions are executed, the fixed per-message execution fee is all
+    /// that is due, no matter which Wasm execution mode the cycles were prepaid for
+    /// and which one the canister has now. In particular, the canister keeps the rest
+    /// of its prepayment even if the prepayment falls short of the cycles that
+    /// executing the response in its current Wasm execution mode would require.
+    ///
+    /// Note that the prepayment is never topped up for such a response: the additional
+    /// cycles would be refunded right away and, unlike this refund, the withdrawal
+    /// could fail.
+    pub fn settle_prepayment_for_unexecuted_response(
+        &self,
+        system_state: &mut SystemState,
+        prepayment_for_response_execution: CompoundCycles<Instructions>,
+        subnet_cycles_config: CyclesAccountManagerSubnetConfig,
+        execution_mode: WasmExecutionMode,
+    ) {
+        // Executing no instructions costs the fixed per-message execution fee only.
+        let base_fee = self.execution_cost(
+            NumInstructions::from(0),
+            subnet_cycles_config,
+            execution_mode,
+        );
+        // The prepayment covers the fixed per-message execution fee, but clamp the
+        // charge to it so that no more than the prepayment is ever charged.
+        let charge = base_fee.min(prepayment_for_response_execution);
+        system_state.refund_cycles(
+            prepayment_for_response_execution,
+            prepayment_for_response_execution - charge,
+        );
     }
 
     /// Returns the amount of cycles required for transmitting the largest

--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -125,6 +125,16 @@ struct ResponseHelper {
     prepayment_for_response_transmission: CompoundCycles<RequestAndResponseTransmission>,
     prepayment_for_call_transmission: CompoundCycles<RequestAndResponseTransmission>,
     refund_for_response_transmission: CompoundCycles<RequestAndResponseTransmission>,
+    /// Cycles prepaid for the execution of this response.
+    ///
+    /// Initially the prepayment recorded in the callback when the corresponding call
+    /// was performed, i.e., the cycles required for executing the response in the
+    /// Wasm execution mode the canister had at that time. Before the callback is
+    /// executed, `adjust_prepayment_for_response_execution()` replaces this with the
+    /// cycles required for executing the response in the canister's current Wasm
+    /// execution mode; for responses whose callback is not executed at all,
+    /// `early_finish()` only refunds an excessive prepayment.
+    prepayment_for_response_execution: CompoundCycles<Instructions>,
     initial_cycles_balance: Cycles,
     response_sender: CanisterId,
     /// Instructions already executed by this callback, if previously paused.
@@ -205,6 +215,7 @@ impl ResponseHelper {
                 .prepayment_for_response_transmission,
             prepayment_for_call_transmission: original.callback.prepayment_for_call_transmission,
             refund_for_response_transmission,
+            prepayment_for_response_execution: original.callback.prepayment_for_response_execution,
             initial_cycles_balance,
             response_sender,
             executed_wasm_instructions: NumInstructions::new(0),
@@ -242,6 +253,51 @@ impl ResponseHelper {
             prepayment_for_call_transmission,
             self.refund_for_response_transmission,
         );
+    }
+
+    /// Returns the Wasm execution mode of the canister executing this response.
+    ///
+    /// This is the mode of the code that actually runs the callback, which is not
+    /// necessarily the mode the canister had when it performed the corresponding
+    /// call: the canister might have been upgraded in the meantime.
+    fn wasm_execution_mode(&self) -> WasmExecutionMode {
+        self.canister
+            .execution_state
+            .as_ref()
+            .map_or(WasmExecutionMode::Wasm32, |state| state.wasm_execution_mode)
+    }
+
+    /// Adjusts the cycles prepaid for the execution of this response to the cycles
+    /// required for executing it in the canister's current Wasm execution mode.
+    ///
+    /// The cycles were prepaid when the corresponding call was performed, i.e.,
+    /// using the instruction costs of the Wasm execution mode of the canister at
+    /// that time. If the canister has been upgraded since then, then the missing
+    /// cycles are withdrawn from the canister's balance (without applying the
+    /// freezing threshold) or the excess cycles are refunded to it.
+    ///
+    /// Returns an error if the canister's balance does not cover the additional
+    /// prepayment, in which case the canister state is left unchanged.
+    fn adjust_prepayment_for_response_execution(
+        &mut self,
+        original: &OriginalContext,
+        round: &RoundContext,
+    ) -> Result<(), CanisterOutOfCyclesError> {
+        let reveal_top_up = self
+            .canister
+            .controllers()
+            .contains(&original.call_origin.get_principal());
+        let execution_mode = self.wasm_execution_mode();
+        self.prepayment_for_response_execution = round
+            .cycles_account_manager
+            .adjust_prepayment_for_response_execution(
+                &mut self.canister.system_state,
+                self.prepayment_for_response_execution,
+                original.subnet_cycles_config,
+                execution_mode,
+                reveal_top_up,
+            )?;
+        Ok(())
     }
 
     /// Checks that the canister has not been uninstalled:
@@ -368,6 +424,7 @@ impl ResponseHelper {
             prepayment_for_response_transmission: paused.prepayment_for_response_transmission,
             prepayment_for_call_transmission: paused.prepayment_for_call_transmission,
             refund_for_response_transmission: paused.refund_for_response_transmission,
+            prepayment_for_response_execution: original.callback.prepayment_for_response_execution,
             initial_cycles_balance: clean_canister.system_state.balance(),
             response_sender: paused.response_sender,
             executed_wasm_instructions: paused.executed_wasm_instructions,
@@ -395,6 +452,27 @@ impl ResponseHelper {
         // the additional cycles are preserved.
         if helper.initial_cycles_balance < paused.initial_cycles_balance {
             let msg = "Mismatch in cycles balance when resuming a response call".to_string();
+            let err = HypervisorError::WasmEngineError(FailedToApplySystemChanges(msg));
+            return Err((helper, err));
+        }
+
+        // Replay the adjustment of the prepayment for the response execution: the
+        // initial steps are replayed on the clean canister state, which does not
+        // contain the changes of the ongoing DTS execution.
+        //
+        // The required prepayment is the same as in `execute_response()`: the Wasm
+        // module, and hence its Wasm execution mode, cannot change while a DTS
+        // execution of this canister is in progress because installing code is not
+        // executed for a canister that has a paused or an aborted execution (see
+        // `can_execute_subnet_msg()`), i.e., it is deferred to a later round. Should
+        // the paused execution be aborted nevertheless, e.g., before a checkpoint,
+        // then the response execution starts over in `execute_response()`, where the
+        // prepayment is adjusted afresh for whatever module is installed by then.
+        //
+        // Together with the check above that the cycles balance of the clean canister
+        // has not decreased, this replay is therefore expected to succeed.
+        if let Err(err) = helper.adjust_prepayment_for_response_execution(original, round) {
+            let msg = format!("Failed to prepay for resuming a response call: {err}");
             let err = HypervisorError::WasmEngineError(FailedToApplySystemChanges(msg));
             return Err((helper, err));
         }
@@ -610,17 +688,14 @@ impl ResponseHelper {
             round.counters.ingress_with_cycles_error,
         );
 
-        let wasm_execution_mode = self
-            .canister
-            .execution_state
-            .as_ref()
-            .map_or(WasmExecutionMode::Wasm32, |state| state.wasm_execution_mode);
+        let wasm_execution_mode = self.wasm_execution_mode();
+        let prepayment_for_response_execution = self.prepayment_for_response_execution;
 
         round.cycles_account_manager.refund_unused_execution_cycles(
             &mut self.canister.system_state,
             instructions_left,
             original.message_instruction_limit,
-            original.callback.prepayment_for_response_execution,
+            prepayment_for_response_execution,
             round.counters.execution_refund_error,
             original.subnet_cycles_config,
             wasm_execution_mode,
@@ -659,13 +734,31 @@ impl ResponseHelper {
 
     /// Completes execution of the response and cleanup callbacks without
     /// consuming any instructions and without producing any heap delta.
+    ///
+    /// No Wasm code is executed at all: the part of the prepayment exceeding what the
+    /// canister's current Wasm execution mode requires is refunded here.
+    ///
+    /// The remaining prepayment is settled by `finish()` as usual, which leaves the
+    /// canister charged the fixed per-message execution fee. Note that the prepayment
+    /// is never topped up here: the additional cycles would be refunded right away
+    /// and, unlike this refund, the withdrawal could fail.
     fn early_finish(
-        self,
+        mut self,
         result: Result<Option<WasmResult>, HypervisorError>,
         original: &OriginalContext,
         round: &RoundContext,
         round_limits: &mut RoundLimits,
     ) -> ExecuteMessageResult {
+        let execution_mode = self.wasm_execution_mode();
+        self.prepayment_for_response_execution = round
+            .cycles_account_manager
+            .refund_excess_prepayment_for_response_execution(
+                &mut self.canister.system_state,
+                self.prepayment_for_response_execution,
+                original.subnet_cycles_config,
+                execution_mode,
+            );
+
         self.finish(
             result,
             original.message_instruction_limit,
@@ -1044,12 +1137,27 @@ pub fn execute_response(
         deallocation_sender,
     );
     helper.apply_initial_refunds();
-    let helper = match helper.validate(&call_context, &original, &round, round_limits) {
+    let mut helper = match helper.validate(&call_context, &original, &round, round_limits) {
         Ok(helper) => helper,
         Err(result) => {
             return result;
         }
     };
+
+    // The cycles prepaid for this response execution when the corresponding call was
+    // performed might not match the cost of executing it in the canister's current
+    // Wasm execution mode. If the canister cannot pay a shortfall, then the response
+    // is rejected without executing the callback.
+    if let Err(err) = helper.adjust_prepayment_for_response_execution(&original, &round) {
+        info!(
+            round.log,
+            "Failed response callback execution of canister {} due to insufficient cycles for the additional prepayment: {:?}.",
+            original.canister_id,
+            err,
+        );
+        let result = Err(HypervisorError::InsufficientCyclesBalance(err));
+        return helper.early_finish(result, &original, &round, round_limits);
+    }
 
     let closure = match response.response_payload {
         Payload::Data(_) => original.callback.on_reply.clone(),

--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -133,7 +133,7 @@ struct ResponseHelper {
     /// executed, `adjust_prepayment_for_response_execution()` replaces this with the
     /// cycles required for executing the response in the canister's current Wasm
     /// execution mode; for responses whose callback is not executed at all,
-    /// `early_finish()` only refunds an excessive prepayment.
+    /// `early_finish()` settles the prepayment in full instead.
     prepayment_for_response_execution: CompoundCycles<Instructions>,
     initial_cycles_balance: Cycles,
     response_sender: CanisterId,
@@ -735,13 +735,15 @@ impl ResponseHelper {
     /// Completes execution of the response and cleanup callbacks without
     /// consuming any instructions and without producing any heap delta.
     ///
-    /// No Wasm code is executed at all: the part of the prepayment exceeding what the
-    /// canister's current Wasm execution mode requires is refunded here.
+    /// No Wasm code is executed at all, hence the fixed per-message execution fee is
+    /// all that is due: it is charged here and the rest of the cycles prepaid for the
+    /// response execution is refunded, independently of the Wasm execution mode the
+    /// cycles were prepaid for and of the one the canister has now. In particular,
+    /// the canister keeps the rest of its prepayment even if the prepayment falls
+    /// short of what its current Wasm execution mode requires.
     ///
-    /// The remaining prepayment is settled by `finish()` as usual, which leaves the
-    /// canister charged the fixed per-message execution fee. Note that the prepayment
-    /// is never topped up here: the additional cycles would be refunded right away
-    /// and, unlike this refund, the withdrawal could fail.
+    /// Note that the prepayment is never topped up here: the additional cycles would
+    /// be refunded right away and, unlike this refund, the withdrawal could fail.
     fn early_finish(
         mut self,
         result: Result<Option<WasmResult>, HypervisorError>,
@@ -750,14 +752,18 @@ impl ResponseHelper {
         round_limits: &mut RoundLimits,
     ) -> ExecuteMessageResult {
         let execution_mode = self.wasm_execution_mode();
-        self.prepayment_for_response_execution = round
+        round
             .cycles_account_manager
-            .refund_excess_prepayment_for_response_execution(
+            .settle_prepayment_for_unexecuted_response(
                 &mut self.canister.system_state,
                 self.prepayment_for_response_execution,
                 original.subnet_cycles_config,
                 execution_mode,
             );
+        // The prepayment has been settled in full, hence there is nothing left for
+        // `finish()` to settle.
+        self.prepayment_for_response_execution =
+            CompoundCycles::new(Cycles::zero(), original.subnet_cycles_config.cost_schedule);
 
         self.finish(
             result,


### PR DESCRIPTION
# Summary

The cycles for a response execution are prepaid when the corresponding call is
performed, i.e., using the instruction costs of the Wasm execution mode of the
calling canister at that time, whereas the refund of the cycles for the unused
instructions is computed using the instruction costs of the Wasm execution mode
that the canister has when the response arrives, which need not be the same.

Before executing a response, the cycles prepaid for its execution are now
adjusted to match the cycles required for executing it in the canister's current
Wasm execution mode, so that the canister ends up being charged exactly as if it
had performed the call in the Wasm execution mode in which the response is
executed.

# Details

`CyclesAccountManager::adjust_prepayment_for_response_execution` withdraws the
missing cycles from the canister's balance or refunds the excess to it:

- no freezing threshold is applied to the withdrawal because the canister
  already committed to executing the response when it performed the
  corresponding call. If its balance does not cover the additional prepayment,
  then the response execution fails with an out-of-cycles error and without
  executing the callback, and the canister is charged the fixed per-message
  execution fee just like for any other response whose callback is not executed;
- the refunded excess does not contribute to the consumed cycles of the
  canister.

The prepayment then matches the requirement exactly, so the refund of the cycles
for the unused instructions settles the response execution in the canister's
current Wasm execution mode.

Responses whose callback is not executed at all, i.e., those whose call context
has been deleted (e.g., because the canister was uninstalled), those whose
canister has no execution state and those whose prepayment could not be topped
up, are settled by
`CyclesAccountManager::settle_prepayment_for_unexecuted_response` in
`ResponseHelper::early_finish`: no instructions are executed, hence the fixed
per-message execution fee is all that is due, it is retained and the rest of the
prepayment is refunded, independently of the Wasm execution mode the cycles were
prepaid for and of the one the canister has now. The prepayment is never topped
up there because the additional cycles would be refunded right away and, unlike
this refund, the withdrawal could fail.

Settling such a response through the refund of the cycles for the unused
instructions instead would not do: that refund is computed in the canister's
current Wasm execution mode and clamped to the prepayment, so a prepayment
falling short of what that mode requires would be refunded in full, i.e. the
fixed per-message execution fee would be refunded as well.

The adjusted prepayment is not persisted in the callback, so both resuming a
paused response execution (which replays the adjustment on the clean canister
state) and restarting an aborted one (which recomputes it for the module
installed by then) remain idempotent. The Wasm module of a canister cannot
change while a DTS execution of that canister is in progress, since installing
code is deferred for a canister that has a paused or an aborted execution.

# Unchanged behaviour

If the Wasm execution mode did not change since the call was performed, which is
the case for every canister that is not upgraded across a call, then the
adjustment is a no-op and the cycles charged for the response execution are
exactly the same as before. In particular,
`CyclesAccountManager::refund_unused_execution_cycles` and the copy of its
formula in `CanisterManager` are left untouched, so no cycle amount changes on
that path.

This change also does not touch:

- the cycles prepaid when the call is performed, hence neither the value
  returned by `ic0.cost_call` nor the cycles reserved per outstanding call
  change;
- any persisted state: no field is added to `Callback` and there is no protobuf
  change, hence no migration is needed.

Failing a response execution because the canister cannot pay for it is new. In
the common case the canister has enough, since the cycles it must hold in order
to execute the message that performs the call are refunded to it and exceed the
additional prepayment; reaching this failure requires the balance to be drained
between performing the call and receiving the response, e.g., by further
outstanding calls, by other messages, or by resource charges.