### PR TITLE
test: Temporarily disable vetkeys in upgrade downgrade tests

### DIFF
--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -12,7 +12,7 @@ use ic_consensus_system_test_utils::rw_message::{
     can_read_msg_with_retries, install_nns_and_check_progress,
 };
 use ic_consensus_threshold_sig_system_test_utils::{
-    ChainSignatureRequest, make_key_ids_for_all_schemes,
+    ChainSignatureRequest, make_key_ids_for_all_idkg_schemes,
 };
 use ic_registry_subnet_features::{ChainKeyConfig, DEFAULT_ECDSA_MAX_QUEUE_SIZE, KeyConfig};
 use ic_registry_subnet_type::SubnetType;
@@ -47,7 +47,8 @@ fn setup(env: TestEnv) {
         .add_nodes(SUBNET_SIZE)
         .with_dkg_interval_length(Height::from(DKG_INTERVAL))
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: make_key_ids_for_all_schemes()
+            // TODO: Switch back to `make_key_ids_for_all_schemes` once mainnet version changes
+            key_configs: make_key_ids_for_all_idkg_schemes()
                 .into_iter()
                 .map(|key_id| KeyConfig {
                     max_queue_size: DEFAULT_ECDSA_MAX_QUEUE_SIZE,
@@ -76,7 +77,8 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
     let nns_node = env.get_first_healthy_system_node_snapshot();
     let target_version = elect_target_version(&env, &nns_node);
     let agent = nns_node.with_default_agent(|agent| async move { agent });
-    let key_ids = make_key_ids_for_all_schemes();
+    // TODO: Switch back to `make_key_ids_for_all_schemes` once mainnet version changes
+    let key_ids = make_key_ids_for_all_idkg_schemes();
     let ecdsa_state = get_chain_key_canister_and_public_key(
         &env,
         &nns_node,


### PR DESCRIPTION
The upgrade-downgrade tests are currently flaky due to a change in vetkeys signatures. See root cause analysis here: https://github.com/dfinity/ic/pull/11410

Making production backward compatible (like the PR above suggests) is not necessary, since replicas are not expected to validate artifacts of different replica versions. Therefore, this PR simply disables vetkeys in upgrade downgrade tests, until the version containing https://github.com/dfinity/ic/pull/11333 is rolled out to all subnets.