### PR TITLE
refactor: Export the monotonic consumed cycles total as the existing gauge

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1379,6 +1379,13 @@ impl CanisterManager {
         );
 
         // Leftover cycles in the canister are considered `consumed`.
+        //
+        // Note that the canister's `consumed_cycles` gauge (rather than its monotonic
+        // `consumed_cycles_monotonic`) is what is moved into the subnet metrics
+        // below. The two are equal here: a canister can only be deleted while
+        // `Stopped` and with empty queues, so it has no callback and no execution
+        // left holding an outstanding prepayment (see
+        // `SystemState::outstanding_prepayments`).
         let leftover_cycles = self
             .cycles_account_manager
             .leftover_cycles_for_canister_to_deleted(

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -11,7 +11,7 @@ use crate::execution_environment::{
 };
 use crate::ic00_permissions::Ic00MethodPermissions;
 use crate::metrics::MeasurementScope;
-use crate::util::process_responses;
+use crate::util::{debug_assert_or_critical_error, process_responses};
 use ic_config::embedders::Config as HypervisorConfig;
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::SchedulerConfig;
@@ -1126,6 +1126,22 @@ impl SchedulerImpl {
 
                 // Abort all paused execution before the checkpoint.
                 abort_all_paused_executions(state, &self.exec_env, cost_schedule, &self.log);
+
+                // Backfill the `consumed_cycles_monotonic` of every canister from
+                // its `consumed_cycles` gauge, which predates it.
+                //
+                // Only done on checkpoint rounds, and only after the paused
+                // executions above have been aborted: a paused execution holds a
+                // prepayment that is not part of the replicated state, which would
+                // make the backfill overestimate the monotonic amount (see
+                // `SystemState::outstanding_prepayments`). Aborting materializes
+                // those prepayments into the canisters' task queues.
+                //
+                // Unconditional and idempotent, like
+                // `migrate_outcalls_cycles_to_use_cases` above: it is a no-op once a
+                // canister has been backfilled, and self-healing if a downgrade
+                // dropped the monotonic amount.
+                migrate_consumed_cycles_to_monotonic(state, &self.metrics, &self.log);
             }
             ExecutionRoundType::OrdinaryRound => {
                 self.abort_paused_executions_above_limit(state);
@@ -2160,4 +2176,62 @@ pub fn abort_all_paused_executions(
     for canister in canister_states.hot_values_mut() {
         abort_canister(canister, subnet_schedule, exec_env, cost_schedule, log);
     }
+}
+
+/// Backfills `CanisterMetrics::consumed_cycles_monotonic` of every canister from
+/// its `consumed_cycles` gauge, which predates it and thus holds the full history. See `SystemState::migrate_consumed_cycles_to_monotonic`.
+///
+/// Must only be called with no paused executions left (i.e. on a checkpoint round,
+/// after `abort_all_paused_executions`); a canister that still has one is skipped,
+/// as its prepayment is not part of the replicated state.
+fn migrate_consumed_cycles_to_monotonic(
+    state: &mut ReplicatedState,
+    metrics: &SchedulerMetrics,
+    log: &ReplicaLogger,
+) {
+    state.canisters_for_each_mut(|_id, canister| {
+        let canister_metrics = canister.system_state.canister_metrics();
+        // The outstanding prepayments could not be derived from the replicated
+        // state, i.e. the canister has a paused execution, whose prepayment is only
+        // held in memory. Unreachable when called as documented.
+        let Some(outstanding) = canister.system_state.outstanding_prepayments() else {
+            debug_assert_or_critical_error!(
+                false,
+                metrics.consumed_cycles_invariant_broken,
+                log,
+                "{}: Canister {}: cannot derive the monotonic consumed cycles, \
+                 unexpected task {:?}",
+                CONSUMED_CYCLES_INVARIANT_BROKEN,
+                canister.canister_id(),
+                canister.system_state.task_queue.paused_or_aborted_task(),
+            );
+            return;
+        };
+        let derived = canister_metrics.consumed_cycles() - outstanding;
+        match derived.cmp(&canister_metrics.consumed_cycles_monotonic()) {
+            // Not backfilled yet, or a downgrade dropped it. Only take a
+            // mutable reference here, so that this stays a read-only pass once every
+            // canister has been backfilled (`Arc::make_mut` clones the canister).
+            std::cmp::Ordering::Greater => {
+                Arc::make_mut(canister)
+                    .system_state
+                    .migrate_consumed_cycles_to_monotonic();
+            }
+            // The invariant that makes the backfill exact; see
+            // `SystemState::outstanding_prepayments`.
+            std::cmp::Ordering::Equal => {}
+            std::cmp::Ordering::Less => debug_assert_or_critical_error!(
+                false,
+                metrics.consumed_cycles_invariant_broken,
+                log,
+                "{}: Canister {}: monotonic consumed cycles {} above the gauge {} net \
+                 of the {} outstanding prepayments",
+                CONSUMED_CYCLES_INVARIANT_BROKEN,
+                canister.canister_id(),
+                canister_metrics.consumed_cycles_monotonic(),
+                canister_metrics.consumed_cycles(),
+                outstanding,
+            ),
+        }
+    });
 }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -15,6 +15,8 @@ pub(crate) const CANISTER_INVARIANT_BROKEN: &str = "scheduler_canister_invariant
 pub(crate) const SCHEDULER_COMPUTE_ALLOCATION_INVARIANT_BROKEN: &str =
     "scheduler_compute_allocation_invariant_broken";
 pub(crate) const SCHEDULER_CORES_INVARIANT_BROKEN: &str = "scheduler_cores_invariant_broken";
+pub(crate) const CONSUMED_CYCLES_INVARIANT_BROKEN: &str =
+    "scheduler_consumed_cycles_invariant_broken";
 
 pub struct SchedulerMetrics {
     pub(super) canister_age: Histogram,
@@ -58,6 +60,7 @@ pub struct SchedulerMetrics {
     pub(super) canister_invariants: IntCounter,
     pub(super) scheduler_compute_allocation_invariant_broken: IntCounter,
     pub(super) scheduler_cores_invariant_broken: IntCounter,
+    pub(super) consumed_cycles_invariant_broken: IntCounter,
     pub(super) scheduler_accumulated_priority_deviation: Gauge,
     pub(super) inducted_messages: IntCounterVec,
     pub(super) delivered_pre_signatures: HistogramVec,
@@ -305,6 +308,7 @@ impl SchedulerMetrics {
             canister_invariants: metrics_registry.error_counter(CANISTER_INVARIANT_BROKEN),
             scheduler_compute_allocation_invariant_broken: metrics_registry.error_counter(SCHEDULER_COMPUTE_ALLOCATION_INVARIANT_BROKEN),
             scheduler_cores_invariant_broken: metrics_registry.error_counter(SCHEDULER_CORES_INVARIANT_BROKEN),
+            consumed_cycles_invariant_broken: metrics_registry.error_counter(CONSUMED_CYCLES_INVARIANT_BROKEN),
             scheduler_accumulated_priority_deviation: metrics_registry.gauge(
                 "scheduler_accumulated_priority_deviation",
                 "The standard deviation of accumulated priorities on the subnet."

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -1104,6 +1104,141 @@ fn threshold_signature_agreements_metric_is_updated() {
     assert!(sign_with_threshold_contexts.is_empty());
 }
 
+/// Asserts the invariant that ties `CanisterMetrics::consumed_cycles` to its
+/// monotonic counterpart: the gauge exceeds the monotonic amount by exactly the
+/// prepayments whose refund is still outstanding. Returns the latter.
+fn assert_consumed_cycles_invariant(
+    test: &SchedulerTest,
+    canister_id: CanisterId,
+) -> NominalCycles {
+    let system_state = &test.canister_state(canister_id).system_state;
+    let outstanding = system_state
+        .outstanding_prepayments()
+        .expect("Canister has a paused execution");
+    let metrics = system_state.canister_metrics();
+    assert_eq!(
+        metrics.consumed_cycles() - outstanding,
+        metrics.consumed_cycles_monotonic(),
+        "consumed cycles gauge {} minus the {outstanding} outstanding prepayments \
+         must equal the monotonic {}",
+        metrics.consumed_cycles(),
+        metrics.consumed_cycles_monotonic(),
+    );
+    outstanding
+}
+
+/// Opens a call to an xnet canister, so that the caller is left with an outstanding
+/// prepayment for the response.
+fn call_xnet_canister(test: &mut SchedulerTest, canister: CanisterId) {
+    let xnet_canister = test.xnet_canister_id();
+    test.send_ingress(
+        canister,
+        ingress(1).call(other_side(xnet_canister, 1), on_response(1)),
+    );
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+}
+
+#[test]
+fn consumed_cycles_monotonic_matches_the_gauge_net_of_outstanding_prepayments() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let canister = test.create_canister();
+
+    call_xnet_canister(&mut test, canister);
+
+    let outstanding = assert_consumed_cycles_invariant(&test, canister);
+    assert_ne!(outstanding, NominalCycles::zero());
+    assert_ne!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_monotonic(),
+        NominalCycles::zero()
+    );
+}
+
+#[test]
+fn checkpoint_round_backfills_consumed_cycles_monotonic() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let canister = test.create_canister();
+
+    call_xnet_canister(&mut test, canister);
+    let outstanding = assert_consumed_cycles_invariant(&test, canister);
+    assert_ne!(outstanding, NominalCycles::zero());
+
+    // Pretend the canister was loaded from a checkpoint predating the field.
+    test.canister_state_mut(canister)
+        .system_state
+        .reset_consumed_cycles_monotonic();
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_monotonic(),
+        NominalCycles::zero()
+    );
+
+    // An ordinary round does not backfill it, a checkpoint round does.
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_monotonic(),
+        NominalCycles::zero()
+    );
+
+    test.execute_round(ExecutionRoundType::CheckpointRound);
+    assert_consumed_cycles_invariant(&test, canister);
+    assert_ne!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_monotonic(),
+        NominalCycles::zero()
+    );
+}
+
+/// A paused execution holds a prepayment that is not part of the replicated state,
+/// so it cannot be backfilled; but a checkpoint round aborts all paused executions
+/// before backfilling, materializing their prepayments into the task queues.
+#[test]
+fn checkpoint_round_backfills_consumed_cycles_monotonic_of_paused_canister() {
+    let mut test = SchedulerTestBuilder::new()
+        .with_scheduler_config(SchedulerConfig {
+            scheduler_cores: 2,
+            max_instructions_per_round: NumInstructions::from(100),
+            max_instructions_per_message: NumInstructions::from(1000),
+            max_instructions_per_slice: NumInstructions::from(100),
+            max_instructions_per_install_code_slice: NumInstructions::from(100),
+            ..SchedulerConfig::application_subnet()
+        })
+        .build();
+    let canister = test.create_canister();
+
+    test.send_ingress(canister, ingress(1000));
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert!(test.canister_state(canister).has_paused_execution());
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .outstanding_prepayments(),
+        None
+    );
+
+    // Pretend the canister was loaded from a checkpoint predating the field.
+    test.canister_state_mut(canister)
+        .system_state
+        .reset_consumed_cycles_monotonic();
+
+    test.execute_round(ExecutionRoundType::CheckpointRound);
+
+    assert!(test.canister_state(canister).has_aborted_execution());
+    let outstanding = assert_consumed_cycles_invariant(&test, canister);
+    // The aborted execution's prepayment is outstanding, and is not part of the
+    // backfilled amount.
+    assert_ne!(outstanding, NominalCycles::zero());
+}
+
 #[test]
 fn consumed_cycles_ecdsa_outcalls_are_added_to_consumed_cycles_total() {
     for cost_schedule in [

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -45,10 +45,11 @@ use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id
 use more_asserts::assert_ge;
 use std::time::Duration;
 
-/// Observes the state metrics at `height`, having first refreshed the derived
-/// consumed-cycles total that the `replicated_state_consumed_cycles_since_replica_started`
-/// gauge reads. Production refreshes it on every `commit_and_certify`, which this
-/// harness never does.
+/// Observes the state metrics at `height`, having first refreshed
+/// `SubnetMetrics::consumed_cycles_total_including_canisters`, the derived
+/// certified total that the assertions below compare the exported gauge against.
+/// Production refreshes it on every `commit_and_certify`, which this harness never
+/// does.
 fn observe_state_metrics(test: &mut SchedulerTest, height: u64) {
     test.state_mut().refresh_consumed_cycles();
     test.state_metrics().observe(
@@ -1567,6 +1568,33 @@ fn consumed_cycles_for_instructions_are_updated_from_valid_canisters() {
             ),]),
         );
     }
+}
+
+/// The exported total is the subnet-level aggregate (already monotonic) plus the
+/// canisters' `consumed_cycles_monotonic`; i.e. the certified
+/// `consumed_cycles_total_including_canisters`, net of the outstanding prepayments.
+#[test]
+fn consumed_cycles_total_is_exported_net_of_outstanding_prepayments() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let canister = test.create_canister();
+
+    call_xnet_canister(&mut test, canister);
+    let outstanding = assert_consumed_cycles_invariant(&test, canister);
+    assert_ne!(outstanding, NominalCycles::zero());
+
+    observe_state_metrics(&mut test, 0);
+
+    let certified_total = test
+        .state()
+        .metadata
+        .subnet_metrics
+        .consumed_cycles_total_including_canisters();
+    let exported = fetch_gauge(
+        test.metrics_registry(),
+        "replicated_state_consumed_cycles_since_replica_started",
+    )
+    .unwrap();
+    assert_eq!((certified_total - outstanding).get() as f64, exported);
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -346,6 +346,9 @@ impl CanisterMetrics {
     /// that [`Self::consumed_cycles`] covers, i.e. everything except HTTPS outcalls,
     /// which are only tracked at the subnet level (and, for the canister, in the
     /// by-use-case map).
+    ///
+    /// See `SystemState::outstanding_prepayments` for the invariant that ties the
+    /// two together.
     pub fn consumed_cycles_monotonic(&self) -> NominalCycles {
         self.consumed_cycles_monotonic
     }
@@ -2259,6 +2262,148 @@ impl SystemState {
         &mut self.canister_metrics
     }
 
+    /// The prepayments that have already been added to
+    /// [`CanisterMetrics::consumed_cycles`] but whose refund has not been observed
+    /// yet; i.e. the amounts that will be reported as the prepayment of a future
+    /// `ConsumingCycles::Refund` observation.
+    ///
+    /// Only `Instructions` and `RequestAndResponseTransmission` charges are ever
+    /// refunded (they are the only two `CyclesUseCaseRefundableKind`s) and an
+    /// outstanding prepayment of either is always recorded in the replicated state:
+    ///
+    ///  * in the `Callback` of a call whose response has not been executed yet
+    ///    (`prepayment_for_response_execution` and
+    ///    `prepayment_for_call_transmission`); or
+    ///  * in the `prepaid_execution_cycles` of an aborted execution or an aborted
+    ///    `install_code`.
+    ///
+    /// (A paused execution records no prepayment of its own: a paused response
+    /// execution is paid for by the callback that the task carries, and any other
+    /// paused execution holds its prepayment in memory only, which is why this
+    /// method returns `None` for it. See below.)
+    ///
+    /// The only way such a prepayment leaves the state other than through the refund
+    /// that its execution or response issues is an aborted `install_code` dropped by
+    /// a subnet split; that path refunds it in full, see
+    /// `Self::drop_in_progress_management_calls_after_split`.
+    ///
+    /// Together with how the two metrics are updated, this yields the invariant
+    ///
+    /// ```text
+    /// consumed_cycles - outstanding_prepayments() == consumed_cycles_monotonic
+    /// ```
+    ///
+    /// which holds whenever no execution is in progress and is what
+    /// [`Self::migrate_consumed_cycles_to_monotonic`] relies on.
+    ///
+    /// Returns `None` if the outstanding prepayments cannot be derived from the
+    /// replicated state, i.e. if the canister has a paused execution whose
+    /// prepayment is not part of it: a paused execution is ephemeral, so (except
+    /// for a paused response execution, whose prepayments live in the callback
+    /// carried by the task) its prepayment is only held in memory. All paused
+    /// executions are aborted before a checkpoint, materializing their prepayments
+    /// into the state, so the caller can retry then.
+    pub fn outstanding_prepayments(&self) -> Option<NominalCycles> {
+        /// The prepayments made when the request behind `callback` was sent (see
+        /// `SandboxSafeSystemState::push_output_request`), to be refunded when its
+        /// response is executed.
+        fn callback_prepayments(callback: &Callback) -> NominalCycles {
+            // `prepayment_for_call_transmission` is zero for callbacks created before
+            // April 2026; the refund path falls back to
+            // `prepayment_for_response_transmission` for those, so mirror it here.
+            let transmission = if callback.prepayment_for_call_transmission.is_zero() {
+                callback.prepayment_for_response_transmission.nominal()
+            } else {
+                callback.prepayment_for_call_transmission.nominal()
+            };
+            callback.prepayment_for_response_execution.nominal() + transmission
+        }
+
+        let mut outstanding = NominalCycles::zero();
+
+        match self.task_queue.paused_or_aborted_task() {
+            Some(ExecutionTask::PausedExecution { input, .. }) => match input {
+                // A response execution prepays nothing of its own: it is paid for by
+                // the callback, which the task carries.
+                CanisterMessageOrTask::Message(CanisterMessage::Response { callback, .. }) => {
+                    outstanding += callback_prepayments(callback)
+                }
+                // Any other paused execution holds its prepayment in memory only.
+                _ => return None,
+            },
+            Some(ExecutionTask::PausedInstallCode(_)) => return None,
+            Some(ExecutionTask::AbortedExecution {
+                input,
+                prepaid_execution_cycles,
+            }) => {
+                // Zero for an aborted response execution, which prepays nothing of
+                // its own.
+                outstanding += prepaid_execution_cycles.nominal();
+                // As for a paused response execution above. The callback was
+                // unregistered from the `CallContextManager` when the response was
+                // popped, so it is not also counted below; and nothing was refunded
+                // yet, because aborting discards the changes that the initial steps
+                // of the response execution made.
+                if let CanisterMessageOrTask::Message(CanisterMessage::Response {
+                    callback, ..
+                }) = input
+                {
+                    outstanding += callback_prepayments(callback);
+                }
+            }
+            Some(ExecutionTask::AbortedInstallCode {
+                prepaid_execution_cycles,
+                ..
+            }) => outstanding += prepaid_execution_cycles.nominal(),
+            // Not a paused or aborted task, so it cannot be in this slot. Bail out
+            // rather than silently returning a bogus amount; the caller flags it.
+            Some(
+                ExecutionTask::Heartbeat
+                | ExecutionTask::GlobalTimer
+                | ExecutionTask::OnLowWasmMemory,
+            ) => return None,
+            None => {}
+        }
+
+        if let Some(call_context_manager) = self.call_context_manager() {
+            for callback in call_context_manager.callbacks().values() {
+                outstanding += callback_prepayments(callback);
+            }
+        }
+
+        Some(outstanding)
+    }
+
+    /// Backfills [`CanisterMetrics::consumed_cycles_monotonic`] from the
+    /// [`CanisterMetrics::consumed_cycles`] gauge, which predates it and thus holds
+    /// the full history.
+    ///
+    /// This derivation is exact, thanks to the invariant documented on
+    /// [`Self::outstanding_prepayments`]: the gauge differs from the monotonic
+    /// amount by exactly the prepayments whose refund is still outstanding, all of
+    /// which are recorded in the replicated state. And because the invariant holds
+    /// at all times (not just before the first observation of a canister), deriving
+    /// the monotonic amount this way is idempotent, so it is safe to redo it in
+    /// every round and after a downgrade has dropped it.
+    ///
+    /// Returns `false` (leaving it untouched) if the canister has a paused
+    /// execution whose prepayment is not part of the replicated state (see
+    /// [`Self::outstanding_prepayments`]); the caller is expected to retry once
+    /// paused executions have been aborted.
+    pub fn migrate_consumed_cycles_to_monotonic(&mut self) -> bool {
+        let Some(outstanding) = self.outstanding_prepayments() else {
+            return false;
+        };
+        // `max` rather than a plain assignment: the monotonic amount must never go
+        // down, not even if a saturating subtraction somewhere made the gauge lag
+        // behind it.
+        self.canister_metrics.consumed_cycles_monotonic = self
+            .canister_metrics
+            .consumed_cycles_monotonic
+            .max(self.canister_metrics.consumed_cycles - outstanding);
+        true
+    }
+
     /// Clears all canister changes and their memory usage,
     /// but keeps the total number of changes recorded.
     pub fn clear_canister_history(&mut self) {
@@ -2590,6 +2735,13 @@ pub mod testing {
             deadline: CoarseTime,
         ) -> (CallbackId, Arc<Callback>);
 
+        /// Testing only: Registers the given callback and returns its ID.
+        fn with_raw_callback(&mut self, callback: Callback) -> CallbackId;
+
+        /// Testing only: Resets `CanisterMetrics::consumed_cycles_monotonic`, e.g. to
+        /// simulate a canister loaded from a checkpoint predating the field.
+        fn reset_consumed_cycles_monotonic(&mut self);
+
         /// Testing only: sets the canister status.
         fn set_status(&mut self, status: CanisterStatus);
 
@@ -2624,6 +2776,16 @@ pub mod testing {
 
         fn pop_input(&mut self) -> Option<CanisterMessage> {
             self.pop_input()
+        }
+
+        fn with_raw_callback(&mut self, callback: Callback) -> CallbackId {
+            call_context_manager_mut(&mut self.status)
+                .unwrap()
+                .register_callback(callback)
+        }
+
+        fn reset_consumed_cycles_monotonic(&mut self) {
+            self.canister_metrics.consumed_cycles_monotonic = NominalCycles::zero();
         }
 
         fn set_status(&mut self, status: CanisterStatus) {

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -23,8 +23,9 @@ use ic_metrics::MetricsRegistry;
 use ic_test_utilities_types::ids::{canister_test_id, message_test_id, user_test_id};
 use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
 use ic_types::messages::{
-    CallContextId, CallbackId, CanisterCall, CanisterMessageOrTask, MAX_RESPONSE_COUNT_BYTES,
-    NO_DEADLINE, StopCanisterCallId, StopCanisterContext,
+    CallContextId, CallbackId, CanisterCall, CanisterMessageOrTask, CanisterTask,
+    MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, RequestMetadata, StopCanisterCallId,
+    StopCanisterContext,
 };
 use ic_types::methods::{Callback, WasmClosure};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
@@ -1049,6 +1050,246 @@ fn full_refund_resets_consumed_cycles() {
     }
 }
 
+/// The prepayments of an open callback are outstanding until its response is
+/// executed: `prepayment_for_response_execution` plus `prepayment_for_call_transmission`.
+#[test]
+fn outstanding_prepayments_of_open_callbacks() {
+    let mut fixture = CanisterStateFixture::new();
+    let system_state = &mut fixture.canister_state.system_state;
+    assert_eq!(
+        system_state.outstanding_prepayments(),
+        Some(NominalCycles::zero())
+    );
+
+    // See `SystemStateTesting::with_callback` for the prepayments of this callback.
+    fixture.make_callback(NO_DEADLINE);
+    assert_eq!(
+        fixture
+            .canister_state
+            .system_state
+            .outstanding_prepayments(),
+        Some(NominalCycles::new(42 + 168))
+    );
+
+    fixture.make_callback(SOME_DEADLINE);
+    assert_eq!(
+        fixture
+            .canister_state
+            .system_state
+            .outstanding_prepayments(),
+        Some(NominalCycles::new(2 * (42 + 168)))
+    );
+}
+
+/// `prepayment_for_call_transmission` is zero for callbacks created before April
+/// 2026; the refund path falls back to `prepayment_for_response_transmission` for
+/// those, and so must the outstanding prepayments.
+#[test]
+fn outstanding_prepayments_of_legacy_callback() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let mut fixture = CanisterStateFixture::new();
+    let call_context_id = fixture
+        .canister_state
+        .system_state
+        .with_call_context(CallContext::new(
+            CallOrigin::SystemTask,
+            false,
+            false,
+            Cycles::zero(),
+            UNIX_EPOCH,
+            RequestMetadata::new(0, UNIX_EPOCH),
+            None,
+        ));
+    fixture
+        .canister_state
+        .system_state
+        .with_raw_callback(Callback::new(
+            call_context_id,
+            OTHER_CANISTER_ID,
+            Cycles::zero(),
+            CompoundCycles::new(Cycles::new(42), cost_schedule),
+            CompoundCycles::new(Cycles::new(84), cost_schedule),
+            CompoundCycles::new(Cycles::zero(), cost_schedule),
+            WasmClosure::new(0, 2),
+            WasmClosure::new(0, 2),
+            None,
+            NO_DEADLINE,
+        ));
+
+    assert_eq!(
+        fixture
+            .canister_state
+            .system_state
+            .outstanding_prepayments(),
+        Some(NominalCycles::new(42 + 84))
+    );
+}
+
+/// The prepayment of an aborted execution is outstanding until the execution is
+/// retried; a paused execution's is not part of the replicated state.
+#[test]
+fn outstanding_prepayments_of_paused_and_aborted_executions() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let prepaid = CompoundCycles::<Instructions>::new(Cycles::new(1000), cost_schedule);
+    let input = CanisterMessageOrTask::Task(CanisterTask::Heartbeat);
+
+    let mut fixture = CanisterStateFixture::new();
+    fixture
+        .canister_state
+        .system_state
+        .task_queue
+        .enqueue(ExecutionTask::AbortedExecution {
+            input: input.clone(),
+            prepaid_execution_cycles: prepaid,
+        });
+    assert_eq!(
+        fixture
+            .canister_state
+            .system_state
+            .outstanding_prepayments(),
+        Some(prepaid.nominal())
+    );
+
+    let mut fixture = CanisterStateFixture::new();
+    fixture
+        .canister_state
+        .system_state
+        .task_queue
+        .enqueue(ExecutionTask::PausedExecution {
+            id: PausedExecutionId(0),
+            input,
+        });
+    assert_eq!(
+        fixture
+            .canister_state
+            .system_state
+            .outstanding_prepayments(),
+        None
+    );
+}
+
+/// A paused or aborted response execution prepays nothing of its own: it is paid for
+/// by the callback that the task carries, which is no longer registered with the
+/// `CallContextManager` (so it must not be counted twice).
+#[test]
+fn outstanding_prepayments_of_aborted_response_execution() {
+    let mut fixture = CanisterStateFixture::new();
+    let callback_id = fixture.make_callback(NO_DEADLINE);
+    let callback = fixture
+        .canister_state
+        .system_state
+        .call_context_manager()
+        .unwrap()
+        .callback(callback_id)
+        .unwrap()
+        .clone();
+    let response = default_input_response(callback_id, NO_DEADLINE);
+
+    let system_state = &mut fixture.canister_state.system_state;
+    system_state.unregister_callback(callback_id).unwrap();
+    system_state
+        .task_queue
+        .enqueue(ExecutionTask::AbortedExecution {
+            input: CanisterMessageOrTask::Message(CanisterMessage::Response {
+                response: response.into(),
+                callback: callback.into(),
+            }),
+            prepaid_execution_cycles: CompoundCycles::new(
+                Cycles::zero(),
+                CanisterCyclesCostSchedule::Normal,
+            ),
+        });
+
+    assert_eq!(
+        system_state.outstanding_prepayments(),
+        Some(NominalCycles::new(42 + 168))
+    );
+}
+
+/// Backfilling the monotonic amount from the gauge is exact, thanks to the
+/// invariant that the gauge exceeds it by exactly the outstanding prepayments. And
+/// it is idempotent, so it can be redone in every round.
+#[test]
+fn migrate_consumed_cycles_to_monotonic_is_exact_and_idempotent() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let mut fixture = CanisterStateFixture::new();
+    let system_state = &mut fixture.canister_state.system_state;
+
+    // Some consumption with all refunds settled...
+    let final_charge = CompoundCycles::<MemoryUseCase>::new(Cycles::new(500), cost_schedule);
+    let prepaid = CompoundCycles::<Instructions>::new(Cycles::new(1000), cost_schedule);
+    let refund = CompoundCycles::<Instructions>::new(Cycles::new(100), cost_schedule);
+    system_state.consume_cycles(final_charge);
+    system_state.consume_cycles(prepaid);
+    system_state.refund_cycles(prepaid, refund);
+    let settled = final_charge.nominal() + (prepaid - refund).nominal();
+
+    // ...plus an outstanding prepayment for a call that has not been responded to.
+    let outstanding = CompoundCycles::<Instructions>::new(Cycles::new(42), cost_schedule).nominal()
+        + CompoundCycles::<RequestAndResponseTransmission>::new(Cycles::new(168), cost_schedule)
+            .nominal();
+    system_state.consume_cycles(CompoundCycles::<Instructions>::new(
+        Cycles::new(42),
+        cost_schedule,
+    ));
+    system_state.consume_cycles(CompoundCycles::<RequestAndResponseTransmission>::new(
+        Cycles::new(168),
+        cost_schedule,
+    ));
+    fixture.make_callback(NO_DEADLINE);
+    let system_state = &mut fixture.canister_state.system_state;
+
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles(),
+        settled + outstanding
+    );
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
+        settled
+    );
+    assert_eq!(system_state.outstanding_prepayments(), Some(outstanding));
+
+    // Pretend the canister was loaded from a checkpoint predating the field.
+    system_state.reset_consumed_cycles_monotonic();
+    assert!(system_state.migrate_consumed_cycles_to_monotonic());
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
+        settled
+    );
+
+    // Redoing it changes nothing.
+    assert!(system_state.migrate_consumed_cycles_to_monotonic());
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
+        settled
+    );
+}
+
+/// A canister with a paused execution cannot be backfilled, as the prepayment of the
+/// paused execution is not part of the replicated state.
+#[test]
+fn migrate_consumed_cycles_to_monotonic_skips_paused_execution() {
+    let mut fixture = CanisterStateFixture::new();
+    let system_state = &mut fixture.canister_state.system_state;
+    system_state.consume_cycles(CompoundCycles::<MemoryUseCase>::new(
+        Cycles::new(500),
+        CanisterCyclesCostSchedule::Normal,
+    ));
+    system_state
+        .task_queue
+        .enqueue(ExecutionTask::PausedExecution {
+            id: PausedExecutionId(0),
+            input: CanisterMessageOrTask::Task(CanisterTask::Heartbeat),
+        });
+
+    system_state.reset_consumed_cycles_monotonic();
+    assert!(!system_state.migrate_consumed_cycles_to_monotonic());
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
+        NominalCycles::zero()
+    );
+}
+
 #[test]
 fn consume_cycles_exceeding_balance_reports_only_the_charged_amount() {
     fn test(cost_schedule: CanisterCyclesCostSchedule) {
@@ -1569,7 +1810,10 @@ fn full_refund_does_not_lower_consumed_cycles_monotonic() {
 
 /// The cycles prepaid for an `install_code` that a subnet split drops are refunded
 /// in full: the execution is never retried (subnet A' rejects the corresponding
-/// call), so the canister has nothing to show for them.
+/// call), so the canister has nothing to show for them. This also keeps the
+/// consumed cycles metrics consistent -- leaving the prepayment in the gauge with
+/// nothing in the state to account for it would break the invariant on
+/// `SystemState::outstanding_prepayments`.
 #[test]
 fn refunds_prepayment_of_aborted_canister_install_dropped_after_split() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
@@ -1590,8 +1834,16 @@ fn refunds_prepayment_of_aborted_canister_install_dropped_after_split() {
     // gauge; nothing has been consumed for good yet, so the monotonic amount is
     // still zero.
     assert_eq!(
+        system_state.outstanding_prepayments(),
+        Some(prepaid.nominal())
+    );
+    assert_eq!(
         system_state.canister_metrics().consumed_cycles(),
         prepaid.nominal()
+    );
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
+        NominalCycles::zero()
     );
     assert_eq!(
         system_state
@@ -1606,12 +1858,21 @@ fn refunds_prepayment_of_aborted_canister_install_dropped_after_split() {
     canister_state.drop_in_progress_management_calls_after_split();
 
     // The prepayment is refunded in full, so the balance is whole again and the gauge
-    // is back to zero. Nothing was consumed, so the monotonic amount stays at zero
-    // too.
+    // is back to zero. Nothing was consumed, so the monotonic amounts stay at zero
+    // too -- and with the prepayment no longer outstanding, the invariant still
+    // holds.
     let system_state = &canister_state.system_state;
     assert_eq!(system_state.balance(), balance_before + prepaid.real());
     assert_eq!(
         system_state.canister_metrics().consumed_cycles(),
+        NominalCycles::zero()
+    );
+    assert_eq!(
+        system_state.outstanding_prepayments(),
+        Some(NominalCycles::zero())
+    );
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles_monotonic(),
         NominalCycles::zero()
     );
     assert_eq!(

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -647,10 +647,12 @@ impl SubnetMetrics {
     /// `CanisterMetrics::consumed_cycles()` over the canisters that currently
     /// exist, as of the end of the last committed round.
     ///
-    /// Every consumer of the full total reads it here -- the certified state tree at
-    /// `/subnet/<subnet_id>/metrics` (from certification version `V29`) and the
-    /// `replicated_state_consumed_cycles_since_replica_started` gauge -- so they
-    /// cannot drift apart.
+    /// This is the certified total: the state tree at `/subnet/<subnet_id>/metrics`
+    /// (from certification version `V29`) reads it here. The
+    /// `replicated_state_consumed_cycles_since_replica_started` gauge deliberately
+    /// exports the monotonic counterpart instead -- this same total, net of the
+    /// prepayments whose refund is not known yet -- see
+    /// `ReplicatedStateMetrics::observe`.
     pub fn consumed_cycles_total_including_canisters(&self) -> NominalCycles {
         self.consumed_cycles_total_including_canisters
     }

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2785,13 +2785,14 @@ fn consumed_cycles_total_calculates_the_right_amount() {
 }
 
 /// The `replicated_state_consumed_cycles_since_replica_started` gauge is set in
-/// `ReplicatedStateMetrics::observe` from
-/// [`SubnetMetrics::consumed_cycles_total_including_canisters`]. This test
-/// exercises every subnet-level use case that contributes to the total, so that
-/// omitting any of them (as the `SchnorrOutcalls`/`VetKd`/`DroppedMessages` use
-/// cases once were) would change the reported value and fail the assertion, plus
-/// the canisters' part of the total. Distinct powers of two are used so that a
-/// missing contribution is always detectable in the total.
+/// `ReplicatedStateMetrics::observe` to [`SubnetMetrics::consumed_cycles_total`]
+/// plus the canisters' monotonic consumption. This test exercises every
+/// subnet-level use case that contributes to the total, so that omitting any of
+/// them (as the `SchnorrOutcalls`/`VetKd`/`DroppedMessages` use cases once were)
+/// would change the reported value and fail the assertion. Distinct powers of two
+/// are used so that a missing contribution is always detectable in the total. (The
+/// canisters' part is covered by the scheduler test
+/// `consumed_cycles_total_is_exported_net_of_outstanding_prepayments`.)
 #[test]
 fn consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases() {
     // The three use cases with a dedicated scalar field are also mirrored in the
@@ -2824,14 +2825,13 @@ fn consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases() {
         consumed_cycles_by_use_case.insert(use_case, NominalCycles::new(1024));
     }
 
-    let mut subnet_metrics = SubnetMetrics {
+    let subnet_metrics = SubnetMetrics {
         consumed_cycles_by_deleted_canisters: NominalCycles::new(1),
         consumed_cycles_ecdsa_outcalls: NominalCycles::new(2),
         consumed_cycles_http_outcalls: NominalCycles::new(4),
         consumed_cycles_by_use_case,
         ..Default::default()
     };
-    subnet_metrics.refresh_consumed_cycles(NominalCycles::new(64));
 
     let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
     state.metadata.subnet_metrics = subnet_metrics;
@@ -2846,7 +2846,7 @@ fn consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases() {
     );
 
     // Deleted canisters (1) + ECDSA (2) + HTTP (4) + Schnorr (8) + VetKd (16)
-    // + dropped messages (32) + the canisters' part (64) = 127. The
+    // + dropped messages (32) = 63; the state holds no canisters. The
     // canister-level use cases inserted into the map above (each worth 1024)
     // must not appear in the total.
     let gauge = fetch_gauge(
@@ -2854,7 +2854,7 @@ fn consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases() {
         "replicated_state_consumed_cycles_since_replica_started",
     )
     .unwrap();
-    assert_eq!(gauge, 127.0);
+    assert_eq!(gauge, 63.0);
 }
 
 #[test]

--- a/rs/replicated_state/src/metrics.rs
+++ b/rs/replicated_state/src/metrics.rs
@@ -164,7 +164,9 @@ impl ReplicatedStateMetrics {
             ),
             consumed_cycles: metrics_registry.gauge(
                 "replicated_state_consumed_cycles_since_replica_started",
-                "Number of cycles consumed",
+                "Number of cycles consumed. Monotonic, except across replica \
+                 restarts and subnet splits: a prepayment is only accounted for \
+                 once the refund it produces is known.",
             ),
             consumed_cycles_by_use_case: metrics_registry.gauge_vec(
                 "replicated_state_consumed_cycles_from_replica_start",
@@ -416,6 +418,7 @@ impl ReplicatedStateMetrics {
 
         let mut consumed_cycles_total_by_use_case = BTreeMap::new();
         let mut consumed_cycles_total_by_use_case_monotonic = BTreeMap::new();
+        let mut consumed_cycles_by_canisters_monotonic = NominalCycles::zero();
 
         let mut ingress_queue_message_count = 0;
         let mut ingress_queue_size_bytes = 0;
@@ -480,6 +483,10 @@ impl ReplicatedStateMetrics {
                     .canister_metrics()
                     .consumed_cycles_by_use_cases(),
             );
+            consumed_cycles_by_canisters_monotonic += canister
+                .system_state
+                .canister_metrics()
+                .consumed_cycles_monotonic();
             // For the purpose of exporting the total counters to prometheus, filter out HTTPS
             // outcalls from canister level metrics as they will be added later from the subnet level metrics.
             // This only applies for the counter version of metrics as the gauge version only updates
@@ -570,14 +577,24 @@ impl ReplicatedStateMetrics {
                 .get_consumed_cycles_by_use_case(),
         );
 
-        // Read from the shared definition rather than re-folding, so the gauge cannot
-        // drift from the certified state tree. The per-use-case breakdowns below do
-        // still fold over the canisters, as no aggregate holds them.
+        // The monotonic counterpart of the certified
+        // `SubnetMetrics::consumed_cycles_total_including_canisters()`, from which it
+        // differs by exactly the prepayments whose refund is not known yet: the
+        // subnet-level aggregate (monotonic already, as subnet-level use cases are
+        // never refunded and a deleted canister's consumption is moved into
+        // `consumed_cycles_by_deleted_canisters`) plus the canisters' monotonic
+        // amounts. Exported in place of the certified total, which it tracks
+        // closely, so that existing rules and dashboards need no change.
+        //
+        // Still a gauge, not a Prometheus `Counter`: the value is recomputed from the
+        // state, so a replica resuming from a checkpoint re-exports a lower value
+        // than it had reached before; and an online subnet split hands the migrating
+        // canisters' consumption over to the other subnet (retaining it here would
+        // count it on both). Both need the same high water mark treatment as the
+        // non-monotonic value did.
         self.consumed_cycles.set(
-            state
-                .metadata
-                .subnet_metrics
-                .consumed_cycles_total_including_canisters()
+            (state.metadata.subnet_metrics.consumed_cycles_total()
+                + consumed_cycles_by_canisters_monotonic)
                 .get() as f64,
         );
 

--- a/rs/state_layout/src/state_layout/proto.rs
+++ b/rs/state_layout/src/state_layout/proto.rs
@@ -103,6 +103,9 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
         let consumed_cycles =
             try_from_option_field(value.consumed_cycles, "CanisterStateBits::consumed_cycles")
                 .unwrap_or_default();
+        // Absent in checkpoints written before the field was introduced; the
+        // scheduler backfills it from `consumed_cycles` (see
+        // `SystemState::migrate_consumed_cycles_to_monotonic`).
         let consumed_cycles_monotonic = try_from_option_field(
             value.consumed_cycles_monotonic,
             "CanisterStateBits::consumed_cycles_monotonic",


### PR DESCRIPTION
> **Stacked on #11490** (`mraszyk/backfill-consumed-cycles-monotonic`), which
> backfills the canister-level monotonic value this builds on. Review that first;
> the diff here is just the export change.
>
> Earlier parts of this stack have landed: #11465 added
> `CanisterMetrics::consumed_cycles_monotonic` (and renamed the pre-existing
> `_as_counter(s)` fields to `_monotonic`), #11464 made a subnet split refund the
> prepayment of a dropped `install_code`.

## What this changes

`replicated_state_consumed_cycles_since_replica_started` (and its
`replicated_state_consumed_cycles` alias) exported
`SubnetMetrics::consumed_cycles_total_including_canisters()`, i.e. the certified
total, which behaves like a gauge: a prepayment raises it and the matching refund
lowers it again. That makes it awkward to build monitoring on top of.

It now exports the monotonic counterpart instead: the subnet-level aggregate plus
the canisters' `consumed_cycles_monotonic`. The subnet-level aggregate needs no
monotonic twin of its own -- subnet-level use cases are only ever charged, never
refunded, and a deleted canister's consumption moves into
`consumed_cycles_by_deleted_canisters`.

**No new metric is added**, and the certified total is untouched:
`CanisterMetrics::consumed_cycles` and
`SubnetMetrics::consumed_cycles_total_including_canisters` are unchanged, so
`/subnet/<subnet_id>/metrics` is unaffected. The two differ by exactly the
prepayments whose refund is not known yet, i.e. the gauge tracks the certified
total closely and is simply better behaved.

## Why reuse the name, and why it stays a gauge

It stays a **gauge**, not a Prometheus `Counter`. The value is recomputed from the
state on every observation, so a replica that restarts mid-interval and resumes
from the last checkpoint re-exports a lower value than it had reached before; a
`Counter`'s `reset()` + `inc_by()` would report that as an increase by the whole
checkpoint value. An online subnet split lowers it for the same reason -- the
migrating canisters' consumption goes to the other subnet, and retaining it here
would count it on both.

So it still needs the same high water mark treatment on the consumer side that the
non-monotonic value already needed; it is just a much better behaved gauge in the
average case. And since it must be a gauge anyway, exporting the monotonic value
under the old name saves rewriting every rule and dashboard (including the public
dashboard) that already scrapes it.

## Tests

* `consumed_cycles_total_is_exported_net_of_outstanding_prepayments`: the exported
  gauge equals the certified total net of the outstanding prepayments.
* `consumed_cycles_gauge_accounts_for_all_subnet_level_use_cases` updated: it now
  covers the subnet-level contributions only, since the state it builds holds no
  canisters.

## Notes for the reviewer

* The follow-up that the backfill PR mentions still applies here: the same trick
  would work for `consumed_cycles_by_use_cases_monotonic` -- split `outstanding`
  into its `Instructions` and `RequestAndResponseTransmission` parts and it falls
  out. Left for later.
* Locally I ran the directly affected targets (`replicated_state`, `state_layout`,
  `state_manager`, `execution_environment`, `canonical_state`,
  `cycles_account_manager`, `messaging`, `replay`, `state_machine_tests`,
  `protobuf`, `types`) plus `rust-lint.sh`. The NNS/SNS/registry integration tests,
  which reach this change only through the regenerated protobuf bindings, exhaust
  the disk on my machine, and the two golden-state tests need internal SSH access;
  those are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
