### PR TITLE
feat(ledger-suite-orchestrator): disable archiving for newly installed ledger suites

### DIFF
--- a/rs/ethereum/ledger-suite-orchestrator/README.adoc
+++ b/rs/ethereum/ledger-suite-orchestrator/README.adoc
@@ -73,6 +73,7 @@ To understand how ckERC20 tokens are managed, it's essential to understand the l
 
 Remarks:
 
+* Archiving is temporarily disabled for newly created ledger suites: the orchestrator sets `trigger_threshold` to `4_200_000_000` so that no archive canister is ever spawned and all blocks remain in the ledger. This is a stopgap until the minters can safely process blocks that were moved to an archive.
 * Upgrading the ledger won't upgrade any spawned archive canisters.
 * The initial version (Git hash `4472b0064d347a88649beb526214fde204f906fb`) of the ledger used doesn't use stable memory.
 * Both the index canister and archive canisters used in ckERC20 use stable memory. It's therefore possible to configure the `archive_options` in such a way that it will be very unlikely that a second archive canister is ever needed.

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -46,6 +46,8 @@ const SEC_NANOS: u64 = 1_000_000_000;
 
 const THREE_GIGA_BYTES: u64 = 3_221_225_472;
 
+const ARCHIVING_DISABLED_TRIGGER_THRESHOLD: usize = 4_200_000_000;
+
 pub const IC_CANISTER_RUNTIME: IcCanisterRuntime = IcCanisterRuntime {};
 
 thread_local! {
@@ -991,7 +993,7 @@ fn icrc1_archive_options(
     cycles_for_archive_creation: Nat,
 ) -> ArchiveOptions {
     ArchiveOptions {
-        trigger_threshold: 2_000,
+        trigger_threshold: ARCHIVING_DISABLED_TRIGGER_THRESHOLD,
         num_blocks_to_archive: 1_000,
         node_max_memory_size_bytes: Some(THREE_GIGA_BYTES),
         max_message_size_bytes: None,

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/tests.rs
@@ -2134,6 +2134,23 @@ mod validate_upgrade_arg {
     }
 }
 
+mod icrc1_archive_options {
+    use crate::scheduler::icrc1_archive_options;
+    use candid::Nat;
+    use ic_base_types::PrincipalId;
+
+    #[test]
+    fn should_disable_archiving_for_new_ledger_suites() {
+        let archive_options = icrc1_archive_options(
+            PrincipalId::new_user_test_id(1),
+            vec![PrincipalId::new_user_test_id(2)],
+            Nat::from(100_000_000_000_000_u64),
+        );
+
+        assert_eq!(archive_options.trigger_threshold, 4_200_000_000);
+    }
+}
+
 mod schema_upgrades {
     use crate::scheduler::test_fixtures::usdc_token_id;
     use crate::scheduler::{UpgradeLedgerSuite, UpgradeLedgerSuiteSubtask};

--- a/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/flow.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/test_utils/src/pocket_ic/flow.rs
@@ -80,9 +80,6 @@ impl ManagedCanistersAssert {
     }
 
     pub fn trigger_creation_of_archive(self) -> Self {
-        // The productive value for `trigger_threshold` is `2_000`,
-        // which would require `2_000` transfers to trigger the creation of an archive.
-        // We set this value to an artificially low number to speed up the test.
         self.upgrade_ledger_to_change_archive_options(ChangeArchiveOptions {
             trigger_threshold: Some(ARCHIVE_TRIGGER_THRESHOLD),
             ..Default::default()


### PR DESCRIPTION
Stacked on #11407. Addresses the [review remark](https://github.com/dfinity/ic/pull/11407#pullrequestreview-5086956827) about the hardcoded archive options for new suites.

## Why

* A token added while archiving is disabled (DEFI-2986) would get a fresh ledger with `trigger_threshold: 2_000` and start archiving once past it, reintroducing the double-mint commit point (DEFI-2967) for that token.

## What

* Raise the default `trigger_threshold` for newly installed ledger suites to 4_200_000_000, the value used to disable archiving on the ckBTC ledger ([proposal 143757](https://dashboard.internetcomputer.org/proposal/143757)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S568wBREAARUA9GvGP5JMP