### PR TITLE
feat: New SEV checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,7 @@ dependencies = [
  "anyhow",
  "attestation",
  "config_types",
+ "der",
  "futures",
  "guest_disk",
  "guest_upgrade_client",

--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::tls::SkipServerCertificateCheck;
 use anyhow::{Context, Error, Result, anyhow, bail};
+use attestation::SevAttestationPackage;
 use attestation::attestation_package::{
     AttestationPackageVerifier, ParsedSevAttestationPackage, SevRootCertificateVerification,
 };
@@ -21,6 +22,7 @@ use rcgen::CertifiedKey;
 use rustls::ClientConfig;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::version::TLS13;
+use sev::firmware::guest::AttestationReport;
 use sev_guest::attestation_package::generate_attestation_package;
 use sev_guest::firmware::SevGuestFirmware;
 use std::io::Write;
@@ -232,19 +234,13 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .get_guest_launch_measurements(registry_version)
             .map_err(|e| anyhow!("Failed to get elected measurements from registry: {e}"))?;
 
-        // Verify the server's attestation report. This is to ensure that the key comes from a
-        // trusted source. Without this check, an attacker could start with a malicious GuestOS,
-        // inject malicious files into the data partition then trigger an upgrade to a
-        // legit version. The malicious data would remain on the data partition.
-        ParsedSevAttestationPackage::parse(
+        verify_server_attestation_package(
             server_attestation_package,
+            &my_attestation_report,
+            &custom_data,
+            elected_measurements,
             self.sev_root_certificate_verification,
-        )
-        .verify_measurement(&elected_measurements)
-        .verify_custom_data(&custom_data)
-        .verify_chip_id(&[my_attestation_report.chip_id])
-        .verify_guest_policy()
-        .context("Server attestation report verification failed")?;
+        )?;
 
         let disk_encryption_key = disk_encryption_data
             .key
@@ -347,6 +343,32 @@ impl DiskEncryptionKeyExchangeClientAgent {
             server_public_key_der,
         ))
     }
+}
+
+pub fn verify_server_attestation_package(
+    server_attestation_package: SevAttestationPackage,
+    my_attestation_report: &AttestationReport,
+    custom_data: &GetDiskEncryptionKeyTokenCustomData<'_>,
+    mut elected_measurements: Vec<Vec<u8>>,
+    sev_root_certificate_verification: SevRootCertificateVerification,
+) -> Result<()> {
+    // Our own launch measurement is not eligible: without this check, an attacker
+    // occupying the server endpoint could reflect our own attestation package back to us.
+    elected_measurements.retain(|measurement| {
+        measurement.as_slice() != my_attestation_report.measurement.as_slice()
+    });
+
+    ParsedSevAttestationPackage::parse(
+        server_attestation_package,
+        sev_root_certificate_verification,
+    )
+    .verify_measurement(&elected_measurements)
+    .verify_custom_data(custom_data)
+    .verify_chip_id(&[my_attestation_report.chip_id])
+    .verify_guest_policy()
+    .context("Server attestation report verification failed")?;
+
+    Ok(())
 }
 
 fn extract_server_public_key_der(conn: &MaybeHttpsStream<TokioIo<TcpStream>>) -> Result<Vec<u8>> {

--- a/rs/ic_os/guest_upgrade/tests/BUILD.bazel
+++ b/rs/ic_os/guest_upgrade/tests/BUILD.bazel
@@ -22,6 +22,7 @@ rust_test(
         "//rs/test_utilities/registry",
         "//rs/types/types",
         "@crate_index//:anyhow",
+        "@crate_index//:der",
         "@crate_index//:futures",
         "@crate_index//:rand",
         "@crate_index//:rustls",

--- a/rs/ic_os/guest_upgrade/tests/Cargo.toml
+++ b/rs/ic_os/guest_upgrade/tests/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = { workspace = true }
 attestation = { path = "../../sev/attestation" }
 config_types = { path = "../../config/types" }
+der = { workspace = true }
 futures = { workspace = true }
 guest_disk = { path = "../../os_tools/guest_disk" }
 guest_upgrade_client = { path = "../client" }

--- a/rs/ic_os/guest_upgrade/tests/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/tests/src/lib.rs
@@ -1,17 +1,21 @@
 #![cfg(test)]
 
 use anyhow::bail;
+use attestation::SevAttestationPackage;
 use attestation::attestation_package::SevRootCertificateVerification;
 use config_types::{
     GuestOSConfig, GuestOSUpgradeConfig, GuestVMType, ICOSSettings,
     TrustedExecutionEnvironmentConfig,
 };
+use der::asn1::OctetStringRef;
 use futures::future::Either;
 use futures::{FutureExt, TryFutureExt};
 use guest_upgrade_client::DiskEncryptionKeyExchangeClientAgent;
 use guest_upgrade_client::MockDiskCryptoOps;
+use guest_upgrade_client::verify_server_attestation_package;
 use guest_upgrade_server::DiskEncryptionKeyExchangeServerAgent;
 use guest_upgrade_shared::DEFAULT_SERVER_PORT;
+use guest_upgrade_shared::attestation::GetDiskEncryptionKeyTokenCustomData;
 use ic_protobuf::registry::replica_version::v1::{
     GuestLaunchMeasurement, GuestLaunchMeasurements, ReplicaVersionRecord,
 };
@@ -20,6 +24,7 @@ use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_test_utilities_registry::add_replica_version_record;
 use ic_types::ReplicaVersion;
 use rand::RngCore;
+use sev_guest::attestation_package::generate_attestation_package;
 use sev_guest::key_deriver::{Key, derive_key_from_sev_measurement};
 use sev_guest_testing::{FakeAttestationReportSigner, MockSevGuestFirmwareBuilder};
 use std::future::Future;
@@ -630,5 +635,60 @@ async fn test_start_upgrade_vm_command_fails() {
     assert!(
         result.to_string().contains("UpgradeVM error: boom"),
         "{result}"
+    );
+}
+
+/// Verifies that the client's own launch measurement is rejected.
+#[test]
+fn test_server_package_verification_rejects_own_launch_measurement() {
+    let signer = FakeAttestationReportSigner::default();
+    let tee_config = TrustedExecutionEnvironmentConfig {
+        sev_cert_chain_pem: signer.get_certificate_chain_pem(),
+    };
+    let custom_data = GetDiskEncryptionKeyTokenCustomData {
+        client_tls_public_key: OctetStringRef::new(b"client tls public key").unwrap(),
+        server_tls_public_key: OctetStringRef::new(b"server tls public key").unwrap(),
+    };
+    let elected_measurements = vec![
+        DEFAULT_CLIENT_MEASUREMENT.to_vec(),
+        DEFAULT_SERVER_MEASUREMENT.to_vec(),
+    ];
+
+    let mut client_firmware = MockSevGuestFirmwareBuilder::new()
+        .with_measurement(DEFAULT_CLIENT_MEASUREMENT)
+        .with_signer(Some(signer.clone()));
+    let client_package =
+        generate_attestation_package(&mut client_firmware, &tee_config, &custom_data).unwrap();
+    let my_attestation_report = *client_package.attestation_report();
+
+    // A genuine server package (a different, elected measurement) verifies.
+    let mut server_firmware = MockSevGuestFirmwareBuilder::new()
+        .with_measurement(DEFAULT_SERVER_MEASUREMENT)
+        .with_signer(Some(signer));
+    let server_package: SevAttestationPackage =
+        generate_attestation_package(&mut server_firmware, &tee_config, &custom_data)
+            .unwrap()
+            .into();
+    verify_server_attestation_package(
+        server_package,
+        &my_attestation_report,
+        &custom_data,
+        elected_measurements.clone(),
+        SevRootCertificateVerification::TestOnlySkipVerification,
+    )
+    .unwrap();
+
+    // The client's own package, reflected back by an attacker, must be rejected.
+    let error = verify_server_attestation_package(
+        client_package.into(),
+        &my_attestation_report,
+        &custom_data,
+        elected_measurements,
+        SevRootCertificateVerification::TestOnlySkipVerification,
+    )
+    .unwrap_err();
+    assert!(
+        format!("{error:?}").contains("InvalidMeasurement"),
+        "unexpected error: {error:?}"
     );
 }

--- a/rs/ic_os/sev/guest/src/key_deriver.rs
+++ b/rs/ic_os/sev/guest/src/key_deriver.rs
@@ -15,6 +15,7 @@ pub fn derive_key_from_sev_measurement(
 ) -> Result<String> {
     let mut field_select = GuestFieldSelect::default();
     field_select.set_measurement(true);
+    field_select.set_guest_policy(true);
 
     let derived_key = sev_firmware
         .get_derived_key(Some(1), DerivedKey::new(false, field_select, 0, 0, 0, None))
@@ -57,6 +58,10 @@ mod tests {
         let mut mock_sev_guest_firmware = MockSevGuestFirmware::new();
         mock_sev_guest_firmware
             .expect_get_derived_key()
+            .withf(|_, request| {
+                request.guest_field_select.get_guest_policy()
+                    && request.guest_field_select.get_measurement()
+            })
             .returning(|_, _| Ok([42; 32]));
 
         assert_eq!(


### PR DESCRIPTION
- Mix in debugging policy into derived keys.
- Verify that the server does not simply mirror the client's attestation package.