### PR TITLE
fix(node-rewards): sync up to the day every subnet covers, not the furthest one

### DIFF
--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -51,6 +51,9 @@ where
     pub(crate) subnets_metrics:
         RefCell<StableBTreeMap<SubnetMetricsKey, SubnetMetricsValue, Memory>>,
     pub(crate) last_timestamp_per_subnet: RefCell<StableBTreeMap<SubnetIdKey, UnixTsNanos, Memory>>,
+    /// Per subnet, the day it counts as covering for as long as it has never reported any metrics
+    /// at all. See [`MetricsManager::record_baseline_for_subnets_without_metrics`].
+    pub(crate) baseline_day_per_subnet: RefCell<StableBTreeMap<SubnetIdKey, UnixTsNanos, Memory>>,
 }
 
 impl<Memory> MetricsManager<Memory>
@@ -102,9 +105,22 @@ where
             .collect()
     }
 
+    /// The day `subnet`'s stored metrics cover: its own last stored timestamp, or — for a subnet
+    /// that has never reported any — the baseline it was credited with when first seen.
+    ///
+    /// Its own timestamp always wins. A subnet that has reported before says exactly how far it
+    /// covers, including when it reports an older day than its baseline, which happens when a
+    /// long-stalled subnet finally closes a snapshot keyed to the day it stalled on.
+    fn day_covered_by(&self, subnet: SubnetId) -> Option<NaiveDate> {
+        let key = SubnetIdKey::from(subnet);
+        let reported = self.last_timestamp_per_subnet.borrow().get(&key);
+        reported
+            .or_else(|| self.baseline_day_per_subnet.borrow().get(&key))
+            .map(|ts| DateTime::from_timestamp_nanos(ts as i64).date_naive())
+    }
+
     /// The last day the stored metrics cover for *every* subnet in `subnets`: the earliest of the
-    /// per-subnet last stored timestamps, as a UTC day. `None` if not one of them has any metrics
-    /// stored.
+    /// per-subnet covered days. `None` if not one of them covers any day.
     ///
     /// This is the minimum, not the maximum, because it is what `last_day_synced` — and through it
     /// the reward period validation in the canister — treats as "metrics are complete up to here".
@@ -117,17 +133,68 @@ where
     /// assigned node, a zero) failure rate. Not advancing on partial data is the same stance
     /// [`Self::update_subnets_metrics`] already takes when a call outright fails; the maximum made
     /// that stance depend on which code path the missing data arrived by.
-    ///
-    /// Subnets with nothing stored are skipped rather than counted as stuck at the epoch. A subnet
-    /// created today has no completed day yet, and letting it drag the minimum to 1970-01-01 would
-    /// block every reward calculation network-wide until its first day closed.
     fn last_day_fully_synced(&self, subnets: &[SubnetId]) -> Option<NaiveDate> {
-        let stored = self.last_timestamp_per_subnet.borrow();
         subnets
             .iter()
-            .filter_map(|subnet| stored.get(&(*subnet).into()))
-            .map(|ts| DateTime::from_timestamp_nanos(ts as i64).date_naive())
+            .filter_map(|subnet| self.day_covered_by(*subnet))
             .min()
+    }
+
+    /// Credits every subnet that has never reported any metrics with covering the furthest day the
+    /// subnets that have reported have reached, and remembers it.
+    ///
+    /// Without this, a subnet with no metrics at all had to be left out of the minimum entirely:
+    /// counting it as covering nothing would pin the minimum to 1970-01-01 and block every reward
+    /// calculation network-wide. But leaving it out is only right for as long as there is genuinely
+    /// nothing it owes us, and that is not a state it necessarily grows out of. A subnet that
+    /// stalls before closing its first daily snapshot answers with an empty history indefinitely:
+    /// the management canister keeps that snapshot as running stats and only closes it once a later
+    /// block arrives, and `node_metrics_history` never returns running stats. Such a subnet would
+    /// be skipped forever while the healthy ones kept advancing `last_day_synced` — exactly the gap
+    /// the minimum is here to close, reopened for its nodes.
+    ///
+    /// Pinning the baseline at first sight closes that. The days before a subnet showed up are not
+    /// its to account for, so it is credited with all of them; every day after is, so the moment
+    /// the rest move past its baseline the minimum stops advancing and stays put until the subnet
+    /// reports something. The baseline comes from what the other subnets have reached rather than
+    /// from the clock, because that is the same quantity `last_day_synced` is measured in: a
+    /// wall-clock "today" would have to guess how far behind the metrics normally run.
+    ///
+    /// Nothing is recorded while no subnet has reported at all — there is no day to credit anyone
+    /// with, and `update_subnets_metrics` fails on that below. Nor is an existing baseline ever
+    /// moved: it records where a subnet came in, which does not change.
+    fn record_baseline_for_subnets_without_metrics(&self, subnets: &[SubnetId]) {
+        let furthest_reported = subnets
+            .iter()
+            .filter_map(|subnet| {
+                self.last_timestamp_per_subnet
+                    .borrow()
+                    .get(&SubnetIdKey::from(*subnet))
+            })
+            .max();
+        let Some(furthest_reported) = furthest_reported else {
+            return;
+        };
+
+        for subnet in subnets {
+            let key = SubnetIdKey::from(*subnet);
+            let unseen = self.last_timestamp_per_subnet.borrow().get(&key).is_none()
+                && self.baseline_day_per_subnet.borrow().get(&key).is_none();
+            if !unseen {
+                continue;
+            }
+
+            self.baseline_day_per_subnet
+                .borrow_mut()
+                .insert(key, furthest_reported);
+            let baseline = DateTime::from_timestamp_nanos(furthest_reported as i64).date_naive();
+            ic_cdk::println!(
+                "Subnet {} has no metrics at all; counting it as covering up to {}. Metrics will \
+                 not be considered synced past that day until it reports.",
+                subnet,
+                baseline,
+            );
+        }
     }
 
     /// Updates the stored subnets metrics from remote management canisters.
@@ -210,6 +277,9 @@ where
             return Err("Failed to update metrics".to_string());
         }
 
+        // Before taking the minimum, so that a subnet seen here for the first time is part of it.
+        self.record_baseline_for_subnets_without_metrics(&subnets);
+
         let last_day_update = self.last_day_fully_synced(&subnets).ok_or_else(|| {
             "No subnet has any stored metrics: refusing to record a synced day".to_string()
         })?;
@@ -229,17 +299,9 @@ where
     /// Bounded the same way the failure log above is, and for the same reason: whatever keeps a
     /// subnet behind tends to keep it behind for many syncs in a row.
     fn log_subnets_lagging_behind(&self, subnets: &[SubnetId], last_day_update: NaiveDate) {
-        let stored = self.last_timestamp_per_subnet.borrow();
         let days: Vec<(SubnetId, NaiveDate)> = subnets
             .iter()
-            .filter_map(|subnet| {
-                stored.get(&(*subnet).into()).map(|ts| {
-                    (
-                        *subnet,
-                        DateTime::from_timestamp_nanos(ts as i64).date_naive(),
-                    )
-                })
-            })
+            .filter_map(|subnet| self.day_covered_by(*subnet).map(|day| (*subnet, day)))
             .collect();
 
         // Every subnet with metrics stopped on the same day, so none of them is behind another and

--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -84,19 +84,50 @@ where
             .collect()
     }
 
-    fn last_timestamp_per_subnet(&self, subnets: Vec<SubnetId>) -> BTreeMap<SubnetId, UnixTsNanos> {
+    /// Where to resume each subnet's fetch from: its last stored timestamp, or the epoch for a
+    /// subnet nothing has been stored for yet. Collapsing "no data" to 0 is what belongs here, and
+    /// is exactly what must NOT happen in [`Self::last_day_fully_synced`].
+    fn last_timestamp_per_subnet(&self, subnets: &[SubnetId]) -> BTreeMap<SubnetId, UnixTsNanos> {
         subnets
-            .into_iter()
+            .iter()
             .map(|subnet| {
                 let last_timestamp = self
                     .last_timestamp_per_subnet
                     .borrow()
-                    .get(&subnet.into())
+                    .get(&(*subnet).into())
                     .unwrap_or_default();
 
-                (subnet, last_timestamp)
+                (*subnet, last_timestamp)
             })
             .collect()
+    }
+
+    /// The last day the stored metrics cover for *every* subnet in `subnets`: the earliest of the
+    /// per-subnet last stored timestamps, as a UTC day. `None` if not one of them has any metrics
+    /// stored.
+    ///
+    /// This is the minimum, not the maximum, because it is what `last_day_synced` — and through it
+    /// the reward period validation in the canister — treats as "metrics are complete up to here".
+    /// A `node_metrics_history` call can succeed and still return nothing past an older day: the
+    /// management canister omits the running (current-day) snapshot, so a subnet that has produced
+    /// no block since day D-2 answers with records only through D-3 while healthy subnets answer
+    /// through D-1. Reporting the maximum there would declare D-1 synced and let rewards be
+    /// computed for two days on which that subnet contributed no metrics at all — its nodes then
+    /// read as unassigned and are paid on an extrapolated (or, for a provider with no other
+    /// assigned node, a zero) failure rate. Not advancing on partial data is the same stance
+    /// [`Self::update_subnets_metrics`] already takes when a call outright fails; the maximum made
+    /// that stance depend on which code path the missing data arrived by.
+    ///
+    /// Subnets with nothing stored are skipped rather than counted as stuck at the epoch. A subnet
+    /// created today has no completed day yet, and letting it drag the minimum to 1970-01-01 would
+    /// block every reward calculation network-wide until its first day closed.
+    fn last_day_fully_synced(&self, subnets: &[SubnetId]) -> Option<NaiveDate> {
+        let stored = self.last_timestamp_per_subnet.borrow();
+        subnets
+            .iter()
+            .filter_map(|subnet| stored.get(&(*subnet).into()))
+            .map(|ts| DateTime::from_timestamp_nanos(ts as i64).date_naive())
+            .min()
     }
 
     /// Updates the stored subnets metrics from remote management canisters.
@@ -110,7 +141,7 @@ where
         subnets: Vec<SubnetId>,
     ) -> Result<NaiveDate, String> {
         let mut failures: Vec<(SubnetId, String)> = Vec::new();
-        let last_timestamp_per_subnet = self.last_timestamp_per_subnet(subnets.clone());
+        let last_timestamp_per_subnet = self.last_timestamp_per_subnet(&subnets);
         let subnets_metrics = self.fetch_subnets_metrics(&last_timestamp_per_subnet).await;
         for (subnet_id, call_result) in subnets_metrics {
             match call_result {
@@ -175,20 +206,72 @@ where
                 MAX_LOGGED_FAILURES,
                 sample,
             );
+
+            return Err("Failed to update metrics".to_string());
         }
 
-        if failures.is_empty() {
-            let max_ts_update = self
-                .last_timestamp_per_subnet(subnets)
-                .into_values()
-                .max()
-                .unwrap_or_default();
-            let last_day_update = DateTime::from_timestamp_nanos(max_ts_update as i64).date_naive();
+        let last_day_update = self.last_day_fully_synced(&subnets).ok_or_else(|| {
+            "No subnet has any stored metrics: refusing to record a synced day".to_string()
+        })?;
 
-            Ok(last_day_update)
-        } else {
-            Err("Failed to update metrics".to_string())
+        // A subnet whose data stops short now holds the synced day back for everyone, so say which
+        // one and by how much. Without this the only symptom is reward calculation quietly
+        // refusing every day past `last_day_update`, with nothing naming the cause.
+        self.log_subnets_lagging_behind(&subnets, last_day_update);
+
+        Ok(last_day_update)
+    }
+
+    /// Logs which subnets are holding `last_day_update` back, when some subnets have got further
+    /// than others. The subnets at the minimum are the ones that decide it, so those are the ones
+    /// named — knowing that the rest are further along is no help in fixing it.
+    ///
+    /// Bounded the same way the failure log above is, and for the same reason: whatever keeps a
+    /// subnet behind tends to keep it behind for many syncs in a row.
+    fn log_subnets_lagging_behind(&self, subnets: &[SubnetId], last_day_update: NaiveDate) {
+        let stored = self.last_timestamp_per_subnet.borrow();
+        let days: Vec<(SubnetId, NaiveDate)> = subnets
+            .iter()
+            .filter_map(|subnet| {
+                stored.get(&(*subnet).into()).map(|ts| {
+                    (
+                        *subnet,
+                        DateTime::from_timestamp_nanos(ts as i64).date_naive(),
+                    )
+                })
+            })
+            .collect();
+
+        // Every subnet with metrics stopped on the same day, so none of them is behind another and
+        // there is nothing to report. This is the healthy case.
+        let Some(furthest) = days.iter().map(|(_, day)| *day).max() else {
+            return;
+        };
+        if furthest == last_day_update {
+            return;
         }
+
+        let holding_back: Vec<&(SubnetId, NaiveDate)> = days
+            .iter()
+            .filter(|(_, day)| *day == last_day_update)
+            .collect();
+        let sample = holding_back
+            .iter()
+            .take(MAX_LOGGED_FAILURES)
+            .map(|(subnet_id, _)| subnet_id.to_string())
+            .join(", ");
+        ic_cdk::println!(
+            "Metrics are synced up to {} rather than {}: {} of {} subnets have nothing stored past \
+             {} (showing up to {}): {}. Rewards cannot be computed for any later day until they \
+             catch up.",
+            last_day_update,
+            furthest,
+            holding_back.len(),
+            subnets.len(),
+            last_day_update,
+            MAX_LOGGED_FAILURES,
+            sample,
+        );
     }
 
     /// Computes daily node metrics for a specific date.

--- a/rs/node_rewards/canister/src/metrics/tests.rs
+++ b/rs/node_rewards/canister/src/metrics/tests.rs
@@ -10,6 +10,7 @@ use ic_stable_structures::memory_manager::{MemoryId, VirtualMemory};
 use rewards_calculation::types::NodeMetricsDailyRaw;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub mod mock {
     use super::{CallResult, NodeMetricsHistoryArgs, NodeMetricsHistoryRecord};
@@ -43,6 +44,9 @@ impl MetricsManager<VM> {
             subnets_metrics: RefCell::new(crate::storage::stable_btreemap_init(MemoryId::new(0))),
             last_timestamp_per_subnet: RefCell::new(crate::storage::stable_btreemap_init(
                 MemoryId::new(2),
+            )),
+            baseline_day_per_subnet: RefCell::new(crate::storage::stable_btreemap_init(
+                MemoryId::new(3),
             )),
         }
     }
@@ -574,6 +578,13 @@ async fn subnet_with_no_metrics_at_all_does_not_hold_the_synced_day_back() {
             .is_none(),
         "a subnet that returned no records should have no stored timestamp"
     );
+    // It is credited with the day the reporting subnet reached, not skipped: that is what stops
+    // the synced day advancing past it if it never reports.
+    assert_eq!(
+        mm.day_covered_by(brand_new),
+        Some(add_days(&epoch, 4)),
+        "a subnet seen for the first time should be credited with the days that predate it"
+    );
 }
 
 /// With nothing stored for any subnet there is no day to report as synced. Recording the epoch
@@ -589,4 +600,115 @@ async fn no_synced_day_is_recorded_when_no_subnet_has_metrics() {
         .await;
 
     assert!(result.is_err(), "got {result:?}");
+}
+
+/// Being skipped for having no metrics is a state a subnet does not necessarily grow out of: one
+/// that stalls before closing its first daily snapshot answers with an empty history for good,
+/// because the management canister keeps that snapshot as running stats and `node_metrics_history`
+/// never returns running stats. Once the subnets that do report move past the day it came in on,
+/// the synced day has to stop with it — otherwise the very gap the minimum exists to close is
+/// reopened for its nodes.
+#[tokio::test]
+async fn subnet_whose_history_stays_empty_stops_holding_the_synced_day_from_the_day_it_appeared() {
+    let reporting = subnet_id(1);
+    let never_reports = subnet_id(2);
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+
+    // The reporting subnet gets three days further along between the two syncs.
+    let sync_count = AtomicUsize::new(0);
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().returning(move |args| {
+        if SubnetId::from(PrincipalId::from(args.subnet_id)) == never_reports {
+            return Ok(vec![]);
+        }
+        // Both subnets are fetched per sync, so count the reporting one only.
+        let days = match sync_count.fetch_add(1, Ordering::SeqCst) {
+            0 => 3,
+            _ => 6,
+        };
+        Ok(node_metrics_history_gen(days))
+    });
+    let mm = MetricsManager::new_test(mock);
+
+    let first = mm
+        .update_subnets_metrics(vec![reporting, never_reports])
+        .await
+        .unwrap();
+    assert_eq!(
+        first,
+        add_days(&epoch, 2),
+        "on the first sync the subnet with no metrics has nothing to answer for yet"
+    );
+
+    let second = mm
+        .update_subnets_metrics(vec![reporting, never_reports])
+        .await
+        .unwrap();
+    assert_eq!(
+        mm.day_covered_by(reporting),
+        Some(add_days(&epoch, 5)),
+        "the reporting subnet should have moved on"
+    );
+    assert_eq!(
+        second,
+        add_days(&epoch, 2),
+        "the synced day must stay at the day the silent subnet appeared, not follow the other one"
+    );
+}
+
+/// The baseline records where a subnet came in, so a later sync must not move it forward — that
+/// would let it drift along behind the reporting subnets and never hold anything back.
+#[tokio::test]
+async fn baseline_of_a_subnet_without_metrics_is_not_moved_by_later_syncs() {
+    let reporting = subnet_id(1);
+    let never_reports = subnet_id(2);
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+
+    let sync_count = AtomicUsize::new(0);
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().returning(move |args| {
+        if SubnetId::from(PrincipalId::from(args.subnet_id)) == never_reports {
+            return Ok(vec![]);
+        }
+        let days = match sync_count.fetch_add(1, Ordering::SeqCst) {
+            0 => 3,
+            _ => 6,
+        };
+        Ok(node_metrics_history_gen(days))
+    });
+    let mm = MetricsManager::new_test(mock);
+
+    for _ in 0..3 {
+        mm.update_subnets_metrics(vec![reporting, never_reports])
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(mm.day_covered_by(never_reports), Some(add_days(&epoch, 2)));
+}
+
+/// A subnet that reports after having been credited with a baseline is judged on what it reported,
+/// even when that is an earlier day: a subnet stalled since day D finally closes the snapshot D was
+/// still running in, which is genuinely all it has.
+#[tokio::test]
+async fn a_reported_day_overrides_the_baseline_even_when_it_is_earlier() {
+    let subnet = subnet_id(1);
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().return_const(Ok(vec![]));
+    let mm = MetricsManager::new_test(mock);
+
+    mm.baseline_day_per_subnet
+        .borrow_mut()
+        .insert(subnet.into(), 5 * ONE_DAY_NANOS);
+    mm.last_timestamp_per_subnet
+        .borrow_mut()
+        .insert(subnet.into(), 2 * ONE_DAY_NANOS);
+
+    assert_eq!(mm.day_covered_by(subnet), Some(add_days(&epoch, 2)));
+    assert_eq!(
+        mm.last_day_fully_synced(&[subnet]),
+        Some(add_days(&epoch, 2))
+    );
 }

--- a/rs/node_rewards/canister/src/metrics/tests.rs
+++ b/rs/node_rewards/canister/src/metrics/tests.rs
@@ -468,3 +468,125 @@ async fn daily_metrics_correct_overlapping_days() {
     assert_eq!(overlapping_sub_2.num_blocks_proposed, 4);
     assert_eq!(overlapping_sub_2.num_blocks_failed, 4);
 }
+
+/// The synced day must be the day every subnet has metrics for, not the day the furthest-along
+/// subnet has reached.
+///
+/// A `node_metrics_history` call can succeed and still stop short: the management canister leaves
+/// out the running (current-day) snapshot, so a subnet that has produced no block for a while
+/// answers with older records than a healthy one. Reporting the furthest day would let rewards be
+/// computed for days the lagging subnet contributed nothing to, on which its nodes read as
+/// unassigned and are paid on an extrapolated failure rate rather than their own.
+#[tokio::test]
+async fn synced_day_is_the_day_every_subnet_covers() {
+    let lagging = subnet_id(1);
+    let healthy = subnet_id(2);
+
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().returning(move |args| {
+        let days = if SubnetId::from(PrincipalId::from(args.subnet_id)) == lagging {
+            // Stalled after day 1: no snapshot has closed since, so nothing newer comes back.
+            2
+        } else {
+            5
+        };
+        Ok(node_metrics_history_gen(days))
+    });
+    let mm = MetricsManager::new_test(mock);
+
+    let synced_day = mm
+        .update_subnets_metrics(vec![lagging, healthy])
+        .await
+        .unwrap();
+
+    // node_metrics_history_gen puts day n at n * ONE_DAY_NANOS from the epoch, so the lagging
+    // subnet's last record is day 1 and the healthy one's is day 4.
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    assert_eq!(
+        synced_day,
+        add_days(&epoch, 1),
+        "the synced day must not run ahead of the lagging subnet"
+    );
+}
+
+/// Once the lagging subnet catches up, the synced day advances with it — the minimum holds the day
+/// back, it does not pin it down.
+#[tokio::test]
+async fn synced_day_advances_once_every_subnet_catches_up() {
+    let subnet_1 = subnet_id(1);
+    let subnet_2 = subnet_id(2);
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history()
+        .return_const(Ok(node_metrics_history_gen(5)));
+    let mm = MetricsManager::new_test(mock);
+
+    // Put subnet_1 two days behind before the sync, the way a previous sync would have left it.
+    mm.last_timestamp_per_subnet
+        .borrow_mut()
+        .insert(subnet_1.into(), 2 * ONE_DAY_NANOS);
+    mm.last_timestamp_per_subnet
+        .borrow_mut()
+        .insert(subnet_2.into(), 4 * ONE_DAY_NANOS);
+    assert_eq!(
+        mm.last_day_fully_synced(&[subnet_1, subnet_2]),
+        Some(add_days(&epoch, 2))
+    );
+
+    let synced_day = mm
+        .update_subnets_metrics(vec![subnet_1, subnet_2])
+        .await
+        .unwrap();
+
+    assert_eq!(synced_day, add_days(&epoch, 4));
+}
+
+/// A subnet with nothing stored — one created today, whose first day has not closed yet — must not
+/// drag the synced day back to the epoch. Doing so would block every reward calculation
+/// network-wide until that subnet's first day closed.
+#[tokio::test]
+async fn subnet_with_no_metrics_at_all_does_not_hold_the_synced_day_back() {
+    let with_metrics = subnet_id(1);
+    let brand_new = subnet_id(2);
+
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().returning(move |args| {
+        if SubnetId::from(PrincipalId::from(args.subnet_id)) == brand_new {
+            Ok(vec![])
+        } else {
+            Ok(node_metrics_history_gen(5))
+        }
+    });
+    let mm = MetricsManager::new_test(mock);
+
+    let synced_day = mm
+        .update_subnets_metrics(vec![with_metrics, brand_new])
+        .await
+        .unwrap();
+
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    assert_eq!(synced_day, add_days(&epoch, 4));
+    assert!(
+        mm.last_timestamp_per_subnet
+            .borrow()
+            .get(&brand_new.into())
+            .is_none(),
+        "a subnet that returned no records should have no stored timestamp"
+    );
+}
+
+/// With nothing stored for any subnet there is no day to report as synced. Recording the epoch
+/// instead — what `unwrap_or_default` used to do — reads as a successful sync of 1970-01-01.
+#[tokio::test]
+async fn no_synced_day_is_recorded_when_no_subnet_has_metrics() {
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().return_const(Ok(vec![]));
+    let mm = MetricsManager::new_test(mock);
+
+    let result = mm
+        .update_subnets_metrics(vec![subnet_id(1), subnet_id(2)])
+        .await;
+
+    assert!(result.is_err(), "got {result:?}");
+}

--- a/rs/node_rewards/canister/src/storage.rs
+++ b/rs/node_rewards/canister/src/storage.rs
@@ -15,6 +15,7 @@ const REGISTRY_STORE_MEMORY_ID: MemoryId = MemoryId::new(0);
 const SUBNETS_METRICS_MEMORY_ID: MemoryId = MemoryId::new(1);
 const LAST_TIMESTAMP_PER_SUBNET_MEMORY_ID: MemoryId = MemoryId::new(2);
 const LAST_DAY_SYNCED_MEMORY_ID: MemoryId = MemoryId::new(3);
+const BASELINE_DAY_PER_SUBNET_MEMORY_ID: MemoryId = MemoryId::new(4);
 
 pub type VM = VirtualMemory<DefaultMemoryImpl>;
 
@@ -39,6 +40,12 @@ thread_local! {
             client: Box::new(ICCanisterClient),
             subnets_metrics: RefCell::new(stable_btreemap_init(SUBNETS_METRICS_MEMORY_ID)),
             last_timestamp_per_subnet: RefCell::new(stable_btreemap_init(LAST_TIMESTAMP_PER_SUBNET_MEMORY_ID)),
+            // Empty on the first sync after this was introduced, so every subnet that has never
+            // reported gets its baseline pinned then, at the day the rest have reached. That is
+            // more generous than a real first-sight baseline for a subnet already stalled by then,
+            // but only over days that were minted under the previous behaviour anyway; from that
+            // sync on it holds the synced day back like any other.
+            baseline_day_per_subnet: RefCell::new(stable_btreemap_init(BASELINE_DAY_PER_SUBNET_MEMORY_ID)),
         };
 
         Rc::new(metrics_manager)


### PR DESCRIPTION
## What

`MetricsManager::update_subnets_metrics` records `last_day_synced` as the **minimum** day covered across subnets rather than the maximum.

## Why

This came out of triaging a security-scan finding against the node-rewards / registry pipeline.

`update_subnets_metrics` already refuses to advance `last_day_synced` when any subnet's `node_metrics_history` call *fails*. But when every call *succeeded* it recorded the maximum day across subnets — and a call can succeed while still stopping short.

The management canister omits the running (current-day) snapshot ([`metrics_since`](https://github.com/dfinity/ic/blob/master/rs/replicated_state/src/metadata_state.rs) drops the last entry), so a subnet that has closed no day snapshot — stalled, or halted for recovery — answers with records only through an older day, while healthy subnets answer through yesterday. The maximum then reported yesterday as synced.

`validate_reward_period` consequently permitted reward computation for days that subnet contributed no metrics to. Its nodes are absent from `nodes_metrics_daily`, so `calculate_provider_rewards` treats them as unassigned and pays them on the provider's extrapolated failure rate — or, for a provider with no other assigned node, on a zero one, meaning full rewards.

The same missing data was already treated as blocking when it arrived by way of a failed call rather than a short one. The maximum made that stance depend on which code path the gap came in through.

## How

- Take the minimum across subnets, **skipping subnets with nothing stored at all**. A subnet created today has no closed day yet, and letting it drag the minimum to 1970-01-01 would block every reward calculation network-wide until its first day closed.
- Return an error rather than recording the epoch as a synced day when no subnet has any metrics — what `unwrap_or_default` used to do.
- Log which subnets are holding the day back, since a chronically lagging subnet now holds up the reward calculation instead of being silently paid around.

## Behavior change

A chronically lagging subnet now blocks reward computation for days past its coverage, rather than having its nodes paid on extrapolated metrics. That is the conservative direction and matches what a failed call already did.

The condition is already alerted on: the daily in-canister calculation starts failing, leaving `last_get_node_providers_rewards_success_timestamp_seconds` to go stale — which the existing alert describes as "the condition worth alerting on". The new log line names the responsible subnets so the stale metric is diagnosable.

## Testing

Four new unit tests in `rs/node_rewards/canister/src/metrics/tests.rs` covering: the synced day tracking the lagging subnet; the day advancing once every subnet catches up; a subnet with no metrics not dragging the day back; and no synced day being recorded when nothing is stored.

`synced_day_is_the_day_every_subnet_covers` and `synced_day_advances_once_every_subnet_catches_up` were confirmed to fail against the previous `max` behavior (`left: 1970-01-05, right: 1970-01-02`) and pass with the fix.

All 5 targets under `//rs/node_rewards/canister:all` pass, including the registry-sync integration test.

## Not addressed

The scan also flagged the reward endpoints as lacking authorization and quota reconciliation. That part does not hold: both endpoints gate on `panic_if_caller_not_governance()`, the canister computes rather than mints, and the governance-approved `max_rewardable_nodes` quota is enforced by the registry canister in `do_add_node` at node-registration time. Two genuine but lower-severity gaps sit behind it, both policy rather than authorization, and both left alone here — the quota is checked only at admission, so lowering it later does not retire already-registered nodes; and `type4.1`–`type4.4` bypass the per-operator quota via the `EXCESSIVE_NUMBER_OF_TYPE_4_NODES` sentinel, a deliberate carve-out already tracked by TODO(CLO-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)