### PR TITLE
docs(node-rewards): say why the synced day is the furthest, not the earliest

### DIFF
--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -103,8 +103,9 @@ where
     ///
     /// This function fetches the nodes metrics for the given subnets from the management canisters
     /// updating the local metrics with the fetched metrics.
-    /// If all subnets metrics are fetched successfully, it returns the last date
-    /// for which metrics were updated.
+    /// If all subnets metrics are fetched successfully, it returns the furthest date any of them
+    /// reached — see the comment on that computation for why it is the furthest and not the
+    /// earliest, which is not the obvious choice.
     pub async fn update_subnets_metrics(
         &self,
         subnets: Vec<SubnetId>,
@@ -178,6 +179,32 @@ where
         }
 
         if failures.is_empty() {
+            // The furthest day any subnet reached, deliberately — not the earliest one.
+            //
+            // Subnets answer with different amounts of history. `node_metrics_history` withholds
+            // the running (current-day) snapshot, and a day's snapshot is only closed once a later
+            // block arrives, so a subnet halted for recovery — or stalled — answers with fewer days
+            // than a healthy one, and a subnet that stalled before closing its first snapshot
+            // answers with nothing at all. Taking the earliest day would hold `last_day_synced`
+            // back to that subnet, and `validate_reward_period` would then reject the whole reward
+            // period: *no* provider paid for those days, the ones with nodes in that subnet
+            // included, and minting frozen for as long as the subnet stayed down.
+            //
+            // That is the wrong way round. A halted or unreachable subnet is a protocol-level event
+            // that node providers do not control, so it must not withhold their rewards. The
+            // reward calculation is built the same way: a node with no metrics for a day counts as
+            // unassigned, which for a provider with a healthy fleet is rewarded in full.
+            //
+            // Completeness is guarded by the all-or-nothing check above rather than by this: a
+            // call that *fails* means data exists that we could not fetch — our own staleness — and
+            // stops the sync without advancing anything. A call that *succeeds* returns every
+            // snapshot the subnet has closed, so whatever is still missing does not yet exist.
+            //
+            // Accepted gap: a subnet that has not rolled over into the new day when the sync runs
+            // reports one day short, its real data arriving minutes later. A mint landing in that
+            // window pays full rewards for a day whose metrics did exist. That is a timing
+            // artefact rather than the protocol-fault case above, and too narrow to be worth a
+            // gate that can stall minting network-wide.
             let max_ts_update = self
                 .last_timestamp_per_subnet(subnets)
                 .into_values()


### PR DESCRIPTION
## What

A comment on the `last_day_synced` computation in `update_subnets_metrics` explaining why it takes the **furthest** day any subnet reached rather than the earliest. Comments only — no behaviour change.

## Why

Taking the maximum across subnets reads like an oversight. A security scan and a [Copilot review](https://github.com/dfinity/ic/pull/11423) both flagged it as one within a day, and nothing in the code said otherwise. Both suggested the minimum instead.

The minimum would be actively harmful. It holds `last_day_synced` back to whichever subnet reported least, so `validate_reward_period` rejects the whole reward period — and then **no** provider is paid for those days, including the ones with nodes in the subnet that fell behind. A subnet that stayed down would freeze minting indefinitely. See #11423, which implemented exactly that and was closed for this reason.

The comment records three things, so the next reader does not have to rediscover them:

1. **Why the maximum.** A halted or unreachable subnet is a protocol-level event that node providers do not control, so it must not withhold their rewards. The reward calculation is built to match: a node with no metrics for a day counts as unassigned, which for a provider with a healthy fleet is rewarded in full.
2. **Why subnets disagree at all.** `node_metrics_history` withholds the running (current-day) snapshot, and a day's snapshot is only closed once a later block arrives — so a halted or stalled subnet answers with fewer days than a healthy one, and one that stalled before closing its first snapshot answers with nothing.
3. **What actually guards completeness**, since it is not this line: the all-or-nothing check on failed calls just above. A *failed* call means data exists that we could not fetch — our own staleness — and stops the sync. A *successful* call returns every snapshot the subnet has closed, so whatever is still missing does not yet exist.

It also records one accepted gap: a subnet that has not rolled over into the new day when the sync runs reports one day short, with its real data arriving minutes later, so a mint landing in that window pays full rewards for a day whose metrics did exist. That is a timing artefact rather than the protocol-fault case, and too narrow to justify a gate that can stall minting network-wide.

## Testing

Comments only. `cargo fmt --check` clean and the crate compiles; the added lines stay inside the 100-column limit (rustfmt does not reflow comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)