### PR TITLE
test(Ledgers): DEFI-2967: Retrieve all ledger blocks using multiple get_blocks calls

### DIFF
--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -243,6 +243,14 @@ fn test_change_trigger_threshold_before_archive_spawned() {
 }
 
 #[test]
+fn test_get_all_blocks_with_archiving_disabled() {
+    ic_ledger_suite_state_machine_tests::test_get_all_blocks_with_archiving_disabled::<_, Tokens>(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
 fn test_upgrade_archive_options() {
     ic_ledger_suite_state_machine_tests::test_upgrade_archive_options(
         ledger_wasm(),

--- a/rs/ledger_suite/test_utils/state_machine_helpers/src/lib.rs
+++ b/rs/ledger_suite/test_utils/state_machine_helpers/src/lib.rs
@@ -24,7 +24,7 @@ use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
 use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
 use icrc_ledger_types::icrc3::archive::ArchiveInfo;
 use icrc_ledger_types::icrc3::blocks::{
-    BlockRange, GetBlocksRequest, GetBlocksResponse, GetBlocksResult, SupportedBlockType,
+    BlockRange, GetBlocksResponse, GetBlocksResult, SupportedBlockType,
 };
 use icrc_ledger_types::icrc3::transactions::GetTransactionsRequest;
 use icrc_ledger_types::icrc3::transactions::GetTransactionsResponse;
@@ -375,55 +375,67 @@ pub fn get_all_ledger_and_archive_blocks<Tokens: TokensType>(
 ) -> Vec<Block<Tokens>> {
     let start_index = start_index.unwrap_or(0);
     let num_blocks = num_blocks.unwrap_or(u32::MAX as u64);
-    let req = GetBlocksRequest {
-        start: icrc_ledger_types::icrc1::transfer::BlockIndex::from(start_index),
-        length: Nat::from(num_blocks),
-    };
-    let req = Encode!(&req).expect("Failed to encode GetBlocksRequest");
-    let res = state_machine
-        .query(ledger_id, "get_blocks", req)
-        .expect("Failed to send get_blocks request")
-        .bytes();
-    let res = Decode!(&res, GetBlocksResponse).expect("Failed to decode GetBlocksResponse");
-    // Assume that all blocks in the ledger can be retrieved in a single call. This should hold for
-    // most tests.
-    let blocks_in_ledger = res
-        .chain_length
-        .saturating_sub(res.first_index.0.to_u64().unwrap());
-    assert!(
-        blocks_in_ledger <= res.blocks.len() as u64,
-        "Chain length: {}, first block index: {}, retrieved blocks: {}",
-        res.chain_length,
-        res.first_index,
-        res.blocks.len()
-    );
+    let ledger_principal = Principal::from(ledger_id);
+    // The ledger returns at most a limited number of blocks per `get_blocks` call, so determine
+    // how many blocks should be retrieved in total, and then keep requesting blocks until they
+    // have all been retrieved.
+    let chain_length = get_blocks(state_machine, ledger_principal, start_index, 0).chain_length;
+    let length = num_blocks.min(chain_length.saturating_sub(start_index));
     let mut blocks = vec![];
-    for archived in res.archived_blocks {
-        let mut remaining = archived.length.clone();
-        let mut next_archived_txid = archived.start.clone();
-        while remaining > 0_u32 {
-            let req = GetTransactionsRequest {
-                start: next_archived_txid.clone(),
-                length: remaining.clone(),
-            };
-            let req =
-                Encode!(&req).expect("Failed to encode GetTransactionsRequest for archive node");
-            let canister_id = archived.callback.canister_id;
-            let res = state_machine
-                .query(
-                    CanisterId::unchecked_from_principal(PrincipalId(canister_id)),
-                    archived.callback.method.clone(),
-                    req,
-                )
-                .expect("Failed to send get_blocks request to archive")
-                .bytes();
-            let res = Decode!(&res, BlockRange).unwrap();
-            next_archived_txid += res.blocks.len() as u64;
-            remaining -= res.blocks.len() as u32;
-            blocks.extend(res.blocks);
+    while length > blocks.len() as u64 {
+        let curr_start = start_index + blocks.len() as u64;
+        let remaining_length = length - blocks.len() as u64;
+        let res = get_blocks(
+            state_machine,
+            ledger_principal,
+            curr_start,
+            remaining_length as usize,
+        );
+        // The blocks returned by a single `get_blocks` call form a contiguous range starting at
+        // `curr_start`, with the archived blocks preceding the blocks held by the ledger itself.
+        let mut new_blocks = vec![];
+        for archived in res.archived_blocks {
+            let mut remaining = archived.length.clone();
+            let mut next_archived_txid = archived.start.clone();
+            while remaining > 0_u32 {
+                let req = GetTransactionsRequest {
+                    start: next_archived_txid.clone(),
+                    length: remaining.clone(),
+                };
+                let req = Encode!(&req)
+                    .expect("Failed to encode GetTransactionsRequest for archive node");
+                let canister_id = archived.callback.canister_id;
+                let res = state_machine
+                    .query(
+                        CanisterId::unchecked_from_principal(PrincipalId(canister_id)),
+                        archived.callback.method.clone(),
+                        req,
+                    )
+                    .expect("Failed to send get_blocks request to archive")
+                    .bytes();
+                let res = Decode!(&res, BlockRange).unwrap();
+                assert!(
+                    !res.blocks.is_empty(),
+                    "Archive {} returned no blocks for the range [{}, {})",
+                    canister_id,
+                    next_archived_txid,
+                    next_archived_txid.clone() + remaining.clone()
+                );
+                next_archived_txid += res.blocks.len() as u64;
+                remaining -= res.blocks.len() as u32;
+                new_blocks.extend(res.blocks);
+            }
         }
+        new_blocks.extend(res.blocks);
+        assert!(
+            !new_blocks.is_empty(),
+            "Ledger {} returned no blocks for the range [{}, {})",
+            ledger_principal,
+            curr_start,
+            curr_start + remaining_length
+        );
+        blocks.extend(new_blocks);
     }
-    blocks.extend(res.blocks);
     blocks
         .into_iter()
         .map(ic_icrc1::Block::try_from)

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -21,10 +21,10 @@ use ic_ledger_suite_in_memory_ledger::{
     AllowancesRecentlyPurged, InMemoryLedger, verify_ledger_state,
 };
 use ic_ledger_suite_state_machine_helpers::{
-    AllowanceProvider, balance_of, fee, get_archive_blocks, get_archive_remaining_capacity,
-    get_archive_transaction, get_archive_transactions, get_blocks, get_canister_info,
-    get_transactions, icrc3_get_blocks, icrc21_consent_message, list_archives, metadata,
-    minting_account, parse_metric, send_approval, send_transfer, send_transfer_from,
+    AllowanceProvider, balance_of, fee, get_all_ledger_and_archive_blocks, get_archive_blocks,
+    get_archive_remaining_capacity, get_archive_transaction, get_archive_transactions, get_blocks,
+    get_canister_info, get_transactions, icrc3_get_blocks, icrc21_consent_message, list_archives,
+    metadata, minting_account, parse_metric, send_approval, send_transfer, send_transfer_from,
     supported_block_types, supported_standards, total_supply, transfer,
 };
 use ic_ledger_suite_state_machine_tests_constants::{
@@ -1453,6 +1453,92 @@ pub fn test_change_trigger_threshold_before_archive_spawned<T>(
         1,
         "restoring the trigger threshold should archive the accumulated backlog"
     );
+}
+
+/// Verify that all the blocks of a ledger can be retrieved also when the ledger itself holds more
+/// blocks than it returns in a single `get_blocks` response, e.g., since archiving was disabled by
+/// raising the archiving trigger threshold.
+pub fn test_get_all_blocks_with_archiving_disabled<T, Tokens>(
+    ledger_wasm: Vec<u8>,
+    encode_init_args: fn(InitArgs) -> T,
+) where
+    T: CandidType,
+    Tokens: Default + TokensType + PartialEq + std::fmt::Debug + std::fmt::Display,
+{
+    // The maximum number of blocks returned in a single ledger `get_blocks` response.
+    const MAX_BLOCKS_PER_LEDGER_RESPONSE: u64 = 2_000;
+    const UNREACHABLE_TRIGGER_THRESHOLD: usize = 1_000_000_000;
+
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+
+    let (env, ledger_id) = setup(
+        ledger_wasm.clone(),
+        encode_init_args,
+        vec![(Account::from(p1.0), 1_000_000_000_000)],
+    );
+
+    // Generate enough blocks to trigger archiving, so that the blocks end up being spread over
+    // both the archive and the ledger.
+    for i in 0..ARCHIVE_TRIGGER_THRESHOLD {
+        transfer(&env, ledger_id, p1.0, p2.0, 10_000 + i).expect("transfer failed");
+    }
+    assert_eq!(
+        list_archives(&env, ledger_id).len(),
+        1,
+        "an archive should have been spawned"
+    );
+
+    // Suppress archiving, so that all the following blocks are retained by the ledger itself.
+    let raise_threshold = LedgerArgument::Upgrade(Some(UpgradeArgs {
+        change_archive_options: Some(ChangeArchiveOptions {
+            trigger_threshold: Some(UNREACHABLE_TRIGGER_THRESHOLD),
+            ..Default::default()
+        }),
+        ..UpgradeArgs::default()
+    }));
+    env.upgrade_canister(ledger_id, ledger_wasm, Encode!(&raise_threshold).unwrap())
+        .expect("failed to raise trigger_threshold");
+
+    // Generate more blocks than the ledger returns in a single `get_blocks` response.
+    for i in 0..=MAX_BLOCKS_PER_LEDGER_RESPONSE {
+        transfer(&env, ledger_id, p1.0, p2.0, 20_000 + i).expect("transfer failed");
+    }
+    let archives = list_archives(&env, ledger_id);
+    let num_archived_blocks = archives
+        .iter()
+        .map(|archive| archive.block_range_end.0.to_u64().unwrap() + 1)
+        .max()
+        .expect("an archive should have been spawned");
+    let chain_length = get_blocks(&env, Principal::from(ledger_id), 0, 0).chain_length;
+    let blocks_in_ledger = chain_length - num_archived_blocks;
+    assert!(
+        blocks_in_ledger > MAX_BLOCKS_PER_LEDGER_RESPONSE,
+        "the ledger should hold more blocks ({blocks_in_ledger}) than it returns in a single \
+         response ({MAX_BLOCKS_PER_LEDGER_RESPONSE})"
+    );
+
+    // Retrieving all the blocks should require multiple calls to the ledger.
+    let blocks = get_all_ledger_and_archive_blocks::<Tokens>(&env, ledger_id, None, None);
+    assert_eq!(
+        blocks.len() as u64,
+        chain_length,
+        "not all the ledger and archive blocks were retrieved"
+    );
+    // The same should hold when retrieving a sub-range of the blocks.
+    let num_blocks = chain_length - 1;
+    let blocks =
+        get_all_ledger_and_archive_blocks::<Tokens>(&env, ledger_id, Some(1), Some(num_blocks));
+    assert_eq!(
+        blocks.len() as u64,
+        num_blocks,
+        "not all the requested ledger and archive blocks were retrieved"
+    );
+
+    // Reconstruct the ledger state from all the retrieved blocks, and verify it against the state
+    // of the ledger itself. This catches any blocks that were retrieved more than once, or not at
+    // all.
+    verify_ledger_state::<Tokens>(&env, ledger_id, None, AllowancesRecentlyPurged::No);
 }
 
 pub fn test_upgrade_archive_options<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)


### PR DESCRIPTION
The test helper that retrieves all the blocks of a ledger suite assumed the blocks held by the ledger itself would always come back in one call, and asserted as much. Since some production ledgers now have archiving effectively disabled, the test helper needs to be modified to potentially make multiple calls to the ledger in order to retrieve all the blocks.