### PR TITLE
chore: send Slack notification on Mainnet NNS Recovery test failure

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -75,6 +75,14 @@ jobs:
               //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state_colocate \
               --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Post Slack Notification
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        if: failure()
+        with:
+          channel-id: eng-consensus-test-failures
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
 
   nns-tests-nightly:
     name: Bazel Test NNS Nightly


### PR DESCRIPTION
This PR sends a Slack message to `#eng-consensus-test-failures` whenever the Mainnet NNS Recovery test fails