### PR TITLE
fix: use given registry version when making registry CUPs

### DIFF
--- a/rs/consensus/cup_utils/src/lib.rs
+++ b/rs/consensus/cup_utils/src/lib.rs
@@ -158,10 +158,10 @@ pub fn make_registry_cup_from_cup_contents(
 pub fn make_registry_cup(
     registry: &dyn RegistryClient,
     subnet_id: SubnetId,
+    registry_version: RegistryVersion,
     logger: &ReplicaLogger,
 ) -> Option<CatchUpPackage> {
-    let versioned_record = match registry.get_cup_contents(subnet_id, registry.get_latest_version())
-    {
+    let versioned_record = match registry.get_cup_contents(subnet_id, registry_version) {
         Ok(versioned_record) => versioned_record,
         Err(e) => {
             warn!(
@@ -320,8 +320,13 @@ mod tests {
     #[test]
     fn test_make_registry_cup() {
         let registry_client = setup_registry(/*registry_store_uri=*/ None);
-        let result =
-            make_registry_cup(&registry_client, subnet_test_id(0), &no_op_logger()).unwrap();
+        let result = make_registry_cup(
+            &registry_client,
+            subnet_test_id(0),
+            registry_client.get_latest_version(),
+            &no_op_logger(),
+        )
+        .unwrap();
 
         assert_eq!(
             result.content.state_hash.get_ref(),
@@ -360,8 +365,13 @@ mod tests {
                 .unwrap_or(LATEST_REGISTRY_VERSION);
 
             let registry_client = setup_registry(registry_store_uri.clone());
-            let cup = make_registry_cup(&registry_client, subnet_test_id(0), &no_op_logger())
-                .expect("Failed to create the registry CUP");
+            let cup = make_registry_cup(
+                &registry_client,
+                subnet_test_id(0),
+                registry_client.get_latest_version(),
+                &no_op_logger(),
+            )
+            .expect("Failed to create the registry CUP");
 
             assert_eq!(
                 cup.content.registry_version(),

--- a/rs/orchestrator/src/registry_helper.rs
+++ b/rs/orchestrator/src/registry_helper.rs
@@ -164,7 +164,7 @@ impl RegistryHelper {
         version: RegistryVersion,
         subnet_id: SubnetId,
     ) -> OrchestratorResult<CatchUpPackage> {
-        make_registry_cup(&*self.registry_client, subnet_id, &self.logger)
+        make_registry_cup(&*self.registry_client, subnet_id, version, &self.logger)
             .ok_or(OrchestratorError::MakeRegistryCupError(subnet_id, version))
     }
 

--- a/rs/replica/src/setup_ic_stack.rs
+++ b/rs/replica/src/setup_ic_stack.rs
@@ -107,9 +107,13 @@ pub fn construct_ic_stack(
             // This case is only possible if the replica is started without an orchestrator which
             // is currently only possible in the local development mode with `dfx`.
             None => {
-                let registry_cup =
-                    ic_consensus_cup_utils::make_registry_cup(&*registry, subnet_id, log)
-                        .expect("Couldn't create a registry CUP");
+                let registry_cup = ic_consensus_cup_utils::make_registry_cup(
+                    &*registry,
+                    subnet_id,
+                    registry.get_latest_version(),
+                    log,
+                )
+                .expect("Couldn't create a registry CUP");
 
                 info!(
                     log,

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -12,7 +12,7 @@ use ic_config::{
     subnet_config::SubnetConfig,
 };
 use ic_consensus::consensus::payload_builder::PayloadBuilderImpl;
-use ic_consensus_cup_utils::make_registry_cup_from_cup_contents;
+use ic_consensus_cup_utils::make_registry_cup;
 use ic_consensus_utils::crypto::SignVerify;
 use ic_crypto_test_utils_crypto_returning_ok::CryptoReturningOk;
 use ic_crypto_test_utils_ni_dkg::{
@@ -654,21 +654,14 @@ fn make_fresh_registry_cup(
     subnet_id: SubnetId,
     replica_logger: &ReplicaLogger,
 ) -> pb::CatchUpPackage {
-    let registry_version = registry_client.get_latest_version();
-    let cup_contents = registry_client
-        .get_cup_contents(subnet_id, registry_version)
-        .unwrap()
-        .value
-        .unwrap();
-    let cup = make_registry_cup_from_cup_contents(
+    make_registry_cup(
         registry_client.as_ref(),
         subnet_id,
-        cup_contents,
-        registry_version,
+        registry_client.get_latest_version(),
         replica_logger,
     )
-    .unwrap();
-    cup.into()
+    .unwrap()
+    .into()
 }
 
 /// Convert an object into CBOR binary.


### PR DESCRIPTION
When looking at the registry for a potential CUP, the looked up registry version is ignored and we instead silently use the latest. As of today, we anyways always look up the latest registry version (modulo a race condition), but this could change in the future.

As secondary change, we also use `make_registry_cup` in state machine tests instead of inlining its contents.