### PR TITLE
fix: deflake //rs/state_manager:state_manager_integration

### DIFF
--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -1749,8 +1749,6 @@ fn cannot_remove_latest_height_or_checkpoint() {
             Some(&Height(10))
         );
 
-        // We need to wait for hashing to complete, otherwise the
-        // checkpoint can be retained until the hashing is complete.
         state_manager.flush_tip_channel();
         state_manager.remove_states_below(Height(11));
         state_manager.remove_inmemory_states_below(Height(11), &BTreeSet::new());
@@ -1800,10 +1798,8 @@ fn can_remove_checkpoints_and_noncheckpoints_separately() {
                 CertificationScope::Metadata
             };
 
-            state_manager.commit_and_certify(state, scope.clone(), None);
+            state_manager.commit_and_certify_sync(state, scope.clone(), None);
         }
-        // We need to wait for hashing to complete, otherwise the
-        // checkpoint can be retained until the hashing is complete.
         state_manager.flush_tip_channel();
 
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
@@ -1855,10 +1851,8 @@ fn remove_inmemory_states_below_can_keep_extra_states() {
                 CertificationScope::Metadata
             };
 
-            state_manager.commit_and_certify(state, scope.clone(), None);
+            state_manager.commit_and_certify_sync(state, scope.clone(), None);
         }
-        // We need to wait for hashing to complete, otherwise the
-        // checkpoint can be retained until the hashing is complete.
         state_manager.flush_tip_channel();
 
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
@@ -2310,7 +2304,7 @@ fn can_keep_the_latest_snapshot_after_removal() {
                 CertificationScope::Metadata
             };
 
-            state_manager.commit_and_certify(state, scope.clone(), None);
+            state_manager.commit_and_certify_sync(state, scope.clone(), None);
         }
         state_manager.flush_tip_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
@@ -2341,7 +2335,7 @@ fn can_purge_intermediate_snapshots() {
                 CertificationScope::Metadata
             };
 
-            state_manager.commit_and_certify(state, scope.clone(), None);
+            state_manager.commit_and_certify_sync(state, scope.clone(), None);
         }
         state_manager.flush_tip_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);


### PR DESCRIPTION
## Root cause

Since async hashing (#8464, re-landed in #10071 on 2026-05-08), `commit_and_certify` with `CertificationScope::Metadata` returns before the `HashThread` has pushed the new state into `states.snapshots`, inserted its `certifications_metadata` entry and bumped `latest_state_height`. Only `Full`-scope commits await the hash thread.

Four tests commit a loop whose last height is `Metadata` scope, call `flush_tip_channel()` and then assert `list_state_heights(CERT_ANY)` equals every committed height:

- `can_purge_intermediate_snapshots` (failed 3x on CI in the last week)
- `can_keep_the_latest_snapshot_after_removal` (1x)
- `remove_inmemory_states_below_can_keep_extra_states` (1x)
- `can_remove_checkpoints_and_noncheckpoints_separately` (identical shape, not yet observed)

`flush_tip_channel()` drains the tip thread (checkpointing, manifest, validation), not the hash thread, so when the hash thread is descheduled on a loaded CI runner the assertion sees the last height missing:

```
thread 'can_purge_intermediate_snapshots' panicked at rs/state_manager/tests/state_manager.rs:2347:9:
assertion `left == right` failed
  left: [0, 1, ..., 20, 21]
 right: [0, 1, ..., 20, 21, 22]
```

Only the last height can ever be missing, because each subsequent `commit_and_certify` needs the previous state hash and blocks on a `HashRequest::Wait` for it.

The comment above the `flush_tip_channel()` calls ("We need to wait for hashing to complete...") dates from 2023, when the tip thread did the manifest hashing and `commit_and_certify` inserted the snapshot synchronously. #10131 introduced `commit_and_certify_sync` and converted most tests, but left these four loops on the async variant.

Reproduced deterministically by inserting a 3 s sleep for `Metadata`-scope requests at the top of the `HashThread`'s `HashState` arm: all four tests fail with byte-identical output to CI; with a hash-thread barrier they pass under the same delay.

## Fix

Switch the four loops to `commit_and_certify_sync`, which is `commit_and_certify` followed by `flush_hash_channel()`. Remove the misleading "wait for hashing" comments (also from `cannot_remove_latest_height_or_checkpoint`, which already used `_sync`). The `flush_tip_channel()` calls stay: the pruning assertions that follow still depend on checkpointing having finished.

Not addressed here (separate root cause, 1 of the last 6 flaky runs): the 19-test `Checkpoint @N didn't complete in 300s` failure mode, where the filesystem-wide `syncfs` in `finalize_and_remove_unverified_marker` blocks every checkpoint validation in the process while the CI runner's disk drains unrelated dirty pages.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/state_manager:state_manager_integration
```

All 3 runs pass (172 passed each, 40 to 41 s). Also run: `cargo check --all-targets --all-features -p ic-state-manager`, `cargo fmt`, `./ci/scripts/rust-lint.sh` (clean), `bazel build` and `bazel test --test_output=errors` on the directly affected targets.

With a temporary 3 s delay injected into the hash thread for `Metadata`-scope requests, the four tests fail deterministically on `master` and pass with this change.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
