### PR TITLE
fix: pass `replica_version` when replaying for mainnet NNS Recovery

### DIFF
--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -552,6 +552,8 @@ fn ic_replay(env: &TestEnv, mut mutate_cmd: impl FnMut(&mut Command)) -> Output 
         .arg(subnet_id.to_string())
         .arg("--data-root")
         .arg(&nns_state_dir)
+        .arg("--replica-version")
+        .arg(get_mainnet_nns_revision().unwrap().to_string())
         .arg(&ic_config_file);
     mutate_cmd(&mut cmd);
     info!(logger, "{cmd:?} ...");


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/11087, `ic-replay` expects a `--replica-version` when replaying without a consensus pool.

The original behaviour was delivering a batch with replica version `0.9.0` which was strictly worse.