### PR TITLE
test(cketh): compute the USD cost of a deposit for the minter

### DIFF
--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -35,7 +35,7 @@ use ic_ethereum_types::Address;
 /// tick — and a chunk that ever exceeds a provider's gas cap fails *every* time, permanently
 /// stalling its pairs. 1_000 keeps a comfortable margin against that for the current token set;
 /// re-measure (and lower if needed) if the supported tokens grow or skew more gas-heavy.
-const MAX_CALLS_PER_BATCH: usize = 1_000;
+pub(crate) const MAX_CALLS_PER_BATCH: usize = 1_000;
 
 pub async fn balance_scan<T: TimeProvider>(time_provider: &T) {
     let now = Timestamp::from_nanos(time_provider.time());

--- a/rs/ethereum/cketh/minter/src/deposit_cost/mod.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_cost/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
@@ -8,6 +8,12 @@ use crate::sweep::MAX_DEPOSITS_PER_SWEEP;
 use ic_ethereum_types::Address;
 use std::ops::Add;
 
+const NODES_IN_FIDUCIARY_SUBNET: u128 = 34;
+const HTTPS_OUTCALL_BASE_CYCLES: u128 =
+    (3_000_000 + 60_000 * NODES_IN_FIDUCIARY_SUBNET) * NODES_IN_FIDUCIARY_SUBNET;
+const HTTPS_OUTCALL_REQUEST_CYCLES_PER_BYTE: u128 = 400 * NODES_IN_FIDUCIARY_SUBNET;
+const HTTPS_OUTCALL_RESPONSE_CYCLES_PER_BYTE: u128 = 800 * NODES_IN_FIDUCIARY_SUBNET;
+
 #[test]
 fn should_compute_deposit_cost_in_usd() {
     for scenario in scenarios() {
@@ -30,64 +36,30 @@ fn should_compute_deposit_cost_in_usd() {
 
 fn scenarios() -> Vec<Scenario> {
     vec![
-        ScenarioBuilder::new("calm gas, lone deposit")
-            .with_balance_scans([1])
+        ScenarioBuilder::new("best case: calm gas, cheap ether, everything amortized")
+            .with_balance_scans([MAX_CALLS_PER_BATCH as u32])
+            .with_sweep_of_size(MAX_DEPOSITS_PER_SWEEP as u32)
             .with_market_conditions(MarketConditions {
                 gas_price_gwei: 0.5,
-                ..Default::default()
-            })
-            .expecting("0.1371", "0.1058", "0.2429"),
-        ScenarioBuilder::new("calm gas, full batch")
-            .with_balance_scans([10])
-            .with_sweep_of_size(10)
-            .with_market_conditions(MarketConditions {
-                gas_price_gwei: 0.5,
-                ..Default::default()
-            })
-            .expecting("0.1020", "0.0732", "0.1752"),
-        ScenarioBuilder::new("typical gas, lone deposit")
-            .with_balance_scans([1])
-            .expecting("0.5484", "0.1058", "0.6542"),
-        ScenarioBuilder::new("typical gas, full batch")
-            .with_balance_scans([10])
-            .with_sweep_of_size(10)
-            .expecting("0.4080", "0.0732", "0.4812"),
-        ScenarioBuilder::new("congested gas, lone deposit")
-            .with_balance_scans([1])
-            .with_market_conditions(MarketConditions {
-                gas_price_gwei: 10.0,
-                ..Default::default()
-            })
-            .expecting("2.7420", "0.1058", "2.8478"),
-        ScenarioBuilder::new("gas spike, lone deposit")
-            .with_balance_scans([1])
-            .with_market_conditions(MarketConditions {
-                gas_price_gwei: 100.0,
-                ..Default::default()
-            })
-            .expecting("27.4200", "0.1058", "27.5258"),
-        ScenarioBuilder::new("bear market ether, typical gas")
-            .with_balance_scans([1])
-            .with_market_conditions(MarketConditions {
                 eth_usd: 2_000.0,
                 ..Default::default()
             })
-            .expecting("0.3656", "0.1058", "0.4714"),
-        ScenarioBuilder::new("bull market ether, typical gas")
-            .with_balance_scans([1])
+            .expecting("0.0680", "0.0731", "0.1411"),
+        ScenarioBuilder::new("middle ground: typical gas, lone deposit found within the hour")
+            .with_balance_scans([1; SCANS_WITHIN_FIRST_HOUR])
+            .expecting("0.5484", "0.1184", "0.6668"),
+        ScenarioBuilder::new("worst case: gas spike, expensive ether, scanned alone for 24h")
+            .with_balance_scans([1; SCAN_GAP_SECS.len()])
             .with_market_conditions(MarketConditions {
-                eth_usd: 10_000.0,
+                gas_price_gwei: 20.0,
+                eth_usd: 5_000.0,
                 ..Default::default()
             })
-            .expecting("1.8280", "0.1058", "1.9338"),
-        ScenarioBuilder::new("scanned alone through the full 24h schedule")
-            .with_balance_scans([1; SCAN_GAP_SECS.len()])
-            .expecting("0.5484", "0.1507", "0.6991"),
-        ScenarioBuilder::new("scanned through the full 24h schedule in full calls")
-            .with_balance_scans([MAX_CALLS_PER_BATCH as u32; SCAN_GAP_SECS.len()])
-            .expecting("0.5484", "0.1050", "0.6534"),
+            .expecting("9.1400", "0.1507", "9.2907"),
     ]
 }
+
+const SCANS_WITHIN_FIRST_HOUR: usize = 10;
 
 struct ScenarioBuilder {
     name: &'static str,
@@ -308,9 +280,3 @@ struct Scenario {
 fn usd(amount: f64) -> String {
     format!("{amount:.4}")
 }
-
-const NODES_IN_FIDUCIARY_SUBNET: u128 = 34;
-const HTTPS_OUTCALL_BASE_CYCLES: u128 =
-    (3_000_000 + 60_000 * NODES_IN_FIDUCIARY_SUBNET) * NODES_IN_FIDUCIARY_SUBNET;
-const HTTPS_OUTCALL_REQUEST_CYCLES_PER_BYTE: u128 = 400 * NODES_IN_FIDUCIARY_SUBNET;
-const HTTPS_OUTCALL_RESPONSE_CYCLES_PER_BYTE: u128 = 800 * NODES_IN_FIDUCIARY_SUBNET;

--- a/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
@@ -1,42 +1,92 @@
-use crate::BALANCE_SCAN_INTERVAL;
 use crate::balance_scan::MAX_CALLS_PER_BATCH;
 use crate::balance_scan::batcher::{BalanceOfCall, encode_balance_batch};
 use crate::deposit_address::DepositAddress;
 use crate::eth_rpc_client::HEADER_SIZE_LIMIT;
 use crate::numeric::GasAmount;
 use crate::state::automatic_deposits::SCAN_GAP_SECS;
-use crate::state::transactions::{AuthorizedSweepItem, sweep_gas_limit};
 use crate::sweep::MAX_DEPOSITS_PER_SWEEP;
-use crate::sweeper_contract::SweepItem;
-use crate::tx::TransactionSignature;
-use candid::Principal;
-use ethnum::u256;
 use ic_ethereum_types::Address;
-use icrc_ledger_types::icrc1::account::Account;
-use std::time::Duration;
+use std::ops::Add;
 
 #[test]
 fn should_compute_deposit_cost_in_usd() {
     for scenario in scenarios() {
-        let cost = deposit_cost_usd(&scenario.conditions);
-
         assert_eq!(
             (
-                usd(cost.gas),
-                usd(cost.threshold_ecdsa),
-                usd(cost.https_outcalls),
-                usd(cost.total()),
+                usd(scenario.cost.ethereum),
+                usd(scenario.cost.internet_computer),
+                usd(scenario.cost.total()),
             ),
             (
-                scenario.gas_usd.to_string(),
-                scenario.threshold_ecdsa_usd.to_string(),
-                scenario.https_outcalls_usd.to_string(),
+                scenario.ethereum_usd.to_string(),
+                scenario.internet_computer_usd.to_string(),
                 scenario.total_usd.to_string(),
             ),
-            "scenario '{}' (gas, threshold ECDSA, HTTPS outcalls, total)",
+            "scenario '{}' (Ethereum, Internet Computer, total)",
             scenario.name
         );
     }
+}
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        ScenarioBuilder::new("calm gas, lone deposit")
+            .with_balance_scans([1])
+            .with_market_conditions(MarketConditions {
+                gas_price_gwei: 0.5,
+                ..Default::default()
+            })
+            .expecting("0.1371", "0.1058", "0.2429"),
+        ScenarioBuilder::new("calm gas, full batch")
+            .with_balance_scans([10])
+            .with_sweep_of_size(10)
+            .with_market_conditions(MarketConditions {
+                gas_price_gwei: 0.5,
+                ..Default::default()
+            })
+            .expecting("0.1020", "0.0732", "0.1752"),
+        ScenarioBuilder::new("typical gas, lone deposit")
+            .with_balance_scans([1])
+            .expecting("0.5484", "0.1058", "0.6542"),
+        ScenarioBuilder::new("typical gas, full batch")
+            .with_balance_scans([10])
+            .with_sweep_of_size(10)
+            .expecting("0.4080", "0.0732", "0.4812"),
+        ScenarioBuilder::new("congested gas, lone deposit")
+            .with_balance_scans([1])
+            .with_market_conditions(MarketConditions {
+                gas_price_gwei: 10.0,
+                ..Default::default()
+            })
+            .expecting("2.7420", "0.1058", "2.8478"),
+        ScenarioBuilder::new("gas spike, lone deposit")
+            .with_balance_scans([1])
+            .with_market_conditions(MarketConditions {
+                gas_price_gwei: 100.0,
+                ..Default::default()
+            })
+            .expecting("27.4200", "0.1058", "27.5258"),
+        ScenarioBuilder::new("bear market ether, typical gas")
+            .with_balance_scans([1])
+            .with_market_conditions(MarketConditions {
+                eth_usd: 2_000.0,
+                ..Default::default()
+            })
+            .expecting("0.3656", "0.1058", "0.4714"),
+        ScenarioBuilder::new("bull market ether, typical gas")
+            .with_balance_scans([1])
+            .with_market_conditions(MarketConditions {
+                eth_usd: 10_000.0,
+                ..Default::default()
+            })
+            .expecting("1.8280", "0.1058", "1.9338"),
+        ScenarioBuilder::new("scanned alone through the full 24h schedule")
+            .with_balance_scans([1; SCAN_GAP_SECS.len()])
+            .expecting("0.5484", "0.1507", "0.6991"),
+        ScenarioBuilder::new("scanned through the full 24h schedule in full calls")
+            .with_balance_scans([MAX_CALLS_PER_BATCH as u32; SCAN_GAP_SECS.len()])
+            .expecting("0.5484", "0.1050", "0.6534"),
+    ]
 }
 
 struct ScenarioBuilder {
@@ -74,6 +124,28 @@ impl ScenarioBuilder {
     pub fn with_market_conditions(mut self, market_conditions: MarketConditions) -> Self {
         self.market = market_conditions;
         self
+    }
+
+    pub fn expecting(
+        self,
+        ethereum_usd: &'static str,
+        internet_computer_usd: &'static str,
+        total_usd: &'static str,
+    ) -> Scenario {
+        Scenario {
+            name: self.name,
+            cost: self.cost_usd(),
+            ethereum_usd,
+            internet_computer_usd,
+            total_usd,
+        }
+    }
+
+    fn cost_usd(&self) -> AmortizedCostUsd {
+        self.balance_scan
+            .iter()
+            .map(|scan| scan.amortized_cost_usd(&self.market))
+            .fold(self.sweep.amortized_cost_usd(&self.market), Add::add)
     }
 }
 
@@ -195,6 +267,23 @@ struct AmortizedCostUsd {
     internet_computer: f64,
 }
 
+impl AmortizedCostUsd {
+    fn total(&self) -> f64 {
+        self.ethereum + self.internet_computer
+    }
+}
+
+impl Add for AmortizedCostUsd {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self {
+            ethereum: self.ethereum + rhs.ethereum,
+            internet_computer: self.internet_computer + rhs.internet_computer,
+        }
+    }
+}
+
 fn scanned_pairs(count: u32) -> Vec<BalanceOfCall> {
     (0..count)
         .map(|_| BalanceOfCall {
@@ -210,212 +299,18 @@ fn hex_encoded_len(bytes: usize) -> usize {
 
 struct Scenario {
     name: &'static str,
-    conditions: DepositConditions,
-    gas_usd: &'static str,
-    threshold_ecdsa_usd: &'static str,
-    https_outcalls_usd: &'static str,
+    cost: AmortizedCostUsd,
+    ethereum_usd: &'static str,
+    internet_computer_usd: &'static str,
     total_usd: &'static str,
-}
-
-fn scenarios() -> Vec<Scenario> {
-    vec![
-        Scenario {
-            name: "calm gas, lone deposit",
-            conditions: conditions(4_500.0, 0.5, 1, 1.0),
-            gas_usd: "0.5062",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "0.6186",
-        },
-        Scenario {
-            name: "calm gas, full batch",
-            conditions: conditions(4_500.0, 0.5, 10, 1.0),
-            gas_usd: "0.3848",
-            threshold_ecdsa_usd: "0.0730",
-            https_outcalls_usd: "0.0020",
-            total_usd: "0.4598",
-        },
-        Scenario {
-            name: "typical gas, lone deposit",
-            conditions: conditions(4_500.0, 2.0, 1, 1.0),
-            gas_usd: "2.0250",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "2.1373",
-        },
-        Scenario {
-            name: "typical gas, full batch",
-            conditions: conditions(4_500.0, 2.0, 10, 1.0),
-            gas_usd: "1.5390",
-            threshold_ecdsa_usd: "0.0730",
-            https_outcalls_usd: "0.0020",
-            total_usd: "1.6140",
-        },
-        Scenario {
-            name: "congested gas, lone deposit",
-            conditions: conditions(4_500.0, 10.0, 1, 1.0),
-            gas_usd: "10.1250",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "10.2373",
-        },
-        Scenario {
-            name: "gas spike, lone deposit",
-            conditions: conditions(4_500.0, 100.0, 1, 1.0),
-            gas_usd: "101.2500",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "101.3623",
-        },
-        Scenario {
-            name: "bear market ether, typical gas",
-            conditions: conditions(2_000.0, 2.0, 1, 1.0),
-            gas_usd: "0.9000",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "1.0123",
-        },
-        Scenario {
-            name: "bull market ether, typical gas",
-            conditions: conditions(10_000.0, 2.0, 1, 1.0),
-            gas_usd: "4.5000",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.0080",
-            total_usd: "4.6123",
-        },
-        Scenario {
-            name: "deposit scanned 100 times before landing",
-            conditions: conditions(4_500.0, 2.0, 1, 100.0),
-            gas_usd: "2.0250",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "0.1396",
-            total_usd: "2.2690",
-        },
-        Scenario {
-            name: "lone deposit scanned alone for 24h",
-            conditions: conditions(
-                4_500.0,
-                2.0,
-                1,
-                balance_scan_outcalls_during(Duration::from_secs(24 * 60 * 60)),
-            ),
-            gas_usd: "2.0250",
-            threshold_ecdsa_usd: "0.1044",
-            https_outcalls_usd: "3.8371",
-            total_usd: "5.9664",
-        },
-    ]
-}
-
-fn balance_scan_outcalls_during(scanning: Duration) -> f64 {
-    scanning.as_secs_f64() / BALANCE_SCAN_INTERVAL.as_secs_f64()
-}
-
-fn conditions(
-    eth_usd: f64,
-    gas_price_gwei: f64,
-    deposits_per_sweep: usize,
-    balance_scan_outcalls_per_deposit: f64,
-) -> DepositConditions {
-    DepositConditions {
-        eth_usd,
-        gas_price_gwei,
-        deposits_per_sweep,
-        balance_scan_outcalls_per_deposit,
-    }
 }
 
 fn usd(amount: f64) -> String {
     format!("{amount:.4}")
 }
 
-const USD_PER_XDR: f64 = 1.33;
-const CYCLES_PER_XDR: f64 = 1e12;
-const WEI_PER_ETH: f64 = 1e18;
-const WEI_PER_GWEI: f64 = 1e9;
-
-const ECDSA_SIGNATURE_CYCLES: f64 = 26_153_846_153.0;
-const ECDSA_SIGNATURES_PER_DEPOSIT: f64 = 2.0;
-const ECDSA_SIGNATURES_PER_SWEEP: f64 = 1.0;
-
 const NODES_IN_FIDUCIARY_SUBNET: u128 = 34;
 const HTTPS_OUTCALL_BASE_CYCLES: u128 =
     (3_000_000 + 60_000 * NODES_IN_FIDUCIARY_SUBNET) * NODES_IN_FIDUCIARY_SUBNET;
 const HTTPS_OUTCALL_REQUEST_CYCLES_PER_BYTE: u128 = 400 * NODES_IN_FIDUCIARY_SUBNET;
 const HTTPS_OUTCALL_RESPONSE_CYCLES_PER_BYTE: u128 = 800 * NODES_IN_FIDUCIARY_SUBNET;
-
-const HTTPS_OUTCALL_CYCLES: f64 = 250_000_000.0;
-const RPC_PROVIDERS_PER_CALL: f64 = 4.0;
-const SWEEP_PIPELINE_RPC_CALLS: f64 = 5.0;
-
-struct DepositConditions {
-    eth_usd: f64,
-    gas_price_gwei: f64,
-    deposits_per_sweep: usize,
-    balance_scan_outcalls_per_deposit: f64,
-}
-
-struct DepositCostUsd {
-    gas: f64,
-    threshold_ecdsa: f64,
-    https_outcalls: f64,
-}
-
-impl DepositCostUsd {
-    fn total(&self) -> f64 {
-        self.gas + self.threshold_ecdsa + self.https_outcalls
-    }
-}
-
-fn deposit_cost_usd(conditions: &DepositConditions) -> DepositCostUsd {
-    DepositCostUsd {
-        gas: gas_cost_usd(conditions),
-        threshold_ecdsa: threshold_ecdsa_cost_usd(conditions),
-        https_outcalls: https_outcalls_cost_usd(conditions),
-    }
-}
-
-fn gas_cost_usd(conditions: &DepositConditions) -> f64 {
-    let gas_per_deposit = sweep_gas_limit(&sweep_items(conditions.deposits_per_sweep)).as_f64()
-        / conditions.deposits_per_sweep as f64;
-    gas_per_deposit * conditions.gas_price_gwei * WEI_PER_GWEI / WEI_PER_ETH * conditions.eth_usd
-}
-
-fn threshold_ecdsa_cost_usd(conditions: &DepositConditions) -> f64 {
-    let signatures_per_deposit = ECDSA_SIGNATURES_PER_DEPOSIT
-        + ECDSA_SIGNATURES_PER_SWEEP / conditions.deposits_per_sweep as f64;
-    cycles_to_usd(signatures_per_deposit * ECDSA_SIGNATURE_CYCLES)
-}
-
-fn https_outcalls_cost_usd(conditions: &DepositConditions) -> f64 {
-    let rpc_calls_per_deposit = conditions.balance_scan_outcalls_per_deposit
-        + SWEEP_PIPELINE_RPC_CALLS / conditions.deposits_per_sweep as f64;
-    cycles_to_usd(rpc_calls_per_deposit * RPC_PROVIDERS_PER_CALL * HTTPS_OUTCALL_CYCLES)
-}
-
-fn cycles_to_usd(cycles: f64) -> f64 {
-    cycles / CYCLES_PER_XDR * USD_PER_XDR
-}
-
-fn sweep_items(deposits: usize) -> Vec<AuthorizedSweepItem> {
-    (1..=deposits)
-        .map(|deposit| {
-            let seed = u8::try_from(deposit).expect("deposits per sweep fits in a u8");
-            AuthorizedSweepItem {
-                item: SweepItem {
-                    deposit: DepositAddress::new(Address::new([seed; 20])),
-                    account: Account {
-                        owner: Principal::management_canister(),
-                        subaccount: Some([seed; 32]),
-                    },
-                    attestation: TransactionSignature {
-                        signature_y_parity: false,
-                        r: u256::from(seed),
-                        s: u256::from(seed),
-                    },
-                },
-                authorization: None,
-            }
-        })
-        .collect()
-}

--- a/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
@@ -1,6 +1,12 @@
 use crate::BALANCE_SCAN_INTERVAL;
+use crate::balance_scan::MAX_CALLS_PER_BATCH;
+use crate::balance_scan::batcher::{BalanceOfCall, encode_balance_batch};
 use crate::deposit_address::DepositAddress;
+use crate::eth_rpc_client::HEADER_SIZE_LIMIT;
+use crate::numeric::GasAmount;
+use crate::state::automatic_deposits::SCAN_GAP_SECS;
 use crate::state::transactions::{AuthorizedSweepItem, sweep_gas_limit};
+use crate::sweep::MAX_DEPOSITS_PER_SWEEP;
 use crate::sweeper_contract::SweepItem;
 use crate::tx::TransactionSignature;
 use candid::Principal;
@@ -31,6 +37,175 @@ fn should_compute_deposit_cost_in_usd() {
             scenario.name
         );
     }
+}
+
+struct ScenarioBuilder {
+    name: &'static str,
+    balance_scan: Vec<BalanceScanStep>,
+    sweep: SweepTransactionStep,
+    market: MarketConditions,
+}
+
+impl ScenarioBuilder {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            balance_scan: Vec::new(),
+            sweep: SweepTransactionStep::new(1),
+            market: Default::default(),
+        }
+    }
+
+    pub fn with_balance_scans<I: IntoIterator<Item = u32>>(mut self, batch_size: I) -> Self {
+        let batches: Vec<_> = batch_size.into_iter().map(BalanceScanStep::new).collect();
+        assert!(
+            batches.len() <= SCAN_GAP_SECS.len(),
+            "BUG: Too many balance scans scheduled"
+        );
+        self.balance_scan = batches;
+        self
+    }
+
+    pub fn with_sweep_of_size(mut self, sweep_size: u32) -> Self {
+        self.sweep = SweepTransactionStep::new(sweep_size);
+        self
+    }
+
+    pub fn with_market_conditions(mut self, market_conditions: MarketConditions) -> Self {
+        self.market = market_conditions;
+        self
+    }
+}
+
+struct BalanceScanStep {
+    batch_size: u32,
+    num_providers: u32,
+}
+
+impl BalanceScanStep {
+    pub fn new(batch_size: u32) -> Self {
+        assert!(0 < batch_size && batch_size as usize <= MAX_CALLS_PER_BATCH);
+        Self {
+            batch_size,
+            num_providers: 4,
+        }
+    }
+
+    fn request_size_bytes(&self) -> usize {
+        let input = encode_balance_batch(&scanned_pairs(self.batch_size));
+        HEADER_SIZE_LIMIT as usize + hex_encoded_len(input.len())
+    }
+
+    fn response_size_bytes(&self) -> usize {
+        let balance_words = 32 * self.batch_size as usize;
+        HEADER_SIZE_LIMIT as usize + hex_encoded_len(balance_words)
+    }
+
+    fn request_cycles_cost(&self) -> u128 {
+        let per_provider = HTTPS_OUTCALL_BASE_CYCLES
+            + HTTPS_OUTCALL_REQUEST_CYCLES_PER_BYTE * self.request_size_bytes() as u128
+            + HTTPS_OUTCALL_RESPONSE_CYCLES_PER_BYTE * self.response_size_bytes() as u128;
+        self.num_providers as u128 * per_provider
+    }
+
+    fn amortized_cost_usd(&self, market: &MarketConditions) -> AmortizedCostUsd {
+        AmortizedCostUsd {
+            internet_computer: market.cycles_to_usd(self.request_cycles_cost())
+                / self.batch_size as f64,
+            ..Default::default()
+        }
+    }
+}
+
+struct SweepTransactionStep {
+    batch_size: u32,
+    with_attestation: bool,
+    with_authorization: bool,
+}
+
+impl SweepTransactionStep {
+    pub fn new(batch_size: u32) -> Self {
+        assert!(0 < batch_size && batch_size as usize <= MAX_DEPOSITS_PER_SWEEP);
+        Self {
+            batch_size,
+            with_attestation: true,
+            with_authorization: true,
+        }
+    }
+
+    fn signature_cycles_cost(&self) -> u128 {
+        const THRESHOLD_ECDSA_FIDUCIARY_CYCLES_COST: u128 = 26_153_846_153;
+        let mut num_signatures = 1; //for the overall Ethereum transaction;
+        if self.with_attestation {
+            num_signatures += self.batch_size;
+        }
+        if self.with_authorization {
+            num_signatures += self.batch_size;
+        }
+        num_signatures as u128 * THRESHOLD_ECDSA_FIDUCIARY_CYCLES_COST
+    }
+
+    fn gas_cost(&self) -> GasAmount {
+        const FIXED_GAS_COST: u128 = 26_000;
+        const PER_ITEM_GAS_COST: u128 = 65_400;
+        GasAmount::new(FIXED_GAS_COST + self.batch_size as u128 * PER_ITEM_GAS_COST)
+    }
+
+    fn amortized_cost_usd(&self, market: &MarketConditions) -> AmortizedCostUsd {
+        AmortizedCostUsd {
+            ethereum: market.gas_to_usd(&self.gas_cost()) / self.batch_size as f64,
+            internet_computer: market.cycles_to_usd(self.signature_cycles_cost())
+                / self.batch_size as f64,
+        }
+    }
+}
+
+struct MarketConditions {
+    eth_usd: f64,
+    gas_price_gwei: f64,
+    xdr_usd: f64,
+}
+
+impl Default for MarketConditions {
+    fn default() -> Self {
+        Self {
+            eth_usd: 3000.0,
+            gas_price_gwei: 2.0,
+            xdr_usd: 1.33,
+        }
+    }
+}
+
+impl MarketConditions {
+    fn cycles_to_usd(&self, cycles: u128) -> f64 {
+        const TCYCLES_XDR: f64 = 1e12;
+        (cycles as f64 * self.xdr_usd) / TCYCLES_XDR
+    }
+
+    fn gas_to_usd(&self, gas: &GasAmount) -> f64 {
+        const GWEI: f64 = 1e9;
+        gas.as_f64() * self.gas_price_gwei * self.eth_usd / GWEI
+    }
+}
+
+/// Cost in USD for 1 deposit.
+#[derive(Default)]
+struct AmortizedCostUsd {
+    ethereum: f64,
+    internet_computer: f64,
+}
+
+fn scanned_pairs(count: u32) -> Vec<BalanceOfCall> {
+    (0..count)
+        .map(|_| BalanceOfCall {
+            token: Address::new([0xaa; 20]),
+            holder: DepositAddress::new(Address::new([0xbb; 20])),
+        })
+        .collect()
+}
+
+fn hex_encoded_len(bytes: usize) -> usize {
+    "0x".len() + 2 * bytes
 }
 
 struct Scenario {
@@ -162,6 +337,12 @@ const WEI_PER_GWEI: f64 = 1e9;
 const ECDSA_SIGNATURE_CYCLES: f64 = 26_153_846_153.0;
 const ECDSA_SIGNATURES_PER_DEPOSIT: f64 = 2.0;
 const ECDSA_SIGNATURES_PER_SWEEP: f64 = 1.0;
+
+const NODES_IN_FIDUCIARY_SUBNET: u128 = 34;
+const HTTPS_OUTCALL_BASE_CYCLES: u128 =
+    (3_000_000 + 60_000 * NODES_IN_FIDUCIARY_SUBNET) * NODES_IN_FIDUCIARY_SUBNET;
+const HTTPS_OUTCALL_REQUEST_CYCLES_PER_BYTE: u128 = 400 * NODES_IN_FIDUCIARY_SUBNET;
+const HTTPS_OUTCALL_RESPONSE_CYCLES_PER_BYTE: u128 = 800 * NODES_IN_FIDUCIARY_SUBNET;
 
 const HTTPS_OUTCALL_CYCLES: f64 = 250_000_000.0;
 const RPC_PROVIDERS_PER_CALL: f64 = 4.0;

--- a/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_cost/tests.rs
@@ -1,0 +1,240 @@
+use crate::BALANCE_SCAN_INTERVAL;
+use crate::deposit_address::DepositAddress;
+use crate::state::transactions::{AuthorizedSweepItem, sweep_gas_limit};
+use crate::sweeper_contract::SweepItem;
+use crate::tx::TransactionSignature;
+use candid::Principal;
+use ethnum::u256;
+use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
+use std::time::Duration;
+
+#[test]
+fn should_compute_deposit_cost_in_usd() {
+    for scenario in scenarios() {
+        let cost = deposit_cost_usd(&scenario.conditions);
+
+        assert_eq!(
+            (
+                usd(cost.gas),
+                usd(cost.threshold_ecdsa),
+                usd(cost.https_outcalls),
+                usd(cost.total()),
+            ),
+            (
+                scenario.gas_usd.to_string(),
+                scenario.threshold_ecdsa_usd.to_string(),
+                scenario.https_outcalls_usd.to_string(),
+                scenario.total_usd.to_string(),
+            ),
+            "scenario '{}' (gas, threshold ECDSA, HTTPS outcalls, total)",
+            scenario.name
+        );
+    }
+}
+
+struct Scenario {
+    name: &'static str,
+    conditions: DepositConditions,
+    gas_usd: &'static str,
+    threshold_ecdsa_usd: &'static str,
+    https_outcalls_usd: &'static str,
+    total_usd: &'static str,
+}
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        Scenario {
+            name: "calm gas, lone deposit",
+            conditions: conditions(4_500.0, 0.5, 1, 1.0),
+            gas_usd: "0.5062",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "0.6186",
+        },
+        Scenario {
+            name: "calm gas, full batch",
+            conditions: conditions(4_500.0, 0.5, 10, 1.0),
+            gas_usd: "0.3848",
+            threshold_ecdsa_usd: "0.0730",
+            https_outcalls_usd: "0.0020",
+            total_usd: "0.4598",
+        },
+        Scenario {
+            name: "typical gas, lone deposit",
+            conditions: conditions(4_500.0, 2.0, 1, 1.0),
+            gas_usd: "2.0250",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "2.1373",
+        },
+        Scenario {
+            name: "typical gas, full batch",
+            conditions: conditions(4_500.0, 2.0, 10, 1.0),
+            gas_usd: "1.5390",
+            threshold_ecdsa_usd: "0.0730",
+            https_outcalls_usd: "0.0020",
+            total_usd: "1.6140",
+        },
+        Scenario {
+            name: "congested gas, lone deposit",
+            conditions: conditions(4_500.0, 10.0, 1, 1.0),
+            gas_usd: "10.1250",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "10.2373",
+        },
+        Scenario {
+            name: "gas spike, lone deposit",
+            conditions: conditions(4_500.0, 100.0, 1, 1.0),
+            gas_usd: "101.2500",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "101.3623",
+        },
+        Scenario {
+            name: "bear market ether, typical gas",
+            conditions: conditions(2_000.0, 2.0, 1, 1.0),
+            gas_usd: "0.9000",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "1.0123",
+        },
+        Scenario {
+            name: "bull market ether, typical gas",
+            conditions: conditions(10_000.0, 2.0, 1, 1.0),
+            gas_usd: "4.5000",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.0080",
+            total_usd: "4.6123",
+        },
+        Scenario {
+            name: "deposit scanned 100 times before landing",
+            conditions: conditions(4_500.0, 2.0, 1, 100.0),
+            gas_usd: "2.0250",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "0.1396",
+            total_usd: "2.2690",
+        },
+        Scenario {
+            name: "lone deposit scanned alone for 24h",
+            conditions: conditions(
+                4_500.0,
+                2.0,
+                1,
+                balance_scan_outcalls_during(Duration::from_secs(24 * 60 * 60)),
+            ),
+            gas_usd: "2.0250",
+            threshold_ecdsa_usd: "0.1044",
+            https_outcalls_usd: "3.8371",
+            total_usd: "5.9664",
+        },
+    ]
+}
+
+fn balance_scan_outcalls_during(scanning: Duration) -> f64 {
+    scanning.as_secs_f64() / BALANCE_SCAN_INTERVAL.as_secs_f64()
+}
+
+fn conditions(
+    eth_usd: f64,
+    gas_price_gwei: f64,
+    deposits_per_sweep: usize,
+    balance_scan_outcalls_per_deposit: f64,
+) -> DepositConditions {
+    DepositConditions {
+        eth_usd,
+        gas_price_gwei,
+        deposits_per_sweep,
+        balance_scan_outcalls_per_deposit,
+    }
+}
+
+fn usd(amount: f64) -> String {
+    format!("{amount:.4}")
+}
+
+const USD_PER_XDR: f64 = 1.33;
+const CYCLES_PER_XDR: f64 = 1e12;
+const WEI_PER_ETH: f64 = 1e18;
+const WEI_PER_GWEI: f64 = 1e9;
+
+const ECDSA_SIGNATURE_CYCLES: f64 = 26_153_846_153.0;
+const ECDSA_SIGNATURES_PER_DEPOSIT: f64 = 2.0;
+const ECDSA_SIGNATURES_PER_SWEEP: f64 = 1.0;
+
+const HTTPS_OUTCALL_CYCLES: f64 = 250_000_000.0;
+const RPC_PROVIDERS_PER_CALL: f64 = 4.0;
+const SWEEP_PIPELINE_RPC_CALLS: f64 = 5.0;
+
+struct DepositConditions {
+    eth_usd: f64,
+    gas_price_gwei: f64,
+    deposits_per_sweep: usize,
+    balance_scan_outcalls_per_deposit: f64,
+}
+
+struct DepositCostUsd {
+    gas: f64,
+    threshold_ecdsa: f64,
+    https_outcalls: f64,
+}
+
+impl DepositCostUsd {
+    fn total(&self) -> f64 {
+        self.gas + self.threshold_ecdsa + self.https_outcalls
+    }
+}
+
+fn deposit_cost_usd(conditions: &DepositConditions) -> DepositCostUsd {
+    DepositCostUsd {
+        gas: gas_cost_usd(conditions),
+        threshold_ecdsa: threshold_ecdsa_cost_usd(conditions),
+        https_outcalls: https_outcalls_cost_usd(conditions),
+    }
+}
+
+fn gas_cost_usd(conditions: &DepositConditions) -> f64 {
+    let gas_per_deposit = sweep_gas_limit(&sweep_items(conditions.deposits_per_sweep)).as_f64()
+        / conditions.deposits_per_sweep as f64;
+    gas_per_deposit * conditions.gas_price_gwei * WEI_PER_GWEI / WEI_PER_ETH * conditions.eth_usd
+}
+
+fn threshold_ecdsa_cost_usd(conditions: &DepositConditions) -> f64 {
+    let signatures_per_deposit = ECDSA_SIGNATURES_PER_DEPOSIT
+        + ECDSA_SIGNATURES_PER_SWEEP / conditions.deposits_per_sweep as f64;
+    cycles_to_usd(signatures_per_deposit * ECDSA_SIGNATURE_CYCLES)
+}
+
+fn https_outcalls_cost_usd(conditions: &DepositConditions) -> f64 {
+    let rpc_calls_per_deposit = conditions.balance_scan_outcalls_per_deposit
+        + SWEEP_PIPELINE_RPC_CALLS / conditions.deposits_per_sweep as f64;
+    cycles_to_usd(rpc_calls_per_deposit * RPC_PROVIDERS_PER_CALL * HTTPS_OUTCALL_CYCLES)
+}
+
+fn cycles_to_usd(cycles: f64) -> f64 {
+    cycles / CYCLES_PER_XDR * USD_PER_XDR
+}
+
+fn sweep_items(deposits: usize) -> Vec<AuthorizedSweepItem> {
+    (1..=deposits)
+        .map(|deposit| {
+            let seed = u8::try_from(deposit).expect("deposits per sweep fits in a u8");
+            AuthorizedSweepItem {
+                item: SweepItem {
+                    deposit: DepositAddress::new(Address::new([seed; 20])),
+                    account: Account {
+                        owner: Principal::management_canister(),
+                        subaccount: Some([seed; 32]),
+                    },
+                    attestation: TransactionSignature {
+                        signature_y_parity: false,
+                        r: u256::from(seed),
+                        s: u256::from(seed),
+                    },
+                },
+                authorization: None,
+            }
+        })
+        .collect()
+}

--- a/rs/ethereum/cketh/minter/src/lib.rs
+++ b/rs/ethereum/cketh/minter/src/lib.rs
@@ -31,6 +31,8 @@ pub mod tx;
 pub mod withdraw;
 
 #[cfg(test)]
+mod deposit_cost;
+#[cfg(test)]
 pub mod test_fixtures;
 #[cfg(test)]
 mod tests;

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -31,7 +31,7 @@ pub const DEPOSIT_ADDRESS_SCAN_WINDOW: Duration = Duration::from_secs(24 * 60 * 
 /// ramps up to five-minute gaps, then settles to hourly scans until the 24h window
 /// closes. Once the schedule is exhausted the deposit is no longer scanned (it
 /// expires at 24h anyway).
-const SCAN_GAP_SECS: [u64; 33] = [
+pub(crate) const SCAN_GAP_SECS: [u64; 33] = [
     // Burst then ramp: cumulative 1_800s (30min) over the first ten scans.
     30, 30, 60, 120, 120, 240, 300, 300, 300, 300,
     // Hourly tail up to the 24h window: 23 more scans of 3_600s (82_800s), for a

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -45,7 +45,7 @@ use std::collections::BTreeSet;
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
-const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+pub(crate) const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.


### PR DESCRIPTION
## Summary

First step for DEFI-2991 (deduct a fee on automatic deposits): a table-driven unit test estimating what one automatic deposit costs the minter in USD, to inform the choice of the fee.

The cost model lives entirely in a test-only module and prices the two chains separately:

- **Internet Computer**: balance-scan HTTPS outcalls priced from their actual batch payload sizes via the outcall fee formula, bounded by the production scan schedule, plus the threshold-ECDSA signatures (attestation, EIP-7702 authorization, transaction).
- **Ethereum**: the sweep transaction's gas, amortized over the sweep batch.

Three scenarios document the envelope: a best case with everything amortized under calm markets (about \$0.14 per deposit), a middle ground with a lone deposit found within the hour (about \$0.67), and a worst case combining a 20 gwei spike, expensive ether and 24h of solo scanning (about \$9.29).

Resolves ticket: [DEFI-2991](https://dfinity.atlassian.net/browse/DEFI-2991)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9

[DEFI-2991]: https://dfinity.atlassian.net/browse/DEFI-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ