### PR TITLE
chore: update UVM and P8s images that now have daemonize and python3 in scope

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1482,13 +1482,13 @@ motoko.toolchain(version = "1.11.0")  # NOTE: keep version in line with Dockerfi
 http_file(
     name = "farm_universal_vm_img",
     downloaded_file_path = "universal-vm.img.zst",
-    sha256 = "ae94e672589c8cb47231976f8d0a4abaac4b8fde9ded1a664de6d7c32f0eac25",
-    url = "https://download.dfinity.systems/farm/universal-vm/ae94e672589c8cb47231976f8d0a4abaac4b8fde9ded1a664de6d7c32f0eac25/x86_64-linux/universal-vm.img.zst",
+    sha256 = "ba8b49004163fa15f13c8ebac1e7cb99499043cda9f0a5dee00eca1b95187aee",
+    url = "https://download.dfinity.systems/farm/universal-vm/ba8b49004163fa15f13c8ebac1e7cb99499043cda9f0a5dee00eca1b95187aee/x86_64-linux/universal-vm.img.zst",
 )
 
 http_file(
     name = "farm_prometheus_vm_img",
     downloaded_file_path = "prometheus-vm.img.zst",
-    sha256 = "3568d6e7e8176636bcbd29f5469dec6b036345e61d2b57c276a0941df0b31c4a",
-    url = "https://download.dfinity.systems/farm/prometheus-vm/3568d6e7e8176636bcbd29f5469dec6b036345e61d2b57c276a0941df0b31c4a/x86_64-linux/prometheus-vm.img.zst",
+    sha256 = "6dc09a214f1975ce55a42a560b67b44ac58a61b52e3c3e9cf03dc2d7fbdd5f02",
+    url = "https://download.dfinity.systems/farm/prometheus-vm/6dc09a214f1975ce55a42a560b67b44ac58a61b52e3c3e9cf03dc2d7fbdd5f02/x86_64-linux/prometheus-vm.img.zst",
 )

--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -1140,7 +1140,6 @@ impl Step for UploadAndHostTarStep {
 
         let upload_dir = UploadAndHostTarStep::get_upload_dir_name();
 
-        ssh_helper.ssh("nix-env -i daemonize python3".to_string())?;
         ssh_helper.ssh(format!(
             "mkdir -p {upload_dir}",
             upload_dir = upload_dir.display()

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -42,7 +42,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/prometheus-vm/<SHA256-HASH>/x86_64-linux/prometheus-vm.img.zst
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "3568d6e7e8176636bcbd29f5469dec6b036345e61d2b57c276a0941df0b31c4a";
+    "6dc09a214f1975ce55a42a560b67b44ac58a61b52e3c3e9cf03dc2d7fbdd5f02";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!(

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -255,7 +255,7 @@ pub fn get_resource_request_for_nested_nodes(
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/universal-vm/<SHA256-HASH>/x86_64-linux/universal-vm.img.zst
 pub const DEFAULT_UNIVERSAL_VM_IMG_SHA256: &str =
-    "ae94e672589c8cb47231976f8d0a4abaac4b8fde9ded1a664de6d7c32f0eac25";
+    "ba8b49004163fa15f13c8ebac1e7cb99499043cda9f0a5dee00eca1b95187aee";
 
 /// Returns the default Universal VM disk image as a Farm-style URL.
 pub fn default_universal_vm_disk_image() -> DiskImage {

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -80,8 +80,11 @@ const MAINNET_NNS_DAPP_CANISTER_ID: &str = "qoctq-giaaa-aaaaa-aaaea-cai";
 // made on top of the current mainnet version and not including the incompatible changes.
 // After switching to `Head`/`Commit` it is then advised to switch back to `Mainnet` when the
 // changes reach mainnet NNS to avoid compatibility bugs.
+
+// TODO: Turn to `Mainnet` after #11437 reaches mainnet NNS
 const IC_REPLAY_VERSION: BinaryVersion = BinaryVersion::Head;
-const IC_RECOVERY_VERSION: BinaryVersion = BinaryVersion::Mainnet;
+// TODO: Turn to `Mainnet` after #11203 reaches mainnet NNS
+const IC_RECOVERY_VERSION: BinaryVersion = BinaryVersion::Head;
 #[allow(dead_code)]
 enum BinaryVersion {
     Mainnet,


### PR DESCRIPTION
This depends on https://github.com/dfinity-lab/farm/commit/9b9453e083dae9839961559a3b6843d9530b9bd9.