### PR TITLE
feat(cketh): accept and sweep plain ETH at delegated deposit addresses

### DIFF
--- a/rs/ethereum/cketh/docs/deposit_from_cex.md
+++ b/rs/ethereum/cketh/docs/deposit_from_cex.md
@@ -461,21 +461,38 @@ with Phase 2):
 | **Single shared address** with *set-and-clear* delegation (install delegate, sweep, re-delegate to `address(0)`) | One address per account | Two tECDSA signatures + ≈ 2 × 12'500–25'000 gas per sweep cycle; short window in which fixed-gas ETH transfers fail at the sender; more complex delegation lifecycle |
 | **Single shared address** with permanent delegation | One address, one authorization ever | Breaks ETH deposits entirely: plain sends to a delegated address without `receive()` revert — funds bounce at the CEX (`R12` holds, but ETH deposits are impossible) |
 
-**Mainnet data point (2026-09-04, DEFI-2993,
+**Mainnet data point (2026-09-04,
 [#11449](https://github.com/dfinity/ic/pull/11449)):** with an empty payable
-`receive()` on the delegate (kept empty to fit the 2'300-gas `transfer`/`send`
-stipend) plus attested `sweepEth`/`sweepEthBatch` entry points, real ETH
-withdrawals from **Binance** and **Kraken** both reached an
-EIP-7702-delegated address — top-level sends with gas limits of 207'128 (flat)
-and 31'830 (estimate-based) respectively, 21'055 gas used in both cases,
-matching the anvil measurement exactly — and were swept back permissionlessly.
+`receive()` on the delegate (kept minimal to fit the 2'300-gas
+`transfer`/`send` stipend) plus attested `sweepEth`/`sweepEthBatch` entry
+points, real ETH withdrawals from **Binance**
+([before delegation](https://etherscan.io/tx/0xaa13310032da7fc310f451f23d013e4b9e69c24bd201ac5cc57b54b15b0afbf2),
+[after](https://etherscan.io/tx/0x59cbb83ac893da16789b15d0494b7c3e5f382e1254f259d9c6fbcef5e45747c1))
+and **Kraken**
+([after](https://etherscan.io/tx/0x3b1dbd6c29b5f56d71c0ce1baae931f8e519852775be199fe62575ba6361b864))
+reached the delegated deposit EOA
+[`0x5e5402ed…`](https://etherscan.io/address/0x5e5402edfe155b5116f1f84d0b97b9e74f5ebc85),
+delegated to the sweeper
+[`0x3983baa1…`](https://etherscan.io/address/0x3983baa1703f69e76669768164c822918e843a25)
+— top-level sends with gas limits of 207'128 (flat) and 31'830
+(estimate-based) respectively, 21'055 gas used in both cases, matching the
+anvil measurement exactly. The funds were swept back permissionlessly through
+a private helper deployment
+[`0x3fc2640f…`](https://etherscan.io/address/0x3fc2640f8529cfafc5bf47ca2bcd05eb51d94c7b)
+to the EOA standing in for the minter,
+[`0x91eba053…`](https://etherscan.io/address/0x91eba053fc03bcac1328de38925f0a1ab9dba586):
+[delegation + first sweep](https://etherscan.io/tx/0x909cab5a08442b7ede39752cb25b497c72d5992cd0fc8c6ee9ac888eb9ff6c98)
+(type-4),
+[second Binance sweep](https://etherscan.io/tx/0xc8e7df2413212215ef2dd27b603d92b99a04ef180b8fa87eebdf6787d4cb715a)
+and
+[Kraken sweep](https://etherscan.io/tx/0x8e7f014001124afe3294f709971ed2de67f7e89f8f338724044af7a75acad8f2).
 Neither exchange hardcodes a 21'000 gas limit or refuses an address carrying a
 delegation designator, so the third variant's "ETH deposits are impossible"
 did not materialize for these two exchanges. The per-asset split stays the
 decided default (exchange behavior is heterogeneous and contract-batched
 withdrawal paths, where the 2'300-gas stipend could still bite, remain
 untested), but the shared permanently-delegated address is a viable Phase 2
-candidate; per-exchange results in DEFI-2993.
+candidate.
 
 ### Step 2: Withdraw from the CEX to the deposit address
 
@@ -1061,10 +1078,16 @@ Notes:
   is the EOA, so the batch gate cannot be written as `msg.sender == address(this)`.
 * The approval is for exactly `balance` and is consumed in full within the same
   call — no standing allowance toward the helper ever survives a sweep.
-* No `receive()`/`fallback` and no ETH sweep entry point on purpose: plain ETH
-  sends to a delegated ERC-20 address must fail rather than be silently accepted
-  (`R12`); Phase 2 ETH addresses are never delegated and sweep via a key-signed
-  `depositEth` call (step 5).
+* The delegate carries an empty payable `receive()` — guarded to revert on the
+  implementation address itself, where no attestation can ever recover and ETH
+  would be locked — plus attested `sweepEth`/`sweepEthBatch` entry points that
+  forward the balance through the helper's `depositEth`
+  ([#11449](https://github.com/dfinity/ic/pull/11449)). This keeps the
+  single-shared-address variant open for Phase 2 (see the mainnet data point in
+  step 1); under the decided per-asset layout the schema-2 ETH addresses are
+  never delegated and sweep via a key-signed `depositEth` call (step 5), and a
+  plain ETH send to a delegated ERC-20 address is accepted as a recoverable
+  wrong-asset deposit (see Non-goals) rather than bounced.
 * Reentrancy is moot: no storage, and funds can only move through the helper
   toward the minter's main address.
 * Supported tokens are assumed standard: non-fee-on-transfer and non-rebasing, so

--- a/rs/ethereum/cketh/docs/deposit_from_cex.md
+++ b/rs/ethereum/cketh/docs/deposit_from_cex.md
@@ -461,6 +461,22 @@ with Phase 2):
 | **Single shared address** with *set-and-clear* delegation (install delegate, sweep, re-delegate to `address(0)`) | One address per account | Two tECDSA signatures + ≈ 2 × 12'500–25'000 gas per sweep cycle; short window in which fixed-gas ETH transfers fail at the sender; more complex delegation lifecycle |
 | **Single shared address** with permanent delegation | One address, one authorization ever | Breaks ETH deposits entirely: plain sends to a delegated address without `receive()` revert — funds bounce at the CEX (`R12` holds, but ETH deposits are impossible) |
 
+**Mainnet data point (2026-09-04, DEFI-2993,
+[#11449](https://github.com/dfinity/ic/pull/11449)):** with an empty payable
+`receive()` on the delegate (kept empty to fit the 2'300-gas `transfer`/`send`
+stipend) plus attested `sweepEth`/`sweepEthBatch` entry points, real ETH
+withdrawals from **Binance** and **Kraken** both reached an
+EIP-7702-delegated address — top-level sends with gas limits of 207'128 (flat)
+and 31'830 (estimate-based) respectively, 21'055 gas used in both cases,
+matching the anvil measurement exactly — and were swept back permissionlessly.
+Neither exchange hardcodes a 21'000 gas limit or refuses an address carrying a
+delegation designator, so the third variant's "ETH deposits are impossible"
+did not materialize for these two exchanges. The per-asset split stays the
+decided default (exchange behavior is heterogeneous and contract-batched
+withdrawal paths, where the 2'300-gas stipend could still bite, remain
+untested), but the shared permanently-delegated address is a viable Phase 2
+candidate; per-exchange results in DEFI-2993.
+
 ### Step 2: Withdraw from the CEX to the deposit address
 
 The user pastes the deposit address into the exchange withdrawal form; the CEX

--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -272,6 +272,7 @@ rust_test(
         "CkSweeperAttested.sol",
         "tests/deposit_from_cex_demo/CkSweeperViaHelper.sol",
         "tests/deposit_from_cex_demo/MockUSDT.sol",
+        "tests/deposit_from_cex_demo/StipendForwarder.sol",
     ],
     env = {
         "ANVIL_BIN": "$(rootpath //:anvil)",
@@ -279,6 +280,7 @@ rust_test(
         "CKSWEEPER_ATTESTED_SOL": "$(rootpath CkSweeperAttested.sol)",
         "CKSWEEPER_VIA_HELPER_SOL": "$(rootpath tests/deposit_from_cex_demo/CkSweeperViaHelper.sol)",
         "MOCKUSDT_SOL": "$(rootpath tests/deposit_from_cex_demo/MockUSDT.sol)",
+        "STIPEND_FORWARDER_SOL": "$(rootpath tests/deposit_from_cex_demo/StipendForwarder.sol)",
         "SOLC_BIN": "$(rootpath //:solc)",
     },
     deps = [

--- a/rs/ethereum/cketh/minter/CkSweeperAttested.sol
+++ b/rs/ethereum/cketh/minter/CkSweeperAttested.sol
@@ -33,16 +33,22 @@ struct SweepItem {
 /// its (r, s, v) components.
 contract CkSweeperAttested {
     address private immutable HELPER;
+    address private immutable SELF;
 
     constructor(address helper) {
         HELPER = helper;
+        SELF = address(this);
     }
 
-    /// Accepts plain ETH sends to a delegated deposit address. Deliberately
-    /// empty: batched CEX withdrawals may forward value with only the 2'300-gas
-    /// `transfer`/`send` stipend, which any extra logic would exceed, and
-    /// detection is balance-based so no event is needed.
-    receive() external payable {}
+    /// Accepts plain ETH sends to a delegated deposit address, but not to the
+    /// implementation itself: no attestation can ever recover to the contract's
+    /// own address, so ETH landing there would be locked forever. Otherwise
+    /// deliberately minimal: batched CEX withdrawals may forward value with only
+    /// the 2'300-gas `transfer`/`send` stipend, and detection is balance-based
+    /// so no event is needed.
+    receive() external payable {
+        require(address(this) != SELF, "implementation cannot be swept");
+    }
 
     /// The attestation digest: keccak256 over a fixed-length, domain-separated
     /// preimage. The ASCII prefix (first byte 0x63) cannot collide with typed

--- a/rs/ethereum/cketh/minter/CkSweeperAttested.sol
+++ b/rs/ethereum/cketh/minter/CkSweeperAttested.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 interface ICkDeposit {
     function depositErc20(address erc20Address, uint256 amount, bytes32 principal, bytes32 subaccount) external;
+    function depositEth(bytes32 principal, bytes32 subaccount) external payable;
 }
 
 interface IErc20Balance {
@@ -37,6 +38,12 @@ contract CkSweeperAttested {
         HELPER = helper;
     }
 
+    /// Accepts plain ETH sends to a delegated deposit address. Deliberately
+    /// empty: batched CEX withdrawals may forward value with only the 2'300-gas
+    /// `transfer`/`send` stipend, which any extra logic would exceed, and
+    /// detection is balance-based so no event is needed.
+    receive() external payable {}
+
     /// The attestation digest: keccak256 over a fixed-length, domain-separated
     /// preimage. The ASCII prefix (first byte 0x63) cannot collide with typed
     /// transactions (0x00-0x04), EIP-7702 authorizations (0x05), EIP-191/712
@@ -66,13 +73,36 @@ contract CkSweeperAttested {
         }
     }
 
+    /// Sweeps the deposit address' entire ETH balance to the minter through the
+    /// helper's `depositEth`, under the same attestation check as `sweepErc20`.
+    function sweepEth(bytes32 principal, bytes32 subaccount, bytes32 r, bytes32 s, uint8 v) external {
+        require(
+            ecrecover(_attestationDigest(principal, subaccount), v, r, s) == address(this),
+            "invalid attestation"
+        );
+        uint256 balance = address(this).balance;
+        if (balance > 0) {
+            ICkDeposit(HELPER).depositEth{value: balance}(principal, subaccount);
+        }
+    }
+
     /// Permissionless batch entry point: sweeps many delegated deposit EOAs in a
     /// single transaction, each with its own attestation.
     function sweepErc20Batch(SweepItem[] calldata items, address[] calldata tokens) external {
         for (uint256 i = 0; i < items.length; ++i) {
             SweepItem calldata item = items[i];
-            CkSweeperAttested(item.deposit).sweepErc20(
+            CkSweeperAttested(payable(item.deposit)).sweepErc20(
                 tokens, item.principal, item.subaccount, item.r, item.s, item.v
+            );
+        }
+    }
+
+    /// The ETH counterpart of `sweepErc20Batch`.
+    function sweepEthBatch(SweepItem[] calldata items) external {
+        for (uint256 i = 0; i < items.length; ++i) {
+            SweepItem calldata item = items[i];
+            CkSweeperAttested(payable(item.deposit)).sweepEth(
+                item.principal, item.subaccount, item.r, item.s, item.v
             );
         }
     }

--- a/rs/ethereum/cketh/minter/CkSweeperAttested.sol
+++ b/rs/ethereum/cketh/minter/CkSweeperAttested.sol
@@ -42,7 +42,9 @@ contract CkSweeperAttested {
 
     /// Accepts plain ETH sends to a delegated deposit address, but not to the
     /// implementation itself: no attestation can ever recover to the contract's
-    /// own address, so ETH landing there would be locked forever. Otherwise
+    /// own address, so ETH landing there via receive() would be locked forever
+    /// (selfdestruct and coinbase payments can still deposit unsweepable ETH —
+    /// the guard closes the only path a plain send takes). Otherwise
     /// deliberately minimal: batched CEX withdrawals may forward value with only
     /// the 2'300-gas `transfer`/`send` stipend, and detection is balance-based
     /// so no event is needed.

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -464,8 +464,8 @@ impl<'a> Deposit<'a> {
 
 fn assert_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
     // `ATTESTED_SCENARIOS` in deposit_from_cex_demo.rs, EIP-7702 (first sweep) column.
-    const DEMO_ONE_DEPOSIT: u64 = 98_000;
-    const DEMO_TEN_DEPOSITS: u64 = 609_431;
+    const DEMO_ONE_DEPOSIT: u64 = 98_075;
+    const DEMO_TEN_DEPOSITS: u64 = 609_750;
     const GAS_BAND_PERCENT: u64 = 10;
 
     assert_eq!(

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -18,7 +18,6 @@ use ic_cketh_minter::endpoints::events::EventPayload;
 use ic_cketh_minter::numeric::Erc20Value;
 use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
-    deploy_sweep_contracts,
 };
 use ic_cketh_test_utils::ckerc20::Erc20Token;
 use ic_cketh_test_utils::live::{Holding, LiveSetup, contract_address};
@@ -280,29 +279,6 @@ fn should_fund_the_sweeper_address_by_burning_cketh_from_the_fee_account() {
         spent <= burned,
         "the ETH debited from the main address ({spent}) must never exceed the ckETH \
          burned for it ({burned})"
-    );
-}
-
-#[test]
-fn should_bounce_eth_sent_to_the_sweeper_implementation() {
-    let anvil = Anvil::start();
-    let contracts = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
-    let sender = address_from_hex(DEV_ACCOUNT);
-
-    assert!(
-        !anvil.plain_transfer_succeeds(
-            &sender,
-            &contracts.delegate,
-            1_000_000_000_000_000,
-            100_000
-        ),
-        "no attestation can recover to the implementation's own address, so ETH landing there \
-         would be locked forever: the guarded receive() must bounce it at the sender"
-    );
-    assert_eq!(
-        anvil.balance(&contracts.delegate),
-        0,
-        "the bounced ETH must not stick to the implementation"
     );
 }
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -18,6 +18,7 @@ use ic_cketh_minter::endpoints::events::EventPayload;
 use ic_cketh_minter::numeric::Erc20Value;
 use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
+    deploy_sweep_contracts,
 };
 use ic_cketh_test_utils::ckerc20::Erc20Token;
 use ic_cketh_test_utils::live::{Holding, LiveSetup, contract_address};
@@ -279,6 +280,29 @@ fn should_fund_the_sweeper_address_by_burning_cketh_from_the_fee_account() {
         spent <= burned,
         "the ETH debited from the main address ({spent}) must never exceed the ckETH \
          burned for it ({burned})"
+    );
+}
+
+#[test]
+fn should_bounce_eth_sent_to_the_sweeper_implementation() {
+    let anvil = Anvil::start();
+    let contracts = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
+    let sender = address_from_hex(DEV_ACCOUNT);
+
+    assert!(
+        !anvil.plain_transfer_succeeds(
+            &sender,
+            &contracts.delegate,
+            1_000_000_000_000_000,
+            100_000
+        ),
+        "no attestation can recover to the implementation's own address, so ETH landing there \
+         would be locked forever: the guarded receive() must bounce it at the sender"
+    );
+    assert_eq!(
+        anvil.balance(&contracts.delegate),
+        0,
+        "the bounced ETH must not stick to the implementation"
     );
 }
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -646,6 +646,70 @@ fn attested_sweep_moves_plain_eth_to_the_minter() {
     assert_eq!(events[0].amount, ETH_DEPOSIT_AMOUNT);
 }
 
+#[test]
+fn a_stipend_transfer_from_a_contract_reaches_a_delegated_deposit_address() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter_key = key_from_hex(MINTER_PRIVATE_KEY);
+    let minter = eth_address(&minter_key.public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+
+    let Contracts { attested, .. } = deploy_contracts(&anvil, &minter, &cex);
+    let forwarder = anvil.deploy(
+        &cex,
+        &deploy_code(&compile("STIPEND_FORWARDER_SOL", "StipendForwarder"), &[]),
+    );
+
+    let key = derive_deposit_key(&Principal::self_authenticating([0xE8]));
+    let deposit = eth_address(&key.public_key());
+    let delegate_only = ICkSweeperAttested::sweepEthBatchCall { items: vec![] }.abi_encode();
+    assert!(
+        status_ok(&anvil.send_eip7702(
+            &minter_key,
+            chain_id,
+            &attested,
+            delegate_only,
+            vec![sign_authorization(&key, chain_id, &attested, 0)]
+        )),
+        "delegation setup reverted"
+    );
+    assert!(!anvil.code(&deposit).is_empty(), "deposit not delegated");
+
+    let tx = anvil.send_transaction_with_value(
+        &cex,
+        Some(&forwarder),
+        &IStipendForwarder::forwardCall {
+            to: alloy_address(&deposit),
+        }
+        .abi_encode(),
+        None,
+        Some(ETH_DEPOSIT_AMOUNT),
+    );
+    assert!(
+        status_ok(&anvil.await_receipt(&tx)),
+        "a 2'300-gas-stipend transfer into the delegated receive() must succeed"
+    );
+    assert_eq!(anvil.balance(&deposit), ETH_DEPOSIT_AMOUNT);
+}
+
+#[test]
+fn the_sweeper_implementation_rejects_plain_eth() {
+    let anvil = Anvil::start();
+
+    let minter = eth_address(&key_from_hex(MINTER_PRIVATE_KEY).public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+
+    let Contracts { attested, .. } = deploy_contracts(&anvil, &minter, &cex);
+
+    let receipt = anvil.send_eth(&cex, &attested, ETH_DEPOSIT_AMOUNT, Some(50_000));
+    assert!(
+        !status_ok(&receipt),
+        "ETH sent to the implementation contract would be locked forever, so it must bounce"
+    );
+    assert_eq!(anvil.balance(&attested), 0);
+}
+
 struct Contracts {
     usdt: Address,
     helper: Address,
@@ -1101,6 +1165,12 @@ sol! {
         uint8 v;
     }
 
+    /// `StipendForwarder.sol`: forwards ETH with `transfer`'s 2'300-gas stipend,
+    /// the worst-case sender profile of a contract-batched CEX withdrawal.
+    interface IStipendForwarder {
+        function forward(address to) external payable;
+    }
+
     interface ICkSweeperAttested {
         function sweepErc20(
             address[] tokens,
@@ -1330,12 +1400,26 @@ impl Anvil {
         data: &[u8],
         gas: Option<u64>,
     ) -> String {
+        self.send_transaction_with_value(from, to, data, gas, None)
+    }
+
+    fn send_transaction_with_value(
+        &self,
+        from: &Address,
+        to: Option<&Address>,
+        data: &[u8],
+        gas: Option<u64>,
+        value: Option<u128>,
+    ) -> String {
         let mut tx = serde_json::json!({"from": to_hex(from.as_ref()), "input": to_hex(data)});
         if let Some(to) = to {
             tx["to"] = serde_json::json!(to_hex(to.as_ref()));
         }
         if let Some(gas) = gas {
             tx["gas"] = serde_json::json!(format!("0x{gas:x}"));
+        }
+        if let Some(value) = value {
+            tx["value"] = serde_json::json!(format!("0x{value:x}"));
         }
         self.rpc("eth_sendTransaction", serde_json::json!([tx]))
             .as_str()

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -25,7 +25,10 @@
 //! matching the proposed design where sweeping is *permissionless* but each sweep
 //! carries a minter attestation (a deposit-key signature binding the address to
 //! its IC account). Those sweeps are submitted by a non-minter relayer, and a
-//! separate test shows a forged attestation is rejected.
+//! separate test shows a forged attestation is rejected. A further test funds a
+//! *delegated* deposit address with plain ETH — accepted by the delegate's empty
+//! `receive()`, while a fixed 21'000-gas send fails at the sender — and moves it
+//! to the minter through the attested `sweepEth`/`sweepEthBatch` entry points.
 //!
 //! Runs the `anvil` binary vendored via `@foundry_bin_*` (see BUILD.bazel);
 //! `ANVIL_BIN` points at it. Requires EIP-7702 support (foundry >= v1.0).
@@ -63,6 +66,8 @@ const RELAYER_PRIVATE_KEY: &str =
 
 const USDT_SUPPLY: u128 = 1_000_000_000_000; // 1M USDT (6 decimals)
 const DEPOSIT_AMOUNT: u128 = 10_000_000; // 10 USDT per deposit
+const ETH_DEPOSIT_AMOUNT: u128 = 1_000_000_000_000_000_000; // 1 ETH
+const PLAIN_TRANSFER_GAS: u64 = 21_000;
 
 // Generous, deterministic fees and a gas limit large enough for a batch of 20;
 // the minter dev account is funded with 10000 ETH. Gas *used* (asserted below)
@@ -120,24 +125,24 @@ const SCENARIOS: [BatchScenario; 3] = [
 const ATTESTED_SCENARIOS: [BatchScenario; 3] = [
     BatchScenario {
         deposits: 1,
-        eip7702_total_gas_used: 98_000,
-        eip7702_average_gas_used: 98_000,
-        eip1559_total_gas_used: 66_320,
-        eip1559_average_gas_used: 66_320,
+        eip7702_total_gas_used: 98_075,
+        eip7702_average_gas_used: 98_075,
+        eip1559_total_gas_used: 66_395,
+        eip1559_average_gas_used: 66_395,
     },
     BatchScenario {
         deposits: 10,
-        eip7702_total_gas_used: 609_431,
-        eip7702_average_gas_used: 60_943,
-        eip1559_total_gas_used: 429_431,
-        eip1559_average_gas_used: 42_943,
+        eip7702_total_gas_used: 609_750,
+        eip7702_average_gas_used: 60_975,
+        eip1559_total_gas_used: 429_750,
+        eip1559_average_gas_used: 42_975,
     },
     BatchScenario {
         deposits: 20,
-        eip7702_total_gas_used: 1_192_900,
-        eip7702_average_gas_used: 59_645,
-        eip1559_total_gas_used: 832_900,
-        eip1559_average_gas_used: 41_645,
+        eip7702_total_gas_used: 1_193_491,
+        eip7702_average_gas_used: 59_674,
+        eip1559_total_gas_used: 833_491,
+        eip1559_average_gas_used: 41_674,
     },
 ];
 
@@ -534,6 +539,111 @@ fn attested_sweep_rejects_a_forged_attestation() {
     let events = received_events(&receipt, &helper);
     assert_eq!(events.len(), 1, "expected one ReceivedEthOrErc20 event");
     assert_eq!(events[0].principal, encode_principal(&principal));
+}
+
+#[test]
+fn attested_sweep_moves_plain_eth_to_the_minter() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter = eth_address(&key_from_hex(MINTER_PRIVATE_KEY).public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+    let relayer_key = key_from_hex(RELAYER_PRIVATE_KEY);
+
+    let Contracts {
+        helper, attested, ..
+    } = deploy_contracts(&anvil, &minter, &cex);
+
+    let principal = Principal::self_authenticating([0xE7]);
+    let key = derive_deposit_key(&principal);
+    let deposit = eth_address(&key.public_key());
+
+    let receipt = anvil.send_eth(&cex, &deposit, ETH_DEPOSIT_AMOUNT, Some(PLAIN_TRANSFER_GAS));
+    assert!(
+        status_ok(&receipt),
+        "a fixed 21'000-gas send to a code-less deposit address must succeed"
+    );
+    assert_eq!(anvil.balance(&deposit), ETH_DEPOSIT_AMOUNT);
+
+    let attestation = attest(&key, chain_id, &helper, &principal, &[0_u8; 32]);
+    let batch_sweep = ICkSweeperAttested::sweepEthBatchCall {
+        items: vec![SweepItem {
+            deposit: alloy_address(&deposit),
+            principal: B256::from(encode_principal(&principal)),
+            subaccount: B256::ZERO,
+            r: B256::from(attestation.r),
+            s: B256::from(attestation.s),
+            v: attestation.v,
+        }],
+    }
+    .abi_encode();
+    let minter_before = anvil.balance(&minter);
+    let receipt = anvil.send_eip7702(
+        &relayer_key,
+        chain_id,
+        &attested,
+        batch_sweep,
+        vec![sign_authorization(&key, chain_id, &attested, 0)],
+    );
+    assert!(status_ok(&receipt), "the batch ETH sweep reverted");
+    assert_eq!(anvil.balance(&deposit), 0, "deposit not swept");
+    assert_eq!(
+        anvil.balance(&minter),
+        minter_before + ETH_DEPOSIT_AMOUNT,
+        "the minter must receive the swept ETH"
+    );
+    let events = received_events(&receipt, &helper);
+    assert_eq!(events.len(), 1, "expected one ReceivedEthOrErc20 event");
+    assert_eq!(events[0].owner, deposit);
+    assert_eq!(events[0].principal, encode_principal(&principal));
+    assert_eq!(events[0].amount, ETH_DEPOSIT_AMOUNT);
+
+    let underfunded = anvil.send_eth(&cex, &deposit, ETH_DEPOSIT_AMOUNT, Some(PLAIN_TRANSFER_GAS));
+    assert!(
+        !status_ok(&underfunded),
+        "a fixed 21'000-gas send to a delegated address must fail on the sender side"
+    );
+    assert_eq!(
+        anvil.balance(&deposit),
+        0,
+        "the failed send must not leave ETH at the deposit address"
+    );
+
+    let receipt = anvil.send_eth(&cex, &deposit, ETH_DEPOSIT_AMOUNT, None);
+    assert!(
+        status_ok(&receipt),
+        "the delegate's receive() must accept a plain send given enough gas"
+    );
+    println!(
+        "plain ETH send into the delegated receive(): {} gas",
+        gas_used(&receipt)
+    );
+    assert!(
+        gas_used(&receipt) > PLAIN_TRANSFER_GAS,
+        "receiving through the delegate must cost more than a plain send"
+    );
+    assert_eq!(anvil.balance(&deposit), ETH_DEPOSIT_AMOUNT);
+
+    let sweep = ICkSweeperAttested::sweepEthCall {
+        principal: B256::from(encode_principal(&principal)),
+        subaccount: B256::ZERO,
+        r: B256::from(attestation.r),
+        s: B256::from(attestation.s),
+        v: attestation.v,
+    }
+    .abi_encode();
+    let minter_before = anvil.balance(&minter);
+    let receipt = anvil.send_eip1559(&relayer_key, chain_id, &deposit, sweep);
+    assert!(status_ok(&receipt), "the attested ETH sweep reverted");
+    assert_eq!(anvil.balance(&deposit), 0, "deposit not swept");
+    assert_eq!(
+        anvil.balance(&minter),
+        minter_before + ETH_DEPOSIT_AMOUNT,
+        "the minter must receive the swept ETH"
+    );
+    let events = received_events(&receipt, &helper);
+    assert_eq!(events.len(), 1, "expected one ReceivedEthOrErc20 event");
+    assert_eq!(events[0].amount, ETH_DEPOSIT_AMOUNT);
 }
 
 struct Contracts {
@@ -1001,6 +1111,8 @@ sol! {
             uint8 v
         ) external;
         function sweepErc20Batch(SweepItem[] items, address[] tokens) external;
+        function sweepEth(bytes32 principal, bytes32 subaccount, bytes32 r, bytes32 s, uint8 v) external;
+        function sweepEthBatch(SweepItem[] items) external;
     }
 }
 
@@ -1229,6 +1341,23 @@ impl Anvil {
             .as_str()
             .unwrap()
             .to_string()
+    }
+
+    fn send_eth(&self, from: &Address, to: &Address, value: u128, gas: Option<u64>) -> Value {
+        let mut tx = serde_json::json!({
+            "from": to_hex(from.as_ref()),
+            "to": to_hex(to.as_ref()),
+            "value": format!("0x{value:x}"),
+        });
+        if let Some(gas) = gas {
+            tx["gas"] = serde_json::json!(format!("0x{gas:x}"));
+        }
+        let hash = self
+            .rpc("eth_sendTransaction", serde_json::json!([tx]))
+            .as_str()
+            .unwrap()
+            .to_string();
+        self.await_receipt(&hash)
     }
 
     fn send_raw(&self, raw: &[u8]) -> String {

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -26,7 +26,7 @@
 //! carries a minter attestation (a deposit-key signature binding the address to
 //! its IC account). Those sweeps are submitted by a non-minter relayer, and a
 //! separate test shows a forged attestation is rejected. A further test funds a
-//! *delegated* deposit address with plain ETH — accepted by the delegate's empty
+//! *delegated* deposit address with plain ETH — accepted by the delegate's
 //! `receive()`, while a fixed 21'000-gas send fails at the sender — and moves it
 //! to the minter through the attested `sweepEth`/`sweepEthBatch` entry points.
 //!
@@ -644,6 +644,73 @@ fn attested_sweep_moves_plain_eth_to_the_minter() {
     let events = received_events(&receipt, &helper);
     assert_eq!(events.len(), 1, "expected one ReceivedEthOrErc20 event");
     assert_eq!(events[0].amount, ETH_DEPOSIT_AMOUNT);
+}
+
+#[test]
+fn attested_eth_sweep_rejects_a_forged_attestation() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter = eth_address(&key_from_hex(MINTER_PRIVATE_KEY).public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+    let attacker_key = key_from_hex(ATTACKER_PRIVATE_KEY);
+    let attacker = eth_address(&attacker_key.public_key());
+
+    let Contracts {
+        helper, attested, ..
+    } = deploy_contracts(&anvil, &minter, &cex);
+
+    let principal = Principal::self_authenticating([0xE9]);
+    let key = derive_deposit_key(&principal);
+    let deposit = eth_address(&key.public_key());
+
+    let delegate_only = ICkSweeperAttested::sweepEthBatchCall { items: vec![] }.abi_encode();
+    assert!(
+        status_ok(&anvil.send_eip7702(
+            &attacker_key,
+            chain_id,
+            &attested,
+            delegate_only,
+            vec![sign_authorization(&key, chain_id, &attested, 0)]
+        )),
+        "delegation setup reverted"
+    );
+    let receipt = anvil.send_eth(&cex, &deposit, ETH_DEPOSIT_AMOUNT, None);
+    assert!(
+        status_ok(&receipt),
+        "funding the delegated deposit reverted"
+    );
+
+    let attacker_principal = Principal::self_authenticating([0xEA]);
+    let forged = attest(
+        &attacker_key,
+        chain_id,
+        &helper,
+        &attacker_principal,
+        &[0_u8; 32],
+    );
+    let attack = anvil.send_transaction(
+        &attacker,
+        Some(&deposit),
+        &ICkSweeperAttested::sweepEthCall {
+            principal: B256::from(encode_principal(&attacker_principal)),
+            subaccount: B256::ZERO,
+            r: B256::from(forged.r),
+            s: B256::from(forged.s),
+            v: forged.v,
+        }
+        .abi_encode(),
+        Some(300_000),
+    );
+    assert!(
+        !status_ok(&anvil.await_receipt(&attack)),
+        "a forged attestation must not move native ETH"
+    );
+    assert_eq!(
+        anvil.balance(&deposit),
+        ETH_DEPOSIT_AMOUNT,
+        "the ETH must stay at the deposit address"
+    );
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo/StipendForwarder.sol
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo/StipendForwarder.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+/// Forwards ETH with Solidity's `transfer`, i.e. a 2'300-gas stipend — the
+/// worst-case sender profile of a contract-batched CEX withdrawal.
+contract StipendForwarder {
+    function forward(address payable to) external payable {
+        to.transfer(msg.value);
+    }
+}

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -263,6 +263,30 @@ impl Anvil {
             .to_string()
     }
 
+    /// Sends `wei` from `from` (an unlocked dev account) to `to` with an explicit gas limit,
+    /// skipping gas estimation so a reverting transfer is mined instead of rejected upfront.
+    /// Returns whether the transaction succeeded.
+    pub fn plain_transfer_succeeds(
+        &self,
+        from: &Address,
+        to: &Address,
+        wei: u128,
+        gas: u64,
+    ) -> bool {
+        let tx = serde_json::json!({
+            "from": to_hex(from.as_ref()),
+            "to": to_hex(to.as_ref()),
+            "value": format!("0x{wei:x}"),
+            "gas": format!("0x{gas:x}"),
+        });
+        let hash = self
+            .rpc("eth_sendTransaction", serde_json::json!([tx]))
+            .as_str()
+            .unwrap()
+            .to_string();
+        status_ok(&self.await_receipt(&hash))
+    }
+
     pub(crate) fn deploy(&self, from: &Address, code: &[u8]) -> Address {
         let hash = self.send_transaction(from, None, code);
         let receipt = self.await_receipt(&hash);

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -263,30 +263,6 @@ impl Anvil {
             .to_string()
     }
 
-    /// Sends `wei` from `from` (an unlocked dev account) to `to` with an explicit gas limit,
-    /// skipping gas estimation so a reverting transfer is mined instead of rejected upfront.
-    /// Returns whether the transaction succeeded.
-    pub fn plain_transfer_succeeds(
-        &self,
-        from: &Address,
-        to: &Address,
-        wei: u128,
-        gas: u64,
-    ) -> bool {
-        let tx = serde_json::json!({
-            "from": to_hex(from.as_ref()),
-            "to": to_hex(to.as_ref()),
-            "value": format!("0x{wei:x}"),
-            "gas": format!("0x{gas:x}"),
-        });
-        let hash = self
-            .rpc("eth_sendTransaction", serde_json::json!([tx]))
-            .as_str()
-            .unwrap()
-            .to_string();
-        status_ok(&self.await_receipt(&hash))
-    }
-
     pub(crate) fn deploy(&self, from: &Address, code: &[u8]) -> Address {
         let hash = self.send_transaction(from, None, code);
         let receipt = self.await_receipt(&hash);


### PR DESCRIPTION
[DEFI-2993](https://dfinity.atlassian.net/browse/DEFI-2993): explore whether ETH deposits from a CEX can reuse the *delegated* (EIP-7702) ERC-20 deposit address instead of requiring a separate, never-delegated per-asset address.

The proposed `CkSweeperAttested` delegate gains an empty payable `receive()` — kept empty so it fits the 2'300-gas `transfer`/`send` stipend of contract-batched CEX withdrawals — and permissionless, attestation-gated `sweepEth`/`sweepEthBatch` entry points that forward the address' ETH balance to the minter through the helper's `depositEth`.

The anvil demo test covers the full flow: a fixed 21'000-gas send works while the address has no code, fails on the sender side once delegated (nothing gets locked), and lands in `receive()` given enough gas (21'055 measured); a non-minter relayer then sweeps the ETH via both entry points. The larger delegate bytecode shifts the attested gas table slightly (re-measured constants, e2e baselines updated).

Validated on Ethereum mainnet: Binance and Kraken ETH withdrawals both reached a delegated address and were swept back — details in [DEFI-2993](https://dfinity.atlassian.net/browse/DEFI-2993).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9

[DEFI-2993]: https://dfinity.atlassian.net/browse/DEFI-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEFI-2993]: https://dfinity.atlassian.net/browse/DEFI-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ