### PR TITLE
test: run 16 more system-tests on the local backend

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -260,7 +260,6 @@ system_test_nns(
 
 system_test_nns(
     name = "subnet_splitting_v2_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 11 * DEFAULT_VCPUS_PER_VM,  # 11 IC Node VMs (1+1 System + 8 Application + 1 VerifiedApplication) * 6 vCPUs.
     enable_metrics = True,
     tags = [

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -40,7 +40,6 @@ rust_library(
 
 system_test_nns(
     name = "sr_app_same_nodes_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -59,7 +58,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_provision_write_access_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -78,7 +76,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_same_nodes_enable_chain_keys_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -97,7 +94,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_same_nodes_with_chain_keys_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 unassigned) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -173,7 +169,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -192,7 +187,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_local_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -211,7 +205,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_enable_chain_keys_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 app) * 6 vCPUs.
     guestos_update = "test",
     tags = [
@@ -230,7 +223,6 @@ system_test_nns(
 
 system_test_nns(
     name = "sr_app_no_upgrade_with_chain_keys_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 12 * DEFAULT_VCPUS_PER_VM,  # 12 IC Node VMs (4 NNS + 4 source app + 4 unassigned) * 6 vCPUs.
     guestos_update = "test",
     tags = [

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -95,7 +95,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_key_rotation_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + Application subnet + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
@@ -227,7 +226,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_life_cycle_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + Application subnet + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     # Remove when CON-937 is resolved
     tags = [
@@ -275,7 +273,6 @@ system_test_nns(
 
 system_test_nns(
     name = "tecdsa_signature_timeout_test",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + Application subnet + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -25,7 +25,6 @@ system_test_nns(
 
 system_test_nns(
     name = "xnet_slo_3_subnets_hotfix_test",
-    backend = "farm",  # Too big for the "local" backend.
     colocated_test_driver_vm_required_host_features = ["performance"],
     cpus = MIN_LOCAL_CPUS + 3 * 4 * DEFAULT_VCPUS_PER_VM,  # 3 subnets * 4 nodes * 6 vCPUs.
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.
@@ -44,7 +43,6 @@ system_test_nns(
 
 system_test_nns(
     name = "xnet_slo_3_subnets_test",
-    backend = "farm",  # Too big for the "local" backend.
     colocated_test_driver_vm_required_host_features = ["performance"],
     cpus = MIN_LOCAL_CPUS + 3 * 4 * DEFAULT_VCPUS_PER_VM,  # 3 subnets * 4 nodes * 6 vCPUs.
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -413,7 +413,6 @@ system_test_nns(
 
 system_test_nns(
     name = "state_sync_performance",
-    backend = "farm",  # Too big for the "local" backend.
     colocated_test_driver_vm_required_host_features = ["performance"],
     cpus = MIN_LOCAL_CPUS + (1 + 12) * DEFAULT_VCPUS_PER_VM,  # 13 IC Node VMs (1 system node + 12 unassigned), 6 vCPUs each.
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.

--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -281,7 +281,6 @@ system_test_nns(
 
 system_test_nns(
     name = "medium",
-    backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 11 * DEFAULT_VCPUS_PER_VM,  # 4 System + 4 Application + 1 unassigned + 1 API boundary node + 1 ic-gateway VM, all 6 vCPUs.
     enable_metrics = True,
     enable_uvm = True,


### PR DESCRIPTION
Namespace RBE workers have 32 CPUs, so a system-test whose `reserved_cpus` (`ceil(cpus / cpus_oversubscription_factor)`, surfaced as `exec_properties["cpu"]`) is ≤ 32 can run on the `"local"` backend there.

25 of the 64 tests carrying `backend = "farm",  # Too big for the "local" backend.` meet that bound. **9 keep the attribute anyway**: `cpus` only ever becomes a CPU reservation, and these ask for 300–500 GiB of RAM via `VmResourceOverrides`, which the local backend passes verbatim to QEMU (`network_reliability_test`, `state_sync_malicious_chunk_test`, `api_bn_performance_test`, and 6 of the `testnets`). The other **16 lose it**.

That un-`manual`s 26 `_local` targets — `subnet_splitting_v2_test`, 8× `sr_app_*`, 3× `tecdsa_*`, 2× `xnet_slo_3_subnets*` — all using default 4 GiB node VMs (≤ 48 GiB per test). `state_sync_performance` and the `medium` testnet are already `manual`, so CI is unchanged for them.

Every non-manual `local_system_test` in the repo now carries a `cpu` exec property, max **25**.

Checks: `bazel build //... --nobuild` clean, `bazel run //:buildifier` a no-op, and the non-manual `local_system_test` set goes 195 → 221 with nothing dropped. The newly-enabled tests have not been run locally (no KVM group on the dev box) — this PR's CI is the first real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
