### PR TITLE
chore(registry): Remove flag for standard engine replica version.

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -209,7 +209,6 @@ fn canister_init() {
     #[cfg(feature = "test")]
     {
         use registry_canister::flags::temporary_overrides::{
-            test_set_blank_replica_version_id_for_cloud_engines_enabled,
             test_set_swapping_enabled_subnets, test_set_swapping_status,
             test_set_swapping_whitelisted_callers,
         };
@@ -235,15 +234,6 @@ fn canister_init() {
         );
         test_set_swapping_enabled_subnets(
             init_payload.swapping_enabled_subnets.unwrap_or_default(),
-        );
-        println!(
-            "{LOG_PREFIX}canister_init: Blank replica_version_id for Cloud Engines enabled: {:?}",
-            init_payload.is_blank_replica_version_id_for_cloud_engines_enabled
-        );
-        test_set_blank_replica_version_id_for_cloud_engines_enabled(
-            init_payload
-                .is_blank_replica_version_id_for_cloud_engines_enabled
-                .unwrap_or_default(),
         );
     }
 }

--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -10,12 +10,6 @@ thread_local! {
     static IS_CHUNKIFYING_LARGE_VALUES_ENABLED: Cell<bool> = const { Cell::new(true) };
     static IS_NODE_SWAPPING_ENABLED: Cell<bool> = const { Cell::new(true) };
 
-    // TODO: When we delete this, also change integration and/or system tests
-    // that exercise this feature so that they use the release build of
-    // registry-canister, not registry-canister-test (grep for
-    // is_blank_replica_version_id_for_cloud_engines_enabled in rs/tests/).
-    static IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED: Cell<bool> = const { Cell::new(true) };
-
     // Temporary flags related to the node swapping feature.
     //
     // These are needed for the phased rollout approach in order
@@ -68,23 +62,6 @@ pub(crate) fn is_subnet_splitting_enabled() -> bool {
     IS_SUBNET_SPLITTING_ENABLED.get()
 }
 
-pub(crate) fn is_blank_replica_version_id_for_cloud_engines_enabled() -> bool {
-    IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED.get()
-}
-
-#[cfg(test)]
-pub(crate) fn temporarily_enable_blank_replica_version_id_for_cloud_engines() -> Temporary {
-    Temporary::new(&IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED, true)
-}
-
-#[cfg(test)]
-pub(crate) fn temporarily_disable_blank_replica_version_id_for_cloud_engines() -> Temporary {
-    Temporary::new(
-        &IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED,
-        false,
-    )
-}
-
 #[cfg(any(test, feature = "test"))]
 pub mod temporary_overrides {
     use super::*;
@@ -101,10 +78,6 @@ pub mod temporary_overrides {
     pub fn test_set_swapping_enabled_subnets(override_subnets: Vec<SubnetId>) {
         let policy = AccessList::allow(override_subnets);
         NODE_SWAPPING_SUBNETS_POLICY.replace(policy);
-    }
-
-    pub fn test_set_blank_replica_version_id_for_cloud_engines_enabled(override_value: bool) {
-        IS_BLANK_REPLICA_VERSION_ID_FOR_CLOUD_ENGINES_ENABLED.replace(override_value);
     }
 }
 

--- a/rs/registry/canister/src/init.rs
+++ b/rs/registry/canister/src/init.rs
@@ -21,10 +21,6 @@ pub struct RegistryCanisterInitPayload {
     pub is_swapping_feature_enabled: Option<bool>,
     pub swapping_whitelisted_callers: Option<Vec<PrincipalId>>,
     pub swapping_enabled_subnets: Option<Vec<SubnetId>>,
-
-    // Same deal as the swapping flags above, but for the blank
-    // replica_version_id (for Cloud Engines) feature.
-    pub is_blank_replica_version_id_for_cloud_engines_enabled: Option<bool>,
 }
 
 impl fmt::Display for RegistryCanisterInitPayload {
@@ -49,7 +45,6 @@ pub struct RegistryCanisterInitPayloadBuilder {
     is_swapping_feature_enabled: bool,
     swapping_whitelisted_callers: BTreeSet<PrincipalId>,
     swapping_enabled_subnets: BTreeSet<SubnetId>,
-    is_blank_replica_version_id_for_cloud_engines_enabled: bool,
 }
 
 #[allow(clippy::new_without_default)]
@@ -60,7 +55,6 @@ impl RegistryCanisterInitPayloadBuilder {
             is_swapping_feature_enabled: false,
             swapping_whitelisted_callers: BTreeSet::new(),
             swapping_enabled_subnets: BTreeSet::new(),
-            is_blank_replica_version_id_for_cloud_engines_enabled: false,
         }
     }
 
@@ -85,9 +79,6 @@ impl RegistryCanisterInitPayloadBuilder {
             swapping_enabled_subnets: Some(
                 self.swapping_enabled_subnets.clone().into_iter().collect(),
             ),
-            is_blank_replica_version_id_for_cloud_engines_enabled: Some(
-                self.is_blank_replica_version_id_for_cloud_engines_enabled,
-            ),
         }
     }
 
@@ -103,11 +94,6 @@ impl RegistryCanisterInitPayloadBuilder {
 
     pub fn whitelist_swapping_feature_caller(&mut self, caller: PrincipalId) -> &mut Self {
         self.swapping_whitelisted_callers.insert(caller);
-        self
-    }
-
-    pub fn enable_blank_replica_version_id_for_cloud_engines(&mut self) -> &mut Self {
-        self.is_blank_replica_version_id_for_cloud_engines_enabled = true;
         self
     }
 }

--- a/rs/registry/canister/src/invariants/replica_version.rs
+++ b/rs/registry/canister/src/invariants/replica_version.rs
@@ -1,12 +1,9 @@
 use std::collections::BTreeSet;
 
-use crate::{
-    flags::is_blank_replica_version_id_for_cloud_engines_enabled,
-    invariants::common::{
-        InvariantCheckError, RegistrySnapshot, assert_valid_urls_and_hash,
-        get_all_replica_version_records, get_api_boundary_node_records_from_snapshot,
-        get_subnet_ids_from_snapshot, get_value_from_snapshot,
-    },
+use crate::invariants::common::{
+    InvariantCheckError, RegistrySnapshot, assert_valid_urls_and_hash,
+    get_all_replica_version_records, get_api_boundary_node_records_from_snapshot,
+    get_subnet_ids_from_snapshot, get_value_from_snapshot,
 };
 
 use ic_base_types::SubnetId;
@@ -111,11 +108,9 @@ fn get_subnet_record(snapshot: &RegistrySnapshot, subnet_id: SubnetId) -> Subnet
 /// Returns the list of replica versions where each version is referred to
 /// by at least one subnet.
 fn get_all_replica_versions_of_subnets(snapshot: &RegistrySnapshot) -> BTreeSet<String> {
-    let cloud_engines_are_allowed_to_have_blank_replica_version_id =
-        is_blank_replica_version_id_for_cloud_engines_enabled()
-            && snapshot
-                .get(make_standard_engine_replica_version_record_key().as_bytes())
-                .is_some();
+    let cloud_engines_are_allowed_to_have_blank_replica_version_id = snapshot
+        .get(make_standard_engine_replica_version_record_key().as_bytes())
+        .is_some();
 
     get_subnet_ids_from_snapshot(snapshot)
         .iter()

--- a/rs/registry/canister/src/invariants/replica_version.rs
+++ b/rs/registry/canister/src/invariants/replica_version.rs
@@ -185,10 +185,6 @@ mod tests {
             GUEST_LAUNCH_MEASUREMENTS, invariant_compliant_registry,
             prepare_registry_with_cloud_engine_subnet,
         },
-        flags::{
-            temporarily_disable_blank_replica_version_id_for_cloud_engines,
-            temporarily_enable_blank_replica_version_id_for_cloud_engines,
-        },
         registry::Registry,
     };
 
@@ -415,13 +411,11 @@ mod tests {
     }
 
     /// One thing not mentioned in the name is that
-    /// StandardEngineReplicaVersionRecord must exist (and this feature must be
-    /// enabled via flag).
+    /// StandardEngineReplicaVersionRecord must exist.
     #[test]
     fn test_blank_replica_version_id_is_allowed() {
         // Step 1: Prepare the world.
 
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let mut registry = invariant_compliant_registry(0);
 
         // Elect replica versions 1 and 2.
@@ -452,37 +446,6 @@ mod tests {
         // The implicit assertion is that the previous line did not panic.
     }
 
-    #[test]
-    #[should_panic(expected = "Using a version that isn't elected.")]
-    fn panic_when_blank_replica_version_id_is_not_enabled_yet() {
-        // Step 1: Prepare the world. The only difference compared to the
-        // previous test is that here, the feature is DISABLED.
-        let _restore_on_drop = temporarily_disable_blank_replica_version_id_for_cloud_engines();
-        let mut registry = invariant_compliant_registry(0);
-        registry.maybe_apply_mutation_internal(elect_version_mutations(vec![
-            REPLICA_VERSION_ID_1.to_string(),
-            REPLICA_VERSION_ID_2.to_string(),
-        ]));
-        registry.maybe_apply_mutation_internal(vec![insert(
-            make_standard_engine_replica_version_record_key().as_bytes(),
-            StandardEngineReplicaVersionRecord {
-                new_replica_version_id: REPLICA_VERSION_ID_2.to_string(),
-                old_replica_version_id: REPLICA_VERSION_ID_1.to_string(),
-                deployment_progress: 0.1,
-            }
-            .encode_to_vec(),
-        )]);
-        let subnet_id = add_cloud_engine_subnet(&mut registry);
-
-        // Step 2: Run the code under test. Same as the previous test.
-        let mutation = blank_replica_version_id_mutation(&registry, subnet_id);
-        registry.check_global_state_invariants(&mutation);
-
-        // Step 3: Verify result(s).
-        // The assertion is at the top: #[should_panic(...)].
-        // Unlike the previous test where the nominal behavior is NO panic.
-    }
-
     /// It is fine for there to be no standard engine replica version if there
     /// are no CloudEngines, but in general, there would be, so the name of this
     /// test does not mention this "and the sun must exist" condition.
@@ -490,7 +453,6 @@ mod tests {
     #[should_panic(expected = "Using a version that isn't elected.")]
     fn panic_when_there_is_no_standard_replica_version() {
         // Step 1: Prepare the world.
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let mut registry = invariant_compliant_registry(0);
         let subnet_id = add_cloud_engine_subnet(&mut registry);
 
@@ -507,7 +469,6 @@ mod tests {
     fn panic_when_non_cloud_engine_subnet_has_blank_replica_version_id() {
         // Step 1: Prepare the world.
 
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let mut registry = invariant_compliant_registry(0);
 
         // Like in previous tests, elect a couple of replica versions, and

--- a/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
@@ -1,6 +1,5 @@
 use crate::{
-    common::LOG_PREFIX, flags::is_blank_replica_version_id_for_cloud_engines_enabled,
-    mutations::common::check_replica_version_is_elected, registry::Registry,
+    common::LOG_PREFIX, mutations::common::check_replica_version_is_elected, registry::Registry,
 };
 
 use candid::{CandidType, Deserialize};
@@ -77,17 +76,11 @@ impl Registry {
     }
 
     /// Panics unless `subnet_id` is allowed to have a blank
-    /// `replica_version_id` — i.e. it is a Cloud Engine, the feature is
-    /// enabled, and there is a StandardEngineReplicaVersionRecord to resolve
-    /// the blank against. Without the last one, blanking would leave the subnet
-    /// with no replica version at all (and trip the SubnetRecord invariant).
+    /// `replica_version_id` — i.e. it is a Cloud Engine, and there is a
+    /// StandardEngineReplicaVersionRecord to resolve the blank against.
+    /// Without the latter, blanking would leave the subnet with no replica
+    /// version at all (and trip the SubnetRecord invariant).
     fn check_engine_can_have_blank_replica_version_id(&self, subnet_id: SubnetId) {
-        assert!(
-            is_blank_replica_version_id_for_cloud_engines_enabled(),
-            "{LOG_PREFIX}do_deploy_guestos_to_all_subnet_nodes: a blank replica_version_id is \
-             not enabled yet.",
-        );
-
         let subnet_record = self.get_subnet_or_panic(subnet_id);
         assert_eq!(
             subnet_record.subnet_type,

--- a/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
+++ b/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_subnet_nodes.rs
@@ -107,10 +107,6 @@ mod tests {
         get_invariant_compliant_subnet_record, invariant_compliant_registry,
         prepare_registry_with_cloud_engine_subnet, prepare_registry_with_nodes,
     };
-    use crate::flags::{
-        temporarily_disable_blank_replica_version_id_for_cloud_engines,
-        temporarily_enable_blank_replica_version_id_for_cloud_engines,
-    };
     use ic_nns_constants::{ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID};
     use ic_protobuf::registry::{
         replica_version::v1::ReplicaVersionRecord,
@@ -268,7 +264,6 @@ mod tests {
 
     #[test]
     fn engine_controller_can_blank_cloud_engine_replica_version() {
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let (mut registry, subnet_id) = make_registry_with_blankable_cloud_engine_subnet();
 
         registry.do_deploy_guestos_to_all_subnet_nodes(
@@ -282,7 +277,6 @@ mod tests {
 
     #[test]
     fn governance_can_blank_cloud_engine_replica_version() {
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let (mut registry, subnet_id) = make_registry_with_blankable_cloud_engine_subnet();
 
         registry.do_deploy_guestos_to_all_subnet_nodes(
@@ -294,24 +288,11 @@ mod tests {
         assert_eq!(subnet_record.replica_version_id, "");
     }
 
-    #[test]
-    #[should_panic(expected = "a blank replica_version_id is not enabled yet")]
-    fn cannot_blank_replica_version_when_feature_is_disabled() {
-        let _restore_on_drop = temporarily_disable_blank_replica_version_id_for_cloud_engines();
-        let (mut registry, subnet_id) = make_registry_with_blankable_cloud_engine_subnet();
-
-        registry.do_deploy_guestos_to_all_subnet_nodes(
-            ENGINE_CONTROLLER_CANISTER_ID.get(),
-            new_blank_replica_version_id_payload(subnet_id),
-        );
-    }
-
     /// Without the standard engine record, a blank id would leave the subnet
     /// with no replica version at all.
     #[test]
     #[should_panic(expected = "Registry has no StandardEngineReplicaVersionRecord")]
     fn cannot_blank_replica_version_without_standard_engine_record() {
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let mut registry = invariant_compliant_registry(0);
         let (mutate_request, subnet_id) = prepare_registry_with_cloud_engine_subnet(1, 2);
         registry.maybe_apply_mutation_internal(mutate_request.mutations);
@@ -328,7 +309,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "only CloudEngine subnets may have a blank replica_version_id")]
     fn cannot_blank_replica_version_of_non_cloud_engine_subnet() {
-        let _restore_on_drop = temporarily_enable_blank_replica_version_id_for_cloud_engines();
         let (mut registry, subnet_id) =
             make_registry_with_non_cloud_engine_subnet(SubnetType::Application);
         add_standard_engine_replica_version_record(&mut registry);

--- a/rs/tests/consensus/orchestrator/standard_engine_replica_version_test.rs
+++ b/rs/tests/consensus/orchestrator/standard_engine_replica_version_test.rs
@@ -92,7 +92,7 @@ use futures::future;
 use ic_base_types::SubnetId;
 use ic_canister_client::Sender;
 use ic_consensus_system_test_upgrade_common::elect_target_version;
-use ic_consensus_system_test_utils::rw_message::install_nns_with_customizations_and_check_progress;
+use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_consensus_system_test_utils::upgrade::{
     assert_assigned_replica_version_with_time, get_assigned_replica_version,
 };
@@ -109,8 +109,7 @@ use ic_system_test_driver::{
         ic::{InternetComputer, Node},
         test_env::TestEnv,
         test_env_api::{
-            HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot,
-            NnsCustomizations, TopologySnapshot,
+            HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot, TopologySnapshot,
         },
     },
     nns::{
@@ -187,10 +186,7 @@ fn setup(env: TestEnv) {
         .expect("failed to setup IC under test");
 
     info!(logger, "[Step 1] Install NNS.");
-    install_nns_with_customizations_and_check_progress(
-        env.topology_snapshot(),
-        NnsCustomizations::default(),
-    );
+    install_nns_and_check_progress(env.topology_snapshot());
 }
 
 /// Creates a Cloud Engine with a blank `replica_version_id` out of

--- a/rs/tests/consensus/orchestrator/standard_engine_replica_version_test.rs
+++ b/rs/tests/consensus/orchestrator/standard_engine_replica_version_test.rs
@@ -35,10 +35,7 @@ Runbook::
 0. Set up an IC with an NNS subnet, plus a pool of unassigned nodes to
    form 2 Cloud Engines.
 
-1. Install NNS. Blank replica_version_id is enabled in Registry.
-   This requires using registry-canister-test, not the regular/release
-   build, registry-canister. Once this feature has survived its
-   probation period, this test can switch to registry-canister.
+1. Install NNS.
 
 2. Elect a second GuestOS/replica version.
 
@@ -124,7 +121,6 @@ use ic_system_test_driver::{
     util::{block_on, runtime_from_url},
 };
 use ic_types::ReplicaVersion;
-use registry_canister::init::RegistryCanisterInitPayload;
 use slog::{Logger, info};
 use std::time::Duration;
 
@@ -193,13 +189,7 @@ fn setup(env: TestEnv) {
     info!(logger, "[Step 1] Install NNS.");
     install_nns_with_customizations_and_check_progress(
         env.topology_snapshot(),
-        NnsCustomizations {
-            registry_canister_init_payload: RegistryCanisterInitPayload {
-                is_blank_replica_version_id_for_cloud_engines_enabled: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
+        NnsCustomizations::default(),
     );
 }
 

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -2815,12 +2815,6 @@ pub async fn install_nns_canisters(
         {
             builder.enable_swapping_feature_for_subnet(subnet);
         }
-        if registry_canister_init_payload
-            .is_blank_replica_version_id_for_cloud_engines_enabled
-            .unwrap_or_default()
-        {
-            builder.enable_blank_replica_version_id_for_cloud_engines();
-        }
 
         builder
     };


### PR DESCRIPTION
This has been in production for a little bit, and seems to be working as intended.