### PR TITLE
fix(sns): validate logo PNG signatures

### DIFF
--- a/rs/nervous_system/common/src/ledger_validation.rs
+++ b/rs/nervous_system/common/src/ledger_validation.rs
@@ -83,25 +83,61 @@ pub fn validate_token_name(token_name: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn validate_token_logo(token_logo: &str) -> Result<(), String> {
+const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+pub fn validate_logo(logo: &str, field_name: &str) -> Result<(), String> {
     const PREFIX: &str = "data:image/png;base64,";
 
-    if token_logo.len() > MAX_LOGO_LENGTH {
+    if logo.len() > MAX_LOGO_LENGTH {
         return Err(format!(
-            "Error: token_logo must be less than {MAX_LOGO_LENGTH} characters, roughly 256 Kb"
+            "{field_name} must be less than {MAX_LOGO_LENGTH} characters, roughly 256 Kb"
         ));
     }
 
-    if !token_logo.starts_with(PREFIX) {
+    if !logo.starts_with(PREFIX) {
         return Err(format!(
-            "Error: token_logo must be a base64 encoded PNG, but the provided \
-            string doesn't begin with `{PREFIX}`."
+            "{field_name} must be a base64 encoded PNG, but the provided string does not begin with `{PREFIX}`."
         ));
     }
 
-    if base64::decode(&token_logo[PREFIX.len()..]).is_err() {
-        return Err("Couldn't decode base64 in SnsMetadata.logo".to_string());
+    let logo_bytes = match base64::decode(&logo[PREFIX.len()..]) {
+        Ok(logo_bytes) => logo_bytes,
+        Err(err) => return Err(format!("Couldn't decode base64 in {field_name}: {err}")),
+    };
+
+    if !logo_bytes.starts_with(&PNG_SIGNATURE) {
+        return Err(format!(
+            "{field_name} must be a PNG, but the decoded bytes are not."
+        ));
     }
 
     Ok(())
+}
+
+pub fn validate_token_logo(token_logo: &str) -> Result<(), String> {
+    validate_logo(token_logo, "token_logo")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_token_logo;
+
+    const VALID_PNG_LOGO: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC";
+
+    #[test]
+    fn test_validate_token_logo_accepts_a_real_png() {
+        validate_token_logo(VALID_PNG_LOGO).unwrap();
+    }
+
+    #[test]
+    fn test_validate_token_logo_rejects_valid_base64_that_is_not_a_png() {
+        let err =
+            validate_token_logo("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==").unwrap_err();
+        assert!(err.contains("PNG"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_validate_token_logo_rejects_wrong_prefix() {
+        validate_token_logo("not-a-logo").unwrap_err();
+    }
 }

--- a/rs/sns/governance/src/governance/test_helpers.rs
+++ b/rs/sns/governance/src/governance/test_helpers.rs
@@ -60,7 +60,7 @@ pub(crate) fn basic_governance_proto() -> GovernanceProto {
         parameters: Some(NervousSystemParameters::with_default_values()),
         mode: governance::Mode::Normal as i32,
         sns_metadata: Some(SnsMetadata {
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             name: Some("ServiceNervousSystem-Test".to_string()),
             description: Some("A project to spin up a ServiceNervousSystem".to_string()),
             url: Some("https://internetcomputer.org".to_string()),

--- a/rs/sns/governance/src/init.rs
+++ b/rs/sns/governance/src/init.rs
@@ -17,7 +17,7 @@ impl GovernanceCanisterInitPayloadBuilder {
                 parameters: Some(NervousSystemParameters::with_default_values()),
                 mode: Mode::PreInitializationSwap as i32,
                 sns_metadata: Some(SnsMetadata {
-                    logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+                    logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
                     name: Some("ServiceNervousSystemTest".to_string()),
                     url: Some("https://internetcomputer.org".to_string()),
                     description: Some("Launch an SNS Project".to_string()),

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -5198,7 +5198,7 @@ Version {
 
     #[test]
     fn test_validate_and_render_manage_ledger_parameters_token_logo() {
-        let new_logo = "data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string();
+        let new_logo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string();
         let render = validate_and_render_manage_ledger_parameters(&ManageLedgerParameters {
             token_logo: Some(new_logo.clone()),
             ..ManageLedgerParameters::default()
@@ -5215,7 +5215,7 @@ Version {
         let new_fee = 751;
         let new_symbol = "COOL".to_string();
         let new_name = "coolcoin".to_string();
-        let new_logo = "data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string();
+        let new_logo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string();
         let render = validate_and_render_manage_ledger_parameters(&ManageLedgerParameters {
             transfer_fee: Some(new_fee),
             token_symbol: Some(new_symbol.clone()),

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -52,7 +52,7 @@ use ic_management_canister_types_private::{
 };
 use ic_nervous_system_common::{
     DEFAULT_TRANSFER_FEE, NervousSystemError, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
-    hash_to_hex_string, ledger_validation::MAX_LOGO_LENGTH,
+    hash_to_hex_string, ledger_validation,
 };
 use ic_nervous_system_common_validation::validate_url;
 use ic_nervous_system_proto::pb::v1::{Duration as PbDuration, Percentage};
@@ -1677,22 +1677,7 @@ impl SnsMetadata {
     }
 
     pub fn validate_logo(logo: &str) -> Result<(), String> {
-        const PREFIX: &str = "data:image/png;base64,";
-        // TODO: Should we check that it's a valid PNG?
-        if logo.len() > MAX_LOGO_LENGTH {
-            return Err(format!(
-                "SnsMetadata.logo must be less than {MAX_LOGO_LENGTH} characters, roughly 256 Kb"
-            ));
-        }
-        if !logo.starts_with(PREFIX) {
-            return Err(format!(
-                "SnsMetadata.logo must be a base64 encoded PNG, but the provided string does't begin with `{PREFIX}`."
-            ));
-        }
-        if base64::decode(&logo[PREFIX.len()..]).is_err() {
-            return Err("Couldn't decode base64 in SnsMetadata.logo".to_string());
-        }
-        Ok(())
+        ledger_validation::validate_logo(logo, "SnsMetadata.logo")
     }
 
     pub fn validate_name(name: &str) -> Result<(), String> {
@@ -1727,7 +1712,7 @@ impl SnsMetadata {
 
     pub fn with_default_values_for_testing() -> Self {
         SnsMetadata {
-            logo: Some("data:image/png;base64,".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             url: Some("https://dfinity.org".to_string()),
             name: Some("SNS-Name".to_string()),
             description: Some("SNS-Description".to_string()),

--- a/rs/sns/governance/src/types/tests.rs
+++ b/rs/sns/governance/src/types/tests.rs
@@ -13,6 +13,7 @@ use candid::Nat;
 use futures::FutureExt;
 use ic_base_types::PrincipalId;
 use ic_management_canister_types_private::ChunkHash;
+use ic_nervous_system_common::ledger_validation::MAX_LOGO_LENGTH;
 use ic_nervous_system_common_test_keys::TEST_USER1_PRINCIPAL;
 use ic_nervous_system_proto::pb::v1::Principals;
 use ic_sns_governance_api::pb::v1::topics::Topic;
@@ -639,7 +640,7 @@ fn test_mode_allows_proposal_action_or_err_panic_when_function_has_no_target_can
 #[test]
 fn test_sns_metadata_validate() {
     let default = SnsMetadata {
-        logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+        logo: Some(VALID_PNG_LOGO.to_string()),
         url: Some("https://forum.dfinity.org".to_string()),
         name: Some("X".repeat(SnsMetadata::MIN_NAME_LENGTH)),
         description: Some("X".repeat(SnsMetadata::MIN_DESCRIPTION_LENGTH)),
@@ -1014,9 +1015,18 @@ fn test_nervous_system_parameters_wont_validate_without_the_required_claimer_per
     }
 }
 
+const VALID_PNG_LOGO: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC";
+
 #[test]
-fn test_validate_logo_lets_base64_through() {
-    SnsMetadata::validate_logo("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==").unwrap();
+fn test_validate_logo_accepts_a_real_png() {
+    SnsMetadata::validate_logo(VALID_PNG_LOGO).unwrap();
+}
+
+#[test]
+fn test_validate_logo_rejects_valid_base64_that_is_not_a_png() {
+    let logo = "data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==";
+    let err = SnsMetadata::validate_logo(logo).unwrap_err();
+    assert!(err.contains("PNG"), "unexpected error: {err}");
 }
 
 #[test]

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+Logo validation now rejects a `logo` whose decoded bytes are not actually a PNG,
+instead of accepting any base64 that carries the `data:image/png;base64,` prefix.
+
 ## Deprecated
 
 ## Removed

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -464,12 +464,12 @@ impl SnsInitPayload {
         Self {
             token_symbol: Some("TEST".to_string()),
             token_name: Some("PlaceHolder".to_string()),
-            token_logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            token_logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             initial_token_distribution: Some(FractionalDeveloperVotingPower(
                 FractionalDVP::with_valid_values_for_testing(),
             )),
             fallback_controller_principal_ids: vec![PrincipalId::new_user_test_id(5822).to_string()],
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             name: Some("ServiceNervousSystemTest".to_string()),
             url: Some("https://internetcomputer.org/".to_string()),
             description: Some("Description of an SNS Project".to_string()),
@@ -2636,7 +2636,7 @@ initial_token_distribution: !FractionalDeveloperVotingPower
         let transaction_fee = 10_000;
         let token_symbol = "SNS".to_string();
         let token_name = "ServiceNervousSystem Coin".to_string();
-        let token_logo = "data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string();
+        let token_logo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string();
 
         let sns_init_payload = SnsInitPayload {
             token_name: Some(token_name.clone()),
@@ -2937,7 +2937,7 @@ initial_token_distribution: !FractionalDeveloperVotingPower
 
         {
             let sns_init_payload = SnsInitPayload {
-                token_logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+                token_logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
                 ..sns_init_payload.clone()
             };
             sns_init_payload.validate_post_execution().unwrap();

--- a/rs/sns/integration_tests/src/manage_ledger_parameters.rs
+++ b/rs/sns/integration_tests/src/manage_ledger_parameters.rs
@@ -157,7 +157,7 @@ fn test_manage_ledger_parameters_change_name_and_symbol_and_logo() {
     let original_symbol = icrc1_token_symbol(&state_machine, sns_canisters.ledger_canister_id);
 
     // change ledger logo, name, and symbol with the ManageLedgerParameters proposal
-    let new_logo = "data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string();
+    let new_logo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string();
     let new_name = "MySns".to_string();
     let new_symbol = "MYS".to_string();
 

--- a/rs/sns/integration_tests/src/neuron.rs
+++ b/rs/sns/integration_tests/src/neuron.rs
@@ -1300,7 +1300,7 @@ async fn zero_total_reward_shares() {
             total_available_e8s_equivalent: None,
         }),
         sns_metadata: Some(SnsMetadata {
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             url: Some("https://internetcomputer.org/".to_string()),
             name: Some("ServiceNervousSystemTest".to_string()),
             description: Some("A project testing the SNS".to_string()),
@@ -1544,7 +1544,7 @@ async fn couple_of_neurons_who_voted_get_rewards() {
 
         sns_metadata: Some(SnsMetadata {
             url: Some("https://internetcomputer.org/".to_string()),
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             name: Some("foo bar baz".to_string()),
             description: Some("foo bar baz".to_string()),
         }),

--- a/rs/sns/integration_tests/test_canisters/sns_governance_mem_test_canister.rs
+++ b/rs/sns/integration_tests/test_canisters/sns_governance_mem_test_canister.rs
@@ -357,7 +357,7 @@ fn populate_canister_state() {
         root_canister_id: Some(CanisterId::from_u64(2).get()),
         swap_canister_id: Some(CanisterId::from_u64(3).get()),
         sns_metadata: Some(SnsMetadata {
-            logo: Some("data:image/png;base64,aGVsbG8gZnJvbSBkZmluaXR5IQ==".to_string()),
+            logo: Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVQIHQEEAPv/AAD/DwIRAQ8HgT3GAAAAAElFTkSuQmCC".to_string()),
             name: Some("ServiceNervousSystem-Test".to_string()),
             description: Some("A project to spin up a ServiceNervousSystem".to_string()),
             url: Some("https://internetcomputer.org".to_string()),


### PR DESCRIPTION
  ## Bug

  - SNS logo validation said the logo must be a PNG.
  - But the code only checked that the logo was base64 text.
  - That means non-image data, like base64-encoded plain text, could be accepted as a logo.

  ## Fix

  - Decode the base64 logo data.
  - Check that the decoded bytes start with the PNG signature.
  - Reuse the same validation logic for both SNS logos and token logos.

  ## Tests

  - Added a test that accepts a real PNG logo.
  - Added a test that rejects base64 text that is not a PNG.
  - Updated existing test fixtures to use a real tiny PNG.

  ## Checks

  - `cargo test -p ic-nervous-system-common test_validate_token_logo`
  - `cargo test -p ic-sns-governance --lib validate_logo`
  - `cargo test -p ic-sns-init test_token_logo_validation`
  - `cargo test -p ic-sns-init test_ledger_init_args_is_valid`
  - `cargo test -p ic-sns-governance --lib test_validate_and_render_manage_ledger_parameters`
