### PR TITLE
fix: Refund the prepayment of an `install_code` dropped by a subnet split

### DIFF
--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -1652,11 +1652,14 @@ impl SystemState {
     /// executing on one subnet, but for which a response may only be produced by
     /// another subnet.
     pub fn drop_in_progress_management_calls_after_split(&mut self) {
-        // Remove aborted install code task.
+        // Remove aborted install code task and fully refund the prepaid execution
+        // cycles.
         //
         // Note that this cannot be a paused install code task, because we abort all
         // paused tasks before triggering the split.
-        self.task_queue.remove_aborted_install_code_task();
+        if let Some(prepaid_execution_cycles) = self.task_queue.remove_aborted_install_code_task() {
+            self.refund_cycles(prepaid_execution_cycles, prepaid_execution_cycles);
+        }
 
         // Roll back `Stopping` canister states to `Running` and drop all their stop
         // contexts (the calls corresponding to the dropped stop contexts will be

--- a/rs/replicated_state/src/canister_state/system_state/task_queue.rs
+++ b/rs/replicated_state/src/canister_state/system_state/task_queue.rs
@@ -4,6 +4,7 @@ use crate::ExecutionTask;
 use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
 use ic_types::CanisterId;
 use ic_types::NumBytes;
+use ic_types_cycles::{CompoundCycles, Instructions};
 use std::collections::VecDeque;
 
 /// `TaskQueue` represents the implementation of queue structure for canister tasks satisfying the following conditions:
@@ -168,10 +169,20 @@ impl TaskQueue {
         }
     }
 
-    /// Removes aborted install code task.
-    pub fn remove_aborted_install_code_task(&mut self) {
-        if let Some(ExecutionTask::AbortedInstallCode { .. }) = &self.paused_or_aborted_task {
-            self.paused_or_aborted_task = None;
+    /// Removes the aborted install code task, if any, returning the execution cycles
+    /// that were prepaid for it. The caller is responsible for settling them, as the
+    /// execution they paid for will not happen.
+    pub fn remove_aborted_install_code_task(&mut self) -> Option<CompoundCycles<Instructions>> {
+        match &self.paused_or_aborted_task {
+            Some(ExecutionTask::AbortedInstallCode {
+                prepaid_execution_cycles,
+                ..
+            }) => {
+                let prepaid_execution_cycles = *prepaid_execution_cycles;
+                self.paused_or_aborted_task = None;
+                Some(prepaid_execution_cycles)
+            }
+            _ => None,
         }
     }
 

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -1475,6 +1475,53 @@ fn drops_aborted_canister_install_after_split() {
     assert_eq!(expected_state, canister_state);
 }
 
+/// The cycles prepaid for an `install_code` that a subnet split drops are refunded
+/// in full: the execution is never retried (subnet A' rejects the corresponding
+/// call), so the canister has nothing to show for them.
+#[test]
+fn refunds_prepayment_of_aborted_canister_install_dropped_after_split() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let prepaid = CompoundCycles::<Instructions>::new(Cycles::new(1000), cost_schedule);
+    let mut canister_state = CanisterStateFixture::new().canister_state;
+
+    let system_state = &mut canister_state.system_state;
+    system_state.consume_cycles(prepaid);
+    system_state
+        .task_queue
+        .enqueue(ExecutionTask::AbortedInstallCode {
+            message: CanisterCall::Request(Arc::new(RequestBuilder::new().build())),
+            call_id: InstallCodeCallId::new(0),
+            prepaid_execution_cycles: prepaid,
+        });
+
+    // The prepayment was taken out of the balance and is in the consumed cycles
+    // gauge; nothing has been consumed for good yet, so the counter is still zero.
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles(),
+        prepaid.nominal()
+    );
+    let balance_before = system_state.balance();
+    assert_eq!(balance_before, INITIAL_CYCLES - prepaid.real());
+
+    canister_state.drop_in_progress_management_calls_after_split();
+
+    // The prepayment is refunded in full, so the balance is whole again and the gauge
+    // is back to zero. Nothing was consumed, so the counter stays at zero too.
+    let system_state = &canister_state.system_state;
+    assert_eq!(system_state.balance(), balance_before + prepaid.real());
+    assert_eq!(
+        system_state.canister_metrics().consumed_cycles(),
+        NominalCycles::zero()
+    );
+    assert_eq!(
+        system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases_as_counters()
+            .get(&CyclesUseCase::Instructions),
+        Some(&NominalCycles::zero())
+    );
+}
+
 #[test]
 fn reverts_stopping_status_after_split() {
     let mut canister_state = CanisterStateFixture::new().canister_state;

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -1500,6 +1500,13 @@ fn refunds_prepayment_of_aborted_canister_install_dropped_after_split() {
         system_state.canister_metrics().consumed_cycles(),
         prepaid.nominal()
     );
+    assert_eq!(
+        system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases_as_counters()
+            .get(&CyclesUseCase::Instructions),
+        Some(&NominalCycles::zero())
+    );
     let balance_before = system_state.balance();
     assert_eq!(balance_before, INITIAL_CYCLES - prepaid.real());
 

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1360,7 +1360,9 @@ fn online_split() {
     take_shapshot(CANISTER_1);
     take_shapshot(CANISTER_2);
 
-    // Add aborted `install_code` tasks to both canisters.
+    // Add aborted `install_code` tasks to both canisters, with the same prepayment.
+    let prepaid_install_code_cycles =
+        CompoundCycles::<Instructions>::new(Cycles::new(3), CanisterCyclesCostSchedule::Normal);
     let mut add_aborted_install_code_task = |canister_id| {
         let canister = fixture.state.canister_state_make_mut(&canister_id).unwrap();
         canister
@@ -1369,10 +1371,7 @@ fn online_split() {
             .enqueue(ExecutionTask::AbortedInstallCode {
                 message: CanisterCall::Request(RequestBuilder::default().build().into()),
                 call_id: InstallCodeCallId::new(3_u64),
-                prepaid_execution_cycles: CompoundCycles::new(
-                    Cycles::new(3),
-                    CanisterCyclesCostSchedule::Normal,
-                ),
+                prepaid_execution_cycles: prepaid_install_code_cycles,
             });
         // Canister must be in the subnet schedule.
         fixture.state.canister_priority_mut(canister_id);
@@ -1432,8 +1431,12 @@ fn online_split() {
     canister_state
         .system_state
         .split_input_schedules(&CANISTER_2, expected.canister_states());
-    // The in-progress `install_code` task should have been silently dropped.
+    // The in-progress `install_code` task should have been dropped, with the cycles
+    // prepaid for it refunded in full.
     canister_state.system_state.task_queue = Default::default();
+    canister_state
+        .system_state
+        .refund_cycles(prepaid_install_code_cycles, prepaid_install_code_cycles);
     expected.put_canister_state(canister_state_arc);
 
     // Streams, subnet queues and refunds should be empty.

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1361,10 +1361,17 @@ fn online_split() {
     take_shapshot(CANISTER_2);
 
     // Add aborted `install_code` tasks to both canisters, with the same prepayment.
+    // The prepayment is actually charged to the canister, as the in-progress
+    // `install_code` would have done, so that the refund below has something to
+    // return and cycle conservation is verifiable.
     let prepaid_install_code_cycles =
         CompoundCycles::<Instructions>::new(Cycles::new(3), CanisterCyclesCostSchedule::Normal);
     let mut add_aborted_install_code_task = |canister_id| {
         let canister = fixture.state.canister_state_make_mut(&canister_id).unwrap();
+        let balance_before_prepayment = canister.system_state.balance();
+        canister
+            .system_state
+            .consume_cycles(prepaid_install_code_cycles);
         canister
             .system_state
             .task_queue
@@ -1375,9 +1382,10 @@ fn online_split() {
             });
         // Canister must be in the subnet schedule.
         fixture.state.canister_priority_mut(canister_id);
+        balance_before_prepayment
     };
     add_aborted_install_code_task(CANISTER_1);
-    add_aborted_install_code_task(CANISTER_2);
+    let canister_2_balance_before_prepayment = add_aborted_install_code_task(CANISTER_2);
 
     //
     // Split off subnet A'.
@@ -1449,6 +1457,17 @@ fn online_split() {
 
     // Everything else should be unchanged.
     assert_eq!(expected, state_b);
+
+    // And, explicitly: the prepayment was refunded in full, so `CANISTER_2` is back
+    // to the balance it had before it was charged.
+    assert_eq!(
+        state_b
+            .canister_state(&CANISTER_2)
+            .unwrap()
+            .system_state
+            .balance(),
+        canister_2_balance_before_prepayment
+    );
 }
 
 #[test]

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1361,17 +1361,26 @@ fn online_split() {
     take_shapshot(CANISTER_2);
 
     // Add aborted `install_code` tasks to both canisters, with the same prepayment.
-    // The prepayment is actually charged to the canister, as the in-progress
-    // `install_code` would have done, so that the refund below has something to
-    // return and cycle conservation is verifiable.
-    let prepaid_install_code_cycles =
-        CompoundCycles::<Instructions>::new(Cycles::new(3), CanisterCyclesCostSchedule::Normal);
+    let prepaid_install_code_cycles = CompoundCycles::<Instructions>::new(
+        Cycles::new(1_000_000),
+        CanisterCyclesCostSchedule::Normal,
+    );
     let mut add_aborted_install_code_task = |canister_id| {
         let canister = fixture.state.canister_state_make_mut(&canister_id).unwrap();
         let balance_before_prepayment = canister.system_state.balance();
         canister
             .system_state
             .consume_cycles(prepaid_install_code_cycles);
+        // The prepayment was consumed in full: out of the balance and into the
+        // consumed cycles gauge.
+        assert_eq!(
+            canister.system_state.balance(),
+            balance_before_prepayment - prepaid_install_code_cycles.real()
+        );
+        assert_eq!(
+            canister.system_state.canister_metrics().consumed_cycles(),
+            prepaid_install_code_cycles.nominal()
+        );
         canister
             .system_state
             .task_queue


### PR DESCRIPTION
`SystemState::drop_in_progress_management_calls_after_split()` drops the canister's `AbortedInstallCode` task on subnet B, discarding the `prepaid_execution_cycles` recorded in it. The cycles are never returned to the canister, so it stays charged for an execution that never happens: an aborted execution discards the slices it had already run and starts over when retried, and this one is never retried — subnet A' rejects the corresponding call, unwinding the operation there as well.

`TaskQueue::remove_aborted_install_code_task()` now returns the prepayment and the caller refunds it in full.

The refund is deterministic across subnet B's replicas and conserves cycles: they move back from consumed to the canister's balance, lowering the `consumed_cycles` gauge and contributing nothing to the `Instructions` by-use-case counter, which is exactly right when nothing was consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
