### PR TITLE
feat(consensus): report at info level that a halted subnet delivers no batches

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -192,7 +192,7 @@ fn deliver_batches(
                 log,
             ) {
                 Some(Status::Halting | Status::Halted) => {
-                    debug!(
+                    info!(
                         every_n_seconds => 5,
                         log,
                         "Batch of height {} is not delivered because replica is halted",


### PR DESCRIPTION
A subnet halting because of the `halt_at_cup_height` flag of its subnet record logged nothing observable: the only trace it left was a `debug!`, which the nodes' log level drops, so nothing outside the replica could tell that such a subnet had come to a stop. The `is_halted` flag, in contrast, is reported at info level by `ConsensusImpl::on_state_change`.

Raise that message to info level, so that both ways of halting a subnet can be observed the same way. It is already emitted at most once every five seconds, so this does not make the logs noticeably busier, and it names the height of the first batch that is not delivered, i.e. one past the state the subnet stopped in.

The motivation for this change is to automate detection that a subnet halted at a CUP height during subnet merging.