### PR TITLE
feat: Prefer more useful XNet slices

### DIFF
--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -23,7 +23,7 @@ use ic_types::{
 };
 use messages::Messages;
 use prometheus::{Histogram, IntCounterVec, IntGauge};
-use std::cmp::Reverse;
+use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeMap;
 use std::convert::{From, TryFrom, TryInto};
 use std::sync::Arc;
@@ -1440,7 +1440,7 @@ impl CertifiedSlicePool {
     }
 
     /// Garbage collects the provided slice and pools the rest, iff more useful than
-    /// the already pooled slice (see `usefulness()`).
+    /// the already pooled slice (see `compare_usefulness()`).
     ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` if
     /// `unpacked` is malformed.
@@ -1462,10 +1462,10 @@ impl CertifiedSlicePool {
             };
         }
 
-        // Retain the more useful slice (`unpacked` vs already pooled), in case e.g.
-        // `unpacked` came from a lagging node.
+        // If there's a pooled slice, only replace it if `unpacked` is more useful (i.e.
+        // has more messages or signals).
         if let Some(pooled) = self.slices.get(&subnet_id)
-            && usefulness(pooled, stream_position) >= usefulness(&unpacked, stream_position)
+            && compare_usefulness(pooled, &unpacked, stream_position).is_ge()
         {
             self.metrics.observe_put(STATUS_LESS_USEFUL);
         } else {
@@ -1597,8 +1597,7 @@ fn witness_count_bytes(
         + pruned_nodes_bytes + known_nodes_bytes + fork_nodes_bytes
 }
 
-/// Returns a measure of how useful a slice is, as a tuple for lexicographic
-/// comparison:
+/// Compares two slices by how useful they are, in decreasing order of weight:
 ///
 ///  * First useful (beyond `stream_position`) message index: a slice beginning
 ///    after it may not have the messages to satisfy the next `take_slice()`.
@@ -1614,31 +1613,35 @@ fn witness_count_bytes(
 ///
 /// Safety never enters into it: the slice has been certified by its source
 /// subnet. The only question is which of two slices is worth holding on to.
-fn usefulness(
-    slice: &UnpackedStreamSlice,
+fn compare_usefulness(
+    lhs: &UnpackedStreamSlice,
+    rhs: &UnpackedStreamSlice,
     stream_position: Option<&ExpectedIndices>,
-) -> (
-    Option<Reverse<StreamIndex>>,
-    Option<StreamIndex>,
-    StreamIndex,
-    StreamIndex,
-) {
-    let messages_begin = match (slice.payload.messages_begin(), stream_position) {
-        (Some(messages_begin), Some(stream_position)) => {
-            // The latest of the slice's begin and the expected message index.
-            Some(messages_begin.max(stream_position.message_index))
-        }
+) -> Ordering {
+    let first_useful_message = |slice: &UnpackedStreamSlice| {
+        match (slice.payload.messages_begin(), stream_position) {
+            (Some(messages_begin), Some(stream_position)) => {
+                Some(messages_begin.max(stream_position.message_index))
+            }
 
-        // No messages or no stream position, go with the slice's begin, if any.
-        _ => slice.payload.messages_begin(),
+            // No messages or no stream position, go with the slice's begin, if any.
+            (messages_begin, _) => messages_begin,
+        }
     };
 
-    (
-        messages_begin.map(Reverse), // Reversed: earlier begin is more useful.
-        slice.payload.messages_end(),
-        slice.payload.header.signals_end(),
-        slice.payload.header.begin(),
-    )
+    // `Reverse` goes inside the `Option`: an earlier begin is more useful, but a
+    // slice with no messages at all is the least useful.
+    first_useful_message(lhs)
+        .map(Reverse)
+        .cmp(&first_useful_message(rhs).map(Reverse))
+        .then_with(|| lhs.payload.messages_end().cmp(&rhs.payload.messages_end()))
+        .then_with(|| {
+            lhs.payload
+                .header
+                .signals_end()
+                .cmp(&rhs.payload.header.signals_end())
+        })
+        .then_with(|| lhs.payload.header.begin().cmp(&rhs.payload.header.begin()))
 }
 
 /// Decodes the certified stream slice coming from `subnet_id` and validates

--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -1605,8 +1605,8 @@ fn witness_count_bytes(
 ///  * Its `messages_end`: more messages are better (and subjectively weighted
 ///    higher than more signals).
 ///  * Its `signals_end`: more signals are better.
-///  * Its stream `begin`: a higher one allows us to garbage collect more of our
-///    messages.
+///  * Its stream `begin`: a higher one allows us to garbage collect more
+///    signals and, as a result, induct more messages.
 ///
 /// Slices beginning after the cached stream position are not hypothetical: the
 /// stream position may regress whenever we built a payload for a block that did

--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -23,6 +23,7 @@ use ic_types::{
 };
 use messages::Messages;
 use prometheus::{Histogram, IntCounterVec, IntGauge};
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::convert::{From, TryFrom, TryInto};
 use std::sync::Arc;
@@ -41,6 +42,7 @@ pub type CertifiedSliceResult<T> = Result<T, CertifiedSliceError>;
 /// Metrics for [`CertifiedSlicePool`].
 struct CertifiedSlicePoolMetrics {
     pool_size_bytes: IntGauge,
+    put_count: IntCounterVec,
     take_count: IntCounterVec,
     take_messages: Histogram,
     take_gced_messages: Histogram,
@@ -48,6 +50,7 @@ struct CertifiedSlicePoolMetrics {
 }
 
 pub const METRIC_POOL_SIZE_BYTES: &str = "xnet_pool_size_bytes";
+pub const METRIC_PUT_COUNT: &str = "xnet_pool_put_count";
 pub const METRIC_TAKE_COUNT: &str = "xnet_pool_take_count";
 pub const METRIC_TAKE_MESSAGES: &str = "xnet_pool_take_messages";
 pub const METRIC_TAKE_SIZE_BYTES: &str = "xnet_pool_take_size_bytes";
@@ -57,6 +60,7 @@ pub const LABEL_STATUS: &str = "status";
 
 pub const STATUS_SUCCESS: &str = "success";
 pub const STATUS_NONE: &str = "none";
+pub const STATUS_LESS_USEFUL: &str = "less_useful";
 
 impl CertifiedSlicePoolMetrics {
     fn new(metrics_registry: &MetricsRegistry) -> Self {
@@ -64,6 +68,11 @@ impl CertifiedSlicePoolMetrics {
             pool_size_bytes: metrics_registry.int_gauge(
                 METRIC_POOL_SIZE_BYTES,
                 "Total size of the XNet slice pool, in bytes.",
+            ),
+            put_count: metrics_registry.int_counter_vec(
+                METRIC_PUT_COUNT,
+                "Count of XNet slice pool puts and appends, by status.",
+                &[LABEL_STATUS]
             ),
             take_count: metrics_registry.int_counter_vec(
                 METRIC_TAKE_COUNT,
@@ -89,6 +98,11 @@ impl CertifiedSlicePoolMetrics {
                 decimal_buckets(2, 6)
             ),
         }
+    }
+
+    /// Observes the status of a pool put or append.
+    fn observe_put(&self, status: &str) {
+        self.put_count.with_label_values(&[status]).inc();
     }
 
     /// Observes the status of a pool take.
@@ -695,6 +709,11 @@ impl Payload {
         self.messages.as_ref().map(|m| m.begin())
     }
 
+    /// Returns the `StreamIndex` just past the last message, if any.
+    fn messages_end(&self) -> Option<StreamIndex> {
+        self.messages.as_ref().map(|m| m.end())
+    }
+
     /// Returns the `FlatMap` contained in a `SubTree`; `Err(InvalidPayload)` if
     /// `tree` is a `Leaf`.
     fn children_of(mut tree: PayloadTree) -> CertifiedSliceResult<PayloadTreeMap> {
@@ -1003,10 +1022,6 @@ pub enum CertifiedSliceError {
     /// Provided slice could not be appended to pooled slice. Provided slice was
     /// discarded.
     InvalidAppend(InvalidAppend),
-
-    /// Attempted to take already garbage-collected messages, slice was dropped
-    /// from pool.
-    TakeBeforeSliceBegin,
 }
 
 /// `CertifiedSliceError::InvalidPayload` and
@@ -1043,7 +1058,6 @@ impl CertifiedSliceError {
             Self::WitnessPruningFailed(_) => "WitnessPruningFailed",
             Self::DecodeFailed(_) => "DecodeFailed",
             Self::InvalidAppend(_) => "InvalidAppend",
-            Self::TakeBeforeSliceBegin => "TakeBeforeSliceBegin",
         }
     }
 }
@@ -1124,15 +1138,17 @@ impl CertifiedSlicePool {
     /// respecting the given message count and byte limits; or, if the provided
     /// `byte_limit` is too small for a header-only slice, returns `Ok(None)`.
     ///
-    /// If a `begin` index was provided, garbage collects all messages before it,
-    /// regardless of whether a non-empty slice was returned.
+    /// If a `begin` index is provided, it first garbage collects all messages
+    /// before it.
     ///
-    /// If all messages are taken, the slice is removed from the pool.
+    /// If the pooled slice begins after `begin.message_index`, its messages cannot
+    /// be taken (yet), so a header-only slice is returned.
+    ///
+    /// If `Ok(Some(_))` is returned and no messages are left, the slice is removed
+    /// from the pool.
     ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` and drops
-    /// the pooled slice if malformed. Returns `Err(TakeBeforeSliceBegin)` and
-    /// drops the pooled slice if `begin`'s `message_index` is before the
-    /// first pooled message.
+    /// the pooled slice if malformed.
     pub fn take_slice(
         &mut self,
         subnet_id: SubnetId,
@@ -1170,14 +1186,12 @@ impl CertifiedSlicePool {
     /// On success, returns a prefix respecting the given limits.
     ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` if
-    /// `self.payload` is malformed. Returns `Err(TakeBeforeSliceBegin)` if
-    /// `begin`'s `message_index` is before the pooled slice's messages begin
-    /// index.
+    /// `self.payload` is malformed.
     fn take_slice_impl(
         &mut self,
         subnet_id: SubnetId,
         begin: Option<&ExpectedIndices>,
-        msg_limit: Option<usize>,
+        mut msg_limit: Option<usize>,
         byte_limit: Option<usize>,
     ) -> CertifiedSliceResult<Option<UnpackedStreamSlice>> {
         // Update the stream position in case we bail out early with no slice returned.
@@ -1203,8 +1217,11 @@ impl CertifiedSlicePool {
             if let Some(actual_begin) = slice.payload.messages_begin()
                 && actual_begin != begin.message_index
             {
-                // Slice's `messages.begin` is past the requested stream index, bail out.
-                return Err(CertifiedSliceError::TakeBeforeSliceBegin);
+                // Slice's `messages.begin` is past the requested stream index, so it does not
+                // have the next expected message. Take the signals only and put the messages
+                // back: the stream position may yet advance past `messages.begin`, e.g. because
+                // another block maker included the messages before it.
+                msg_limit = Some(0);
             }
         }
 
@@ -1322,15 +1339,22 @@ impl CertifiedSlicePool {
     /// Places the provided slice into the pool, after trimming off any prefix
     /// before the corresponding `self.stream_positions` entry.
     ///
-    /// On success always replaces the pooled slice regardless of its contents,
-    /// as slices may originate from malicious replicas and we would rather
-    /// temporarily replace a good slice with a bad one than be stuck with a bad
-    /// one (e.g. because it has an exceedingly high `signals_end`).
-    ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` if
     /// `slice` is malformed. Returns `Err(DecodeStreamError)` if the slice could
     /// not be decoded or its certification was invalid.
     pub fn put(
+        &mut self,
+        subnet_id: SubnetId,
+        slice: CertifiedStreamSlice,
+        registry_version: RegistryVersion,
+        log: ReplicaLogger,
+    ) -> CertifiedSliceResult<()> {
+        self.put_impl(subnet_id, slice, registry_version, log)
+            .inspect_err(|e| self.metrics.observe_put(e.to_label_value()))
+    }
+
+    /// Helper function to allow easy instrumentation of `put` results.
+    fn put_impl(
         &mut self,
         subnet_id: SubnetId,
         slice: CertifiedStreamSlice,
@@ -1345,7 +1369,7 @@ impl CertifiedSlicePool {
             log,
         )?;
 
-        self.put_impl(subnet_id, slice.try_into()?)
+        self.pool_slice(subnet_id, slice.try_into()?)
     }
 
     /// Appends a partial slice to the corresponding pool entry, trimming
@@ -1364,6 +1388,18 @@ impl CertifiedSlicePool {
     /// Returns `Err(DecodeStreamError)` if the partial slice could not be decoded
     /// or the certification was invalid for the merged slice.
     pub fn append(
+        &mut self,
+        subnet_id: SubnetId,
+        partial: CertifiedStreamSlice,
+        registry_version: RegistryVersion,
+        log: ReplicaLogger,
+    ) -> CertifiedSliceResult<()> {
+        self.append_impl(subnet_id, partial, registry_version, log)
+            .inspect_err(|e| self.metrics.observe_put(e.to_label_value()))
+    }
+
+    /// Helper function to allow easy instrumentation of `append` results.
+    fn append_impl(
         &mut self,
         subnet_id: SubnetId,
         partial: CertifiedStreamSlice,
@@ -1400,29 +1436,43 @@ impl CertifiedSlicePool {
             log,
         )?;
 
-        self.put_impl(subnet_id, slice)?;
-        Ok(())
+        self.pool_slice(subnet_id, slice)
     }
 
-    /// Garbage collects the provided slice and pools the rest, if any.
+    /// Garbage collects the provided slice and pools the rest, iff more useful than
+    /// the already pooled slice (see `usefulness()`).
     ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` if
     /// `unpacked` is malformed.
-    fn put_impl(
+    fn pool_slice(
         &mut self,
         subnet_id: SubnetId,
         mut unpacked: UnpackedStreamSlice,
     ) -> CertifiedSliceResult<()> {
         // Trim off everything before the cached stream position.
-        if let Some(cutoff) = self.stream_positions.get(&subnet_id) {
-            unpacked = match unpacked.garbage_collect(cutoff)? {
+        let stream_position = self.stream_positions.get(&subnet_id);
+        if let Some(stream_position) = stream_position {
+            unpacked = match unpacked.garbage_collect(stream_position)? {
                 Some(unpacked) => unpacked,
                 // Bail out if nothing left.
-                None => return Ok(()),
+                None => {
+                    self.metrics.observe_put(STATUS_NONE);
+                    return Ok(());
+                }
             };
         }
 
-        self.slices.insert(subnet_id, unpacked);
+        // Retain the more useful slice (`unpacked` vs already pooled), in case e.g.
+        // `unpacked` came from a lagging node.
+        if let Some(pooled) = self.slices.get(&subnet_id)
+            && usefulness(pooled, stream_position) >= usefulness(&unpacked, stream_position)
+        {
+            self.metrics.observe_put(STATUS_LESS_USEFUL);
+        } else {
+            self.slices.insert(subnet_id, unpacked);
+            self.metrics.observe_put(STATUS_SUCCESS);
+        }
+
         Ok(())
     }
 
@@ -1545,6 +1595,50 @@ fn witness_count_bytes(
         - PRUNED_NODE_BYTES + MESSAGES_LABEL_BYTES
         // And added all the pruned, known and fork nodes.
         + pruned_nodes_bytes + known_nodes_bytes + fork_nodes_bytes
+}
+
+/// Returns a measure of how useful a slice is, as a tuple for lexicographic
+/// comparison:
+///
+///  * First useful (beyond `stream_position`) message index: a slice beginning
+///    after it may not have the messages to satisfy the next `take_slice()`.
+///  * Its `messages_end`: more messages are better (and subjectively weighted
+///    higher than more signals).
+///  * Its `signals_end`: more signals are better.
+///  * Its stream `begin`: a higher one allows us to garbage collect more of our
+///    messages.
+///
+/// Slices beginning after the cached stream position are not hypothetical: the
+/// stream position may regress whenever we built a payload for a block that did
+/// not get finalized (e.g. the rank 1 block was picked instead).
+///
+/// Safety never enters into it: the slice has been certified by its source
+/// subnet. The only question is which of two slices is worth holding on to.
+fn usefulness(
+    slice: &UnpackedStreamSlice,
+    stream_position: Option<&ExpectedIndices>,
+) -> (
+    Option<Reverse<StreamIndex>>,
+    Option<StreamIndex>,
+    StreamIndex,
+    StreamIndex,
+) {
+    let messages_begin = match (slice.payload.messages_begin(), stream_position) {
+        (Some(messages_begin), Some(stream_position)) => {
+            // The latest of the slice's begin and the expected message index.
+            Some(messages_begin.max(stream_position.message_index))
+        }
+
+        // No messages or no stream position, go with the slice's begin, if any.
+        _ => slice.payload.messages_begin(),
+    };
+
+    (
+        messages_begin.map(Reverse), // Reversed: earlier begin is more useful.
+        slice.payload.messages_end(),
+        slice.payload.header.signals_end(),
+        slice.payload.header.begin(),
+    )
 }
 
 /// Decodes the certified stream slice coming from `subnet_id` and validates

--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -73,12 +73,14 @@ pub trait XNetSlicePool: Send + Sync {
     /// respecting the given message count and byte limits; or, if the provided
     /// `byte_limit` is too small for a header-only slice, returns `Ok(None)`.
     ///
-    /// If all messages are taken, the slice is removed from the pool.
+    /// If the pooled slice begins after `begin.message_index`, its messages cannot
+    /// be taken (yet), so a header-only slice is returned.
+    ///
+    /// If `Ok(Some(_))` is returned and no messages are left, the slice is removed
+    /// from the pool.
     ///
     /// Returns `Err(InvalidPayload)` or `Err(WitnessPruningFailed)` and drops
-    /// the pooled slice if malformed. Returns `Err(TakeBeforeSliceBegin)` and
-    /// drops the pooled slice if `begin`'s `message_index` is before the
-    /// first pooled message.
+    /// the pooled slice if malformed.
     fn take_slice(
         &self,
         subnet_id: SubnetId,
@@ -1503,7 +1505,7 @@ impl PoolRefillTask {
                                     .unwrap()
                                     .append(subnet_id, slice, registry_version, log)
                             } else {
-                                // Pulled a complete stream, replace pooled slice (if any).
+                                // Pulled a complete stream, put it into the pool.
                                 pool.lock()
                                     .unwrap()
                                     .put(subnet_id, slice, registry_version, log)

--- a/rs/xnet/payload_builder/src/tests.rs
+++ b/rs/xnet/payload_builder/src/tests.rs
@@ -391,7 +391,11 @@ async fn validate_broken_count_bytes_fn() {
         let fixture = PayloadBuilderTestFixture::with_xnet_state(0);
         let xnet_payload_builder = fixture
             .new_xnet_payload_builder_impl(log)
-            .with_count_bytes_fn(|_| Err(CertifiedSliceError::TakeBeforeSliceBegin));
+            .with_count_bytes_fn(|_| {
+                Err(CertifiedSliceError::DecodeFailed(
+                    ProxyDecodeError::MissingField("test"),
+                ))
+            });
 
         // Validate newest `XNetPayload` in `payloads` against previous ones + state.
         let payloads = fixture.past_payloads();

--- a/rs/xnet/payload_builder/tests/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/tests/certified_slice_pool.rs
@@ -15,7 +15,8 @@ use ic_types::xnet::{CertifiedStreamSlice, StreamIndex};
 use ic_types::{CountBytes, RegistryVersion, SubnetId};
 use ic_xnet_payload_builder::certified_slice_pool::{
     CertifiedSliceError, CertifiedSlicePool, InvalidAppend, InvalidSlice, LABEL_STATUS,
-    STATUS_NONE, STATUS_SUCCESS, UnpackedStreamSlice, certified_slice_count_bytes, testing,
+    STATUS_LESS_USEFUL, STATUS_NONE, STATUS_SUCCESS, UnpackedStreamSlice,
+    certified_slice_count_bytes, testing,
 };
 use ic_xnet_payload_builder::{ExpectedIndices, MAX_SIGNALS, max_message_index};
 use maplit::btreemap;
@@ -1404,5 +1405,149 @@ fn pool_garbage_collect_deleted_subnet(
         // Both the stream position and the slice should have been dropped.
         assert!(pool.peers().next().is_none());
         assert_eq!((None, None, 0, 0), pool.slice_stats(SRC_SUBNET));
+    });
+}
+
+/// Tests that a pooled slice is only ever replaced by a more useful one: one
+/// with more messages; or, failing that, with more signals.
+#[test_strategy::proptest(ProptestConfig::with_cases(10))]
+fn pool_put_more_useful_slice_only(
+    #[strategy(arb_stream_slice(
+        2, // min_size
+        10, // max_size
+        0, // min_signal_count
+        10, // max_signal_count
+        CURRENT_CERTIFICATION_VERSION,
+    ))]
+    test_slice: (Stream, StreamIndex, usize),
+) {
+    let (mut stream, from, msg_count) = test_slice;
+
+    with_test_replica_logger(|log| {
+        let fixture =
+            StateManagerFixture::remote(log.clone()).with_stream(DST_SUBNET, stream.clone());
+        let prefix_slice = fixture.get_slice(DST_SUBNET, from, 1);
+        let slice = fixture.get_slice(DST_SUBNET, from, msg_count);
+
+        // The same slice, but with one extra signal.
+        stream.push_accept_signal();
+        let fixture = fixture.with_stream(DST_SUBNET, stream.clone());
+        let more_signals_slice = fixture.get_slice(DST_SUBNET, from, msg_count);
+
+        let mut certified_stream_store = MockCertifiedStreamStore::new();
+        // Actual return value does not matter as long as it's `Ok(_)`.
+        certified_stream_store
+            .expect_decode_certified_stream_slice()
+            .returning(|_, _, _| Ok(StreamSliceBuilder::new().build()));
+        let mut pool =
+            CertifiedSlicePool::new(Arc::new(certified_stream_store) as Arc<_>, &fixture.metrics);
+
+        let put = |pool: &mut CertifiedSlicePool, slice| {
+            pool.put(SRC_SUBNET, slice, REGISTRY_VERSION, log.clone())
+                .unwrap();
+        };
+
+        // Pool a single message slice, then replace it with the full slice.
+        put(&mut pool, prefix_slice.clone());
+        assert_matches!(pool.slice_stats(SRC_SUBNET), (_, _, 1, _));
+        put(&mut pool, slice.clone());
+        assert_matches!(pool.slice_stats(SRC_SUBNET), (_, _, count, _) if count == msg_count);
+
+        // Putting the single message slice again is a no-op: it has fewer messages.
+        put(&mut pool, prefix_slice);
+        assert_matches!(pool.slice_stats(SRC_SUBNET), (_, _, count, _) if count == msg_count);
+
+        // But the same messages plus an extra signal do replace it...
+        put(&mut pool, more_signals_slice.clone());
+        // ...while the slice with fewer signals does not.
+        put(&mut pool, slice);
+        assert_opt_slices_eq(
+            Some(more_signals_slice),
+            pool.take_slice(SRC_SUBNET, None, None, None)
+                .unwrap()
+                .map(|(slice, _)| slice),
+        );
+
+        assert_eq!(
+            metric_vec(&[
+                (&[(LABEL_STATUS, STATUS_SUCCESS)], 3),
+                (&[(LABEL_STATUS, STATUS_LESS_USEFUL)], 2)
+            ]),
+            fixture.fetch_pool_put_count()
+        );
+    });
+}
+
+/// Tests that a pooled slice beginning after the stream position is replaced by
+/// one beginning at the stream position, even if the latter has fewer messages.
+#[test_strategy::proptest(ProptestConfig::with_cases(10))]
+fn pool_put_after_stream_position_regression(
+    #[strategy(arb_stream_slice(
+        2, // min_size
+        10, // max_size
+        0, // min_signal_count
+        10, // max_signal_count
+        CURRENT_CERTIFICATION_VERSION,
+    ))]
+    test_slice: (Stream, StreamIndex, usize),
+) {
+    let (stream, from, msg_count) = test_slice;
+
+    with_test_replica_logger(|log| {
+        let fixture = StateManagerFixture::remote(log.clone()).with_stream(DST_SUBNET, stream);
+        let prefix_slice = fixture.get_slice(DST_SUBNET, from, 1);
+        let slice = fixture.get_slice(DST_SUBNET, from, msg_count);
+
+        let mut certified_stream_store = MockCertifiedStreamStore::new();
+        // Actual return value does not matter as long as it's `Ok(_)`.
+        certified_stream_store
+            .expect_decode_certified_stream_slice()
+            .returning(|_, _, _| Ok(StreamSliceBuilder::new().build()));
+        let mut pool =
+            CertifiedSlicePool::new(Arc::new(certified_stream_store) as Arc<_>, &fixture.metrics);
+
+        let position_at = |message_index| ExpectedIndices {
+            message_index,
+            signal_index: StreamIndex::from(0),
+        };
+
+        pool.garbage_collect(btreemap! {SRC_SUBNET => position_at(from)});
+        pool.put(SRC_SUBNET, slice, REGISTRY_VERSION, log.clone())
+            .unwrap();
+
+        // Consume the first message, then have the stream position regress, as it
+        // would if the block the payload went into did not get finalized.
+        pool.garbage_collect(btreemap! {SRC_SUBNET => position_at(from.increment())});
+        pool.garbage_collect(btreemap! {SRC_SUBNET => position_at(from)});
+        assert_matches!(
+            pool.slice_stats(SRC_SUBNET),
+            (_, Some(messages_begin), count, _)
+                if messages_begin == from.increment() && count == msg_count - 1
+        );
+
+        // No messages can be taken, `take_slice` returns a header-only slice.
+        let taken = pool
+            .take_slice(SRC_SUBNET, Some(&position_at(from)), None, None)
+            .unwrap()
+            .map(|(slice, _)| slice)
+            .unwrap();
+        assert_eq!(
+            0,
+            testing::slice_len(&UnpackedStreamSlice::try_from(taken).unwrap())
+        );
+        // Messages are still pooled.
+        assert_matches!(
+            pool.slice_stats(SRC_SUBNET),
+            (_, Some(messages_begin), count, _)
+                if messages_begin == from.increment() && count == msg_count - 1
+        );
+
+        // A single message slice beginning at the stream position replaces it.
+        pool.put(SRC_SUBNET, prefix_slice, REGISTRY_VERSION, log)
+            .unwrap();
+        assert_matches!(
+            pool.slice_stats(SRC_SUBNET),
+            (_, Some(messages_begin), 1, _) if messages_begin == from
+        );
     });
 }

--- a/rs/xnet/payload_builder/tests/common/mod.rs
+++ b/rs/xnet/payload_builder/tests/common/mod.rs
@@ -24,8 +24,8 @@ use ic_types::{
     xnet::{CertifiedStreamSlice, StreamIndex},
 };
 use ic_xnet_payload_builder::certified_slice_pool::{
-    METRIC_POOL_SIZE_BYTES, METRIC_TAKE_COUNT, METRIC_TAKE_GCED_MESSAGES, METRIC_TAKE_MESSAGES,
-    METRIC_TAKE_SIZE_BYTES, UnpackedStreamSlice,
+    METRIC_POOL_SIZE_BYTES, METRIC_PUT_COUNT, METRIC_TAKE_COUNT, METRIC_TAKE_GCED_MESSAGES,
+    METRIC_TAKE_MESSAGES, METRIC_TAKE_SIZE_BYTES, UnpackedStreamSlice,
 };
 use std::{convert::TryFrom, sync::Arc};
 use tempfile::{Builder, TempDir};
@@ -140,6 +140,11 @@ impl StateManagerFixture {
     /// Returns the value of the `METRIC_POOL_SIZE_BYTES` gauge.
     pub fn fetch_pool_size_bytes(&self) -> usize {
         fetch_gauge(&self.metrics, METRIC_POOL_SIZE_BYTES).unwrap() as usize
+    }
+
+    /// Returns the value of the `METRIC_PUT_COUNT` counters.
+    pub fn fetch_pool_put_count(&self) -> MetricVec<u64> {
+        fetch_int_counter_vec(&self.metrics, METRIC_PUT_COUNT)
     }
 
     /// Returns the value of the `METRIC_TAKE_COUNT` counters.


### PR DESCRIPTION
Unify the criteria for when a newly pulled slice should replace a pooled slice across all `put()` and `append()` paths.

Only replace a pooled slice with one at least as useful: beginning no later; failing that, with more messages; failing that, more signals; failing that, higher stream begin. Prevents a slice from a lagging node from clobbering a good slice. New `xnet_pool_put_count` metric records the outcome.

Also, when the pooled slice begins after the requested stream position (which may regress, e.g. when the block we built a payload for was not finalized), take its signals only and retain the messages, instead of dropping the slice. Drops `CertifiedSliceError::TakeBeforeSliceBegin`.