### PR TITLE
fix(cketh): remove duplicated 0x prefix when displaying EventSource

### DIFF
--- a/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/mod.rs
@@ -133,7 +133,7 @@ pub struct EventSource {
 
 impl fmt::Display for EventSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{}:{}", self.transaction_hash, self.log_index)
+        write!(f, "{}:{}", self.transaction_hash, self.log_index)
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/tests.rs
@@ -557,3 +557,26 @@ mod encode_principal {
         );
     }
 }
+
+mod event_source {
+    use crate::eth_logs::EventSource;
+    use crate::eth_rpc::Hash;
+    use crate::numeric::LogIndex;
+    use std::str::FromStr;
+
+    #[test]
+    fn should_display_event_source_with_single_hex_prefix() {
+        let event_source = EventSource {
+            transaction_hash: Hash::from_str(
+                "0x705f826861c802b407843e99af986cfde8749b669e5e0a5a150f4350bcaa9bc3",
+            )
+            .unwrap(),
+            log_index: LogIndex::from(29_u8),
+        };
+
+        assert_eq!(
+            event_source.to_string(),
+            "0x705f826861c802b407843e99af986cfde8749b669e5e0a5a150f4350bcaa9bc3:29"
+        );
+    }
+}


### PR DESCRIPTION
The `Display` implementation of `EventSource` prepended a `0x` prefix to the transaction hash, whose own `Display` implementation already includes it, so log messages and the dashboard showed sources as `0x0x<hash>:<index>`. The redundant prefix is removed and the expected format is pinned by a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9