### PR TITLE
chore: disable daily recovery test

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: ./.github/actions/netrc
       - *backup-pod-access
       - name: Run NNS Recovery Test with Mainnet State
+        if: false # this test will fail until this PR is merged: https://github.com/dfinity/ic/pull/11203
         uses: ./.github/actions/bazel
         with:
           run: |
@@ -77,7 +78,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-        if: failure()
+        if: true # we keep reminding the team to fix the test
         with:
           channel-id: eng-consensus-test-failures
           slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"


### PR DESCRIPTION
The test is consistently failing. To reduce noise in alerts, we disable the test until it is green again (will require https://github.com/dfinity/ic/pull/11203 to be merged).