### PR TITLE
test: move system-tests that are too big for Namespace to system_test_large

### DIFF
--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -117,7 +117,7 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "long_test",  # since it takes longer than 5 minutes.
+        "system_test_large",
         "subnet_recovery",
     ],
     test_timeout = "eternal",
@@ -136,7 +136,7 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "long_test",
+        "system_test_large",
         "subnet_recovery",
     ],
     test_timeout = "eternal",
@@ -155,7 +155,7 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "long_test",
+        "system_test_large",
         "subnet_recovery",
     ],
     test_timeout = "eternal",

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -117,8 +117,8 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "system_test_large",
         "subnet_recovery",
+        "system_test_large",
     ],
     test_timeout = "eternal",
     runtime_deps = RECOVERY_TOOLS_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,
@@ -136,8 +136,8 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "system_test_large",
         "subnet_recovery",
+        "system_test_large",
     ],
     test_timeout = "eternal",
     runtime_deps = RECOVERY_TOOLS_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,
@@ -155,8 +155,8 @@ system_test_nns(
     guestos_update = "test",
     tags = [
         "colocate",
-        "system_test_large",
         "subnet_recovery",
+        "system_test_large",
     ],
     test_timeout = "eternal",
     runtime_deps = RECOVERY_TOOLS_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -142,7 +142,7 @@ system_test_nns(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + 2 Application subnets + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS,
     deps = [
@@ -165,7 +165,7 @@ system_test_nns(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + 2 Application subnets + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS,
     deps = [
@@ -184,7 +184,7 @@ system_test_nns(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + 2 Application subnets + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS,
     deps = [
@@ -257,7 +257,7 @@ system_test_nns(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (4 + 4 + 4 + 4) * DEFAULT_VCPUS_PER_VM,  # System + 2 Application subnets + unassigned nodes, 4 IC Node VMs each, 6 vCPUs each.
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS,
     deps = [

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -140,7 +140,7 @@ system_test(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + (1 + 5 * 4) * DEFAULT_VCPUS_PER_VM,  # 1 API BN + 5 subnets * 4 nodes * 6 vCPUs each
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | NNS_CANISTER_RUNTIME_DEPS,
     deps = [

--- a/rs/tests/nested/nns_recovery/BUILD.bazel
+++ b/rs/tests/nested/nns_recovery/BUILD.bazel
@@ -54,7 +54,7 @@ system_test_nns(
     env = ENV,
     guestos_update = "test",
     setupos = True,
-    tags = ["long_test"],
+    tags = ["system_test_large"],
     test_timeout = "eternal",
     runtime_deps = RUNTIME_DEPS,
     deps = [
@@ -117,7 +117,7 @@ system_test_nns(
     env = ENV,
     guestos_update = "test",
     setupos = True,
-    tags = ["long_test"],
+    tags = ["system_test_large"],
     test_timeout = "eternal",
     runtime_deps = RUNTIME_DEPS,
     deps = [
@@ -136,7 +136,7 @@ system_test_nns(
     env = ENV,
     guestos_update = "test",
     setupos = True,
-    tags = ["long_test"],
+    tags = ["system_test_large"],
     test_timeout = "eternal",
     runtime_deps = RUNTIME_DEPS,
     deps = [
@@ -155,7 +155,7 @@ system_test_nns(
     env = ENV,
     guestos_update = "test",
     setupos = True,
-    tags = ["long_test"],
+    tags = ["system_test_large"],
     test_timeout = "eternal",
     runtime_deps = RUNTIME_DEPS,
     deps = [

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -286,11 +286,6 @@ rust_binary(
 
 system_test_nns(
     name = "nns_delegation_mainnet_nns_version_test",
-    # The nodes run the mainnet GuestOS, whose replica predates
-    # `extra_api_boundary_node_trust_anchors_pem`. It therefore only trusts
-    # publicly issued API boundary node certificates, which rules out the local
-    # backend's own CA. Drop this once the field has reached mainnet.
-    backend = "farm",
     cpus = MIN_LOCAL_CPUS + 4 * DEFAULT_VCPUS_PER_VM + 1 * DEFAULT_VCPUS_PER_VM,  # 4 single-node subnets + 1 API BN, 6 vCPUs each.
     guestos = "mainnet_nns",
     guestos_update = True,

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -40,7 +40,7 @@ system_test_nns(
     backend = "farm",  # Too big for the "local" backend.
     cpus = MIN_LOCAL_CPUS + 32 * DEFAULT_VCPUS_PER_VM,  # 4 NNS + 4 App + 24 unassigned IC Node VMs * 6 vCPUs.
     tags = [
-        "long_test",
+        "system_test_large",
     ],
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | NNS_CANISTER_RUNTIME_DEPS,
     deps = [

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -38,9 +38,9 @@ system_test_nns(
 system_test_nns(
     name = "create_subnet_test",
     backend = "farm",  # Too big for the "local" backend.
-    cpus = MIN_LOCAL_CPUS + 32 * DEFAULT_VCPUS_PER_VM,  # 4 NNS + 4 App + 24 unassigned IC Node VMs * 6 vCPUs.
+    cpus = MIN_LOCAL_CPUS + 36 * DEFAULT_VCPUS_PER_VM,  # (3 original subnets * 4 nodes + 24 unassigned nodes (6 new subnets * 4 nodes per subnet)) * 6 vCPUs.
     tags = [
-        "system_test_large",
+        "nns_tests_nightly",
     ],
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | NNS_CANISTER_RUNTIME_DEPS,
     deps = [


### PR DESCRIPTION
To prepare for moving the "CI Main" workflow fully to Namespace we need to move out any system-test that's too big for Namespace's 32 CPU RBE workers. 

The following tests are moved to the "Release System Tests" job of the "Release Testing" workflow which runs on pushes to `rc--*` branches which are created from `master` every night:

* `//rs/tests/consensus/subnet_recovery:sr_app_failover_nodes_test`
* `//rs/tests/consensus/subnet_recovery:sr_app_failover_nodes_enable_chain_keys_test`
* `//rs/tests/consensus/subnet_recovery:tecdsa_signature_same_subnet_test`
* `//rs/tests/message_routing/xnet:subnet_delete_test`
* `//rs/tests/nested/nns_recovery:nr_broken_dfinity_node`
* `//rs/tests/nested/nns_recovery:nr_local`
* `//rs/tests/nested/nns_recovery:nr_no_elect_fix_like_np`
* `//rs/tests/nested/nns_recovery:nr_all_broken_seq_np_actions`
* `//rs/tests/nns:nns_delegation_mainnet_nns_version_test`

`//rs/tests/networking:nns_delegation_mainnet_nns_version_test` is now supported on the local backend.