### PR TITLE
perf(dkg): iterate over less entries, stop cloning and simplify DKG pool purging

### DIFF
--- a/rs/artifact_pool/src/dkg_pool.rs
+++ b/rs/artifact_pool/src/dkg_pool.rs
@@ -58,27 +58,11 @@ impl DkgPoolImpl {
     /// purged
     fn purge(&mut self, height: Height) -> Vec<DkgMessageId> {
         self.current_start_height = height;
-        // TODO: use drain_filter once it's stable.
-        let unvalidated_keys: Vec<_> = self
-            .unvalidated
-            .keys()
-            .filter(|id| id.height < height)
-            .cloned()
-            .collect();
-        for id in unvalidated_keys {
-            self.unvalidated.remove(&id);
-        }
+        self.unvalidated
+            .extract_keys_in(DkgMessageId::less_than_height(height));
 
-        let validated_keys: Vec<_> = self
-            .validated
-            .keys()
-            .filter(|id| id.height < height)
-            .cloned()
-            .collect();
-        for hash in &validated_keys {
-            self.validated.remove(hash);
-        }
-        validated_keys
+        self.validated
+            .extract_keys_in(DkgMessageId::less_than_height(height))
     }
 }
 

--- a/rs/artifact_pool/src/dkg_pool.rs
+++ b/rs/artifact_pool/src/dkg_pool.rs
@@ -64,7 +64,6 @@ impl DkgPoolImpl {
             .extract_keys_below(&DkgMessageId::smallest_at_height(height));
         self.validated
             .extract_keys_below(&DkgMessageId::smallest_at_height(height))
-            .collect()
     }
 }
 

--- a/rs/artifact_pool/src/dkg_pool.rs
+++ b/rs/artifact_pool/src/dkg_pool.rs
@@ -58,11 +58,13 @@ impl DkgPoolImpl {
     /// purged
     fn purge(&mut self, height: Height) -> Vec<DkgMessageId> {
         self.current_start_height = height;
-        self.unvalidated
-            .extract_keys_in(DkgMessageId::less_than_height(height));
 
+        let _ = self
+            .unvalidated
+            .extract_keys_below(&DkgMessageId::smallest_at_height(height));
         self.validated
-            .extract_keys_in(DkgMessageId::less_than_height(height))
+            .extract_keys_below(&DkgMessageId::smallest_at_height(height))
+            .collect()
     }
 }
 

--- a/rs/artifact_pool/src/pool_common.rs
+++ b/rs/artifact_pool/src/pool_common.rs
@@ -1,5 +1,5 @@
 use ic_metrics::MetricsRegistry;
-use std::{collections::BTreeMap, ops::RangeBounds};
+use std::collections::BTreeMap;
 
 use crate::metrics::PoolMetrics;
 
@@ -69,18 +69,14 @@ impl<K: Ord, V: HasLabel> PoolSection<K, V> {
         self.messages.values()
     }
 
-    /// Removes all entries inside `range` and returns their keys.
-    pub(crate) fn extract_keys_in<R>(&mut self, range: R) -> Vec<K>
-    where
-        R: RangeBounds<K>,
-    {
-        self.messages
-            .extract_if(range, |_, _| true)
-            .map(|(key, value)| {
-                self.metrics
-                    .observe_remove(MESSAGE_SIZE_BYTES, value.label());
-                key
-            })
-            .collect()
+    /// Removes all entries with keys below the given key and returns the removed keys.
+    pub(crate) fn extract_keys_below(&mut self, key: &K) -> impl Iterator<Item = K> {
+        let above_key = self.messages.split_off(key);
+        let below_key = std::mem::replace(&mut self.messages, above_key);
+
+        below_key.into_iter().map(|(k, v)| {
+            self.metrics.observe_remove(MESSAGE_SIZE_BYTES, v.label());
+            k
+        })
     }
 }

--- a/rs/artifact_pool/src/pool_common.rs
+++ b/rs/artifact_pool/src/pool_common.rs
@@ -70,13 +70,16 @@ impl<K: Ord, V: HasLabel> PoolSection<K, V> {
     }
 
     /// Removes all entries with keys below the given key and returns the removed keys.
-    pub(crate) fn extract_keys_below(&mut self, key: &K) -> impl Iterator<Item = K> {
+    pub(crate) fn extract_keys_below(&mut self, key: &K) -> Vec<K> {
         let above_key = self.messages.split_off(key);
         let below_key = std::mem::replace(&mut self.messages, above_key);
 
-        below_key.into_iter().map(|(k, v)| {
-            self.metrics.observe_remove(MESSAGE_SIZE_BYTES, v.label());
-            k
-        })
+        below_key
+            .into_iter()
+            .map(|(k, v)| {
+                self.metrics.observe_remove(MESSAGE_SIZE_BYTES, v.label());
+                k
+            })
+            .collect()
     }
 }

--- a/rs/artifact_pool/src/pool_common.rs
+++ b/rs/artifact_pool/src/pool_common.rs
@@ -1,5 +1,5 @@
 use ic_metrics::MetricsRegistry;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::RangeBounds};
 
 use crate::metrics::PoolMetrics;
 
@@ -67,5 +67,20 @@ impl<K: Ord, V: HasLabel> PoolSection<K, V> {
 
     pub(crate) fn values(&self) -> std::collections::btree_map::Values<'_, K, V> {
         self.messages.values()
+    }
+
+    /// Removes all entries inside `range` and returns their keys.
+    pub(crate) fn extract_keys_in<R>(&mut self, range: R) -> Vec<K>
+    where
+        R: RangeBounds<K>,
+    {
+        self.messages
+            .extract_if(range, |_, _| true)
+            .map(|(key, value)| {
+                self.metrics
+                    .observe_remove(MESSAGE_SIZE_BYTES, value.label());
+                key
+            })
+            .collect()
     }
 }

--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -481,12 +481,12 @@ mod tests {
             let bouncer = bouncer_factory.new_bouncer(&dkg_pool);
 
             let height_500_id = DkgMessageId {
-                hash: CryptoHash(vec![0]).into(),
                 height: Height::from(500),
+                hash: CryptoHash(vec![0]).into(),
             };
             let height_1000_id = DkgMessageId {
-                hash: CryptoHash(vec![1]).into(),
                 height: Height::from(1000),
+                hash: CryptoHash(vec![1]).into(),
             };
             assert_eq!(bouncer(&height_500_id), BouncerValue::Wants);
             assert_eq!(bouncer(&height_1000_id), BouncerValue::MaybeWantsLater);

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ic_protobuf::types::v1 as pb;
 use serde_with::serde_as;
-use std::{collections::BTreeMap, ops::RangeBounds};
+use std::collections::BTreeMap;
 
 /// Contains a Node's contribution to a DKG dealing.
 pub type Message = BasicSigned<DealingContent>;
@@ -47,10 +47,9 @@ pub struct DkgMessageId {
 }
 
 impl DkgMessageId {
-    /// Returns a range bound that includes all DKG messages with a height less than the given
-    /// height.
-    pub fn less_than_height(height: Height) -> impl RangeBounds<DkgMessageId> {
-        ..DkgMessageId {
+    /// Returns the lexicographically-smallest DkgMessageId at the given height.
+    pub fn smallest_at_height(height: Height) -> Self {
+        Self {
             height,
             // The lexicographically-smallest possible hash is an empty vector
             hash: CryptoHashOf::from(CryptoHash(vec![])),
@@ -945,6 +944,8 @@ mod tests {
 
     #[test]
     fn test_dkg_message_id_less_than_height() {
+        const TEST_HASHES: [Vec<u8>; 4] = [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]];
+
         fn message_id(height: u64, hash: &[u8]) -> DkgMessageId {
             DkgMessageId {
                 height: Height::from(height),
@@ -952,25 +953,36 @@ mod tests {
             }
         }
 
-        let range = DkgMessageId::less_than_height(Height::from(10));
+        let smallest_at_height = DkgMessageId::smallest_at_height(Height::from(10));
         for height in [0, 1, 9] {
-            for hash in [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]] {
-                let id = message_id(height, &hash);
-                assert!(range.contains(&id), "expected {id:?} to be in range");
+            for hash in &TEST_HASHES {
+                let id = message_id(height, hash);
+                assert!(
+                    id < smallest_at_height,
+                    "expected {id:?} to be less than smallest_at_height"
+                );
             }
         }
         for height in [10, 11, u64::MAX] {
-            for hash in [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]] {
-                let id = message_id(height, &hash);
-                assert!(!range.contains(&id), "expected {id:?} to be out of range");
+            for hash in &TEST_HASHES {
+                let id = message_id(height, hash);
+                assert!(
+                    smallest_at_height <= id,
+                    "expected {id:?} to be greater than or equal to smallest_at_height"
+                );
             }
         }
 
         // Edge-case: height is 0
-        let range = DkgMessageId::less_than_height(Height::from(0));
-        for hash in [vec![], vec![0], vec![u8::MAX; 32]] {
-            let id = message_id(0, &hash);
-            assert!(!range.contains(&id), "expected {id:?} to be out of range");
+        let smallest_at_height = DkgMessageId::smallest_at_height(Height::from(0));
+        for height in [0, 1, u64::MAX] {
+            for hash in &TEST_HASHES {
+                let id = message_id(height, hash);
+                assert!(
+                    smallest_at_height <= id,
+                    "expected {id:?} to be greater than or equal to smallest_at_height"
+                );
+            }
         }
     }
 }

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -944,7 +944,7 @@ mod tests {
 
     #[test]
     fn test_dkg_message_id_less_than_height() {
-        const TEST_HASHES: [Vec<u8>; 4] = [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]];
+        const TEST_HASHES: [&[u8]; 4] = [&[], &[0], &[42; 32], &[u8::MAX; 32]];
 
         fn message_id(height: u64, hash: &[u8]) -> DkgMessageId {
             DkgMessageId {
@@ -955,7 +955,7 @@ mod tests {
 
         let smallest_at_height = DkgMessageId::smallest_at_height(Height::from(10));
         for height in [0, 1, 9] {
-            for hash in &TEST_HASHES {
+            for hash in TEST_HASHES {
                 let id = message_id(height, hash);
                 assert!(
                     id < smallest_at_height,
@@ -964,7 +964,7 @@ mod tests {
             }
         }
         for height in [10, 11, u64::MAX] {
-            for hash in &TEST_HASHES {
+            for hash in TEST_HASHES {
                 let id = message_id(height, hash);
                 assert!(
                     smallest_at_height <= id,
@@ -976,7 +976,7 @@ mod tests {
         // Edge-case: height is 0
         let smallest_at_height = DkgMessageId::smallest_at_height(Height::from(0));
         for height in [0, 1, u64::MAX] {
-            for hash in &TEST_HASHES {
+            for hash in TEST_HASHES {
                 let id = message_id(height, hash);
                 assert!(
                     smallest_at_height <= id,

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ic_protobuf::types::v1 as pb;
 use serde_with::serde_as;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::RangeBounds};
 
 /// Contains a Node's contribution to a DKG dealing.
 pub type Message = BasicSigned<DealingContent>;
@@ -42,15 +42,27 @@ impl PbArtifact for Message {
 /// Identifier of a DKG message.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct DkgMessageId {
-    pub hash: CryptoHashOf<Message>,
     pub height: Height,
+    pub hash: CryptoHashOf<Message>,
+}
+
+impl DkgMessageId {
+    /// Returns a range bound that includes all DKG messages with a height less than the given
+    /// height.
+    pub fn less_than_height(height: Height) -> impl RangeBounds<DkgMessageId> {
+        ..DkgMessageId {
+            height,
+            // The lexicographically-smallest possible hash is an empty vector
+            hash: CryptoHashOf::from(CryptoHash(vec![])),
+        }
+    }
 }
 
 impl From<&Message> for DkgMessageId {
     fn from(msg: &Message) -> Self {
         Self {
-            hash: crypto_hash(msg),
             height: msg.content.dkg_id.start_block_height,
+            hash: crypto_hash(msg),
         }
     }
 }
@@ -58,8 +70,8 @@ impl From<&Message> for DkgMessageId {
 impl From<DkgMessageId> for pb::DkgMessageId {
     fn from(id: DkgMessageId) -> Self {
         Self {
-            hash: id.hash.clone().get().0,
             height: id.height.get(),
+            hash: id.hash.clone().get().0,
         }
     }
 }
@@ -69,8 +81,8 @@ impl TryFrom<pb::DkgMessageId> for DkgMessageId {
 
     fn try_from(id: pb::DkgMessageId) -> Result<Self, Self::Error> {
         Ok(Self {
-            hash: CryptoHash(id.hash.clone()).into(),
             height: Height::from(id.height),
+            hash: CryptoHash(id.hash.clone()).into(),
         })
     }
 }
@@ -929,5 +941,36 @@ mod tests {
         assert_eq!(get_faults_tolerated(7), 2);
         assert_eq!(get_faults_tolerated(28), 9);
         assert_eq!(get_faults_tolerated(64), 21);
+    }
+
+    #[test]
+    fn test_dkg_message_id_less_than_height() {
+        fn message_id(height: u64, hash: &[u8]) -> DkgMessageId {
+            DkgMessageId {
+                height: Height::from(height),
+                hash: CryptoHashOf::from(CryptoHash(hash.to_vec())),
+            }
+        }
+
+        let range = DkgMessageId::less_than_height(Height::from(10));
+        for height in [0, 1, 9] {
+            for hash in [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]] {
+                let id = message_id(height, &hash);
+                assert!(range.contains(&id), "expected {id:?} to be in range");
+            }
+        }
+        for height in [10, 11, u64::MAX] {
+            for hash in [vec![], vec![0], vec![42; 32], vec![u8::MAX; 32]] {
+                let id = message_id(height, &hash);
+                assert!(!range.contains(&id), "expected {id:?} to be out of range");
+            }
+        }
+
+        // Edge-case: height is 0
+        let range = DkgMessageId::less_than_height(Height::from(0));
+        for hash in [vec![], vec![0], vec![u8::MAX; 32]] {
+            let id = message_id(0, &hash);
+            assert!(!range.contains(&id), "expected {id:?} to be out of range");
+        }
     }
 }


### PR DESCRIPTION
Index the DKG pool by height first, such that purging below a certain height is done more efficiently: iterate over less entries (only ones below the given height) and stop cloning.