### PR TITLE
feat(cketh): deposit_eth endpoint deriving the caller's deposit address

### DIFF
--- a/rs/ethereum/cketh/docs/deposit_from_cex.md
+++ b/rs/ethereum/cketh/docs/deposit_from_cex.md
@@ -1208,8 +1208,7 @@ the minter can `sign_with_ecdsa` for it under the same `path`. The paths are
 master key (+ root chain code)
 ├── []                            → minter main address      (MAIN_DERIVATION_PATH; withdrawals, R6 destination)
 ├── [1, principal, subaccount]    → deposit address, one per IC account (ERC-20 and, Phase 2, ETH)
-├── [2, principal, subaccount]    → reserved (CKETH_DEPOSIT_SCHEMA_TAG; the discarded per-asset ETH address — defined in code, never derived)
-└── [3]                           → dedicated sweeper address (R17; its own schema tag, no account components)
+└── [3]                           → dedicated sweeper address (R17; its own schema tag, no account components; tag 2, once planned for a per-asset ETH address, was never used)
 ```
 
 A deposit EOA is **not** derived beneath the sweeper. Tree position carries no

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -409,6 +409,23 @@ type WithdrawalError = variant {
     TemporarilyUnavailable : text;
 };
 
+// Argument for the deposit_eth endpoint.
+type DepositEthArg = record {
+    mode : DepositMode;
+};
+
+// Response of the deposit_eth endpoint.
+type DepositEthResponse = record {
+    // The Ethereum deposit address derived for the caller. It is the same address as the one
+    // derived by the deposit_erc20 endpoint for the same account, whatever the ERC-20 token.
+    address : text;
+};
+
+type DepositEthError = variant {
+    // The minter is temporarily unavailable, retry the request.
+    TemporarilyUnavailable : text;
+};
+
 // Argument for the deposit_erc20 endpoint.
 type DepositErc20Arg = record {
     // The Ethereum ERC-20 contract address of the token to deposit (e.g. USDC).
@@ -949,6 +966,12 @@ service : (MinterArg) -> {
     // (nanoseconds since the Unix epoch) until which a deposit to it is guaranteed to be noticed,
     // and the minimum balance of the requested token the address must hold to be noticed.
     deposit_erc20 : (DepositErc20Arg) -> (variant { Ok : DepositErc20Response; Err : DepositErc20Error });
+
+    // Derive the ETH deposit address for the caller.
+    // The account is derived from the caller's principal and the subaccount in the argument.
+    // Returns the EIP-55 checksummed deposit address, which is the same address as the one
+    // derived by deposit_erc20 for the same account, whatever the ERC-20 token.
+    deposit_eth : (DepositEthArg) -> (variant { Ok : DepositEthResponse; Err : DepositEthError });
 
     // Retrieve the status of a Eth withdrawal request.
     retrieve_eth_status : (nat64) -> (RetrieveEthStatus);

--- a/rs/ethereum/cketh/minter/src/attestation/mod.rs
+++ b/rs/ethereum/cketh/minter/src/attestation/mod.rs
@@ -10,7 +10,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
+use crate::deposit_address::AddressSchema;
 use crate::eth_logs::encode_principal;
 use crate::eth_rpc::Hash;
 use crate::runtime::CanisterRuntime;
@@ -70,7 +70,7 @@ impl AttestationRequest {
     }
 
     pub fn derivation_path(&self) -> Vec<ByteBuf> {
-        deposit_derivation_path(DepositAddressSchema::CkErc20, &self.account)
+        AddressSchema::Deposit(self.account).derivation_path()
     }
 
     /// `"ck-deposit-owner" || chain_id || deposit_helper || principal || subaccount`, exactly what

--- a/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
@@ -47,8 +47,8 @@ impl FromStr for DepositAddress {
 
 /// Family of Ethereum addresses the minter derives from its master threshold-ECDSA public key,
 /// each owning the derivation path its addresses are derived under. The leading tag byte keeps
-/// the families collision-free and must never change or be reused: tag `2`, once planned for a
-/// separate ckETH deposit family, is retired since ETH and ckERC20 deposits share one address.
+/// the families collision-free and must never change once used; tag `2`, initially planned for a
+/// separate ckETH deposit family, was never used since ETH and ckERC20 deposits share one address.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum AddressSchema {
     /// The deposit address of an IC account, shared by ETH and ckERC20 deposits.

--- a/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/mod.rs
@@ -45,58 +45,56 @@ impl FromStr for DepositAddress {
     }
 }
 
-const CKERC20_DEPOSIT_SCHEMA_TAG: u8 = 1;
-const CKETH_DEPOSIT_SCHEMA_TAG: u8 = 2;
-const SWEEPER_SCHEMA_TAG: u8 = 3;
-
-/// Schema tag distinguishing the families of per-account deposit addresses
-/// derived by the minter.
+/// Family of Ethereum addresses the minter derives from its master threshold-ECDSA public key,
+/// each owning the derivation path its addresses are derived under. The leading tag byte keeps
+/// the families collision-free and must never change or be reused: tag `2`, once planned for a
+/// separate ckETH deposit family, is retired since ETH and ckERC20 deposits share one address.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub enum DepositAddressSchema {
-    CkErc20,
-    CkEth,
+pub enum AddressSchema {
+    /// The deposit address of an IC account, shared by ETH and ckERC20 deposits.
+    Deposit(Account),
+    /// The minter's dedicated sweeper address.
+    Sweeper,
 }
 
-impl DepositAddressSchema {
-    fn tag(self) -> u8 {
+impl AddressSchema {
+    pub fn derivation_path(&self) -> Vec<ByteBuf> {
+        const DEPOSIT_SCHEMA_TAG: u8 = 1;
+        const SWEEPER_SCHEMA_TAG: u8 = 3;
+
         match self {
-            DepositAddressSchema::CkErc20 => CKERC20_DEPOSIT_SCHEMA_TAG,
-            DepositAddressSchema::CkEth => CKETH_DEPOSIT_SCHEMA_TAG,
+            AddressSchema::Deposit(account) => vec![
+                ByteBuf::from(vec![DEPOSIT_SCHEMA_TAG]),
+                ByteBuf::from(account.owner.as_slice().to_vec()),
+                ByteBuf::from(account.effective_subaccount().to_vec()),
+            ],
+            AddressSchema::Sweeper => vec![ByteBuf::from(vec![SWEEPER_SCHEMA_TAG])],
         }
     }
 }
 
-/// Derive the deposit address of an IC account for the given schema from the
-/// minter's master threshold-ECDSA public key.
+/// Derive the deposit address of an IC account from the minter's master
+/// threshold-ECDSA public key.
 pub fn deposit_address(
     master_public_key: &PublicKey,
     chain_code: &[u8; 32],
-    schema: DepositAddressSchema,
     account: &Account,
 ) -> DepositAddress {
     DepositAddress::new(derive_address(
         master_public_key,
         chain_code,
-        deposit_derivation_path(schema, account),
+        AddressSchema::Deposit(*account).derivation_path(),
     ))
 }
 
 /// Derive the minter's dedicated sweeper address from its master
 /// threshold-ECDSA public key.
 pub fn sweeper_address(master_public_key: &PublicKey, chain_code: &[u8; 32]) -> Address {
-    derive_address(master_public_key, chain_code, sweeper_derivation_path())
-}
-
-pub fn deposit_derivation_path(schema: DepositAddressSchema, account: &Account) -> Vec<ByteBuf> {
-    vec![
-        ByteBuf::from(vec![schema.tag()]),
-        ByteBuf::from(account.owner.as_slice().to_vec()),
-        ByteBuf::from(account.effective_subaccount().to_vec()),
-    ]
-}
-
-pub(crate) fn sweeper_derivation_path() -> Vec<ByteBuf> {
-    vec![ByteBuf::from(vec![SWEEPER_SCHEMA_TAG])]
+    derive_address(
+        master_public_key,
+        chain_code,
+        AddressSchema::Sweeper.derivation_path(),
+    )
 }
 
 fn derive_address(

--- a/rs/ethereum/cketh/minter/src/deposit_address/tests.rs
+++ b/rs/ethereum/cketh/minter/src/deposit_address/tests.rs
@@ -1,5 +1,5 @@
 use crate::address::ecdsa_public_key_to_address;
-use crate::deposit_address::{DepositAddressSchema, deposit_address, sweeper_address};
+use crate::deposit_address::{deposit_address, sweeper_address};
 use crate::test_fixtures::arb::arb_principal;
 use candid::Principal;
 use ic_secp256k1::{PrivateKey, PublicKey};
@@ -19,14 +19,12 @@ proptest! {
     ) {
         let (pk, cc) = master_key();
 
-        for schema in [DepositAddressSchema::CkErc20, DepositAddressSchema::CkEth] {
-            let addresses: BTreeSet<_> = owners
-                .iter()
-                .map(|owner| deposit_address(&pk, &cc, schema, &account(*owner, subaccount)))
-                .collect();
+        let addresses: BTreeSet<_> = owners
+            .iter()
+            .map(|owner| deposit_address(&pk, &cc, &account(*owner, subaccount)))
+            .collect();
 
-            prop_assert_eq!(addresses.len(), owners.len());
-        }
+        prop_assert_eq!(addresses.len(), owners.len());
     }
 
     #[test]
@@ -36,14 +34,12 @@ proptest! {
     ) {
         let (pk, cc) = master_key();
 
-        for schema in [DepositAddressSchema::CkErc20, DepositAddressSchema::CkEth] {
-            let addresses: BTreeSet<_> = subaccounts
-                .iter()
-                .map(|subaccount| deposit_address(&pk, &cc, schema, &account(owner, Some(*subaccount))))
-                .collect();
+        let addresses: BTreeSet<_> = subaccounts
+            .iter()
+            .map(|subaccount| deposit_address(&pk, &cc, &account(owner, Some(*subaccount))))
+            .collect();
 
-            prop_assert_eq!(addresses.len(), subaccounts.len());
-        }
+        prop_assert_eq!(addresses.len(), subaccounts.len());
     }
 
     #[test]
@@ -54,27 +50,11 @@ proptest! {
         let (pk, cc) = master_key();
         let main_address = ecdsa_public_key_to_address(&pk);
         let sweeper = sweeper_address(&pk, &cc);
-        let account = account(owner, subaccount);
 
-        for schema in [DepositAddressSchema::CkErc20, DepositAddressSchema::CkEth] {
-            let deposit = deposit_address(&pk, &cc, schema, &account);
-            prop_assert_ne!(deposit.as_address(), &main_address);
-            prop_assert_ne!(deposit.as_address(), &sweeper);
-        }
-    }
+        let deposit = deposit_address(&pk, &cc, &account(owner, subaccount));
 
-    #[test]
-    fn should_derive_distinct_addresses_for_distinct_schemas(
-        owner in arb_principal(),
-        subaccount in option::of(uniform32(any::<u8>())),
-    ) {
-        let (pk, cc) = master_key();
-        let account = account(owner, subaccount);
-
-        let ckerc20 = deposit_address(&pk, &cc, DepositAddressSchema::CkErc20, &account);
-        let cketh = deposit_address(&pk, &cc, DepositAddressSchema::CkEth, &account);
-
-        prop_assert_ne!(ckerc20, cketh);
+        prop_assert_ne!(deposit.as_address(), &main_address);
+        prop_assert_ne!(deposit.as_address(), &sweeper);
     }
 }
 
@@ -87,43 +67,17 @@ fn should_derive_stable_addresses() {
     let mut s2 = [0_u8; 32];
     s2[31] = 1;
 
-    // (owner, subaccount, expected ckERC20 address, expected ckETH address)
     let cases = [
-        (
-            p1,
-            s1,
-            "0xD89FE581Db8Dbcb45736c5A9d6abdBE78913bD89",
-            "0xBdB75DE85a7E7221525180d559F57FdE80a3709f",
-        ),
-        (
-            p1,
-            s2,
-            "0xB4fB9b1fA6820deF3E4417a074497000F58ef167",
-            "0x8c08A03915F5E15AC41381500219100f92d8e4d5",
-        ),
-        (
-            p2,
-            s1,
-            "0x98c8C7b65485928e6cffDAA806a8eE27Cf1fF39C",
-            "0xE9400F21Ef90d541A605725114F59037919E05b7",
-        ),
-        (
-            p2,
-            s2,
-            "0x5D396800716451E5202Fb935e436Ab82aCe52881",
-            "0x7513b3849F4B53301f620487cD5304240A5E963d",
-        ),
+        (p1, s1, "0xD89FE581Db8Dbcb45736c5A9d6abdBE78913bD89"),
+        (p1, s2, "0xB4fB9b1fA6820deF3E4417a074497000F58ef167"),
+        (p2, s1, "0x98c8C7b65485928e6cffDAA806a8eE27Cf1fF39C"),
+        (p2, s2, "0x5D396800716451E5202Fb935e436Ab82aCe52881"),
     ];
 
-    for (owner, subaccount, expected_ckerc20, expected_cketh) in cases {
-        let account = account(owner, Some(subaccount));
+    for (owner, subaccount, expected) in cases {
         assert_eq!(
-            deposit_address(&pk, &cc, DepositAddressSchema::CkErc20, &account).to_string(),
-            expected_ckerc20
-        );
-        assert_eq!(
-            deposit_address(&pk, &cc, DepositAddressSchema::CkEth, &account).to_string(),
-            expected_cketh
+            deposit_address(&pk, &cc, &account(owner, Some(subaccount))).to_string(),
+            expected
         );
     }
 }
@@ -143,9 +97,7 @@ fn account(owner: Principal, subaccount: Option<Subaccount>) -> Account {
 }
 
 mod derive_public_key {
-    use crate::deposit_address::{
-        DepositAddressSchema, deposit_address, derive_public_key, sweeper_derivation_path,
-    };
+    use crate::deposit_address::{AddressSchema, deposit_address, derive_public_key};
     use crate::{MAIN_DERIVATION_PATH, address::ecdsa_public_key_to_address};
     use candid::Principal;
     use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
@@ -159,15 +111,13 @@ mod derive_public_key {
         let master = master_private_key().public_key();
         let account = account();
 
-        for schema in [DepositAddressSchema::CkErc20, DepositAddressSchema::CkEth] {
-            let path = super::super::deposit_derivation_path(schema, &account);
-            let derived = derive_public_key(&master, &CHAIN_CODE, &path);
+        let path = AddressSchema::Deposit(account).derivation_path();
+        let derived = derive_public_key(&master, &CHAIN_CODE, &path);
 
-            assert_eq!(
-                &ecdsa_public_key_to_address(&derived),
-                deposit_address(&master, &CHAIN_CODE, schema, &account).as_address()
-            );
-        }
+        assert_eq!(
+            &ecdsa_public_key_to_address(&derived),
+            deposit_address(&master, &CHAIN_CODE, &account).as_address()
+        );
     }
 
     #[test]
@@ -189,8 +139,8 @@ mod derive_public_key {
         let digest = [0x42_u8; 32];
 
         for path in [
-            super::super::deposit_derivation_path(DepositAddressSchema::CkErc20, &account()),
-            sweeper_derivation_path(),
+            AddressSchema::Deposit(account()).derivation_path(),
+            AddressSchema::Sweeper.derivation_path(),
         ] {
             let (signing_key, _chain_code) =
                 master.derive_subkey_with_chain_code(&to_derivation_path(&path), &CHAIN_CODE);

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -292,6 +292,25 @@ pub struct DetectedDeposit {
     pub detected_at_block: Nat,
 }
 
+/// Argument for the `deposit_eth` endpoint.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DepositEthArg {
+    pub mode: DepositMode,
+}
+
+/// Response of the `deposit_eth` endpoint.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DepositEthResponse {
+    /// The Ethereum deposit address derived for the caller.
+    pub address: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum DepositEthError {
+    /// The minter is temporarily unavailable, retry the request.
+    TemporarilyUnavailable(String),
+}
+
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum DepositErc20Error {
     /// The `erc20_contract_address` is not a ckERC20 token supported by the minter.

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -14,10 +14,10 @@ use ic_cketh_minter::endpoints::events::{
 };
 use ic_cketh_minter::endpoints::{
     AddCkErc20Token, DecodeLedgerMemoArgs, DecodeLedgerMemoResult, DepositErc20Arg,
-    DepositErc20Error, DepositErc20Response, DepositMode, Eip1559TransactionPrice,
-    Eip1559TransactionPriceArg, Erc20Balance, Erc20MinimumDeposit, GasFeeEstimate, MinterInfo,
-    RetrieveEthRequest, RetrieveEthStatus, WithdrawalArg, WithdrawalDetail, WithdrawalError,
-    WithdrawalSearchParameter,
+    DepositErc20Error, DepositErc20Response, DepositEthArg, DepositEthError, DepositEthResponse,
+    DepositMode, Eip1559TransactionPrice, Eip1559TransactionPriceArg, Erc20Balance,
+    Erc20MinimumDeposit, GasFeeEstimate, MinterInfo, RetrieveEthRequest, RetrieveEthStatus,
+    WithdrawalArg, WithdrawalDetail, WithdrawalError, WithdrawalSearchParameter,
 };
 use ic_cketh_minter::erc20::CkTokenSymbol;
 use ic_cketh_minter::eth_logs::{
@@ -200,6 +200,25 @@ async fn minter_address() -> String {
     state::minter_address(&IC_CANISTER_RUNTIME)
         .await
         .to_string()
+}
+
+#[update]
+async fn deposit_eth(arg: DepositEthArg) -> Result<DepositEthResponse, DepositEthError> {
+    let caller = validate_caller_not_anonymous();
+    let DepositMode::Unsponsored { subaccount } = arg.mode;
+    let account = Account {
+        owner: caller,
+        subaccount,
+    };
+    state::lazy_call_ecdsa_public_key_with_chain_code(&IC_CANISTER_RUNTIME).await;
+    let address = read_state(|s| s.deposit_address(&account)).ok_or_else(|| {
+        DepositEthError::TemporarilyUnavailable(
+            "Minter's ECDSA public key not yet initialized".to_string(),
+        )
+    })?;
+    Ok(DepositEthResponse {
+        address: address.to_string(),
+    })
 }
 
 #[update]

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -1,6 +1,8 @@
 use crate::address::ecdsa_public_key_to_address;
 use crate::attestation::AttestationRequest;
-use crate::deposit_address::{DepositAddressSchema, deposit_address, sweeper_address};
+use crate::deposit_address::{
+    DepositAddress, DepositAddressSchema, deposit_address, sweeper_address,
+};
 use crate::endpoints::{CandidBlockTag, DepositErc20Error};
 use crate::erc20::{CkErc20Token, CkTokenSymbol};
 use crate::eth_logs::{EventSource, ReceivedEvent};
@@ -260,6 +262,18 @@ impl State {
     pub fn sweeper_address(&self) -> Option<Address> {
         let (master_public_key, chain_code) = self.public_key_and_chain_code()?;
         Some(sweeper_address(&master_public_key, &chain_code))
+    }
+
+    /// The deposit address derived for `account`, shared by ETH and ckERC20 deposits, or `None`
+    /// while the master public key is still unknown.
+    pub fn deposit_address(&self, account: &Account) -> Option<DepositAddress> {
+        let (master_public_key, chain_code) = self.public_key_and_chain_code()?;
+        Some(deposit_address(
+            &master_public_key,
+            &chain_code,
+            DepositAddressSchema::CkErc20,
+            account,
+        ))
     }
 
     /// What a ckERC20 deposit address must attest to in order to be swept: the account it credits,
@@ -847,17 +861,11 @@ impl State {
         account: Account,
         token: Address,
     ) -> Result<Entry<ScanProgress>, DepositErc20Error> {
-        let (master_public_key, chain_code) =
-            self.public_key_and_chain_code()
+        let address =
+            self.deposit_address(&account)
                 .ok_or(DepositErc20Error::TemporarilyUnavailable(
                     "Minter's ECDSA public key not yet initialized".to_string(),
                 ))?;
-        let address = deposit_address(
-            &master_public_key,
-            &chain_code,
-            DepositAddressSchema::CkErc20,
-            &account,
-        );
         self.automatic_deposits
             .watch_deposit(now, account, token, address)
     }

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -1,8 +1,6 @@
 use crate::address::ecdsa_public_key_to_address;
 use crate::attestation::AttestationRequest;
-use crate::deposit_address::{
-    DepositAddress, DepositAddressSchema, deposit_address, sweeper_address,
-};
+use crate::deposit_address::{DepositAddress, deposit_address, sweeper_address};
 use crate::endpoints::{CandidBlockTag, DepositErc20Error};
 use crate::erc20::{CkErc20Token, CkTokenSymbol};
 use crate::eth_logs::{EventSource, ReceivedEvent};
@@ -268,12 +266,7 @@ impl State {
     /// while the master public key is still unknown.
     pub fn deposit_address(&self, account: &Account) -> Option<DepositAddress> {
         let (master_public_key, chain_code) = self.public_key_and_chain_code()?;
-        Some(deposit_address(
-            &master_public_key,
-            &chain_code,
-            DepositAddressSchema::CkErc20,
-            account,
-        ))
+        Some(deposit_address(&master_public_key, &chain_code, account))
     }
 
     /// What a ckERC20 deposit address must attest to in order to be swept: the account it credits,

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::sweeper_contract::SweepItem;
 use crate::{
-    deposit_address::sweeper_derivation_path,
+    deposit_address::AddressSchema,
     guard::TimerGuard,
     logs::{DEBUG, INFO},
     numeric::TransactionCount,
@@ -428,7 +428,7 @@ async fn sign_transactions_batch<R: CanisterRuntime>(runtime: &R) {
             .map(|(sweep_id, tx)| async move {
                 (
                     sweep_id,
-                    crate::tx::sign(tx, sweeper_derivation_path(), runtime).await,
+                    crate::tx::sign(tx, AddressSchema::Sweeper.derivation_path(), runtime).await,
                 )
             }),
     )

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,5 +1,5 @@
 use crate::attestation::AttestationRequest;
-use crate::deposit_address::{DepositAddressSchema, deposit_derivation_path};
+use crate::deposit_address::AddressSchema;
 use crate::management::{CallError, Reason};
 use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
@@ -382,7 +382,8 @@ fn authorization_digest(delegate: Address) -> [u8; 32] {
 }
 
 fn derivation_path_bytes() -> Vec<Vec<u8>> {
-    deposit_derivation_path(DepositAddressSchema::CkErc20, &account())
+    AddressSchema::Deposit(account())
+        .derivation_path()
         .into_iter()
         .map(|index| index.into_vec())
         .collect()

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -2,7 +2,7 @@ use super::{
     AccessList, SignableTransaction, Signed, TransactionPrice, TransactionSignature, encode_u256,
 };
 use crate::{
-    deposit_address::{DepositAddressSchema, deposit_derivation_path},
+    deposit_address::AddressSchema,
     eth_rpc::Hash,
     numeric::{GasAmount, TransactionNonce, Wei, WeiPerGas},
 };
@@ -90,7 +90,7 @@ impl AuthorizationRequest {
     }
 
     pub fn derivation_path(&self) -> Vec<ByteBuf> {
-        deposit_derivation_path(DepositAddressSchema::CkErc20, &self.account)
+        AddressSchema::Deposit(self.account).derivation_path()
     }
 
     pub fn authorization(&self) -> Authorization {

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -145,6 +145,55 @@ fn should_mint_with_ckerc20_setup() {
         .expect_mint();
 }
 
+mod deposit_eth {
+    use candid::Principal;
+    use ic_cketh_test_utils::ckerc20::{CkErc20Setup, ckwbtc};
+    use ic_cketh_test_utils::{DEFAULT_USER_SUBACCOUNT, format_ethereum_address_to_eip_55};
+
+    #[test]
+    fn should_derive_same_address_as_deposit_erc20() {
+        let mut ckerc20 = CkErc20Setup::default()
+            .add_supported_erc20_tokens()
+            .add_supported_erc20_token(ckwbtc());
+        let caller = ckerc20.caller();
+        let tokens: Vec<String> = ckerc20
+            .supported_erc20_tokens
+            .iter()
+            .map(|token| format_ethereum_address_to_eip_55(&token.contract.address))
+            .collect();
+        assert!(
+            tokens.len() > 1,
+            "BUG: need several tokens to show the address does not depend on the token"
+        );
+
+        for subaccount in [None, Some(DEFAULT_USER_SUBACCOUNT)] {
+            let (setup, eth_response) = ckerc20
+                .call_minter_deposit_eth(caller, subaccount)
+                .expect_deposit_response();
+            ckerc20 = setup;
+
+            for token in &tokens {
+                let (setup, erc20_response) = ckerc20
+                    .call_minter_deposit_erc20(caller, subaccount, token.clone())
+                    .expect_deposit_response();
+                ckerc20 = setup;
+
+                assert_eq!(
+                    eth_response.address, erc20_response.address,
+                    "BUG: deposit_eth and deposit_erc20 disagree for token {token} and subaccount {subaccount:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_trap_when_caller_anonymous() {
+        CkErc20Setup::default()
+            .call_minter_deposit_eth(Principal::anonymous(), None)
+            .expect_trap("anonymous");
+    }
+}
+
 mod deposit_erc20 {
     use assert_matches::assert_matches;
     use candid::{Nat, Principal};

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -24,7 +24,8 @@ use ic_cketh_minter::endpoints::ckerc20::{
 };
 use ic_cketh_minter::endpoints::events::{EventPayload, EventSource};
 use ic_cketh_minter::endpoints::{
-    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode, MinterInfo,
+    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositEthArg,
+    DepositEthError, DepositEthResponse, DepositMode, MinterInfo,
 };
 use ic_cketh_minter::numeric::{BlockNumber, Erc20Value};
 use ic_cketh_minter::{
@@ -406,6 +407,29 @@ impl CkErc20Setup {
             )
             .expect("failed to submit withdraw_erc20 call");
         RefreshGasFeeEstimate {
+            setup: self,
+            message_id,
+        }
+    }
+
+    pub fn call_minter_deposit_eth(
+        self,
+        from: Principal,
+        subaccount: Option<[u8; 32]>,
+    ) -> DepositEthFlow {
+        let arg = DepositEthArg {
+            mode: DepositMode::Unsponsored { subaccount },
+        };
+        let message_id = self
+            .env
+            .submit_call(
+                self.cketh.minter_id,
+                from,
+                "deposit_eth",
+                Encode!(&arg).expect("failed to encode deposit_eth args"),
+            )
+            .expect("failed to submit deposit_eth call");
+        DepositEthFlow {
             setup: self,
             message_id,
         }
@@ -1056,6 +1080,29 @@ impl Erc20WithdrawalFlow {
             Result<RetrieveErc20Request, WithdrawErc20Error>
         )
         .unwrap()
+    }
+}
+
+pub struct DepositEthFlow {
+    pub setup: CkErc20Setup,
+    pub message_id: RawMessageId,
+}
+
+impl DepositEthFlow {
+    pub fn expect_trap(self, error_substring: &str) -> CkErc20Setup {
+        let result = self.setup.env.await_call(self.message_id.clone());
+        assert_matches!(result, Err(e) if e.error_code == ErrorCode::CanisterCalledTrap && e.reject_message.contains(error_substring));
+        self.setup
+    }
+
+    pub fn expect_deposit_response(self) -> (CkErc20Setup, DepositEthResponse) {
+        let response = Decode!(
+            &assert_reply(self.setup.env.await_call(self.message_id.clone())),
+            Result<DepositEthResponse, DepositEthError>
+        )
+        .unwrap()
+        .expect("BUG: unexpected error from minter during deposit_eth");
+        (self.setup, response)
     }
 }
 


### PR DESCRIPTION
Skeleton of the ETH counterpart of `deposit_erc20`: the new `deposit_eth` endpoint only derives the deposit address for the caller's account (principal and subaccount), using the same derivation as `deposit_erc20`, so both endpoints hand out the same address whatever the ERC-20 token. Registration for balance scanning and sweeping come in later tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9