### PR TITLE
feat: Do not execute canister messages nor queries while cooling down

### DIFF
--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -2712,16 +2712,7 @@ fn ingress_message_to_cooling_down_subnet_is_rejected() {
     test.should_accept_ingress_message(canister, "update", vec![])
         .unwrap();
 
-    let own_subnet_id = test.state().metadata.own_subnet_id;
-    test.state_mut()
-        .metadata
-        .modify_network_topology(|network_topology| {
-            network_topology
-                .subnets_mut()
-                .get_mut(&own_subnet_id)
-                .unwrap()
-                .cooling_down = true;
-        });
+    test.set_cooling_down(true);
 
     // Both canister-addressed and subnet-addressed messages are now rejected.
     let err = test

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -182,7 +182,8 @@ impl InternalHttpQueryHandler {
 
         // While the subnet is cooling down it rejects all query calls, the ones
         // addressed to the management canister included. System queries, i.e. the
-        // `transform` functions of HTTP outcalls, are still executed.
+        // `transform` functions of HTTP outcalls, are still executed, because subnet
+        // messages are still executed by a cooling down subnet.
         if matches!(query.source, QuerySource::User { .. })
             && state.get_ref().metadata.is_cooling_down()
         {

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -180,14 +180,9 @@ impl InternalHttpQueryHandler {
     ) -> Result<WasmResult, UserError> {
         let measurement_scope = MeasurementScope::root(&self.metrics.query);
 
-        // While the subnet is cooling down its canisters execute no messages, so the
-        // state that a query would be evaluated against is frozen; and the subnet may
-        // be about to hand over its canisters altogether. It therefore rejects all
-        // query calls, the ones addressed to the management canister included.
-        //
-        // System queries (i.e. the `transform` functions of in-flight HTTP outcalls)
-        // are still executed, so that the outcalls the subnet has already made can be
-        // responded to while it is draining its subnet queues.
+        // While the subnet is cooling down it rejects all query calls, the ones
+        // addressed to the management canister included. System queries, i.e. the
+        // `transform` functions of HTTP outcalls, are still executed.
         if matches!(query.source, QuerySource::User { .. })
             && state.get_ref().metadata.is_cooling_down()
         {

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -178,6 +178,8 @@ impl InternalHttpQueryHandler {
         instruction_observation: Option<Arc<AtomicU64>>,
         max_instructions: Option<NumInstructions>,
     ) -> Result<WasmResult, UserError> {
+        let measurement_scope = MeasurementScope::root(&self.metrics.query);
+
         // While the subnet is cooling down its canisters execute no messages, so the
         // state that a query would be evaluated against is frozen; and the subnet may
         // be about to hand over its canisters altogether. It therefore rejects all
@@ -197,8 +199,6 @@ impl InternalHttpQueryHandler {
                 ),
             ));
         }
-
-        let measurement_scope = MeasurementScope::root(&self.metrics.query);
 
         // Serve the query locally if it is addressed to the management canister.
         if query.receiver == CanisterId::ic_00() {

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -19,7 +19,7 @@ use ic_config::execution_environment::Config;
 use ic_config::flag_status::FlagStatus;
 use ic_crypto_tree_hash::{Label, LabeledTree, LabeledTree::SubTree, flatmap};
 use ic_cycles_account_manager::CyclesAccountManager;
-use ic_error_types::UserError;
+use ic_error_types::{ErrorCode, UserError};
 use ic_interfaces::execution_environment::{
     QueryExecutionError, QueryExecutionInput, QueryExecutionResponse, QueryExecutionService,
     TransformExecutionInput, TransformExecutionService,
@@ -36,7 +36,7 @@ use ic_types::messages::CertificateDelegationMetadata;
 use ic_types::{
     CanisterId, NumInstructions,
     ingress::WasmResult,
-    messages::{Blob, Certificate, CertificateDelegation, Query},
+    messages::{Blob, Certificate, CertificateDelegation, Query, QuerySource},
 };
 use prometheus::{Histogram, histogram_opts, labels};
 use serde::Serialize;
@@ -178,6 +178,26 @@ impl InternalHttpQueryHandler {
         instruction_observation: Option<Arc<AtomicU64>>,
         max_instructions: Option<NumInstructions>,
     ) -> Result<WasmResult, UserError> {
+        // While the subnet is cooling down its canisters execute no messages, so the
+        // state that a query would be evaluated against is frozen; and the subnet may
+        // be about to hand over its canisters altogether. It therefore rejects all
+        // query calls, the ones addressed to the management canister included.
+        //
+        // System queries (i.e. the `transform` functions of in-flight HTTP outcalls)
+        // are still executed, so that the outcalls the subnet has already made can be
+        // responded to while it is draining its subnet queues.
+        if matches!(query.source, QuerySource::User { .. })
+            && state.get_ref().metadata.is_cooling_down()
+        {
+            return Err(UserError::new(
+                ErrorCode::SubnetCoolingDown,
+                format!(
+                    "Subnet {} is cooling down and does not accept query calls",
+                    state.get_ref().metadata.own_subnet_id
+                ),
+            ));
+        }
+
         let measurement_scope = MeasurementScope::root(&self.metrics.query);
 
         // Serve the query locally if it is addressed to the management canister.

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -12,6 +12,7 @@ use ic_management_canister_types_private::{
 use ic_registry_resource_limits::ResourceLimits;
 use ic_test_utilities::universal_canister::{call_args, wasm};
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
+use ic_test_utilities_metrics::fetch_histogram_stats;
 use ic_test_utilities_state::CanisterStateBuilder;
 use ic_test_utilities_types::ids::{canister_test_id, subnet_test_id, user_test_id};
 use ic_types::{
@@ -672,6 +673,13 @@ fn query_calls_to_cooling_down_subnet_are_rejected() {
 
     test.set_cooling_down(true);
 
+    let queries_handled = |test: &ExecutionTest| {
+        fetch_histogram_stats(test.metrics_registry(), "execution_query_duration_seconds")
+            .unwrap()
+            .count
+    };
+    let queries_handled_before = queries_handled(&test);
+
     // Both canister-addressed and subnet-addressed query calls are now rejected.
     let expected_err = UserError::new(
         ErrorCode::SubnetCoolingDown,
@@ -694,6 +702,9 @@ fn query_calls_to_cooling_down_subnet_are_rejected() {
     // has already made can be responded to while it drains its subnet queues.
     test.system_query(canister, "query", wasm().reply().build())
         .unwrap();
+
+    // All 3 queries above were observed by the query handler metrics.
+    assert_eq!(queries_handled_before + 3, queries_handled(&test));
 }
 
 const COMPOSITE_QUERY_WAT: &str = r#"

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -648,6 +648,54 @@ fn queries_to_frozen_canisters_are_rejected() {
     assert!(result.is_ok());
 }
 
+/// Tests that the query handler rejects all query calls with
+/// `ErrorCode::SubnetCoolingDown` while the subnet is cooling down, but still
+/// executes system queries (i.e. the `transform` functions of HTTP outcalls).
+#[test]
+fn query_calls_to_cooling_down_subnet_are_rejected() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let own_subnet_id = test.state().metadata.own_subnet_id;
+    let canister = test.universal_canister_with_cycles(CYCLES_BALANCE).unwrap();
+    let fetch_canister_logs = FetchCanisterLogsRequest::new(canister).encode();
+
+    // Sanity check: query calls are executed while the subnet is not cooling down.
+    test.non_replicated_query(canister, "query", wasm().reply().build())
+        .unwrap();
+    test.non_replicated_query(
+        CanisterId::ic_00(),
+        "fetch_canister_logs",
+        fetch_canister_logs.clone(),
+    )
+    .unwrap();
+    test.system_query(canister, "query", wasm().reply().build())
+        .unwrap();
+
+    test.set_cooling_down(true);
+
+    // Both canister-addressed and subnet-addressed query calls are now rejected.
+    let expected_err = UserError::new(
+        ErrorCode::SubnetCoolingDown,
+        format!("Subnet {own_subnet_id} is cooling down and does not accept query calls"),
+    );
+    assert_eq!(
+        Err(expected_err.clone()),
+        test.non_replicated_query(canister, "query", wasm().reply().build())
+    );
+    assert_eq!(
+        Err(expected_err),
+        test.non_replicated_query(
+            CanisterId::ic_00(),
+            "fetch_canister_logs",
+            fetch_canister_logs
+        )
+    );
+
+    // But system queries are still executed, so that the HTTP outcalls the subnet
+    // has already made can be responded to while it drains its subnet queues.
+    test.system_query(canister, "query", wasm().reply().build())
+        .unwrap();
+}
+
 const COMPOSITE_QUERY_WAT: &str = r#"
         (module
             (import "ic0" "msg_reply" (func $msg_reply))

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -698,8 +698,8 @@ fn query_calls_to_cooling_down_subnet_are_rejected() {
         )
     );
 
-    // But system queries are still executed, so that the HTTP outcalls the subnet
-    // has already made can be responded to while it drains its subnet queues.
+    // But system queries, i.e. the `transform` functions of HTTP outcalls, are
+    // still executed.
     test.system_query(canister, "query", wasm().reply().build())
         .unwrap();
 

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -475,8 +475,7 @@ impl SchedulerImpl {
             // canister messages (and no `Heartbeat` or `GlobalTimer` tasks either) and
             // it inducts no messages on the same subnet (which is equivalent to routing
             // them through the loopback stream, something a cooling down subnet does not
-            // do). This way its canisters' input and output queues are frozen, except
-            // for the responses produced by draining the subnet queues.
+            // do).
             if state.metadata.is_cooling_down() {
                 self.metrics
                     .round_skipped_canister_execution_due_to_cooling_down

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -472,10 +472,14 @@ impl SchedulerImpl {
             }
 
             // A cooling down subnet only drains its subnet queues: it executes no
-            // canister messages (and no `Heartbeat` or `GlobalTimer` tasks either) and
-            // it inducts no messages on the same subnet (which is equivalent to routing
-            // them through the loopback stream, something a cooling down subnet does not
-            // do).
+            // canister messages and no canister tasks, i.e. neither `Heartbeat` and
+            // `GlobalTimer` (which are not even enqueued, as they are enqueued right
+            // below) nor the on-low-wasm-memory hook (which, unlike the former two, is
+            // a persistent part of the canister's task queue and is thus simply left
+            // there until the subnet stops cooling down).
+            //
+            // It follows that a cooling down subnet also has no messages to induct on
+            // the same subnet.
             if state.metadata.is_cooling_down() {
                 self.metrics
                     .round_skipped_canister_execution_due_to_cooling_down

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -471,6 +471,19 @@ impl SchedulerImpl {
                 scheduler_round_limits.update_subnet_round_limits(&subnet_round_limits);
             }
 
+            // A cooling down subnet only drains its subnet queues: it executes no
+            // canister messages (and no `Heartbeat` or `GlobalTimer` tasks either) and
+            // it inducts no messages on the same subnet (which is equivalent to routing
+            // them through the loopback stream, something a cooling down subnet does not
+            // do). This way its canisters' input and output queues are frozen, except
+            // for the responses produced by draining the subnet queues.
+            if state.metadata.is_cooling_down() {
+                self.metrics
+                    .round_skipped_canister_execution_due_to_cooling_down
+                    .inc();
+                break state;
+            }
+
             let mut round_limits = scheduler_round_limits.canister_round_limits();
             if round_limits.instructions_reached() {
                 self.metrics

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -26,6 +26,7 @@ pub struct SchedulerMetrics {
     pub(super) executed_canisters_per_round: Histogram,
     pub(super) expired_ingress_messages_count: IntCounter,
     pub(super) round_skipped_due_to_current_heap_delta_above_limit: IntCounter,
+    pub(super) round_skipped_canister_execution_due_to_cooling_down: IntCounter,
     pub(super) execute_round_called: IntCounter,
     pub(super) inner_loop_processed_non_zero_inputs_count: IntCounter,
     pub(super) inner_round_loop_consumed_max_instructions: IntCounter,
@@ -134,6 +135,11 @@ impl SchedulerMetrics {
                 "round_skipped_due_to_current_heap_delta_above_limit",
                 "The number of rounds that were skipped because the current \
                       heap delta size exceeded the allowed max",
+            ),
+            round_skipped_canister_execution_due_to_cooling_down: metrics_registry.int_counter(
+                "round_skipped_canister_execution_due_to_cooling_down",
+                "The number of rounds in which no canister messages were executed \
+                      because the subnet was cooling down",
             ),
             execute_round_called: metrics_registry.int_counter(
                 "execute_round_called",

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -166,6 +166,20 @@ impl SchedulerTest {
         self.state().canister_state(&canister_id).unwrap()
     }
 
+    /// Sets whether this subnet is cooling down.
+    pub fn set_cooling_down(&mut self, cooling_down: bool) {
+        let own_subnet_id = self.state().metadata.own_subnet_id;
+        self.state_mut()
+            .metadata
+            .modify_network_topology(|network_topology| {
+                network_topology
+                    .subnets_mut()
+                    .get_mut(&own_subnet_id)
+                    .unwrap()
+                    .cooling_down = cooling_down;
+            });
+    }
+
     pub fn metrics_registry(&self) -> &MetricsRegistry {
         &self.metrics_registry
     }

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -166,20 +166,6 @@ impl SchedulerTest {
         self.state().canister_state(&canister_id).unwrap()
     }
 
-    /// Sets whether this subnet is cooling down.
-    pub fn set_cooling_down(&mut self, cooling_down: bool) {
-        let own_subnet_id = self.state().metadata.own_subnet_id;
-        self.state_mut()
-            .metadata
-            .modify_network_topology(|network_topology| {
-                network_topology
-                    .subnets_mut()
-                    .get_mut(&own_subnet_id)
-                    .unwrap()
-                    .cooling_down = cooling_down;
-            });
-    }
-
     pub fn metrics_registry(&self) -> &MetricsRegistry {
         &self.metrics_registry
     }

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -1,4 +1,6 @@
-use super::test_utilities::{SchedulerTestBuilder, ingress, on_response, other_side};
+use super::test_utilities::{
+    SchedulerTest, SchedulerTestBuilder, ingress, instructions, on_response, other_side,
+};
 use super::*;
 use candid::Encode;
 use ic_base_types::PrincipalId;
@@ -19,6 +21,7 @@ use ic_test_utilities_metrics::{fetch_counter, fetch_histogram_vec_buckets};
 use ic_test_utilities_state::get_running_canister;
 use ic_test_utilities_types::messages::RequestBuilder;
 use ic_types::messages::{CallbackId, Payload, RejectContext};
+use ic_types::methods::SystemMethod;
 use ic_types::time::{UNIX_EPOCH, expiry_time_from_now};
 use ic_types_cycles::Cycles;
 use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id, user_test_id};
@@ -797,6 +800,58 @@ fn finalization_prunes_expired_ingress_history_entries() {
     assert_eq!(test.ingress_status(&msg_b), IngressStatus::Unknown);
     // The ingress history should be empty.
     assert_eq!(test.state().metadata.ingress_history.len(), 0);
+}
+
+/// Tests that while the subnet is cooling down it only drains its subnet queues:
+/// it executes no canister messages and no `Heartbeat` tasks, but the calls it
+/// has already accepted are still responded to.
+#[test]
+fn cooling_down_subnet_only_drains_subnet_queues() {
+    let mut test = SchedulerTestBuilder::new().build();
+    let canister = test.create_canister_with(
+        Cycles::new(1_000_000_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::default(),
+        Some(SystemMethod::CanisterHeartbeat),
+        None,
+        None,
+    );
+
+    let rounds_with_skipped_canister_execution = |test: &SchedulerTest| {
+        test.scheduler()
+            .metrics
+            .round_skipped_canister_execution_due_to_cooling_down
+            .get()
+    };
+
+    // An ingress message and a heartbeat for the canister; plus a subnet message.
+    test.send_ingress(canister, ingress(10));
+    test.expect_heartbeat(canister, instructions(10));
+    test.inject_call_to_ic00(
+        Method::CanisterStatus,
+        Encode!(&CanisterIdRecord::from(canister)).unwrap(),
+        Cycles::zero(),
+        test.xnet_canister_id(),
+        InputQueueType::RemoteSubnet,
+    );
+
+    test.set_cooling_down(true);
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    // The subnet message was executed and responded to.
+    assert_eq!(1, test.get_responses_to_injected_calls().len());
+    // But neither the ingress message nor the heartbeat were executed.
+    assert_eq!(1, test.ingress_queue_size(canister));
+    assert_eq!(1, test.system_task_count(&canister));
+    assert_eq!(1, rounds_with_skipped_canister_execution(&test));
+
+    // Once the subnet stops cooling down, the canister messages are executed.
+    test.set_cooling_down(false);
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    assert_eq!(0, test.ingress_queue_size(canister));
+    assert_eq!(0, test.system_task_count(&canister));
+    assert_eq!(1, rounds_with_skipped_canister_execution(&test));
 }
 
 fn zero_instruction_messages(metrics_registry: &MetricsRegistry) -> u64 {

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -1,12 +1,13 @@
 use super::test_utilities::{
-    SchedulerTest, SchedulerTestBuilder, ingress, instructions, on_response, other_side,
+    SchedulerTest, SchedulerTestBuilder, ingress, on_response, other_side,
 };
 use super::*;
+use assert_matches::assert_matches;
 use candid::Encode;
 use ic_base_types::PrincipalId;
 use ic_config::execution_environment::STOP_CANISTER_TIMEOUT_DURATION;
 use ic_config::subnet_config::SchedulerConfig;
-use ic_error_types::RejectCode;
+use ic_error_types::{ErrorCode, RejectCode};
 use ic_management_canister_types_private::{
     self as ic00, BoundedHttpHeaders, CanisterHttpResponsePayload, CanisterIdRecord,
     CanisterStatusType, EcdsaKeyId, EmptyBlob, Method, Payload as _, SchnorrKeyId,
@@ -16,21 +17,19 @@ use ic_replicated_state::{
     CanisterStatus,
     metadata_state::testing::{NetworkTopologyTesting, SystemMetadataTesting},
 };
-use ic_state_machine_tests::{PayloadBuilder, StateMachineBuilder};
+use ic_state_machine_tests::{PayloadBuilder, StateMachine, StateMachineBuilder};
 use ic_test_utilities_metrics::{fetch_counter, fetch_histogram_vec_buckets};
 use ic_test_utilities_state::get_running_canister;
 use ic_test_utilities_types::messages::RequestBuilder;
 use ic_types::messages::{CallbackId, Payload, RejectContext};
-use ic_types::methods::SystemMethod;
 use ic_types::time::{UNIX_EPOCH, expiry_time_from_now};
 use ic_types_cycles::Cycles;
 use ic_types_test_utils::ids::{canister_test_id, message_test_id, subnet_test_id, user_test_id};
 use ic00::{CanisterHttpRequestArgs, HttpMethod};
+use more_asserts::assert_gt;
 use proptest::prelude::*;
 use std::collections::BTreeMap;
 use std::time::Duration;
-
-const PAGE_SIZE: NumBytes = NumBytes::new(ic_sys::PAGE_SIZE as u64);
 
 mod charging;
 mod dts;
@@ -804,68 +803,177 @@ fn finalization_prunes_expired_ingress_history_entries() {
     assert_eq!(test.state().metadata.ingress_history.len(), 0);
 }
 
-/// Tests that while the subnet is cooling down it only drains its subnet queues:
-/// it executes no canister messages and no `Heartbeat` tasks, but the calls it
-/// has already accepted are still responded to.
+/// Tests that while the subnet is cooling down it executes no canister messages
+/// and no `Heartbeat` tasks, and rejects query calls; subnet messages are still
+/// executed.
 #[test]
-fn cooling_down_subnet_only_drains_subnet_queues() {
-    let mut test = SchedulerTestBuilder::new().build();
-    let canister = test.create_canister_with(
-        Cycles::new(1_000_000_000_000),
-        ComputeAllocation::zero(),
-        MemoryAllocation::default(),
-        Some(SystemMethod::CanisterHeartbeat),
-        None,
-        None,
-    );
+fn cooling_down_subnet_only_executes_subnet_messages() {
+    use ic_universal_canister::{UNIVERSAL_CANISTER_WASM, call_args, wasm};
 
-    let rounds_with_skipped_canister_execution = |test: &SchedulerTest| {
-        test.scheduler()
-            .metrics
-            .round_skipped_canister_execution_due_to_cooling_down
-            .get()
+    let test = StateMachineBuilder::new().build();
+    let canister_id = test
+        .install_canister(UNIVERSAL_CANISTER_WASM.to_vec(), vec![], None)
+        .unwrap();
+
+    // Have the canister increment its global counter on every heartbeat.
+    test.execute_ingress(
+        canister_id,
+        "update",
+        wasm()
+            .set_heartbeat(wasm().inc_global_counter().build())
+            .reply()
+            .build(),
+    )
+    .unwrap();
+
+    let global_counter = |test: &StateMachine| {
+        let result = test
+            .query(
+                canister_id,
+                "query",
+                wasm().get_global_counter().reply_int64().build(),
+            )
+            .unwrap();
+        u64::from_le_bytes(result.bytes().try_into().unwrap())
+    };
+    let tasks = |test: &StateMachine| {
+        test.get_latest_state()
+            .canister_state(&canister_id)
+            .unwrap()
+            .system_state
+            .task_queue
+            .len()
+    };
+    let input_messages = |test: &StateMachine| {
+        test.get_latest_state()
+            .canister_state(&canister_id)
+            .unwrap()
+            .system_state
+            .queues()
+            .input_queues_message_count()
+    };
+    let http_request_contexts = |test: &StateMachine| {
+        test.get_latest_state()
+            .metadata
+            .subnet_call_context_manager
+            .canister_http_request_contexts
+            .len()
     };
 
-    // An ingress message and a heartbeat for the canister; plus a subnet message.
-    test.send_ingress(canister, ingress(10));
-    test.expect_heartbeat(canister, instructions(10));
-    test.inject_call_to_ic00(
-        Method::CanisterStatus,
-        Encode!(&CanisterIdRecord::from(canister)).unwrap(),
-        Cycles::zero(),
-        test.xnet_canister_id(),
-        InputQueueType::RemoteSubnet,
+    // Sanity check: heartbeats are executed while the subnet is not cooling down.
+    test.tick();
+    let counter_before = global_counter(&test);
+    assert_gt!(counter_before, 0);
+
+    // Make an HTTP outcall, so that the subnet has a subnet message to execute
+    // (and a response to deliver to the canister) while it is cooling down.
+    let payload = Encode!(&CanisterHttpRequestArgs {
+        url: "https://example.com".to_string(),
+        headers: BoundedHttpHeaders::new(vec![]),
+        method: HttpMethod::GET,
+        body: None,
+        transform: None,
+        max_response_bytes: None,
+        is_replicated: None,
+        pricing_version: None,
+    })
+    .unwrap();
+    let msg_id = test.send_ingress(
+        PrincipalId::new_anonymous(),
+        canister_id,
+        "update",
+        wasm()
+            .call_simple(
+                ic00::IC_00,
+                "http_request",
+                call_args()
+                    .other_side(payload)
+                    .on_reject(wasm().reject_message().reject()),
+            )
+            .build(),
     );
+    test.tick();
+    assert_matches!(
+        test.ingress_status(&msg_id),
+        IngressStatus::Known {
+            state: IngressState::Processing,
+            ..
+        }
+    );
+    assert_eq!(1, http_request_contexts(&test));
 
     test.set_cooling_down(true);
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // The subnet message was executed and responded to.
-    assert_eq!(1, test.get_responses_to_injected_calls().len());
-    // But neither the ingress message nor the heartbeat were executed.
-    assert_eq!(1, test.ingress_queue_size(canister));
-    assert_eq!(1, test.system_task_count(&canister));
-    assert_eq!(1, rounds_with_skipped_canister_execution(&test));
+    // Deliver the HTTP response. The subnet message is executed, i.e. the outcall
+    // context is consumed and the response is routed to the canister (via the
+    // loopback stream, whence it is inducted in the next round).
+    let response = CanisterHttpResponsePayload {
+        status: 200,
+        headers: vec![],
+        body: vec![],
+    };
+    test.execute_payload(PayloadBuilder::new().http_response(CallbackId::from(0), &response));
+    assert_eq!(0, http_request_contexts(&test));
 
-    // Once the subnet stops cooling down, the canister messages are executed.
+    // But the canister does not execute the response: further rounds only ever
+    // induct it into the canister's input queue, where it stays. And they leave no
+    // task behind in the canister's task queue: a `Heartbeat` task is only ever
+    // enqueued right before the canister execution that a cooling down round skips
+    // altogether, so there is none to pop or to clean up.
+    for _ in 0..3 {
+        test.tick();
+        assert_eq!(1, input_messages(&test));
+        assert_eq!(0, tasks(&test));
+        assert_matches!(
+            test.ingress_status(&msg_id),
+            IngressStatus::Known {
+                state: IngressState::Processing,
+                ..
+            }
+        );
+    }
+
+    // And query calls are rejected while the subnet is cooling down.
+    let err = test
+        .query(
+            canister_id,
+            "query",
+            wasm().get_global_counter().reply_int64().build(),
+        )
+        .unwrap_err();
+    assert_eq!(ErrorCode::SubnetCoolingDown, err.code());
+    assert_eq!(RejectCode::SysTransient, err.reject_code());
+
+    // Once the subnet stops cooling down, a single round executes the response and
+    // exactly one heartbeat: none of the 4 cooling down rounds above executed any.
     test.set_cooling_down(false);
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    test.tick();
 
-    assert_eq!(0, test.ingress_queue_size(canister));
-    assert_eq!(0, test.system_task_count(&canister));
-    assert_eq!(1, rounds_with_skipped_canister_execution(&test));
+    assert_eq!(0, input_messages(&test));
+    assert_matches!(
+        test.ingress_status(&msg_id),
+        IngressStatus::Known {
+            state: IngressState::Completed(_),
+            ..
+        }
+    );
+    assert_eq!(counter_before + 1, global_counter(&test));
 }
 
 /// Tests that while the subnet is cooling down it inducts no messages on the same
 /// subnet, which is equivalent to routing them through the loopback stream,
 /// something a cooling down subnet does not do.
+///
+/// This is a `SchedulerTest` rather than a `StateMachine` test because it requires
+/// a round that ends between executing a message and inducting the messages it
+/// produced, which only `max_heap_delta_per_iteration` can bring about.
 #[test]
 fn cooling_down_subnet_does_not_induct_messages_on_same_subnet() {
     // One dirty page per message is enough to end an iteration, i.e. to stop the
     // first round just before it would induct messages on the same subnet.
     let mut test = SchedulerTestBuilder::new()
         .with_scheduler_config(SchedulerConfig {
-            max_heap_delta_per_iteration: PAGE_SIZE,
+            max_heap_delta_per_iteration: NumBytes::new(ic_sys::PAGE_SIZE as u64),
             ..SchedulerConfig::application_subnet()
         })
         .build();
@@ -905,6 +1013,13 @@ fn cooling_down_subnet_does_not_induct_messages_on_same_subnet() {
 
     assert_eq!(1, output_requests(&test, sender));
     assert_eq!(0, input_messages(&test, receiver));
+    assert_eq!(
+        1,
+        test.scheduler()
+            .metrics
+            .round_skipped_canister_execution_due_to_cooling_down
+            .get()
+    );
 
     // Once the subnet stops cooling down, the request is inducted (and executed).
     test.set_cooling_down(false);

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -30,6 +30,8 @@ use proptest::prelude::*;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+const PAGE_SIZE: NumBytes = NumBytes::new(ic_sys::PAGE_SIZE as u64);
+
 mod charging;
 mod dts;
 mod ecdsa;
@@ -852,6 +854,63 @@ fn cooling_down_subnet_only_drains_subnet_queues() {
     assert_eq!(0, test.ingress_queue_size(canister));
     assert_eq!(0, test.system_task_count(&canister));
     assert_eq!(1, rounds_with_skipped_canister_execution(&test));
+}
+
+/// Tests that while the subnet is cooling down it inducts no messages on the same
+/// subnet, which is equivalent to routing them through the loopback stream,
+/// something a cooling down subnet does not do.
+#[test]
+fn cooling_down_subnet_does_not_induct_messages_on_same_subnet() {
+    // One dirty page per message is enough to end an iteration, i.e. to stop the
+    // first round just before it would induct messages on the same subnet.
+    let mut test = SchedulerTestBuilder::new()
+        .with_scheduler_config(SchedulerConfig {
+            max_heap_delta_per_iteration: PAGE_SIZE,
+            ..SchedulerConfig::application_subnet()
+        })
+        .build();
+    let sender = test.create_canister();
+    let receiver = test.create_canister();
+
+    let output_requests = |test: &SchedulerTest, canister: CanisterId| {
+        test.canister_state(canister)
+            .system_state
+            .queues()
+            .output_queues_message_count()
+    };
+    let input_messages = |test: &SchedulerTest, canister: CanisterId| {
+        test.canister_state(canister)
+            .system_state
+            .queues()
+            .input_queues_message_count()
+    };
+
+    // Have `sender` produce a request to the subnet-local `receiver`. The round
+    // ends right after the execution, before the request is inducted.
+    test.send_ingress(
+        sender,
+        ingress(10)
+            .dirty_pages(1)
+            .call(other_side(receiver, 10), on_response(10)),
+    );
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+    assert_eq!(1, output_requests(&test, sender));
+    assert_eq!(0, input_messages(&test, receiver));
+
+    // While the subnet is cooling down, the request is retained in `sender`'s
+    // output queue, rather than being inducted into `receiver`'s input queue.
+    test.set_cooling_down(true);
+    test.send_ingress(sender, ingress(10));
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    assert_eq!(1, output_requests(&test, sender));
+    assert_eq!(0, input_messages(&test, receiver));
+
+    // Once the subnet stops cooling down, the request is inducted (and executed).
+    test.set_cooling_down(false);
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    assert_eq!(0, output_requests(&test, sender));
 }
 
 fn zero_instruction_messages(metrics_registry: &MetricsRegistry) -> u64 {

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -1,6 +1,4 @@
-use super::test_utilities::{
-    SchedulerTest, SchedulerTestBuilder, ingress, on_response, other_side,
-};
+use super::test_utilities::{SchedulerTestBuilder, ingress, on_response, other_side};
 use super::*;
 use assert_matches::assert_matches;
 use candid::Encode;
@@ -804,7 +802,7 @@ fn finalization_prunes_expired_ingress_history_entries() {
 }
 
 /// Tests that while the subnet is cooling down it executes no canister messages
-/// and no `Heartbeat` tasks, and rejects query calls; subnet messages are still
+/// and no canister tasks, and rejects query calls; subnet messages are still
 /// executed.
 #[test]
 fn cooling_down_subnet_only_executes_subnet_messages() {
@@ -917,9 +915,9 @@ fn cooling_down_subnet_only_executes_subnet_messages() {
 
     // But the canister does not execute the response: further rounds only ever
     // induct it into the canister's input queue, where it stays. And they leave no
-    // task behind in the canister's task queue: a `Heartbeat` task is only ever
-    // enqueued right before the canister execution that a cooling down round skips
-    // altogether, so there is none to pop or to clean up.
+    // task behind in the canister's task queue either: a `Heartbeat` task is only
+    // ever enqueued right before the canister execution that a cooling down round
+    // skips altogether, so there is none to pop or to clean up.
     for _ in 0..3 {
         test.tick();
         assert_eq!(1, input_messages(&test));
@@ -958,74 +956,6 @@ fn cooling_down_subnet_only_executes_subnet_messages() {
         }
     );
     assert_eq!(counter_before + 1, global_counter(&test));
-}
-
-/// Tests that while the subnet is cooling down it inducts no messages on the same
-/// subnet, which is equivalent to routing them through the loopback stream,
-/// something a cooling down subnet does not do.
-///
-/// This is a `SchedulerTest` rather than a `StateMachine` test because it requires
-/// a round that ends between executing a message and inducting the messages it
-/// produced, which only `max_heap_delta_per_iteration` can bring about.
-#[test]
-fn cooling_down_subnet_does_not_induct_messages_on_same_subnet() {
-    // One dirty page per message is enough to end an iteration, i.e. to stop the
-    // first round just before it would induct messages on the same subnet.
-    let mut test = SchedulerTestBuilder::new()
-        .with_scheduler_config(SchedulerConfig {
-            max_heap_delta_per_iteration: NumBytes::new(ic_sys::PAGE_SIZE as u64),
-            ..SchedulerConfig::application_subnet()
-        })
-        .build();
-    let sender = test.create_canister();
-    let receiver = test.create_canister();
-
-    let output_requests = |test: &SchedulerTest, canister: CanisterId| {
-        test.canister_state(canister)
-            .system_state
-            .queues()
-            .output_queues_message_count()
-    };
-    let input_messages = |test: &SchedulerTest, canister: CanisterId| {
-        test.canister_state(canister)
-            .system_state
-            .queues()
-            .input_queues_message_count()
-    };
-
-    // Have `sender` produce a request to the subnet-local `receiver`. The round
-    // ends right after the execution, before the request is inducted.
-    test.send_ingress(
-        sender,
-        ingress(10)
-            .dirty_pages(1)
-            .call(other_side(receiver, 10), on_response(10)),
-    );
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
-    assert_eq!(1, output_requests(&test, sender));
-    assert_eq!(0, input_messages(&test, receiver));
-
-    // While the subnet is cooling down, the request is retained in `sender`'s
-    // output queue, rather than being inducted into `receiver`'s input queue.
-    test.set_cooling_down(true);
-    test.send_ingress(sender, ingress(10));
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
-
-    assert_eq!(1, output_requests(&test, sender));
-    assert_eq!(0, input_messages(&test, receiver));
-    assert_eq!(
-        1,
-        test.scheduler()
-            .metrics
-            .round_skipped_canister_execution_due_to_cooling_down
-            .get()
-    );
-
-    // Once the subnet stops cooling down, the request is inducted (and executed).
-    test.set_cooling_down(false);
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
-
-    assert_eq!(0, output_requests(&test, sender));
 }
 
 fn zero_instruction_messages(metrics_registry: &MetricsRegistry) -> u64 {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -387,8 +387,7 @@ pub struct SubnetTopology {
     ///    expiring message statuses;
     ///  * it rejects all query calls;
     ///  * it executes no canister messages (and no `Heartbeat` or `GlobalTimer`
-    ///    tasks either), only draining its subnet queues, so that the calls it has
-    ///    already accepted can be responded to;
+    ///    tasks either), only draining its subnet queues;
     ///  * (on all subnets) no messages are routed to a cooling down subnet --
     ///    including into the cooling down subnet's own loopback stream -- but
     ///    retained in their respective output queues, so that streams to the

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -386,8 +386,9 @@ pub struct SubnetTopology {
     ///  * it inducts no ingress messages, so the ingress history becomes free of
     ///    expiring message statuses;
     ///  * it rejects all query calls;
-    ///  * it executes no canister messages (and no `Heartbeat` or `GlobalTimer`
-    ///    tasks either), only draining its subnet queues;
+    ///  * it executes no canister messages and no canister tasks (`Heartbeat`,
+    ///    `GlobalTimer` or the on-low-wasm-memory hook), only draining its subnet
+    ///    queues;
     ///  * (on all subnets) no messages are routed to a cooling down subnet --
     ///    including into the cooling down subnet's own loopback stream -- but
     ///    retained in their respective output queues, so that streams to the

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -385,6 +385,10 @@ pub struct SubnetTopology {
     ///
     ///  * it inducts no ingress messages, so the ingress history becomes free of
     ///    expiring message statuses;
+    ///  * it rejects all query calls;
+    ///  * it executes no canister messages (and no `Heartbeat` or `GlobalTimer`
+    ///    tasks either), only draining its subnet queues, so that the calls it has
+    ///    already accepted can be responded to;
     ///  * (on all subnets) no messages are routed to a cooling down subnet --
     ///    including into the cooling down subnet's own loopback stream -- but
     ///    retained in their respective output queues, so that streams to the

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2659,6 +2659,29 @@ impl StateMachine {
         self.state_manager.get_latest_state().take()
     }
 
+    /// Sets the `cooling_down` flag of this subnet's registry record, at a new
+    /// registry version, and updates this subnet's registry client to it. The
+    /// flag takes effect in the next round, when the network topology is
+    /// repopulated from the registry.
+    pub fn set_cooling_down(&self, cooling_down: bool) {
+        let registry_version = self.registry_client.get_latest_version();
+        let mut subnet_record = self
+            .registry_client
+            .get_subnet_record(self.subnet_id, registry_version)
+            .expect("malformed subnet record")
+            .expect("missing subnet record");
+        subnet_record.cooling_down = cooling_down;
+        add_single_subnet_record(
+            &self.registry_data_provider,
+            registry_version.increment().get(),
+            self.subnet_id,
+            subnet_record,
+        );
+
+        self.reload_registry();
+        self.registry_client.update_to_latest_version();
+    }
+
     /// Generates a certified stream slice to a remote subnet.
     fn generate_certified_stream_slice(
         &self,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -376,6 +376,20 @@ impl ExecutionTest {
         self.sender_info = None;
     }
 
+    /// Sets whether this subnet is cooling down.
+    pub fn set_cooling_down(&mut self, cooling_down: bool) {
+        let own_subnet_id = self.state().metadata.own_subnet_id;
+        self.state_mut()
+            .metadata
+            .modify_network_topology(|network_topology| {
+                network_topology
+                    .subnets_mut()
+                    .get_mut(&own_subnet_id)
+                    .unwrap()
+                    .cooling_down = cooling_down;
+            });
+    }
+
     pub fn state(&self) -> &ReplicatedState {
         self.state.as_ref().unwrap()
     }


### PR DESCRIPTION
While a subnet is cooling down it now stops executing regular canister messages
and stops serving query calls, so that all it still does is quiesce: drain its
subnet queues and its streams.

**Execution:** while the subnet is cooling down, the scheduler only drains its
subnet queues. It executes no canister messages and no canister tasks: neither
`Heartbeat` nor `GlobalTimer` -- these are not even enqueued, as the check breaks
out of `inner_round()` right before `add_heartbeat_and_global_timer_tasks()` --
nor the on-low-wasm-memory hook, which, being a persistent part of a canister's
task queue, is simply left there until the subnet stops cooling down. It follows
that a cooling down subnet also has no messages to induct on the same subnet.
Rounds with skipped canister execution are counted in the new
`round_skipped_canister_execution_due_to_cooling_down` metric.

**Queries:** the query handler rejects all query calls with
`ErrorCode::SubnetCoolingDown` (a `SysTransient` reject code), the ones addressed
to the management canister included. System queries, i.e. the `transform`
functions of HTTP outcalls, are still executed, because subnet messages are still
executed by a cooling down subnet. Rejected query calls are observed by the
`execution_query_*` metrics, exactly like all other rejected queries.

The test is a `StateMachine` test, i.e. it exercises the whole production path
from the `cooling_down` registry flag down: an HTTP outcall response is delivered
while the subnet is cooling down, showing that the subnet message is executed and
its response routed to the canister, while the canister neither executes that
response nor a single heartbeat, and query calls are rejected. To that end it adds
a `StateMachine::set_cooling_down()` helper, which sets the flag in the subnet's
registry record at a new registry version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)