### PR TITLE
feat(cketh): record which signed authorizations were applied on chain

### DIFF
--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1367,6 +1367,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Number of delegation authorizations the minter has signed and stored.",
                 )?;
 
+                w.encode_gauge(
+                    "cketh_minter_applied_authorizations",
+                    s.automatic_deposits.applied_authorizations_len() as f64,
+                    "Number of stored delegation authorizations a finalized sweep applied on chain.",
+                )?;
+
                 w.encode_counter(
                     "cketh_minter_sweeper_funding_cketh_burned_total",
                     s.sweeper_funding.cumulative_burned().as_f64(),

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1370,7 +1370,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                 w.encode_gauge(
                     "cketh_minter_applied_authorizations",
                     s.automatic_deposits.applied_authorizations_len() as f64,
-                    "Number of stored delegation authorizations a finalized sweep applied on chain.",
+                    "Number of deposit addresses whose delegation a finalized sweep installed on chain.",
                 )?;
 
                 w.encode_counter(

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations.rs
@@ -111,8 +111,9 @@ impl AuthorizationStore {
     }
 
     fn next_nonce(&self, account: &Account) -> TransactionNonce {
-        self.delegation(account)
-            .map_or(TransactionNonce::ZERO, |delegation| delegation.nonce)
+        self.accounts
+            .get(account)
+            .map_or(TransactionNonce::ZERO, Authorizations::next_nonce)
     }
 }
 
@@ -137,6 +138,18 @@ impl Authorizations {
     fn is_delegated(&self) -> bool {
         self.delegation.is_some()
     }
+
+    fn next_nonce(&self) -> TransactionNonce {
+        self.delegation
+            .as_ref()
+            .map_or(TransactionNonce::ZERO, |applied| {
+                applied
+                    .authorization
+                    .nonce
+                    .checked_increment()
+                    .expect("BUG: authorization nonce space exhausted")
+            })
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -150,11 +163,7 @@ impl AppliedDelegation {
     fn delegation(&self) -> Delegation {
         Delegation {
             delegate: self.authorization.delegate,
-            nonce: self
-                .authorization
-                .nonce
-                .checked_increment()
-                .expect("BUG: authorization nonce space exhausted"),
+            nonce: self.authorization.nonce,
         }
     }
 }
@@ -164,7 +173,6 @@ impl AppliedDelegation {
 pub struct Delegation {
     /// The contract the address' code points at.
     pub delegate: Address,
-    /// The nonce the address has reached, one past the nonce of the authorization that installed
-    /// the delegation.
+    /// The nonce of the authorization that installed the delegation, spent by applying it.
     pub nonce: TransactionNonce,
 }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations.rs
@@ -1,0 +1,170 @@
+#[cfg(test)]
+mod tests;
+
+use crate::numeric::TransactionNonce;
+use crate::state::transactions::SweepId;
+use crate::tx::{Authorization, AuthorizationRequest, TransactionSignature};
+use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeMap;
+
+/// Every EIP-7702 authorization the minter has signed for its deposit addresses and is still
+/// accountable for, per account: the tuples signed but not yet settled, and the one delegation
+/// the account's deposit address carries on chain. At most one tuple ever applies per account
+/// nonce; applying one settles that nonce and discards its rival tuples, the same way the
+/// transaction pipeline finalizes one sent transaction per nonce and drops the superseded
+/// resubmissions.
+///
+/// The store grows with the number of accounts that have ever been swept and is never emptied:
+/// an account keeps its applied delegation forever. [`Self::stored_len`] is exported as a metric
+/// so that growth is visible before it needs bounding.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct AuthorizationStore {
+    accounts: BTreeMap<Account, Authorizations>,
+}
+
+impl AuthorizationStore {
+    /// The signature already stored for `request`, whether still pending or already applied:
+    /// signing another would cost a threshold-ECDSA signature for the same tuple.
+    pub fn signature(&self, request: &AuthorizationRequest) -> Option<&TransactionSignature> {
+        let stored = self.accounts.get(&request.account())?;
+        let authorization = request.authorization();
+        stored
+            .pending
+            .get(&authorization)
+            .or_else(|| stored.applied_signature(&authorization))
+    }
+
+    pub fn record_signed(
+        &mut self,
+        request: AuthorizationRequest,
+        signature: TransactionSignature,
+    ) {
+        self.accounts
+            .entry(request.account())
+            .or_default()
+            .pending
+            .insert(request.authorization(), signature);
+    }
+
+    /// Record that `sweep_id` applied `request`'s tuple on chain, unless the protocol skipped it:
+    /// a tuple applies only at the authority's current nonce, and applying one spends that nonce,
+    /// so a tuple signed for any other leaves the address as it was. Applying settles the nonce:
+    /// the tuple becomes the account's delegation and the rival tuples the spent nonce
+    /// invalidated are dropped.
+    ///
+    /// Callers must settle finalized sweeps in the order the chain executed them: a receipt does
+    /// not say which of its tuples applied, so the store infers it from the nonce each account
+    /// has reached.
+    ///
+    /// # Panics
+    ///
+    /// If the tuple is at the account's current nonce but was never signed. The minter is the
+    /// only signer for its deposit addresses, so a sweep carrying an unknown tuple means the
+    /// store has stopped describing what the minter signed.
+    pub fn record_applied(&mut self, request: AuthorizationRequest, sweep_id: SweepId) {
+        if request.nonce() != self.next_nonce(&request.account()) {
+            return;
+        }
+        let stored = self
+            .accounts
+            .get_mut(&request.account())
+            .expect("BUG: a sweep carried an authorization the minter never signed");
+        let authorization = request.authorization();
+        let signature = stored
+            .pending
+            .remove(&authorization)
+            .expect("BUG: a sweep carried an authorization the minter never signed");
+        stored
+            .pending
+            .retain(|pending, _signature| pending.nonce > authorization.nonce);
+        stored.delegation = Some(AppliedDelegation {
+            authorization,
+            signature,
+            applied_by: sweep_id,
+        });
+    }
+
+    /// The delegation `account`'s deposit address carries on chain, as the tuples applied to it
+    /// say. `None` while none of the minter's tuples for the address has been applied, which for
+    /// a deposit address means it holds no delegation at all: only the minter ever authorizes
+    /// one.
+    pub fn delegation(&self, account: &Account) -> Option<Delegation> {
+        self.accounts
+            .get(account)?
+            .delegation
+            .as_ref()
+            .map(AppliedDelegation::delegation)
+    }
+
+    /// The number of tuples the store holds, pending and applied.
+    pub fn stored_len(&self) -> usize {
+        self.accounts.values().map(Authorizations::len).sum()
+    }
+
+    /// The number of accounts whose deposit address carries a delegation.
+    pub fn applied_len(&self) -> usize {
+        self.accounts
+            .values()
+            .filter(|authorizations| authorizations.is_delegated())
+            .count()
+    }
+
+    fn next_nonce(&self, account: &Account) -> TransactionNonce {
+        self.delegation(account)
+            .map_or(TransactionNonce::ZERO, |delegation| delegation.nonce)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+struct Authorizations {
+    delegation: Option<AppliedDelegation>,
+    pending: BTreeMap<Authorization, TransactionSignature>,
+}
+
+impl Authorizations {
+    fn applied_signature(&self, authorization: &Authorization) -> Option<&TransactionSignature> {
+        self.delegation
+            .as_ref()
+            .filter(|applied| &applied.authorization == authorization)
+            .map(|applied| &applied.signature)
+    }
+
+    fn len(&self) -> usize {
+        self.pending.len() + usize::from(self.delegation.is_some())
+    }
+
+    fn is_delegated(&self) -> bool {
+        self.delegation.is_some()
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+struct AppliedDelegation {
+    authorization: Authorization,
+    signature: TransactionSignature,
+    applied_by: SweepId,
+}
+
+impl AppliedDelegation {
+    fn delegation(&self) -> Delegation {
+        Delegation {
+            delegate: self.authorization.delegate,
+            nonce: self
+                .authorization
+                .nonce
+                .checked_increment()
+                .expect("BUG: authorization nonce space exhausted"),
+        }
+    }
+}
+
+/// The delegation a deposit address carries on chain.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct Delegation {
+    /// The contract the address' code points at.
+    pub delegate: Address,
+    /// The nonce the address has reached, one past the nonce of the authorization that installed
+    /// the delegation.
+    pub nonce: TransactionNonce,
+}

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations/tests.rs
@@ -35,7 +35,7 @@ fn should_apply_a_tuple_at_the_account_nonce() {
         store.delegation(&account()),
         Some(Delegation {
             delegate: DELEGATE,
-            nonce: TransactionNonce::ONE,
+            nonce: TransactionNonce::ZERO,
         })
     );
     assert_eq!(applied_by(&store), Some(SweepId(0)));
@@ -94,7 +94,7 @@ fn should_drop_the_rival_tuple_the_applied_nonce_invalidated() {
         store.delegation(&account()),
         Some(Delegation {
             delegate: DELEGATE,
-            nonce: TransactionNonce::ONE,
+            nonce: TransactionNonce::ZERO,
         })
     );
 }
@@ -127,7 +127,7 @@ fn should_report_the_delegate_of_the_highest_applied_nonce() {
         store.delegation(&account()),
         Some(Delegation {
             delegate: ANOTHER_DELEGATE,
-            nonce: TransactionNonce::new(2),
+            nonce: TransactionNonce::ONE,
         })
     );
     assert_eq!(applied_by(&store), Some(SweepId(1)));

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/authorizations/tests.rs
@@ -1,0 +1,169 @@
+use super::{AuthorizationStore, Delegation};
+use crate::numeric::TransactionNonce;
+use crate::state::transactions::SweepId;
+use crate::test_fixtures::{account, transaction_signature};
+use crate::tx::AuthorizationRequest;
+use ic_ethereum_types::Address;
+
+const DELEGATE: Address = Address::new([0xde; 20]);
+const ANOTHER_DELEGATE: Address = Address::new([0x1e; 20]);
+const CHAIN_ID: u64 = 11_155_111;
+
+#[test]
+fn should_hold_no_delegation_before_a_tuple_applies() {
+    let mut store = AuthorizationStore::default();
+    let request = authorization_request(DELEGATE, 0);
+
+    store.record_signed(request.clone(), transaction_signature());
+
+    assert!(store.signature(&request).is_some());
+    assert_eq!(store.delegation(&account()), None);
+    assert_eq!(applied_by(&store), None);
+    assert_eq!(store.stored_len(), 1);
+    assert_eq!(store.applied_len(), 0);
+}
+
+#[test]
+fn should_apply_a_tuple_at_the_account_nonce() {
+    let mut store = AuthorizationStore::default();
+    let request = authorization_request(DELEGATE, 0);
+    store.record_signed(request.clone(), transaction_signature());
+
+    store.record_applied(request, SweepId(0));
+
+    assert_eq!(
+        store.delegation(&account()),
+        Some(Delegation {
+            delegate: DELEGATE,
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(applied_by(&store), Some(SweepId(0)));
+    assert_eq!(store.applied_len(), 1);
+}
+
+#[test]
+fn should_keep_serving_the_signature_of_an_applied_tuple() {
+    let mut store = AuthorizationStore::default();
+    let request = authorization_request(DELEGATE, 0);
+    store.record_signed(request.clone(), transaction_signature());
+
+    store.record_applied(request.clone(), SweepId(0));
+
+    assert_eq!(store.signature(&request), Some(&transaction_signature()));
+}
+
+#[test]
+fn should_skip_a_tuple_whose_nonce_the_account_has_spent() {
+    let mut store = AuthorizationStore::default();
+    let request = authorization_request(DELEGATE, 0);
+    store.record_signed(request.clone(), transaction_signature());
+    store.record_applied(request.clone(), SweepId(0));
+
+    store.record_applied(request, SweepId(1));
+
+    assert_eq!(applied_by(&store), Some(SweepId(0)));
+}
+
+#[test]
+fn should_skip_a_tuple_signed_for_a_nonce_the_account_has_not_reached() {
+    let mut store = AuthorizationStore::default();
+    let ahead = authorization_request(DELEGATE, 1);
+    store.record_signed(ahead.clone(), transaction_signature());
+
+    store.record_applied(ahead.clone(), SweepId(0));
+
+    assert_eq!(store.delegation(&account()), None);
+    assert!(store.signature(&ahead).is_some());
+}
+
+#[test]
+fn should_drop_the_rival_tuple_the_applied_nonce_invalidated() {
+    let mut store = AuthorizationStore::default();
+    let incumbent = authorization_request(DELEGATE, 0);
+    let rival = authorization_request(ANOTHER_DELEGATE, 0);
+    store.record_signed(incumbent.clone(), transaction_signature());
+    store.record_signed(rival.clone(), transaction_signature());
+
+    store.record_applied(incumbent.clone(), SweepId(0));
+
+    assert!(store.signature(&rival).is_none());
+    assert!(store.signature(&incumbent).is_some());
+    assert_eq!(store.stored_len(), 1);
+    assert_eq!(
+        store.delegation(&account()),
+        Some(Delegation {
+            delegate: DELEGATE,
+            nonce: TransactionNonce::ONE,
+        })
+    );
+}
+
+#[test]
+fn should_keep_a_tuple_ahead_of_the_applied_nonce() {
+    let mut store = AuthorizationStore::default();
+    let current = authorization_request(DELEGATE, 0);
+    let ahead = authorization_request(ANOTHER_DELEGATE, 1);
+    store.record_signed(current.clone(), transaction_signature());
+    store.record_signed(ahead.clone(), transaction_signature());
+
+    store.record_applied(current, SweepId(0));
+
+    assert!(store.signature(&ahead).is_some());
+}
+
+#[test]
+fn should_report_the_delegate_of_the_highest_applied_nonce() {
+    let mut store = AuthorizationStore::default();
+    let first = authorization_request(DELEGATE, 0);
+    let rotated = authorization_request(ANOTHER_DELEGATE, 1);
+    store.record_signed(first.clone(), transaction_signature());
+    store.record_applied(first, SweepId(0));
+    store.record_signed(rotated.clone(), transaction_signature());
+
+    store.record_applied(rotated, SweepId(1));
+
+    assert_eq!(
+        store.delegation(&account()),
+        Some(Delegation {
+            delegate: ANOTHER_DELEGATE,
+            nonce: TransactionNonce::new(2),
+        })
+    );
+    assert_eq!(applied_by(&store), Some(SweepId(1)));
+    assert_eq!(store.applied_len(), 1);
+}
+
+#[test]
+fn equality_should_notice_which_sweep_applied_a_tuple() {
+    let request = authorization_request(DELEGATE, 0);
+    let mut left = AuthorizationStore::default();
+    left.record_signed(request.clone(), transaction_signature());
+    let mut right = left.clone();
+
+    left.record_applied(request.clone(), SweepId(0));
+    right.record_applied(request, SweepId(1));
+
+    assert_ne!(left, right);
+}
+
+#[test]
+#[should_panic(expected = "BUG: a sweep carried an authorization the minter never signed")]
+fn should_refuse_to_apply_a_tuple_that_was_never_signed() {
+    let mut store = AuthorizationStore::default();
+
+    store.record_applied(authorization_request(DELEGATE, 0), SweepId(0));
+}
+
+fn authorization_request(delegate: Address, nonce: u128) -> AuthorizationRequest {
+    AuthorizationRequest::new(account(), CHAIN_ID, delegate, TransactionNonce::new(nonce))
+}
+
+fn applied_by(store: &AuthorizationStore) -> Option<SweepId> {
+    store
+        .accounts
+        .get(&account())?
+        .delegation
+        .as_ref()
+        .map(|applied| applied.applied_by)
+}

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -1,5 +1,8 @@
+mod authorizations;
 #[cfg(test)]
 mod tests;
+
+pub use authorizations::Delegation;
 
 use crate::asset::{Asset, Erc20Asset, EthAsset};
 use crate::attestation::AttestationRequest;
@@ -8,6 +11,7 @@ use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
 use crate::logs::INFO;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionCount, TransactionNonce};
+use crate::state::automatic_deposits::authorizations::AuthorizationStore;
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
 use crate::state::transactions::{
     ResubmitTransactionError, SweepId, SweepRequest, SweeperTransactionPipeline,
@@ -76,15 +80,9 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::attestations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     attestations: BTreeMap<AttestationRequest, TransactionSignature>,
-    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed, each
-    /// recording whether a sweep has applied it on chain. A signature only delegates the chain, the
-    /// sweeper contract and the nonce its request names, so re-pointing the minter at another
-    /// sweeper contract misses this map rather than reusing a tuple that delegates the old one.
-    ///
-    /// Nothing prunes this map: it grows with the number of accounts that have ever been swept, and
-    /// entries naming a retired helper stay behind forever. [`Self::authorizations_len`] is exported
-    /// as a metric so that growth is visible before it needs bounding.
-    authorizations: BTreeMap<AuthorizationRequest, StoredAuthorization>,
+    /// Delegation authorizations the minter has signed and the delegations applying them
+    /// installed, per deposit-address account (see [`AuthorizationStore`]).
+    authorizations: AuthorizationStore,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -234,7 +232,7 @@ impl AutomaticDeposits {
         }
 
         for authorization in authorizations {
-            self.record_applied_authorization(authorization, id);
+            self.authorizations.record_applied(authorization, id);
         }
         finalized
     }
@@ -273,12 +271,10 @@ impl AutomaticDeposits {
         self.attestations.insert(request, signature);
     }
 
-    /// The authorization already stored for `account`, if any: signing another would cost a
+    /// The authorization already stored for `request`, if any: signing another would cost a
     /// threshold-ECDSA signature for the same tuple.
     pub fn authorization(&self, request: &AuthorizationRequest) -> Option<&TransactionSignature> {
-        self.authorizations
-            .get(request)
-            .map(|stored| &stored.signature)
+        self.authorizations.signature(request)
     }
 
     pub fn record_authorization(
@@ -286,67 +282,12 @@ impl AutomaticDeposits {
         request: AuthorizationRequest,
         signature: TransactionSignature,
     ) {
-        self.authorizations.insert(
-            request,
-            StoredAuthorization {
-                signature,
-                applied_by: None,
-            },
-        );
+        self.authorizations.record_signed(request, signature);
     }
 
-    /// The delegation `account`'s deposit address carries on chain, as the authorizations applied
-    /// to it say: the delegate the highest applied nonce names, and the nonce the address has
-    /// reached. `None` while none of the minter's authorizations for the address has been applied,
-    /// which for a deposit address means it holds no delegation at all: only the minter ever
-    /// authorizes one.
+    /// The delegation `account`'s deposit address carries on chain, if any.
     pub fn delegation(&self, account: &Account) -> Option<Delegation> {
-        self.authorizations_of(account)
-            .filter(|(_request, stored)| stored.applied_by.is_some())
-            .map(|(request, _stored)| request)
-            .max_by_key(|request| request.nonce())
-            .map(|request| Delegation {
-                delegate: request.delegate(),
-                nonce: request
-                    .nonce()
-                    .checked_increment()
-                    .expect("BUG: authorization nonce space exhausted"),
-            })
-    }
-
-    /// The authorizations signed for `account`, in key order. An [`AuthorizationRequest`] orders by
-    /// its account first, so one account's authorizations are a contiguous range: reaching them
-    /// costs the account's own entries rather than a scan of every account ever swept, which
-    /// matters on replay, where every finalized sweep consults them.
-    fn authorizations_of(
-        &self,
-        account: &Account,
-    ) -> impl Iterator<Item = (&AuthorizationRequest, &StoredAuthorization)> {
-        let first =
-            AuthorizationRequest::new(*account, u64::MIN, Address::ZERO, TransactionNonce::ZERO);
-        self.authorizations
-            .range(first..)
-            .take_while(move |(request, _stored)| request.account() == *account)
-    }
-
-    /// The nonce `account`'s deposit address is at, and therefore the only nonce a further
-    /// authorization of it can be signed for.
-    fn next_authorization_nonce(&self, account: &Account) -> TransactionNonce {
-        self.delegation(account)
-            .map_or(TransactionNonce::ZERO, |delegation| delegation.nonce)
-    }
-
-    /// Record that `sweep_id` applied `request`'s authorization on chain, unless the protocol
-    /// skipped it: a tuple applies only at the authority's current nonce, and applying one spends
-    /// that nonce, so a tuple signed for any other leaves the address as it was.
-    fn record_applied_authorization(&mut self, request: AuthorizationRequest, sweep_id: SweepId) {
-        if request.nonce() != self.next_authorization_nonce(&request.account()) {
-            return;
-        }
-        self.authorizations
-            .get_mut(&request)
-            .expect("BUG: a sweep carried an authorization the minter never signed")
-            .applied_by = Some(sweep_id);
+        self.authorizations.delegation(account)
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.
@@ -593,14 +534,11 @@ impl AutomaticDeposits {
     }
 
     pub fn authorizations_len(&self) -> usize {
-        self.authorizations.len()
+        self.authorizations.stored_len()
     }
 
     pub fn applied_authorizations_len(&self) -> usize {
-        self.authorizations
-            .values()
-            .filter(|stored| stored.applied_by.is_some())
-            .count()
+        self.authorizations.applied_len()
     }
 
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
@@ -683,7 +621,7 @@ impl Default for AutomaticDeposits {
             watchlist: TimedSizedMap::new(DEPOSIT_ADDRESS_SCAN_WINDOW, MAX_ACTIVE_DEPOSITS),
             sweep: BTreeMap::new(),
             attestations: BTreeMap::new(),
-            authorizations: BTreeMap::new(),
+            authorizations: AuthorizationStore::default(),
             sweeper_transactions: SweeperTransactionPipeline::new(TransactionNonce::ZERO),
         }
     }
@@ -798,25 +736,6 @@ impl ScanTarget<Erc20Asset> {
     pub fn token(&self) -> Address {
         self.asset.contract_address()
     }
-}
-
-/// An EIP-7702 authorization the minter has signed, and the sweep that applied it on chain if one
-/// has. Signing a tuple only makes it available to a sweep: the delegation it authorizes exists on
-/// chain only once a sweep carrying the tuple has finalized with the authority at its nonce.
-#[derive(Clone, PartialEq, Debug)]
-struct StoredAuthorization {
-    signature: TransactionSignature,
-    applied_by: Option<SweepId>,
-}
-
-/// The delegation a deposit address carries on chain.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub struct Delegation {
-    /// The contract the address' code points at.
-    pub delegate: Address,
-    /// The nonce the address has reached, one past the nonce of the authorization that installed
-    /// the delegation.
-    pub nonce: TransactionNonce,
 }
 
 /// A funded token awaiting sweeping at a [`DepositRequest`]'s deposit address.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -76,15 +76,15 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::attestations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     attestations: BTreeMap<AttestationRequest, TransactionSignature>,
-    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed. A
-    /// signature only delegates the chain, the sweeper contract and the nonce its request names, so
-    /// re-pointing the minter at another sweeper contract misses this map rather than reusing a
-    /// tuple that delegates the old one.
+    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed, each
+    /// recording whether a sweep has applied it on chain. A signature only delegates the chain, the
+    /// sweeper contract and the nonce its request names, so re-pointing the minter at another
+    /// sweeper contract misses this map rather than reusing a tuple that delegates the old one.
     ///
     /// Nothing prunes this map: it grows with the number of accounts that have ever been swept, and
     /// entries naming a retired helper stay behind forever. [`Self::authorizations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
-    authorizations: BTreeMap<AuthorizationRequest, TransactionSignature>,
+    authorizations: BTreeMap<AuthorizationRequest, StoredAuthorization>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -189,6 +189,9 @@ impl AutomaticDeposits {
     /// leave the queue on success because the funds moved, and on failure because the minter does
     /// not retry them.
     ///
+    /// The authorizations the sweep carried are settled either way too: an EIP-7702 tuple applies
+    /// before the call it travels with runs, and stays applied when that call reverts.
+    ///
     /// # Panics
     ///
     /// If the sweep has no processed request, or a deposit it named is not queued or is held by
@@ -207,6 +210,11 @@ impl AutomaticDeposits {
             .expect("BUG: missing sweep request");
         let asset = request.asset;
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
+        let authorizations = request.authorization_requests();
+
+        for authorization in authorizations {
+            self.record_applied_authorization(authorization, id);
+        }
 
         for account in accounts {
             let request = DepositRequest::new(account, asset);
@@ -268,7 +276,9 @@ impl AutomaticDeposits {
     /// The authorization already stored for `account`, if any: signing another would cost a
     /// threshold-ECDSA signature for the same tuple.
     pub fn authorization(&self, request: &AuthorizationRequest) -> Option<&TransactionSignature> {
-        self.authorizations.get(request)
+        self.authorizations
+            .get(request)
+            .map(|stored| &stored.signature)
     }
 
     pub fn record_authorization(
@@ -276,7 +286,54 @@ impl AutomaticDeposits {
         request: AuthorizationRequest,
         signature: TransactionSignature,
     ) {
-        self.authorizations.insert(request, signature);
+        self.authorizations.insert(
+            request,
+            StoredAuthorization {
+                signature,
+                applied_by: None,
+            },
+        );
+    }
+
+    /// The delegation `account`'s deposit address carries on chain, as the authorizations applied
+    /// to it say: the delegate the highest applied nonce names, and the nonce the address has
+    /// reached. `None` while none of the minter's authorizations for the address has been applied,
+    /// which for a deposit address means it holds no delegation at all: only the minter ever
+    /// authorizes one.
+    pub fn delegation(&self, account: &Account) -> Option<Delegation> {
+        self.authorizations
+            .iter()
+            .filter(|(request, stored)| {
+                request.account() == *account && stored.applied_by.is_some()
+            })
+            .map(|(request, _stored)| request)
+            .max_by_key(|request| request.nonce())
+            .map(|request| Delegation {
+                delegate: request.delegate(),
+                nonce: request
+                    .nonce()
+                    .checked_increment()
+                    .expect("BUG: authorization nonce space exhausted"),
+            })
+    }
+
+    /// The nonce `account`'s deposit address is at, and therefore the only nonce a further
+    /// authorization of it can be signed for.
+    fn next_authorization_nonce(&self, account: &Account) -> TransactionNonce {
+        self.delegation(account)
+            .map_or(TransactionNonce::ZERO, |delegation| delegation.nonce)
+    }
+
+    /// Record that `sweep_id` applied `request`'s authorization on chain, unless the protocol
+    /// skipped it: a tuple applies only at the authority's current nonce, and applying one spends
+    /// that nonce, so a tuple signed for any other leaves the address as it was.
+    fn record_applied_authorization(&mut self, request: AuthorizationRequest, sweep_id: SweepId) {
+        if request.nonce() != self.next_authorization_nonce(&request.account()) {
+            return;
+        }
+        if let Some(stored) = self.authorizations.get_mut(&request) {
+            stored.applied_by.get_or_insert(sweep_id);
+        }
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.
@@ -526,6 +583,13 @@ impl AutomaticDeposits {
         self.authorizations.len()
     }
 
+    pub fn applied_authorizations_len(&self) -> usize {
+        self.authorizations
+            .values()
+            .filter(|stored| stored.applied_by.is_some())
+            .count()
+    }
+
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
     /// funds queued for sweeping (so it must be registered). Reports
     /// [`DepositStage::AwaitingSweep`] once funds have been detected and queued, otherwise
@@ -721,6 +785,25 @@ impl ScanTarget<Erc20Asset> {
     pub fn token(&self) -> Address {
         self.asset.contract_address()
     }
+}
+
+/// An EIP-7702 authorization the minter has signed, and the sweep that applied it on chain if one
+/// has. Signing a tuple only makes it available to a sweep: the delegation it authorizes exists on
+/// chain only once a sweep carrying the tuple has finalized with the authority at its nonce.
+#[derive(Clone, PartialEq, Debug)]
+struct StoredAuthorization {
+    signature: TransactionSignature,
+    applied_by: Option<SweepId>,
+}
+
+/// The delegation a deposit address carries on chain.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct Delegation {
+    /// The contract the address' code points at.
+    pub delegate: Address,
+    /// The nonce the address has reached, one past the nonce of the authorization that installed
+    /// the delegation.
+    pub nonce: TransactionNonce,
 }
 
 /// A funded token awaiting sweeping at a [`DepositRequest`]'s deposit address.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -212,10 +212,6 @@ impl AutomaticDeposits {
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
         let authorizations = request.authorization_requests();
 
-        for authorization in authorizations {
-            self.record_applied_authorization(authorization, id);
-        }
-
         for account in accounts {
             let request = DepositRequest::new(account, asset);
             let entry = self
@@ -235,6 +231,10 @@ impl AutomaticDeposits {
                     entry.address
                 );
             }
+        }
+
+        for authorization in authorizations {
+            self.record_applied_authorization(authorization, id);
         }
         finalized
     }
@@ -301,11 +301,8 @@ impl AutomaticDeposits {
     /// which for a deposit address means it holds no delegation at all: only the minter ever
     /// authorizes one.
     pub fn delegation(&self, account: &Account) -> Option<Delegation> {
-        self.authorizations
-            .iter()
-            .filter(|(request, stored)| {
-                request.account() == *account && stored.applied_by.is_some()
-            })
+        self.authorizations_of(account)
+            .filter(|(_request, stored)| stored.applied_by.is_some())
             .map(|(request, _stored)| request)
             .max_by_key(|request| request.nonce())
             .map(|request| Delegation {
@@ -315,6 +312,21 @@ impl AutomaticDeposits {
                     .checked_increment()
                     .expect("BUG: authorization nonce space exhausted"),
             })
+    }
+
+    /// The authorizations signed for `account`, in key order. An [`AuthorizationRequest`] orders by
+    /// its account first, so one account's authorizations are a contiguous range: reaching them
+    /// costs the account's own entries rather than a scan of every account ever swept, which
+    /// matters on replay, where every finalized sweep consults them.
+    fn authorizations_of(
+        &self,
+        account: &Account,
+    ) -> impl Iterator<Item = (&AuthorizationRequest, &StoredAuthorization)> {
+        let first =
+            AuthorizationRequest::new(*account, u64::MIN, Address::ZERO, TransactionNonce::ZERO);
+        self.authorizations
+            .range(first..)
+            .take_while(move |(request, _stored)| request.account() == *account)
     }
 
     /// The nonce `account`'s deposit address is at, and therefore the only nonce a further
@@ -331,9 +343,10 @@ impl AutomaticDeposits {
         if request.nonce() != self.next_authorization_nonce(&request.account()) {
             return;
         }
-        if let Some(stored) = self.authorizations.get_mut(&request) {
-            stored.applied_by.get_or_insert(sweep_id);
-        }
+        self.authorizations
+            .get_mut(&request)
+            .expect("BUG: a sweep carried an authorization the minter never signed")
+            .applied_by = Some(sweep_id);
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -34,8 +34,9 @@ use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
 
 /// A delegate other than the sweeper contract every fixture sweep names, for the tests that rotate
-/// an account onto a second one.
-const ANOTHER_DELEGATE: Address = Address::new([0x9e; 20]);
+/// an account onto a second one. Sorts before the incumbent, so a test reading the delegation off
+/// the last key rather than off the highest nonce fails.
+const ANOTHER_DELEGATE: Address = Address::new([0x1e; 20]);
 
 #[test]
 fn should_watch_a_pair_for_the_scan_window() {
@@ -1043,7 +1044,7 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
         transaction_signature(),
     );
 
-    finalize_sweep_carrying(&mut deposits, account(0), None);
+    finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
     // Signing a tuple is not applying it: an address only a sweep that left it out has swept
     // holds no delegation.
@@ -1053,17 +1054,16 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 }
 
 #[tokio::test]
-async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_it() {
+async fn should_not_mark_a_tuple_whose_nonce_the_account_has_already_spent() {
     let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
     finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
     let authorization = first.items[0].authorization.clone();
     assert!(authorization.is_some(), "the fixture must carry a tuple");
 
-    // The protocol skips a tuple whose nonce the account has already spent, so re-carrying it
-    // changes nothing on chain.
-    let second = finalize_sweep_carrying(&mut deposits, account(0), authorization);
+    // Applying the tuple spent nonce zero, so the protocol skips the very same tuple when a later
+    // sweep carries it again: the mark stays on the sweep that did apply it.
+    finalize_sweep_carrying(&mut deposits, SweepId(1), authorization);
 
-    assert_ne!(second, first.id);
     assert_eq!(
         applied_by(
             &deposits,
@@ -1081,6 +1081,45 @@ async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_i
     assert_eq!(deposits.applied_authorizations_len(), 1);
 }
 
+/// Two sweeps of the same account can be in flight at once — one per token it has queued — and
+/// both carry a tuple for nonce zero, since the minter always signs for nonce zero. Whichever
+/// lands first spends the nonce; the other is skipped, even when it names a different delegate.
+#[test]
+fn should_apply_only_the_first_of_two_sweeps_carrying_the_same_nonce() {
+    let mut deposits = AutomaticDeposits::default();
+    let incumbent = authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO);
+    let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ZERO);
+    deposits.record_authorization(incumbent.clone(), transaction_signature());
+    deposits.record_authorization(rotated.clone(), transaction_signature());
+
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&incumbent)));
+    finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
+
+    assert_eq!(applied_by(&deposits, &incumbent), Some(SweepId(0)));
+    assert_eq!(applied_by(&deposits, &rotated), None);
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 1);
+}
+
+#[test]
+fn should_not_mark_a_tuple_signed_for_a_nonce_the_account_has_not_reached() {
+    let mut deposits = AutomaticDeposits::default();
+    let ahead = authorization_request(account(0), sweeper_contract(), TransactionNonce::ONE);
+    deposits.record_authorization(ahead.clone(), transaction_signature());
+
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&ahead)));
+
+    assert_eq!(applied_by(&deposits, &ahead), None);
+    assert_eq!(deposits.delegation(&account(0)), None);
+    assert_eq!(deposits.applied_authorizations_len(), 0);
+}
+
 #[tokio::test]
 async fn should_report_the_delegate_of_the_highest_applied_authorization() {
     let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
@@ -1088,11 +1127,7 @@ async fn should_report_the_delegate_of_the_highest_applied_authorization() {
 
     let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ONE);
     deposits.record_authorization(rotated.clone(), transaction_signature());
-    finalize_sweep_carrying(
-        &mut deposits,
-        account(0),
-        Some(rotated.signed_with(transaction_signature())),
-    );
+    finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
 
     assert_eq!(
         deposits.delegation(&account(0)),
@@ -1157,24 +1192,29 @@ fn replay_of_the_event_log() -> State {
     state
 }
 
-/// Queue `account`'s USDT, hand it to a sweep of its own carrying `authorization`, and finalize
-/// that sweep. Numbered after the sweep a fixture enqueues, so it can follow one.
+/// Queue [`account(0)`]'s deposit of the token sweep `id` alone moves, hand it to that sweep
+/// carrying `authorization`, and finalize the sweep. One token per id, so several sweeps of the
+/// same account can follow one another.
 fn finalize_sweep_carrying(
     deposits: &mut AutomaticDeposits,
-    account: Account,
+    id: SweepId,
     authorization: Option<SignedAuthorization>,
-) -> SweepId {
-    let id = SweepId(1);
+) {
+    let account = account(0);
+    let token = token(id.0 as u8);
     let request = sweep_request(
         id,
-        Asset::Erc20(usdt()),
+        Asset::Erc20(token),
         vec![authorized_item(account, authorization)],
     );
-    queue(deposits, &[(account, usdt())]);
-    deposits.record_sweep_scheduled(id, Asset::Erc20(usdt()), [account]);
+    queue(deposits, &[(account, token)]);
+    deposits.record_sweep_scheduled(id, Asset::Erc20(token), [account]);
     deposits.record_sweep_request(request.clone());
     finalize_sweep(deposits, &request, TransactionStatus::Success);
-    id
+}
+
+fn signed(request: &AuthorizationRequest) -> SignedAuthorization {
+    request.signed_with(transaction_signature())
 }
 
 fn sweep_request(id: SweepId, asset: Asset, items: Vec<AuthorizedSweepItem>) -> SweepRequest {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1046,8 +1046,8 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 
     finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
-    // Signing a tuple is not applying it: an address only a sweep that left it out has swept
-    // holds no delegation.
+    // Signing a tuple is not applying it: a sweep that leaves the tuple out leaves the address
+    // without a delegation.
     assert_eq!(deposits.authorizations_len(), 1);
     assert_eq!(deposits.applied_authorizations_len(), 0);
     assert_eq!(deposits.delegation(&account(0)), None);

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, DepositRequest, DepositStage,
+    AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, Delegation, DepositRequest, DepositStage,
     DepositStatusInfo, MAX_ACTIVE_DEPOSITS, MAX_ASSETS_PER_ACCOUNT, RegisterDepositError,
     SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry, SweepTarget,
 };
@@ -8,18 +8,34 @@ use crate::deposit_address::DepositAddress;
 use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
 use crate::lifecycle::EthereumNetwork;
-use crate::numeric::{BlockNumber, Erc20Value};
+use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
+use crate::state::State;
+use crate::state::audit::{EventType, apply_state_transition, process_event};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::{PipelineRequest, SweepId, SweepRequest};
+use crate::state::transactions::{
+    AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest, sweep_gas_limit,
+};
+use crate::storage::with_event_iter;
+use crate::sweeper_contract::SweepItem;
+use crate::test_fixtures::mock::MockTimeProvider;
 use crate::test_fixtures::{
-    deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, usdc, usdt,
+    deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, initial_state,
+    prepay_sweep_gas, state_with_enqueued_sweep, sweeper_contract, transaction_signature, usdc,
+    usdt,
 };
 use crate::timed_sized_map::{Entry, Timestamp};
-use crate::tx::{SignableTransaction, Signed, TransactionSignature};
+use crate::tx::{
+    AuthorizationRequest, SignableTransaction, Signed, SignedAuthorization, SweepTransaction,
+    TransactionSignature,
+};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
+
+/// A delegate other than the sweeper contract every fixture sweep names, for the tests that rotate
+/// an account onto a second one.
+const ANOTHER_DELEGATE: Address = Address::new([0x9e; 20]);
 
 #[test]
 fn should_watch_a_pair_for_the_scan_window() {
@@ -947,7 +963,7 @@ async fn should_release_a_deposit_once_its_sweep_succeeds() {
     let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
     queue(&mut deposits, &[(account(1), usdc())]);
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
 
     // The swept pair is gone from the queue; the pair queued after the sweep was decided is still
     // offered.
@@ -962,7 +978,7 @@ async fn should_release_a_deposit_once_its_sweep_succeeds() {
 async fn should_drop_a_deposit_once_its_sweep_fails() {
     let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
 
     // A reverted sweep moved nothing, but the minter does not retry: the pair leaves the queue and
     // has to be armed afresh.
@@ -975,7 +991,7 @@ async fn should_release_every_account_a_sweep_held() {
     let (mut deposits, request) =
         deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
 
     assert_eq!(deposits.sweep_len(), 0);
 }
@@ -992,27 +1008,282 @@ async fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
     deposits.record_sweep_scheduled(SweepId(0), Asset::Erc20(usdc()), [account(0)]);
     deposits.record_sweep_request(request.clone());
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
+}
+
+#[tokio::test]
+async fn should_mark_the_authorizations_a_finalized_sweep_carried_as_applied() {
+    // A tuple applies before the call runs and stays applied when the call reverts, so both
+    // outcomes leave the delegation installed.
+    for status in [TransactionStatus::Success, TransactionStatus::Failure] {
+        let (mut deposits, request) =
+            deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+
+        finalize_sweep(&mut deposits, &request, status);
+
+        for account in [account(0), account(1)] {
+            assert_eq!(
+                deposits.delegation(&account),
+                Some(Delegation {
+                    delegate: sweeper_contract(),
+                    nonce: TransactionNonce::ONE,
+                }),
+                "a {status:?} sweep installs the delegations it carried"
+            );
+        }
+        assert_eq!(deposits.applied_authorizations_len(), 2);
+    }
+}
+
+#[test]
+fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
+    let mut deposits = AutomaticDeposits::default();
+    deposits.record_authorization(
+        authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO),
+        transaction_signature(),
+    );
+
+    finalize_sweep_carrying(&mut deposits, account(0), None);
+
+    // Signing a tuple is not applying it: an address only a sweep that left it out has swept
+    // holds no delegation.
+    assert_eq!(deposits.authorizations_len(), 1);
+    assert_eq!(deposits.applied_authorizations_len(), 0);
+    assert_eq!(deposits.delegation(&account(0)), None);
+}
+
+#[tokio::test]
+async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_it() {
+    let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
+    let authorization = first.items[0].authorization.clone();
+    assert!(authorization.is_some(), "the fixture must carry a tuple");
+
+    // The protocol skips a tuple whose nonce the account has already spent, so re-carrying it
+    // changes nothing on chain.
+    let second = finalize_sweep_carrying(&mut deposits, account(0), authorization);
+
+    assert_ne!(second, first.id);
+    assert_eq!(
+        applied_by(
+            &deposits,
+            &authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO)
+        ),
+        Some(first.id)
+    );
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 1);
+}
+
+#[tokio::test]
+async fn should_report_the_delegate_of_the_highest_applied_authorization() {
+    let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
+
+    let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ONE);
+    deposits.record_authorization(rotated.clone(), transaction_signature());
+    finalize_sweep_carrying(
+        &mut deposits,
+        account(0),
+        Some(rotated.signed_with(transaction_signature())),
+    );
+
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: ANOTHER_DELEGATE,
+            nonce: TransactionNonce::new(2),
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 2);
+}
+
+#[tokio::test]
+async fn should_rebuild_the_applied_marks_by_replaying_the_event_log() {
+    let (mut live, request) = state_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    let mut time_provider = MockTimeProvider::new();
+    time_provider.expect_time().return_const(0_u64);
+    for event in sweep_pipeline_events(
+        live.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Success,
+    ) {
+        process_event(&mut live, event, &time_provider);
+    }
+
+    let replayed = replay_of_the_event_log();
+
+    assert_eq!(
+        replayed.automatic_deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(
+        replayed
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(())
+    );
+
+    let mut unmarked = replayed.automatic_deposits.clone();
+    for stored in unmarked.authorizations.values_mut() {
+        stored.applied_by = None;
+    }
+    assert_ne!(
+        unmarked.is_equivalent_to(&live.automatic_deposits),
+        Ok(()),
+        "equivalence must notice which authorizations were applied"
+    );
+}
+
+/// The minter state the event log alone reconstructs. The prepaid sweep gas is not event-sourced,
+/// so it is put back by hand for the accepted sweeps in the log to draw on.
+fn replay_of_the_event_log() -> State {
+    let mut state = initial_state();
+    prepay_sweep_gas(&mut state);
+    with_event_iter(|events| {
+        for event in events {
+            apply_state_transition(&mut state, &event.payload);
+        }
+    });
+    state
+}
+
+/// Queue `account`'s USDT, hand it to a sweep of its own carrying `authorization`, and finalize
+/// that sweep. Numbered after the sweep a fixture enqueues, so it can follow one.
+fn finalize_sweep_carrying(
+    deposits: &mut AutomaticDeposits,
+    account: Account,
+    authorization: Option<SignedAuthorization>,
+) -> SweepId {
+    let id = SweepId(1);
+    let request = sweep_request(
+        id,
+        Asset::Erc20(usdt()),
+        vec![authorized_item(account, authorization)],
+    );
+    queue(deposits, &[(account, usdt())]);
+    deposits.record_sweep_scheduled(id, Asset::Erc20(usdt()), [account]);
+    deposits.record_sweep_request(request.clone());
+    finalize_sweep(deposits, &request, TransactionStatus::Success);
+    id
+}
+
+fn sweep_request(id: SweepId, asset: Asset, items: Vec<AuthorizedSweepItem>) -> SweepRequest {
+    let max_transaction_fee = gas_fee_estimate()
+        .to_price(sweep_gas_limit(&items))
+        .max_transaction_fee();
+    SweepRequest {
+        id,
+        destination: sweeper_contract(),
+        asset,
+        items,
+        max_transaction_fee,
+        created_at: 0,
+    }
+}
+
+fn authorized_item(
+    account: Account,
+    authorization: Option<SignedAuthorization>,
+) -> AuthorizedSweepItem {
+    AuthorizedSweepItem {
+        item: SweepItem {
+            deposit: deposit_address(&account),
+            account,
+            attestation: transaction_signature(),
+        },
+        authorization,
+    }
+}
+
+fn authorization_request(
+    account: Account,
+    delegate: Address,
+    nonce: TransactionNonce,
+) -> AuthorizationRequest {
+    AuthorizationRequest::new(
+        account,
+        EthereumNetwork::default().chain_id(),
+        delegate,
+        nonce,
+    )
+}
+
+fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> Option<SweepId> {
+    deposits
+        .authorizations
+        .get(request)
+        .and_then(|stored| stored.applied_by)
 }
 
 /// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.
 fn finalize_sweep(
     deposits: &mut AutomaticDeposits,
-    request: SweepRequest,
+    request: &SweepRequest,
     status: TransactionStatus,
 ) {
-    let id = request.id;
+    let sweep = sweep_pipeline_outcome(deposits.next_sweeper_transaction_nonce(), request, status);
+    deposits.record_created_sweep_transaction(request.id, sweep.transaction);
+    deposits.record_signed_sweep_transaction(sweep.signed);
+    deposits.record_finalized_sweep_transaction(request.id, &sweep.receipt);
+}
+
+/// The events the sweeper pipeline records taking the already-accepted `request` from its
+/// transaction to a receipt of `status`.
+fn sweep_pipeline_events(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> Vec<EventType> {
+    let sweep = sweep_pipeline_outcome(nonce, request, status);
+    vec![
+        EventType::CreatedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.transaction,
+        },
+        EventType::SignedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.signed,
+        },
+        EventType::FinalizedSweeperTransaction {
+            sweep_id: request.id,
+            transaction_receipt: sweep.receipt,
+        },
+    ]
+}
+
+/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction
+/// signed, and the receipt finalizing it.
+struct SweepPipelineOutcome {
+    transaction: SweepTransaction,
+    signed: Signed<SweepTransaction>,
+    receipt: TransactionReceipt,
+}
+
+fn sweep_pipeline_outcome(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> SweepPipelineOutcome {
     let transaction = request
         .create_transaction(
-            deposits.next_sweeper_transaction_nonce(),
+            nonce,
             gas_fee_estimate(),
             request.gas_limit(),
             EthereumNetwork::Sepolia,
         )
         .expect("BUG: the fixture prices the request with the estimate it creates with");
-    deposits.record_created_sweep_transaction(id, transaction.clone());
     let signed = Signed::from((
-        transaction,
+        transaction.clone(),
         TransactionSignature {
             signature_y_parity: false,
             r: Default::default(),
@@ -1027,8 +1298,11 @@ fn finalize_sweep(
         status,
         transaction_hash: signed.hash(),
     };
-    deposits.record_signed_sweep_transaction(signed);
-    deposits.record_finalized_sweep_transaction(id, &receipt);
+    SweepPipelineOutcome {
+        transaction,
+        signed,
+        receipt,
+    }
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1037,7 +1037,7 @@ async fn should_mark_the_authorizations_a_finalized_sweep_carried_as_applied() {
 }
 
 #[test]
-fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
+fn should_leave_a_tuple_unapplied_and_its_address_undelegated_when_a_sweep_leaves_it_out() {
     let mut deposits = AutomaticDeposits::default();
     deposits.record_authorization(
         authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO),
@@ -1046,8 +1046,6 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 
     finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
-    // Signing a tuple is not applying it: a sweep that leaves the tuple out leaves the address
-    // without a delegation.
     assert_eq!(deposits.authorizations_len(), 1);
     assert_eq!(deposits.applied_authorizations_len(), 0);
     assert_eq!(deposits.delegation(&account(0)), None);

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1063,13 +1063,6 @@ async fn should_not_mark_a_tuple_whose_nonce_the_account_has_already_spent() {
     finalize_sweep_carrying(&mut deposits, SweepId(1), authorization);
 
     assert_eq!(
-        applied_by(
-            &deposits,
-            &authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO)
-        ),
-        Some(first.id)
-    );
-    assert_eq!(
         deposits.delegation(&account(0)),
         Some(Delegation {
             delegate: sweeper_contract(),
@@ -1093,8 +1086,10 @@ fn should_apply_only_the_first_of_two_sweeps_carrying_the_same_nonce() {
     finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&incumbent)));
     finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
 
-    assert_eq!(applied_by(&deposits, &incumbent), Some(SweepId(0)));
-    assert_eq!(applied_by(&deposits, &rotated), None);
+    assert!(
+        deposits.authorization(&rotated).is_none(),
+        "applying the incumbent tuple spent the nonce the rotated one was signed for"
+    );
     assert_eq!(
         deposits.delegation(&account(0)),
         Some(Delegation {
@@ -1113,7 +1108,6 @@ fn should_not_mark_a_tuple_signed_for_a_nonce_the_account_has_not_reached() {
 
     finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&ahead)));
 
-    assert_eq!(applied_by(&deposits, &ahead), None);
     assert_eq!(deposits.delegation(&account(0)), None);
     assert_eq!(deposits.applied_authorizations_len(), 0);
 }
@@ -1134,7 +1128,7 @@ async fn should_report_the_delegate_of_the_highest_applied_authorization() {
             nonce: TransactionNonce::new(2),
         })
     );
-    assert_eq!(deposits.applied_authorizations_len(), 2);
+    assert_eq!(deposits.applied_authorizations_len(), 1);
 }
 
 #[tokio::test]
@@ -1164,16 +1158,6 @@ async fn should_rebuild_the_applied_marks_by_replaying_the_event_log() {
             .automatic_deposits
             .is_equivalent_to(&live.automatic_deposits),
         Ok(())
-    );
-
-    let mut unmarked = replayed.automatic_deposits.clone();
-    for stored in unmarked.authorizations.values_mut() {
-        stored.applied_by = None;
-    }
-    assert_ne!(
-        unmarked.is_equivalent_to(&live.automatic_deposits),
-        Ok(()),
-        "equivalence must notice which authorizations were applied"
     );
 }
 
@@ -1254,13 +1238,6 @@ fn authorization_request(
         delegate,
         nonce,
     )
-}
-
-fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> Option<SweepId> {
-    deposits
-        .authorizations
-        .get(request)
-        .and_then(|stored| stored.applied_by)
 }
 
 /// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1027,7 +1027,7 @@ async fn should_mark_the_authorizations_a_finalized_sweep_carried_as_applied() {
                 deposits.delegation(&account),
                 Some(Delegation {
                     delegate: sweeper_contract(),
-                    nonce: TransactionNonce::ONE,
+                    nonce: TransactionNonce::ZERO,
                 }),
                 "a {status:?} sweep installs the delegations it carried"
             );
@@ -1066,7 +1066,7 @@ async fn should_not_mark_a_tuple_whose_nonce_the_account_has_already_spent() {
         deposits.delegation(&account(0)),
         Some(Delegation {
             delegate: sweeper_contract(),
-            nonce: TransactionNonce::ONE,
+            nonce: TransactionNonce::ZERO,
         })
     );
     assert_eq!(deposits.applied_authorizations_len(), 1);
@@ -1094,7 +1094,7 @@ fn should_apply_only_the_first_of_two_sweeps_carrying_the_same_nonce() {
         deposits.delegation(&account(0)),
         Some(Delegation {
             delegate: sweeper_contract(),
-            nonce: TransactionNonce::ONE,
+            nonce: TransactionNonce::ZERO,
         })
     );
     assert_eq!(deposits.applied_authorizations_len(), 1);
@@ -1125,7 +1125,7 @@ async fn should_report_the_delegate_of_the_highest_applied_authorization() {
         deposits.delegation(&account(0)),
         Some(Delegation {
             delegate: ANOTHER_DELEGATE,
-            nonce: TransactionNonce::new(2),
+            nonce: TransactionNonce::ONE,
         })
     );
     assert_eq!(deposits.applied_authorizations_len(), 1);
@@ -1150,7 +1150,7 @@ async fn should_rebuild_the_applied_marks_by_replaying_the_event_log() {
         replayed.automatic_deposits.delegation(&account(0)),
         Some(Delegation {
             delegate: sweeper_contract(),
-            nonce: TransactionNonce::ONE,
+            nonce: TransactionNonce::ZERO,
         })
     );
     assert_eq!(

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -19,8 +19,8 @@ use crate::numeric::{
 };
 use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::{
-    Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
-    Resubmittable, SignableTransaction, Signed, SignedAuthorization,
+    AuthorizationRequest, Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction,
+    GasFeeEstimate, Resubmittable, SignableTransaction, Signed, SignedAuthorization,
     SignedEip1559TransactionRequest, TransactionPrice,
 };
 use candid::Principal;
@@ -298,9 +298,9 @@ const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 ///
 /// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
 /// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
-/// matches — is charged the same 25'000 and refunded 12'500 for an authority the state trie
-/// already holds. That refund lands after execution and so cannot shrink the limit the transaction
-/// had to declare, leaving 25'000 the figure to budget either way. Rounded up as its siblings are.
+/// matches — costs the full 25'000: the 12'500 refund for an authority the state trie already
+/// holds is granted only past the nonce check, and a tuple failing that check ends there. Rounded
+/// up as its siblings are.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
@@ -352,6 +352,23 @@ impl SweepRequest {
         self.items
             .iter()
             .filter_map(|item| item.authorization.clone())
+            .collect()
+    }
+
+    /// The delegations this sweep carries, each named as what its signature was signed over, which
+    /// is the key the minter stores it under.
+    pub fn authorization_requests(&self) -> Vec<AuthorizationRequest> {
+        self.items
+            .iter()
+            .filter_map(|item| {
+                let authorization = item.authorization.as_ref()?;
+                Some(AuthorizationRequest::new(
+                    item.item.account,
+                    authorization.chain_id,
+                    authorization.delegate,
+                    authorization.nonce,
+                ))
+            })
             .collect()
     }
 }

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -27,8 +27,8 @@ use crate::{
         automatic_deposits::SweepTarget,
         mutate_state, read_state,
         transactions::{
-            AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepRequest,
-            sweep_gas_limit,
+            AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepId,
+            SweepRequest, sweep_gas_limit,
         },
     },
     time::TimeProvider,
@@ -38,10 +38,12 @@ use crate::{
         send_signed_transactions,
     },
 };
+use candid::Nat;
+use evm_rpc_types::TransactionReceipt as EvmTransactionReceipt;
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
@@ -470,6 +472,26 @@ async fn send_transactions_batch(
     send_signed_transactions(sender, &transactions_to_send).await;
 }
 
+/// The finalized sweeps of `receipts`, in the order the chain executed them: by block, then by
+/// position within it. The sweeper queue reschedules a sweep it cannot yet pay for, which lets a
+/// lower [`SweepId`] hold a higher transaction nonce, so id order is not chain order; the
+/// authorizations a sweep applied follow from the nonce its deposit addresses had reached when it
+/// ran, which only chain order tells.
+fn in_chain_execution_order(
+    receipts: BTreeMap<SweepId, EvmTransactionReceipt>,
+) -> Vec<(SweepId, EvmTransactionReceipt)> {
+    let mut ordered: Vec<_> = receipts.into_iter().collect();
+    ordered.sort_by(|(_, left), (_, right)| chain_position(left).cmp(&chain_position(right)));
+    ordered
+}
+
+fn chain_position(receipt: &EvmTransactionReceipt) -> (&Nat, &Nat) {
+    (
+        receipt.block_number.as_ref(),
+        receipt.transaction_index.as_ref(),
+    )
+}
+
 async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_provider: &T) {
     if read_state(|s| s.automatic_deposits.is_sent_sweep_tx_empty()) {
         return;
@@ -481,7 +503,7 @@ async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_prov
                     .sent_sweep_transactions_to_finalize(&finalized_tx_count)
             });
             if let Some(receipts) = fetch_finalized_receipts(txs_to_finalize).await {
-                for (sweep_id, transaction_receipt) in receipts {
+                for (sweep_id, transaction_receipt) in in_chain_execution_order(receipts) {
                     mutate_state(|s| {
                         process_event(
                             s,

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -9,7 +9,7 @@ use crate::state::event::AutomaticDeposit;
 use crate::state::transactions::{SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
-use crate::sweep::create_pending_sweeper_requests;
+use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
@@ -17,10 +17,14 @@ use crate::test_fixtures::{
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
+use evm_rpc_types::{
+    Hex20, Hex32, Hex256, HexByte, Nat256, TransactionReceipt as EvmTransactionReceipt,
+};
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
 use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
 use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeMap;
 
 const NOW: u64 = 1_620_328_630_000_000_000;
 const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
@@ -307,6 +311,28 @@ async fn should_leave_out_a_deposit_whose_attestation_could_not_be_signed() {
     assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 2);
 }
 
+#[test]
+fn should_order_finalized_sweeps_as_the_chain_executed_them() {
+    let earliest = receipt_mined_at(7, 3);
+    let second = receipt_mined_at(8, 0);
+    let latest = receipt_mined_at(8, 1);
+    let receipts = BTreeMap::from([
+        (SweepId(0), latest.clone()),
+        (SweepId(1), earliest.clone()),
+        (SweepId(2), second.clone()),
+    ]);
+
+    assert_eq!(
+        in_chain_execution_order(receipts),
+        vec![
+            (SweepId(1), earliest),
+            (SweepId(2), second),
+            (SweepId(0), latest),
+        ],
+        "a sweep mined earlier must be finalized first, whatever its id"
+    );
+}
+
 fn pending_sweeps() -> Vec<SweepRequest> {
     read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
 }
@@ -481,6 +507,26 @@ fn expected_signature(request: &AttestationRequest) -> TransactionSignature {
 
 fn recorded_events() -> Vec<EventType> {
     with_event_iter(|events| events.map(|event| event.payload).collect())
+}
+
+fn receipt_mined_at(block_number: u64, transaction_index: u64) -> EvmTransactionReceipt {
+    EvmTransactionReceipt {
+        block_hash: Hex32::from([0_u8; 32]),
+        block_number: Nat256::from(block_number),
+        effective_gas_price: Nat256::ZERO,
+        gas_used: Nat256::ZERO,
+        cumulative_gas_used: Nat256::ZERO,
+        status: Some(Nat256::from(1_u8)),
+        root: None,
+        transaction_hash: Hex32::from([0_u8; 32]),
+        contract_address: None,
+        from: Hex20::from([0_u8; 20]),
+        logs: vec![],
+        logs_bloom: Hex256::from([0_u8; 256]),
+        to: None,
+        transaction_index: Nat256::from(transaction_index),
+        tx_type: HexByte::from(2_u8),
+    }
 }
 
 fn mock() -> MockCanisterRuntime {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -9,7 +9,7 @@ use crate::lifecycle::init::InitArg;
 use crate::numeric::{
     BlockNumber, Erc20Value, GasAmount, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas,
 };
-use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::audit::{EventType, process_event};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::event::AutomaticDeposit;
@@ -205,25 +205,29 @@ pub fn prepay_sweep_gas(state: &mut State) {
 /// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
-/// the sweep is assembled by the production path without the runtime signing anything.
+/// the sweep is assembled by the production path without the runtime signing anything, and the log
+/// alone reconstructs the state the fixture hands back.
 pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
     const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
 
+    let mut runtime = mock::MockCanisterRuntime::new();
+    runtime.expect_time().return_const(SWEEP_DECIDED_AT);
     let mut state = state_with_deposit_helper(deposit_helper());
     prepay_sweep_gas(&mut state);
     state.sweeper_contract_address = Some(sweeper_contract());
     state.last_transaction_price_estimate = Some((SWEEP_DECIDED_AT, gas_fee_estimate()));
     let chain_id = state.ethereum_network.chain_id();
     for (account, token) in pairs {
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AutomaticDepositReceived(AutomaticDeposit {
+            EventType::AutomaticDepositReceived(AutomaticDeposit {
                 owner: account.owner,
                 subaccount: account.subaccount,
                 address: deposit_address(account),
                 asset: Asset::Erc20(*token),
                 ..automatic_deposit()
             }),
+            &runtime,
         );
     }
     for account in pairs
@@ -231,16 +235,17 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
         .map(|(account, _token)| *account)
         .collect::<BTreeSet<_>>()
     {
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AttestedDepositAddress {
+            EventType::AttestedDepositAddress {
                 request: AttestationRequest::new(chain_id, deposit_helper(), account),
                 signature: transaction_signature(),
             },
+            &runtime,
         );
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AuthorizedDepositAddress {
+            EventType::AuthorizedDepositAddress {
                 request: AuthorizationRequest::new(
                     account,
                     chain_id,
@@ -249,11 +254,10 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
                 ),
                 signature: transaction_signature(),
             },
+            &runtime,
         );
     }
     init_state(state);
-    let mut runtime = mock::MockCanisterRuntime::new();
-    runtime.expect_time().return_const(SWEEP_DECIDED_AT);
 
     create_pending_sweeper_requests(&runtime).await;
 

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -122,7 +122,7 @@ impl AuthorizationRequest {
 }
 
 /// An unsigned EIP-7702 authorization signed over by an authority to delegate its code.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Authorization {
     pub chain_id: u64,
     pub delegate: Address,

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -89,6 +89,14 @@ impl AuthorizationRequest {
         self.account
     }
 
+    pub fn delegate(&self) -> Address {
+        self.delegate
+    }
+
+    pub fn nonce(&self) -> TransactionNonce {
+        self.nonce
+    }
+
     pub fn derivation_path(&self) -> Vec<ByteBuf> {
         AddressSchema::Deposit(self.account).derivation_path()
     }

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1368,7 +1368,8 @@ fn should_export_the_stored_attestation_and_authorization_metrics() {
     CkEthSetup::default()
         .check_minter_metrics()
         .assert_contains_metric_matching(r"cketh_minter_stored_attestations 0 \d+")
-        .assert_contains_metric_matching(r"cketh_minter_stored_authorizations 0 \d+");
+        .assert_contains_metric_matching(r"cketh_minter_stored_authorizations 0 \d+")
+        .assert_contains_metric_matching(r"cketh_minter_applied_authorizations 0 \d+");
 }
 
 /// Tests with the EVM RPC canister


### PR DESCRIPTION
### Why

* The minter stores every EIP-7702 authorization it signs, but signed is not applied. A tuple may sit in a sweep still in flight, or never be sent, and once the configured sweeper contract changes the store holds tuples for two delegates at the same nonce.
* Replacing the sweeper delegate (design: `R18` in #11491) needs to know, per deposit address, which delegate its code points at and which nonce it has reached. Only the minter holds the deposit keys, so both follow from which of its own tuples were applied.

### What

* Each stored authorization records the sweep that applied it. When a sweep finalizes, successful or reverted, its carried tuples are marked applied when their nonce matches the address' next nonce. Others were skipped by the protocol.
* A derived `delegation(account)` reports the delegate named by the highest applied tuple and the address' next nonce.
* The marks replay from the existing events. No new event, no Candid change.
* A new gauge counts applied authorizations next to the existing count of stored ones.
* Corrects the gas doc comment on skipped tuples: EIP-7702 checks the nonce before granting the existing-account refund, so a skipped tuple costs the full 25'000.

Sweeps still carry the same tuples as before. The first PR of a stack of three: next come tuple-less sweeps of already-delegated addresses, then rotation to a new delegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X44H4nAU65nAexEUvG15MK
