### PR TITLE
feat(cketh): sweep an already-delegated address without a tuple

### DIFF
--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -308,34 +308,46 @@ impl State {
         )
     }
 
-    /// What every deposit address in `accounts` authorizes to let the configured sweeper contract
-    /// sweep it: the tuple naming this minter's chain, that contract, and nonce zero. `None` while
-    /// no sweeper contract is configured.
-    ///
-    /// The nonce is always zero, whatever the address actually holds. A deposit address is at
-    /// nonce zero exactly while it has never been delegated — applying an authorization spends it
-    /// — so the tuple either installs the delegation or is skipped, and both are correct in any
-    /// order the sweeps carrying them land. That is what lets a sweep authorize every address it
-    /// touches without tracking which ones are already delegated, at the price of the intrinsic
-    /// gas a skipped tuple still costs.
+    /// What each deposit address in `accounts` still has to authorize to let the configured sweeper
+    /// contract sweep it, one entry per account and in the same order. The outer `None` says no
+    /// sweeper contract is configured; an inner `None` says that address needs no tuple, being
+    /// delegated to that very contract already. A sweep every address of which is delegated carries
+    /// no authorization at all and is sent as a plain EIP-1559 transaction.
     pub fn authorization_requests<T: AsRef<Account>>(
         &self,
         accounts: &[T],
-    ) -> Option<Vec<AuthorizationRequest>> {
+    ) -> Option<Vec<Option<AuthorizationRequest>>> {
         let delegate = self.sweeper_contract_address?;
         Some(
             accounts
                 .iter()
-                .map(|account| {
-                    AuthorizationRequest::new(
-                        *account.as_ref(),
-                        self.ethereum_network.chain_id(),
-                        delegate,
-                        TransactionNonce::ZERO,
-                    )
-                })
+                .map(|account| self.authorization_request(*account.as_ref(), delegate))
                 .collect(),
         )
+    }
+
+    /// The tuple `account`'s deposit address has to authorize for `delegate`'s code to run at it,
+    /// or `None` if it already delegates `delegate`.
+    ///
+    /// An address that has never been delegated is at nonce zero, and authorizes there. So does one
+    /// delegated to another contract, whose nonce zero is spent: that tuple is skipped on chain,
+    /// which is what leaves the address on its current delegate until re-delegating it is supported.
+    fn authorization_request(
+        &self,
+        account: Account,
+        delegate: Address,
+    ) -> Option<AuthorizationRequest> {
+        let nonce = match self.automatic_deposits.delegation(&account) {
+            Some(delegation) if delegation.delegate == delegate => return None,
+            Some(_delegated_elsewhere) => TransactionNonce::ZERO,
+            None => TransactionNonce::ZERO,
+        };
+        Some(AuthorizationRequest::new(
+            account,
+            self.ethereum_network.chain_id(),
+            delegate,
+            nonce,
+        ))
     }
 
     /// The attestation `account`'s ckERC20 deposit address has already signed for the configuration

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -344,6 +344,7 @@ impl State {
             Some(delegation) if delegation.delegate == delegate => {
                 return SweepAuthorization::AlreadyDelegated;
             }
+            //TODO DEFI-2997: track and increment nonce of deposit address
             Some(_delegated_elsewhere) => TransactionNonce::ZERO,
             None => TransactionNonce::ZERO,
         };

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -136,6 +136,16 @@ pub struct State {
     pub sweeper_funding: SweeperFundingAccounting,
 }
 
+/// What a sweep of one deposit address has to carry for the sweeper contract's code to run at it.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum SweepAuthorization {
+    /// The tuple the address has yet to authorize, which the sweep signs once and carries.
+    Required(AuthorizationRequest),
+    /// Nothing: the address already delegates the configured sweeper contract. A sweep every
+    /// address of which is delegated carries no authorization and is a plain EIP-1559 transaction.
+    AlreadyDelegated,
+}
+
 #[derive(Eq, PartialEq, Debug)]
 pub enum InvalidStateError {
     InvalidTransactionNonce(String),
@@ -308,41 +318,36 @@ impl State {
         )
     }
 
-    /// What each deposit address in `accounts` still has to authorize to let the configured sweeper
-    /// contract sweep it, one entry per account and in the same order. The outer `None` says no
-    /// sweeper contract is configured; an inner `None` says that address needs no tuple, being
-    /// delegated to that very contract already. A sweep every address of which is delegated carries
-    /// no authorization at all and is sent as a plain EIP-1559 transaction.
+    /// What a sweep has to carry for each deposit address in `accounts` to let the configured
+    /// sweeper contract's code run at it, one entry per account and in the same order. `None` while
+    /// no sweeper contract is configured.
     pub fn authorization_requests<T: AsRef<Account>>(
         &self,
         accounts: &[T],
-    ) -> Option<Vec<Option<AuthorizationRequest>>> {
+    ) -> Option<Vec<SweepAuthorization>> {
         let delegate = self.sweeper_contract_address?;
         Some(
             accounts
                 .iter()
-                .map(|account| self.authorization_request(*account.as_ref(), delegate))
+                .map(|account| self.sweep_authorization(*account.as_ref(), delegate))
                 .collect(),
         )
     }
 
-    /// The tuple `account`'s deposit address has to authorize for `delegate`'s code to run at it,
-    /// or `None` if it already delegates `delegate`.
+    /// What a sweep of `account`'s deposit address has to carry for `delegate`'s code to run at it.
     ///
     /// An address that has never been delegated is at nonce zero, and authorizes there. So does one
     /// delegated to another contract, whose nonce zero is spent: that tuple is skipped on chain,
     /// which is what leaves the address on its current delegate until re-delegating it is supported.
-    fn authorization_request(
-        &self,
-        account: Account,
-        delegate: Address,
-    ) -> Option<AuthorizationRequest> {
+    fn sweep_authorization(&self, account: Account, delegate: Address) -> SweepAuthorization {
         let nonce = match self.automatic_deposits.delegation(&account) {
-            Some(delegation) if delegation.delegate == delegate => return None,
+            Some(delegation) if delegation.delegate == delegate => {
+                return SweepAuthorization::AlreadyDelegated;
+            }
             Some(_delegated_elsewhere) => TransactionNonce::ZERO,
             None => TransactionNonce::ZERO,
         };
-        Some(AuthorizationRequest::new(
+        SweepAuthorization::Required(AuthorizationRequest::new(
             account,
             self.ethereum_network.chain_id(),
             delegate,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -5,29 +5,23 @@ use super::{
 };
 use crate::asset::Asset;
 use crate::deposit_address::DepositAddress;
-use crate::eth_rpc::Hash;
-use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
 use crate::state::State;
-use crate::state::audit::{EventType, apply_state_transition, process_event};
+use crate::state::audit::{apply_state_transition, process_event};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::{
-    AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest, sweep_gas_limit,
-};
+use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest, sweep_gas_limit};
 use crate::storage::with_event_iter;
 use crate::sweeper_contract::SweepItem;
 use crate::test_fixtures::mock::MockTimeProvider;
 use crate::test_fixtures::{
     deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, initial_state,
-    prepay_sweep_gas, state_with_enqueued_sweep, sweeper_contract, transaction_signature, usdc,
-    usdt,
+    prepay_sweep_gas, state_with_enqueued_sweep, sweep_pipeline_events, sweep_pipeline_outcome,
+    sweeper_contract, transaction_signature, usdc, usdt,
 };
 use crate::timed_sized_map::{Entry, Timestamp};
-use crate::tx::{
-    AuthorizationRequest, SignableTransaction, Signed, SignedAuthorization, SweepTransaction,
-    TransactionSignature,
-};
+use crate::tx::{AuthorizationRequest, SignedAuthorization};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -1250,74 +1244,6 @@ fn finalize_sweep(
     deposits.record_created_sweep_transaction(request.id, sweep.transaction);
     deposits.record_signed_sweep_transaction(sweep.signed);
     deposits.record_finalized_sweep_transaction(request.id, &sweep.receipt);
-}
-
-/// The events the sweeper pipeline records taking the already-accepted `request` from its
-/// transaction to a receipt of `status`.
-fn sweep_pipeline_events(
-    nonce: TransactionNonce,
-    request: &SweepRequest,
-    status: TransactionStatus,
-) -> Vec<EventType> {
-    let sweep = sweep_pipeline_outcome(nonce, request, status);
-    vec![
-        EventType::CreatedSweeperTransaction {
-            sweep_id: request.id,
-            transaction: sweep.transaction,
-        },
-        EventType::SignedSweeperTransaction {
-            sweep_id: request.id,
-            transaction: sweep.signed,
-        },
-        EventType::FinalizedSweeperTransaction {
-            sweep_id: request.id,
-            transaction_receipt: sweep.receipt,
-        },
-    ]
-}
-
-/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction
-/// signed, and the receipt finalizing it.
-struct SweepPipelineOutcome {
-    transaction: SweepTransaction,
-    signed: Signed<SweepTransaction>,
-    receipt: TransactionReceipt,
-}
-
-fn sweep_pipeline_outcome(
-    nonce: TransactionNonce,
-    request: &SweepRequest,
-    status: TransactionStatus,
-) -> SweepPipelineOutcome {
-    let transaction = request
-        .create_transaction(
-            nonce,
-            gas_fee_estimate(),
-            request.gas_limit(),
-            EthereumNetwork::Sepolia,
-        )
-        .expect("BUG: the fixture prices the request with the estimate it creates with");
-    let signed = Signed::from((
-        transaction.clone(),
-        TransactionSignature {
-            signature_y_parity: false,
-            r: Default::default(),
-            s: Default::default(),
-        },
-    ));
-    let receipt = TransactionReceipt {
-        block_hash: Hash([0x11; 32]),
-        block_number: BlockNumber::new(4_190_269),
-        effective_gas_price: signed.transaction().max_fee_per_gas(),
-        gas_used: signed.transaction().gas_limit(),
-        status,
-        transaction_hash: signed.hash(),
-    };
-    SweepPipelineOutcome {
-        transaction,
-        signed,
-        receipt,
-    }
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -294,37 +294,39 @@ const SWEEP_GAS_PER_BALANCE_CHECK: GasAmount = GasAmount::new(15_000);
 const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 
 /// Gas one EIP-7702 authorization costs: 25'000 (`PER_EMPTY_ACCOUNT_COST`) charged upfront for
-/// every tuple, before any of them is looked at.
+/// every tuple, before any of them is looked at. Rounded up as its siblings are.
 ///
-/// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
-/// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
-/// matches — costs the full 25'000: the 12'500 refund for an authority the state trie already
-/// holds is granted only past the nonce check, and a tuple failing that check ends there. Rounded
-/// up as its siblings are.
+/// Budgeted for the tuples the sweep carries, which are those of the addresses it still has to
+/// delegate. A tuple the EVM skips — another sweep delegated the address in between, so the nonce
+/// it was signed for no longer matches — costs the full 25'000: the 12'500 refund for an authority
+/// the state trie already holds is granted only past the nonce check, and a tuple failing that
+/// check ends there.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
-    let addresses = u64::try_from(
+    let saturating_count = |occurrences: usize| u64::try_from(occurrences).unwrap_or(u64::MAX);
+    let addresses = saturating_count(
         items
             .iter()
             .map(|authorized| authorized.item.deposit)
             .collect::<BTreeSet<_>>()
             .len(),
-    )
-    .unwrap_or(u64::MAX);
+    );
+    let authorizations = saturating_count(
+        items
+            .iter()
+            .filter(|authorized| authorized.authorization.is_some())
+            .count(),
+    );
     [
-        SWEEP_GAS_PER_BALANCE_CHECK,
-        SWEEP_GAS_PER_TRANSFER,
-        SWEEP_GAS_PER_AUTHORIZATION,
+        (SWEEP_GAS_PER_BALANCE_CHECK, addresses),
+        (SWEEP_GAS_PER_TRANSFER, addresses),
+        (SWEEP_GAS_PER_AUTHORIZATION, authorizations),
     ]
     .into_iter()
-    .fold(SWEEP_BASE_GAS, |total, gas_per_address| {
+    .fold(SWEEP_BASE_GAS, |total, (gas_each, occurrences)| {
         total
-            .checked_add(
-                gas_per_address
-                    .checked_mul(addresses)
-                    .unwrap_or(GasAmount::MAX),
-            )
+            .checked_add(gas_each.checked_mul(occurrences).unwrap_or(GasAmount::MAX))
             .unwrap_or(GasAmount::MAX)
     })
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -3059,7 +3059,9 @@ mod sweep_lane {
         const MEASURED_TEN_DEPOSIT_SWEEP_GAS: u128 = 609_431;
 
         let items_for = |addresses: u8| -> Vec<AuthorizedSweepItem> {
-            (1..=addresses).map(|seed| sweep_item(seed, None)).collect()
+            (1..=addresses)
+                .map(|seed| sweep_item(seed, Some(authorization(seed))))
+                .collect()
         };
 
         assert_eq!(sweep_gas_limit(&items_for(1)), GasAmount::new(225_000));
@@ -3069,7 +3071,28 @@ mod sweep_lane {
         let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
         assert_eq!(
             sweep_gas_limit(&one_address_ten_times),
-            sweep_gas_limit(&items_for(1))
+            sweep_gas_limit(&[sweep_item(1, None)])
+        );
+    }
+
+    #[test]
+    fn should_budget_the_authorization_gas_only_for_the_items_carrying_a_tuple() {
+        let delegated = sweep_item(1, None);
+        let to_delegate = sweep_item(2, Some(authorization(2)));
+        let also_to_delegate = sweep_item(3, Some(authorization(3)));
+
+        assert_eq!(
+            sweep_gas_limit(std::slice::from_ref(&delegated)),
+            GasAmount::new(185_000),
+            "an address swept without a tuple costs its balance check and its transfer only"
+        );
+        assert_eq!(
+            sweep_gas_limit(&[delegated, to_delegate.clone()]),
+            GasAmount::new(350_000)
+        );
+        assert_eq!(
+            sweep_gas_limit(&[to_delegate, also_to_delegate]),
+            GasAmount::new(390_000)
         );
     }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2968,6 +2968,7 @@ mod sweep_lane {
     use ethnum::u256;
     use ic_ethereum_types::Address;
     use icrc_ledger_types::icrc1::account::Account;
+    use std::slice::from_ref;
 
     const EIP1559_TX_ID: u8 = 2;
     const SET_CODE_TX_ID: u8 = 4;
@@ -3068,10 +3069,14 @@ mod sweep_lane {
         assert_eq!(sweep_gas_limit(&items_for(10)), GasAmount::new(1_710_000));
         assert!(sweep_gas_limit(&items_for(10)) > GasAmount::new(MEASURED_TEN_DEPOSIT_SWEEP_GAS));
 
-        let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
+        let one_address_ten_times: Vec<_> = (0..10)
+            .map(|_| sweep_item(1, Some(authorization(1))))
+            .collect();
         assert_eq!(
             sweep_gas_limit(&one_address_ten_times),
-            sweep_gas_limit(&[sweep_item(1, None)])
+            GasAmount::new(585_000),
+            "the balance check and the transfer collapse onto the one address walked, while every \
+             tuple in the list is charged"
         );
     }
 
@@ -3082,7 +3087,7 @@ mod sweep_lane {
         let also_to_delegate = sweep_item(3, Some(authorization(3)));
 
         assert_eq!(
-            sweep_gas_limit(std::slice::from_ref(&delegated)),
+            sweep_gas_limit(from_ref(&delegated)),
             GasAmount::new(185_000),
             "an address swept without a tuple costs its balance check and its transfer only"
         );

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -103,7 +103,11 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             return;
         };
         sign_attestations_batch(attestation_requests, runtime).await;
-        sign_authorizations_batch(authorization_requests, runtime).await;
+        sign_authorizations_batch(
+            authorization_requests.into_iter().flatten().collect(),
+            runtime,
+        )
+        .await;
         enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
@@ -113,7 +117,8 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 ///
 /// A target whose attestation or authorization is missing is left out rather than swept: its
 /// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
-/// delegate it with. It stays queued, and the next tick tries it again.
+/// delegate it with. It stays queued, and the next tick tries it again. A target already delegated
+/// to the sweeper contract asks for no authorization, and is swept carrying none.
 fn enqueue_sweep<R: CanisterRuntime>(
     asset: Asset,
     targets: &[SweepTarget],
@@ -138,14 +143,20 @@ fn enqueue_sweep<R: CanisterRuntime>(
             .zip(authorization_requests)
             .filter_map(|((target, attestation_request), authorization_request)| {
                 let attestation = s.automatic_deposits.attestation(&attestation_request)?;
-                let authorization = s.automatic_deposits.authorization(&authorization_request)?;
+                let authorization = match authorization_request {
+                    Some(request) => {
+                        let signature = s.automatic_deposits.authorization(&request)?.clone();
+                        Some(request.signed_with(signature))
+                    }
+                    None => None,
+                };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
                         deposit: target.address(),
                         account: target.account(),
                         attestation: attestation.clone(),
                     },
-                    authorization: Some(authorization_request.signed_with(authorization.clone())),
+                    authorization,
                 })
             })
             .collect();

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     numeric::TransactionCount,
     runtime::CanisterRuntime,
     state::{
-        State, TaskType,
+        State, SweepAuthorization, TaskType,
         audit::{EventType, process_event},
         automatic_deposits::SweepTarget,
         mutate_state, read_state,
@@ -32,7 +32,7 @@ use crate::{
         },
     },
     time::TimeProvider,
-    tx::{AuthorizationRequest, GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
+    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -103,11 +103,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             return;
         };
         sign_attestations_batch(attestation_requests, runtime).await;
-        sign_authorizations_batch(
-            authorization_requests.into_iter().flatten().collect(),
-            runtime,
-        )
-        .await;
+        sign_authorizations_batch(authorization_requests, runtime).await;
         enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
@@ -141,14 +137,14 @@ fn enqueue_sweep<R: CanisterRuntime>(
             .iter()
             .zip(attestation_requests)
             .zip(authorization_requests)
-            .filter_map(|((target, attestation_request), authorization_request)| {
+            .filter_map(|((target, attestation_request), sweep_authorization)| {
                 let attestation = s.automatic_deposits.attestation(&attestation_request)?;
-                let authorization = match authorization_request {
-                    Some(request) => {
+                let authorization = match sweep_authorization {
+                    SweepAuthorization::Required(request) => {
                         let signature = s.automatic_deposits.authorization(&request)?.clone();
                         Some(request.signed_with(signature))
                     }
-                    None => None,
+                    SweepAuthorization::AlreadyDelegated => None,
                 };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
@@ -234,18 +230,23 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
     }
 }
 
-/// Signs the authorizations in `requests` that the minter has not signed before, recording each so
-/// a later sweep of the same address reuses it.
+/// Signs the authorizations `authorizations` requires and the minter has not signed before,
+/// recording each so a later sweep of the same address reuses it. An address already delegated
+/// requires none, and so costs no threshold signature.
 ///
 /// A request names the chain, the delegate and the nonce it authorizes, so re-pointing the minter
 /// at another sweeper contract misses the recorded ones and signs afresh.
 async fn sign_authorizations_batch<R: CanisterRuntime>(
-    requests: Vec<AuthorizationRequest>,
+    authorizations: Vec<SweepAuthorization>,
     runtime: &R,
 ) {
     let requests_to_sign: BTreeSet<_> = read_state(|s| {
-        requests
+        authorizations
             .into_iter()
+            .filter_map(|authorization| match authorization {
+                SweepAuthorization::Required(request) => Some(request),
+                SweepAuthorization::AlreadyDelegated => None,
+            })
             .filter(|request| s.automatic_deposits.authorization(request).is_none())
             .collect()
     });

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,6 +1,7 @@
 use crate::asset::Asset;
 use crate::attestation::AttestationRequest;
 use crate::deposit_address::AddressSchema;
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::management::{CallError, Reason};
 use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
@@ -13,9 +14,12 @@ use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep, usdc, usdt,
+    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
+    sweep_pipeline_outcome, usdc, usdt,
 };
-use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
+use crate::tx::{
+    Authorization, AuthorizationRequest, GasFeeEstimate, SignableTransaction, TransactionSignature,
+};
 use ethnum::u256;
 use evm_rpc_types::{
     Hex20, Hex32, Hex256, HexByte, Nat256, TransactionReceipt as EvmTransactionReceipt,
@@ -29,6 +33,7 @@ use std::collections::BTreeMap;
 const NOW: u64 = 1_620_328_630_000_000_000;
 const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
 const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
+const SET_CODE_TX_ID: u8 = 4;
 const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
 const ANOTHER_SWEEPER_CONTRACT: Address = Address::new([0x99; 20]);
 const CHAIN_CODE: [u8; 32] = [0_u8; 32];
@@ -120,7 +125,7 @@ async fn should_sign_and_record_one_authorization_for_every_account() {
             .count(),
         1
     );
-    assert!(stored_authorization(SWEEPER_CONTRACT).is_some());
+    assert!(stored_authorization(account(), SWEEPER_CONTRACT).is_some());
 }
 
 #[tokio::test]
@@ -153,7 +158,7 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
-    let first = stored_authorization(SWEEPER_CONTRACT);
+    let first = stored_authorization(account(), SWEEPER_CONTRACT);
     assert!(first.is_some());
 
     mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
@@ -162,10 +167,10 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     queue_deposit(&account(), &usdt());
 
     create_pending_sweeper_requests(&runtime).await;
-    let second = stored_authorization(ANOTHER_SWEEPER_CONTRACT);
+    let second = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT);
     assert!(second.is_some());
     assert_ne!(first, second);
-    assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
+    assert_eq!(stored_authorization(account(), SWEEPER_CONTRACT), first);
 }
 
 #[tokio::test]
@@ -208,12 +213,48 @@ async fn should_authorize_at_nonce_zero_an_address_delegated_to_another_contract
 
     create_pending_sweeper_requests(&runtime).await;
 
+    let signature = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT)
+        .expect("BUG: the sweep must have signed a tuple for the new sweeper contract");
     assert_eq!(
         swept_item(Asset::Erc20(usdt())).authorization,
-        stored_authorization(ANOTHER_SWEEPER_CONTRACT).map(|signature| authorization_request(
-            ANOTHER_SWEEPER_CONTRACT
-        )
-        .signed_with(signature))
+        Some(authorization_request(account(), ANOTHER_SWEEPER_CONTRACT).signed_with(signature))
+    );
+}
+
+#[tokio::test]
+async fn should_batch_a_delegated_and_a_fresh_address_into_one_sweep() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+    queue_deposit(&account(), &usdt());
+    queue_deposit(&another_account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    let [sweep] = <[SweepRequest; 1]>::try_from(pending_sweeps())
+        .expect("BUG: expected the two deposits of one token to become one sweep");
+    let [delegated, fresh] = <[AuthorizedSweepItem; 2]>::try_from(sweep.items.clone())
+        .expect("BUG: expected the sweep to hold both deposits");
+    assert_eq!(delegated.item.account, account());
+    assert_eq!(fresh.item.account, another_account());
+    assert_eq!(
+        delegated.authorization, None,
+        "the address the earlier sweep delegated must be swept carrying no tuple"
+    );
+    let signature = stored_authorization(another_account(), SWEEPER_CONTRACT)
+        .expect("BUG: the sweep must have signed a tuple for the address it still has to delegate");
+    assert_eq!(
+        fresh.authorization,
+        Some(authorization_request(another_account(), SWEEPER_CONTRACT).signed_with(signature)),
+        "the tuple must be the one signed for the fresh address, at nonce zero"
+    );
+    assert_eq!(
+        sweep_pipeline_outcome(TransactionNonce::ZERO, &sweep, TransactionStatus::Success)
+            .transaction
+            .transaction_type(),
+        SET_CODE_TX_ID,
+        "a sweep still delegating one of its addresses rides an EIP-7702 transaction"
     );
 }
 
@@ -279,10 +320,10 @@ async fn should_carry_the_signed_attestation_and_authorization_of_every_swept_ac
         item.authorization,
         read_state(|s| s
             .automatic_deposits
-            .authorization(&authorization_request(SWEEPER_CONTRACT))
-            .map(
-                |signature| authorization_request(SWEEPER_CONTRACT).signed_with(signature.clone())
-            ))
+            .authorization(&authorization_request(account(), SWEEPER_CONTRACT))
+            .map(|signature| {
+                authorization_request(account(), SWEEPER_CONTRACT).signed_with(signature.clone())
+            }))
     );
 }
 
@@ -444,17 +485,17 @@ fn sign_digest_with_derived_key(
 /// Spelled out rather than taken from `delegation_authorization`, so that changing the tuple the
 /// minter signs — its delegate, or the nonce 0 that makes a stale authorization skip harmlessly
 /// rather than sink the sweep — fails here.
-fn stored_authorization(delegate: Address) -> Option<TransactionSignature> {
+fn stored_authorization(account: Account, delegate: Address) -> Option<TransactionSignature> {
     read_state(|s| {
         s.automatic_deposits
-            .authorization(&authorization_request(delegate))
+            .authorization(&authorization_request(account, delegate))
             .cloned()
     })
 }
 
-fn authorization_request(delegate: Address) -> AuthorizationRequest {
+fn authorization_request(account: Account, delegate: Address) -> AuthorizationRequest {
     AuthorizationRequest::new(
-        account(),
+        account,
         initial_state().ethereum_network.chain_id(),
         delegate,
         TransactionNonce::ZERO,

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -6,14 +6,14 @@ use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::{SweepId, SweepRequest};
+use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
 use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    prepay_sweep_gas, state_with_deposit_helper, usdc, usdt,
+    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep, usdc, usdt,
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
@@ -166,6 +166,55 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     assert!(second.is_some());
     assert_ne!(first, second);
     assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
+}
+
+#[tokio::test]
+async fn should_sweep_without_a_tuple_an_address_an_earlier_sweep_delegated() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    queue_deposit(&account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        None,
+        "an address the earlier sweep delegated to the sweeper contract needs no further tuple"
+    );
+    assert_eq!(
+        recorded_events()
+            .into_iter()
+            .filter(|event| matches!(event, EventType::AuthorizedDepositAddress { .. }))
+            .count(),
+        1,
+        "signing another tuple for a delegated address would pay for a threshold signature the \
+         sweep cannot use"
+    );
+}
+
+/// Re-pointing the minter at another sweeper contract makes an address delegated to the old one
+/// authorize afresh, still at nonce zero — a tuple the chain skips, since applying the first one
+/// spent that nonce. Rotating a delegation onto another contract takes more than this.
+#[tokio::test]
+async fn should_authorize_at_nonce_zero_an_address_delegated_to_another_contract() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, ANOTHER_SWEEPER_CONTRACT, 1);
+    expect_signing(&mut runtime);
+    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+    queue_deposit(&account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        stored_authorization(ANOTHER_SWEEPER_CONTRACT).map(|signature| authorization_request(
+            ANOTHER_SWEEPER_CONTRACT
+        )
+        .signed_with(signature))
+    );
 }
 
 #[tokio::test]
@@ -335,6 +384,20 @@ fn should_order_finalized_sweeps_as_the_chain_executed_them() {
 
 fn pending_sweeps() -> Vec<SweepRequest> {
     read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
+}
+
+/// The one item of the one pending sweep of `asset`.
+fn swept_item(asset: Asset) -> AuthorizedSweepItem {
+    let [sweep] = <[SweepRequest; 1]>::try_from(
+        pending_sweeps()
+            .into_iter()
+            .filter(|sweep| sweep.asset == asset)
+            .collect::<Vec<_>>(),
+    )
+    .expect("BUG: expected exactly one pending sweep of the asset");
+    let [item] = <[AuthorizedSweepItem; 1]>::try_from(sweep.items)
+        .expect("BUG: expected the sweep to hold exactly one item");
+    item
 }
 
 /// Expects `times` signatures over the authorization tuple every deposit address delegates with:

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -5,6 +5,7 @@ use crate::deposit_address::DepositAddress;
 use crate::eth_logs::LedgerSubaccount;
 use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::lifecycle::EthereumNetwork;
 use crate::lifecycle::init::InitArg;
 use crate::numeric::{
     BlockNumber, Erc20Value, GasAmount, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas,
@@ -13,12 +14,12 @@ use crate::state::audit::{EventType, process_event};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::{EthWithdrawalRequest, SweepRequest};
-use crate::state::{State, read_state};
+use crate::state::transactions::{EthWithdrawalRequest, PipelineRequest, SweepRequest};
+use crate::state::{State, mutate_state, read_state};
 use crate::sweep::create_pending_sweeper_requests;
 use crate::tx::{
     AccessList, AuthorizationRequest, Eip1559TransactionRequest, FinalizedEip1559Transaction,
-    GasFeeEstimate, Signed, TransactionSignature,
+    GasFeeEstimate, SignableTransaction, Signed, SweepTransaction, TransactionSignature,
 };
 use candid::{Nat, Principal};
 use ethnum::u256;
@@ -202,14 +203,15 @@ pub fn prepay_sweep_gas(state: &mut State) {
         ));
 }
 
+/// When every sweep fixture decides its sweep, and the age its gas fee estimate is fresh at.
+const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
+
 /// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
 /// the sweep is assembled by the production path without the runtime signing anything, and the log
 /// alone reconstructs the state the fixture hands back.
 pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
-    const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
-
     let mut runtime = mock::MockCanisterRuntime::new();
     runtime.expect_time().return_const(SWEEP_DECIDED_AT);
     let mut state = state_with_deposit_helper(deposit_helper());
@@ -267,6 +269,91 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
                 .expect("BUG: expected the pairs to become exactly one sweep");
         (s.clone(), request)
     })
+}
+
+/// [`state_with_enqueued_sweep`]'s state once the sweeper pipeline has taken that sweep all the way
+/// to a successful receipt, so every address it swept holds the delegation the tuple it carried
+/// installed.
+pub async fn state_with_finalized_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
+    let (state, request) = state_with_enqueued_sweep(pairs).await;
+    let mut time_provider = mock::MockTimeProvider::new();
+    time_provider.expect_time().return_const(SWEEP_DECIDED_AT);
+    for event in sweep_pipeline_events(
+        state.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Success,
+    ) {
+        mutate_state(|s| process_event(s, event, &time_provider));
+    }
+    (read_state(State::clone), request)
+}
+
+/// The events the sweeper pipeline records taking the already-accepted `request` from its
+/// transaction to a receipt of `status`.
+pub fn sweep_pipeline_events(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> Vec<EventType> {
+    let sweep = sweep_pipeline_outcome(nonce, request, status);
+    vec![
+        EventType::CreatedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.transaction,
+        },
+        EventType::SignedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.signed,
+        },
+        EventType::FinalizedSweeperTransaction {
+            sweep_id: request.id,
+            transaction_receipt: sweep.receipt,
+        },
+    ]
+}
+
+/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction signed,
+/// and the receipt finalizing it.
+pub struct SweepPipelineOutcome {
+    pub transaction: SweepTransaction,
+    pub signed: Signed<SweepTransaction>,
+    pub receipt: TransactionReceipt,
+}
+
+pub fn sweep_pipeline_outcome(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> SweepPipelineOutcome {
+    let transaction = request
+        .create_transaction(
+            nonce,
+            gas_fee_estimate(),
+            request.gas_limit(),
+            EthereumNetwork::Sepolia,
+        )
+        .expect("BUG: the fixture prices the request with the estimate it creates with");
+    let signed = Signed::from((
+        transaction.clone(),
+        TransactionSignature {
+            signature_y_parity: false,
+            r: Default::default(),
+            s: Default::default(),
+        },
+    ));
+    let receipt = TransactionReceipt {
+        block_hash: Hash([0x11; 32]),
+        block_number: BlockNumber::new(4_190_269),
+        effective_gas_price: signed.transaction().max_fee_per_gas(),
+        gas_used: signed.transaction().gas_limit(),
+        status,
+        transaction_hash: signed.hash(),
+    };
+    SweepPipelineOutcome {
+        transaction,
+        signed,
+        receipt,
+    }
 }
 
 pub fn sweeper_contract() -> Address {

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -21,7 +21,8 @@ use ic_cketh_test_utils::anvil::{
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{
-    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
+    CexDeposit, DELEGATING_SWEEP_TRANSACTION_TYPE, DepositPlan, EthCexDeposit, EthDepositPlan,
+    LiveSetup, PLAIN_SWEEP_TRANSACTION_TYPE,
 };
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 
@@ -642,7 +643,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
 }
 
 #[test]
-fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()
@@ -709,19 +710,20 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
             if detected.scanned_balance == second_deposits[0].amount
     );
 
-    let (setup, sweeps) = setup
-        .await_sweeps(&sweeper, 2)
-        .expect_all_delegating_sweeps();
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        PLAIN_SWEEP_TRANSACTION_TYPE,
+    ]);
     let second_sweep = &sweeps[1];
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
-        vec![0],
-        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+        Vec::<u64>::new(),
+        "an address already delegated is swept without any authorization to install"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
         1,
-        "a skipped stale authorization must not advance the deposit address' nonce"
+        "sweeping without a tuple must leave the deposit address at the nonce the first sweep spent"
     );
 
     let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];
@@ -740,7 +742,7 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
 }
 
 #[test]
-fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()
@@ -810,19 +812,20 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == second_deposits[0].amount
     );
 
-    let (setup, sweeps) = setup
-        .await_sweeps(&sweeper, 2)
-        .expect_all_delegating_sweeps();
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        PLAIN_SWEEP_TRANSACTION_TYPE,
+    ]);
     let second_sweep = &sweeps[1];
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
-        vec![0],
-        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+        Vec::<u64>::new(),
+        "an address already delegated is swept without any authorization to install"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
         1,
-        "a skipped stale authorization must not advance the deposit address' nonce"
+        "sweeping without a tuple must leave the deposit address at the nonce the first sweep spent"
     );
 
     let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -672,9 +672,14 @@ fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authoriza
         .credit_eth_deposits_from_cex(&first_deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
-    let (setup, _first_sweeps) = setup
+    let (setup, first_sweeps) = setup
         .await_sweeps(&sweeper, 1)
         .expect_all_delegating_sweeps();
+    assert_eq!(
+        setup.anvil().authorization_nonces(&first_sweeps[0].hash),
+        vec![0],
+        "the first sweep of an address must carry the tuple delegating it, signed for nonce 0"
+    );
     let setup = setup
         .expect_sweeps_finalized(1)
         .expect_cketh_mints(&first_deposits);
@@ -718,7 +723,8 @@ fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authoriza
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
         Vec::<u64>::new(),
-        "an address already delegated is swept without any authorization to install"
+        "the type-2 transaction above is what proves no tuple was sent: an address already \
+         delegated is swept carrying none"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
@@ -774,9 +780,14 @@ fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authori
         .credit_deposits_from_cex(&first_deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
-    let (setup, _first_sweeps) = setup
+    let (setup, first_sweeps) = setup
         .await_sweeps(&sweeper, 1)
         .expect_all_delegating_sweeps();
+    assert_eq!(
+        setup.anvil().authorization_nonces(&first_sweeps[0].hash),
+        vec![0],
+        "the first sweep of an address must carry the tuple delegating it, signed for nonce 0"
+    );
     let setup = setup
         .expect_sweeps_finalized(1)
         .expect_mints(&first_deposits);
@@ -820,7 +831,8 @@ fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authori
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
         Vec::<u64>::new(),
-        "an address already delegated is swept without any authorization to install"
+        "the type-2 transaction above is what proves no tuple was sent: an address already \
+         delegated is swept carrying none"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -385,15 +385,19 @@ impl Anvil {
             .unwrap_or_else(|e| panic!("not a u64 transaction count {count}: {e}"))
     }
 
+    /// The nonces of the EIP-7702 tuples `tx_hash` carries, in the order it lists them. Empty for a
+    /// transaction carrying no authorization list at all, which is what a sweep of addresses that
+    /// are all delegated already is.
     pub fn authorization_nonces(&self, tx_hash: &str) -> Vec<u64> {
         let transaction = self.rpc("eth_getTransactionByHash", serde_json::json!([tx_hash]));
         assert!(
             !transaction.is_null(),
             "no transaction {tx_hash} on the chain"
         );
-        transaction["authorizationList"]
-            .as_array()
-            .unwrap_or_else(|| panic!("transaction {tx_hash} carries no authorization list"))
+        let Some(tuples) = transaction["authorizationList"].as_array() else {
+            return Vec::new();
+        };
+        tuples
             .iter()
             .map(|tuple| {
                 let nonce = tuple["nonce"].as_str().unwrap_or_else(|| {

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -136,6 +136,14 @@ const CREDIT_TICKS: u32 = 6;
 
 const FUNDING_TICKS: u32 = 6;
 
+/// The EIP-2718 type of a sweep that still installs a delegation, and so carries an EIP-7702
+/// authorization list.
+pub const DELEGATING_SWEEP_TRANSACTION_TYPE: u64 = 4;
+
+/// The EIP-2718 type of a sweep of addresses all delegated already, which carries no authorization
+/// and so is a plain EIP-1559 transaction.
+pub const PLAIN_SWEEP_TRANSACTION_TYPE: u64 = 2;
+
 pub struct DepositPlan {
     pub owner: Principal,
     pub subaccount: [u8; 32],
@@ -1539,12 +1547,30 @@ pub struct SweepsSent {
 }
 
 impl SweepsSent {
+    /// Asserts every sweep succeeded riding a type-4 transaction, as a sweep still installing a
+    /// delegation must.
     pub fn expect_all_delegating_sweeps(self) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
-        for sweep in &self.sweeps {
+        let delegating = vec![DELEGATING_SWEEP_TRANSACTION_TYPE; self.sweeps.len()];
+        self.expect_sweeps_of_types(&delegating)
+    }
+
+    /// Asserts every sweep succeeded riding the transaction type its position in `expected` names:
+    /// type 4 while it still delegates an address it sweeps, type 2 once they are all delegated.
+    pub fn expect_sweeps_of_types(
+        self,
+        expected: &[u64],
+    ) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
+        assert_eq!(
+            self.sweeps.len(),
+            expected.len(),
+            "expected {} sweeps, got {:?}",
+            expected.len(),
+            self.sweeps
+        );
+        for (sweep, expected_type) in self.sweeps.iter().zip(expected) {
             assert_eq!(
-                sweep.transaction_type, 4,
-                "a sweep here always carries its EIP-7702 authorizations, installed or re-sent, \
-                 so it must be a type-4 transaction: {sweep:?}"
+                sweep.transaction_type, *expected_type,
+                "the sweep did not ride the expected transaction type: {sweep:?}"
             );
             assert!(sweep.succeeded, "the sweep reverted: {sweep:?}");
         }


### PR DESCRIPTION
### Why

* Every sweep re-carries the nonce-0 authorization of each address it touches. On an address already delegated the tuple is skipped by the protocol, but it still costs the full 25'000 gas (EIP-7702 grants the existing-account refund only after the nonce check).
* With the applied marks of #11496 the minter knows which addresses already point at the configured sweeper contract.

### What

* A target whose recorded delegation names the configured sweeper contract gets no authorization. Its sweep item carries no tuple.
* A sweep whose items all carry no tuple is a plain EIP-1559 transaction; one with at least one tuple stays EIP-7702.
* The gas budget counts the authorization cost only for items that carry a tuple.
* A target delegated to another sweeper contract keeps today's nonce-0 request, in a branch made explicit for the rotation PR that follows.

Second PR of this stack, stacked on #11496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X44H4nAU65nAexEUvG15MK
