### PR TITLE
feat(cketh): re-delegate deposit addresses to a newly configured sweeper contract

### DIFF
--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -310,9 +310,11 @@ rust_test(
         "//:anvil",
         "//:solc",
         # Contract sources compiled at test time by the vendored solc: the mock ERC-20, the real
-        # deposit helper the sweep transfers through, and the delegate it sweeps with.
+        # deposit helper the sweep transfers through, the delegate it sweeps with, and the
+        # superseded delegate a rotation test starts the minter on.
         "DepositHelperWithSubaccount.sol",
         "CkSweeperAttested.sol",
+        "tests/deposit_from_cex_demo/CkSweeperAttestedLegacy.sol",
         "tests/deposit_from_cex_demo/MockUSDT.sol",
         # End-to-end balance scan and sweeper funding on a live PocketIC + local anvil node.
         ":cketh_minter_debug.wasm.gz",
@@ -331,6 +333,7 @@ rust_test(
         # stamped with an expiry the auto-progressing clock then moves past, never to be answered.
         "RUST_TEST_THREADS": "1",
         "CKSWEEPER_ATTESTED_SOL": "$(rootpath CkSweeperAttested.sol)",
+        "CKSWEEPER_ATTESTED_LEGACY_SOL": "$(rootpath tests/deposit_from_cex_demo/CkSweeperAttestedLegacy.sol)",
         "MOCKUSDT_SOL": "$(rootpath tests/deposit_from_cex_demo/MockUSDT.sol)",
         "SOLC_BIN": "$(rootpath //:solc)",
         "CARGO_MANIFEST_DIR": "rs/ethereum/cketh/minter",

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -871,9 +871,22 @@ type Event = record {
             owner : principal;
             subaccount : opt blob;
             // The tuple the deposit address signed, delegating its code to the
-            // sweeper contract. Its nonce is always zero: the delegation is
-            // installed the first time the tuple is applied.
+            // sweeper contract. Its nonce is the one the address stands at,
+            // which is the only nonce the protocol applies a tuple at: zero the
+            // first time, and the address' current nonce when re-delegating it
+            // to a newly configured sweeper contract.
             authorization : SignedAuthorization;
+        };
+        // The nonce a ckERC20 deposit address was read to stand at, after a
+        // reverted sweep left the minter unable to say which of the tuples it
+        // had signed for that address the chain applied. The minter signs at
+        // most one tuple per (deposit address, nonce), so the nonce alone says
+        // which of them applied.
+        ObservedDepositAddressNonce : record {
+            owner : principal;
+            subaccount : opt blob;
+            // The nonce the deposit address was read to stand at.
+            nonce : nat;
         };
     };
 };

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -771,6 +771,12 @@ pub mod events {
             subaccount: Option<ByteBuf>,
             authorization: SignedAuthorization,
         },
+        ObservedDepositAddressNonce {
+            owner: Principal,
+            subaccount: Option<ByteBuf>,
+            /// The nonce the deposit address was read to stand at.
+            nonce: Nat,
+        },
         AcceptedSweepRequest {
             sweep_id: Nat,
             destination: String,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1367,6 +1367,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Number of delegation authorizations the minter has signed and stored.",
                 )?;
 
+                w.encode_gauge(
+                    "cketh_minter_applied_authorizations",
+                    s.automatic_deposits.applied_authorizations_len() as f64,
+                    "Number of stored delegation authorizations a finalized sweep applied on chain.",
+                )?;
+
                 w.encode_counter(
                     "cketh_minter_sweeper_funding_cketh_burned_total",
                     s.sweeper_funding.cumulative_burned().as_f64(),

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1079,14 +1079,14 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                 EventType::AcceptedSweepRequest(SweepRequest {
                     id,
                     destination,
-                    token,
+                    asset,
                     items,
                     max_transaction_fee,
                     created_at,
                 }) => EP::AcceptedSweepRequest {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
-                    asset: Asset::Erc20(token).into(),
+                    asset: asset.into(),
                     items: map_authorized_sweep_items(&items),
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1076,6 +1076,13 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                             .expect("BUG: one authorization in, one out"),
                     }
                 }
+                EventType::ObservedDepositAddressNonce { account, nonce } => {
+                    EP::ObservedDepositAddressNonce {
+                        owner: account.owner,
+                        subaccount: account.subaccount.map(ByteBuf::from),
+                        nonce: nonce.into(),
+                    }
+                }
                 EventType::AcceptedSweepRequest(SweepRequest {
                     id,
                     destination,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1380,6 +1380,18 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     "Number of stored delegation authorizations a finalized sweep applied on chain.",
                 )?;
 
+                w.encode_gauge(
+                    "cketh_minter_unverified_deposit_address_nonces",
+                    s.automatic_deposits.unverified_nonces_len() as f64,
+                    "Number of deposit addresses whose nonce a reverted sweep left to be read back off the chain.",
+                )?;
+
+                w.encode_gauge(
+                    "cketh_minter_unresolved_deposit_address_nonces",
+                    s.automatic_deposits.unresolved_nonces_len() as f64,
+                    "Number of deposit addresses whose nonce was read back but could not be squared with the record, and which are therefore out of every sweep.",
+                )?;
+
                 w.encode_counter(
                     "cketh_minter_sweeper_funding_cketh_burned_total",
                     s.sweeper_funding.cumulative_burned().as_f64(),

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -308,34 +308,46 @@ impl State {
         )
     }
 
-    /// What every deposit address in `accounts` authorizes to let the configured sweeper contract
-    /// sweep it: the tuple naming this minter's chain, that contract, and nonce zero. `None` while
-    /// no sweeper contract is configured.
-    ///
-    /// The nonce is always zero, whatever the address actually holds. A deposit address is at
-    /// nonce zero exactly while it has never been delegated — applying an authorization spends it
-    /// — so the tuple either installs the delegation or is skipped, and both are correct in any
-    /// order the sweeps carrying them land. That is what lets a sweep authorize every address it
-    /// touches without tracking which ones are already delegated, at the price of the intrinsic
-    /// gas a skipped tuple still costs.
+    /// What each deposit address in `accounts` still has to authorize to let the configured sweeper
+    /// contract sweep it, one entry per account and in the same order. The outer `None` says no
+    /// sweeper contract is configured; an inner `None` says that address needs no tuple, being
+    /// delegated to that very contract already. A sweep every address of which is delegated carries
+    /// no authorization at all and is sent as a plain EIP-1559 transaction.
     pub fn authorization_requests<T: AsRef<Account>>(
         &self,
         accounts: &[T],
-    ) -> Option<Vec<AuthorizationRequest>> {
+    ) -> Option<Vec<Option<AuthorizationRequest>>> {
         let delegate = self.sweeper_contract_address?;
         Some(
             accounts
                 .iter()
-                .map(|account| {
-                    AuthorizationRequest::new(
-                        *account.as_ref(),
-                        self.ethereum_network.chain_id(),
-                        delegate,
-                        TransactionNonce::ZERO,
-                    )
-                })
+                .map(|account| self.authorization_request(*account.as_ref(), delegate))
                 .collect(),
         )
+    }
+
+    /// The tuple `account`'s deposit address has to authorize for `delegate`'s code to run at it,
+    /// or `None` if it already delegates `delegate`.
+    ///
+    /// An address that has never been delegated is at nonce zero, and authorizes there. So does one
+    /// delegated to another contract, whose nonce zero is spent: that tuple is skipped on chain,
+    /// which is what leaves the address on its current delegate until re-delegating it is supported.
+    fn authorization_request(
+        &self,
+        account: Account,
+        delegate: Address,
+    ) -> Option<AuthorizationRequest> {
+        let nonce = match self.automatic_deposits.delegation(&account) {
+            Some(delegation) if delegation.delegate == delegate => return None,
+            Some(_delegated_elsewhere) => TransactionNonce::ZERO,
+            None => TransactionNonce::ZERO,
+        };
+        Some(AuthorizationRequest::new(
+            account,
+            self.ethereum_network.chain_id(),
+            delegate,
+            nonce,
+        ))
     }
 
     /// The attestation `account`'s ckERC20 deposit address has already signed for the configuration

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -344,6 +344,7 @@ impl State {
             Some(delegation) if delegation.delegate == delegate => {
                 return SweepAuthorization::AlreadyDelegated;
             }
+            //TODO DEFI-2997: track and increment nonce of deposit address
             Some(_delegated_elsewhere) => TransactionNonce::ZERO,
             None => TransactionNonce::ZERO,
         };

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -145,10 +145,11 @@ pub enum SweepAuthorization {
     /// Nothing: the address already delegates the configured sweeper contract. A sweep every
     /// address of which is delegated carries no authorization and is a plain EIP-1559 transaction.
     AlreadyDelegated,
-    /// Nothing a sweep may use: a reverted sweep left the nonce the address stands at unverified,
-    /// so any tuple would be signed for a guessed nonce. The address is left out of the sweep until
-    /// the minter has read its nonce back off the chain.
-    NonceUnverified,
+    /// Nothing a sweep may use: the minter cannot say what nonce the address stands at — a reverted
+    /// sweep left it to be read back off the chain, or the read that came back could not be squared
+    /// with the record — so any tuple would be signed for a guessed nonce. The address is left out
+    /// of the sweep.
+    NonceUnknown,
 }
 
 #[derive(Eq, PartialEq, Debug)]
@@ -352,8 +353,8 @@ impl State {
     /// them happen to mine in. The rotation is then signed at the next nonce, once the record shows
     /// that tuple applied.
     fn sweep_authorization(&self, account: Account, delegate: Address) -> SweepAuthorization {
-        if self.automatic_deposits.has_unverified_nonce(&account) {
-            return SweepAuthorization::NonceUnverified;
+        if !self.automatic_deposits.has_trusted_nonce(&account) {
+            return SweepAuthorization::NonceUnknown;
         }
         let nonce = match self.automatic_deposits.delegation(&account) {
             Some(delegation) if delegation.delegate == delegate => {
@@ -364,7 +365,7 @@ impl State {
         };
         SweepAuthorization::Required(
             self.automatic_deposits
-                .unapplied_authorization_at(&account, nonce)
+                .unapplied_authorization_at(&account, self.ethereum_network.chain_id(), nonce)
                 .cloned()
                 .unwrap_or_else(|| {
                     AuthorizationRequest::new(

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -139,7 +139,8 @@ pub struct State {
 /// What a sweep of one deposit address has to carry for the sweeper contract's code to run at it.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum SweepAuthorization {
-    /// The tuple the address has yet to authorize, which the sweep signs once and carries.
+    /// The tuple the address has yet to have applied, which the sweep signs unless the minter
+    /// already has, and carries.
     Required(AuthorizationRequest),
     /// Nothing: the address already delegates the configured sweeper contract. A sweep every
     /// address of which is delegated carries no authorization and is a plain EIP-1559 transaction.
@@ -336,24 +337,37 @@ impl State {
 
     /// What a sweep of `account`'s deposit address has to carry for `delegate`'s code to run at it.
     ///
-    /// An address that has never been delegated is at nonce zero, and authorizes there. So does one
-    /// delegated to another contract, whose nonce zero is spent: that tuple is skipped on chain,
-    /// which is what leaves the address on its current delegate until re-delegating it is supported.
+    /// An address that has never been delegated is at nonce zero and authorizes there. One
+    /// delegated to another contract authorizes `delegate` at the nonce it has reached — the
+    /// rotation — since a tuple applies only at the authority's current nonce and one signed for
+    /// any other is skipped.
+    ///
+    /// Either way, a tuple already signed for that nonce is re-carried rather than replaced,
+    /// whatever delegate it names: it is the one the chain will apply, and a second tuple for the
+    /// same nonce would leave the delegate the address ends up on to the order the sweeps carrying
+    /// them happen to mine in. The rotation is then signed at the next nonce, once the record shows
+    /// that tuple applied.
     fn sweep_authorization(&self, account: Account, delegate: Address) -> SweepAuthorization {
         let nonce = match self.automatic_deposits.delegation(&account) {
             Some(delegation) if delegation.delegate == delegate => {
                 return SweepAuthorization::AlreadyDelegated;
             }
-            //TODO DEFI-2997: track and increment nonce of deposit address
-            Some(_delegated_elsewhere) => TransactionNonce::ZERO,
+            Some(delegated_elsewhere) => delegated_elsewhere.nonce,
             None => TransactionNonce::ZERO,
         };
-        SweepAuthorization::Required(AuthorizationRequest::new(
-            account,
-            self.ethereum_network.chain_id(),
-            delegate,
-            nonce,
-        ))
+        SweepAuthorization::Required(
+            self.automatic_deposits
+                .unapplied_authorization_at(&account, nonce)
+                .cloned()
+                .unwrap_or_else(|| {
+                    AuthorizationRequest::new(
+                        account,
+                        self.ethereum_network.chain_id(),
+                        delegate,
+                        nonce,
+                    )
+                }),
+        )
     }
 
     /// The attestation `account`'s ckERC20 deposit address has already signed for the configuration

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -136,6 +136,16 @@ pub struct State {
     pub sweeper_funding: SweeperFundingAccounting,
 }
 
+/// What a sweep of one deposit address has to carry for the sweeper contract's code to run at it.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum SweepAuthorization {
+    /// The tuple the address has yet to authorize, which the sweep signs once and carries.
+    Required(AuthorizationRequest),
+    /// Nothing: the address already delegates the configured sweeper contract. A sweep every
+    /// address of which is delegated carries no authorization and is a plain EIP-1559 transaction.
+    AlreadyDelegated,
+}
+
 #[derive(Eq, PartialEq, Debug)]
 pub enum InvalidStateError {
     InvalidTransactionNonce(String),
@@ -308,41 +318,36 @@ impl State {
         )
     }
 
-    /// What each deposit address in `accounts` still has to authorize to let the configured sweeper
-    /// contract sweep it, one entry per account and in the same order. The outer `None` says no
-    /// sweeper contract is configured; an inner `None` says that address needs no tuple, being
-    /// delegated to that very contract already. A sweep every address of which is delegated carries
-    /// no authorization at all and is sent as a plain EIP-1559 transaction.
+    /// What a sweep has to carry for each deposit address in `accounts` to let the configured
+    /// sweeper contract's code run at it, one entry per account and in the same order. `None` while
+    /// no sweeper contract is configured.
     pub fn authorization_requests<T: AsRef<Account>>(
         &self,
         accounts: &[T],
-    ) -> Option<Vec<Option<AuthorizationRequest>>> {
+    ) -> Option<Vec<SweepAuthorization>> {
         let delegate = self.sweeper_contract_address?;
         Some(
             accounts
                 .iter()
-                .map(|account| self.authorization_request(*account.as_ref(), delegate))
+                .map(|account| self.sweep_authorization(*account.as_ref(), delegate))
                 .collect(),
         )
     }
 
-    /// The tuple `account`'s deposit address has to authorize for `delegate`'s code to run at it,
-    /// or `None` if it already delegates `delegate`.
+    /// What a sweep of `account`'s deposit address has to carry for `delegate`'s code to run at it.
     ///
     /// An address that has never been delegated is at nonce zero, and authorizes there. So does one
     /// delegated to another contract, whose nonce zero is spent: that tuple is skipped on chain,
     /// which is what leaves the address on its current delegate until re-delegating it is supported.
-    fn authorization_request(
-        &self,
-        account: Account,
-        delegate: Address,
-    ) -> Option<AuthorizationRequest> {
+    fn sweep_authorization(&self, account: Account, delegate: Address) -> SweepAuthorization {
         let nonce = match self.automatic_deposits.delegation(&account) {
-            Some(delegation) if delegation.delegate == delegate => return None,
+            Some(delegation) if delegation.delegate == delegate => {
+                return SweepAuthorization::AlreadyDelegated;
+            }
             Some(_delegated_elsewhere) => TransactionNonce::ZERO,
             None => TransactionNonce::ZERO,
         };
-        Some(AuthorizationRequest::new(
+        SweepAuthorization::Required(AuthorizationRequest::new(
             account,
             self.ethereum_network.chain_id(),
             delegate,

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -145,6 +145,10 @@ pub enum SweepAuthorization {
     /// Nothing: the address already delegates the configured sweeper contract. A sweep every
     /// address of which is delegated carries no authorization and is a plain EIP-1559 transaction.
     AlreadyDelegated,
+    /// Nothing a sweep may use: a reverted sweep left the nonce the address stands at unverified,
+    /// so any tuple would be signed for a guessed nonce. The address is left out of the sweep until
+    /// the minter has read its nonce back off the chain.
+    NonceUnverified,
 }
 
 #[derive(Eq, PartialEq, Debug)]
@@ -348,6 +352,9 @@ impl State {
     /// them happen to mine in. The rotation is then signed at the next nonce, once the record shows
     /// that tuple applied.
     fn sweep_authorization(&self, account: Account, delegate: Address) -> SweepAuthorization {
+        if self.automatic_deposits.has_unverified_nonce(&account) {
+            return SweepAuthorization::NonceUnverified;
+        }
         let nonce = match self.automatic_deposits.delegation(&account) {
             Some(delegation) if delegation.delegate == delegate => {
                 return SweepAuthorization::AlreadyDelegated;

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -119,6 +119,11 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
                 .automatic_deposits
                 .record_authorization(request.clone(), signature.clone());
         }
+        EventType::ObservedDepositAddressNonce { account, nonce } => {
+            state
+                .automatic_deposits
+                .record_observed_deposit_address_nonce(*account, *nonce);
+        }
         EventType::AcceptedSweepRequest(request) => {
             state.next_sweep_id = request.id.next();
             state.automatic_deposits.record_sweep_scheduled(

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -123,7 +123,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             state.next_sweep_id = request.id.next();
             state.automatic_deposits.record_sweep_scheduled(
                 request.id,
-                request.token,
+                request.asset,
                 request.items.iter().map(|item| item.item.account),
             );
             state.update_sweeper_balance_upon_accepted_sweep(request);

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -11,7 +11,7 @@ use crate::erc20::CkErc20Token;
 use crate::eth_logs::{LedgerSubaccount, ReceivedErc20Event, ReceivedEthEvent};
 use crate::eth_rpc_client::responses::TransactionReceipt;
 use crate::lifecycle::EthereumNetwork;
-use crate::numeric::Wei;
+use crate::numeric::{TransactionNonce, Wei};
 use crate::state::audit::{Event, replay_events_internal};
 use crate::state::transactions::{
     AuthorizedSweepItem, Erc20WithdrawalRequest, Reimbursed, ReimbursementIndex,
@@ -560,6 +560,19 @@ impl GetEventsFile {
                         },
                     }
                 }
+                EventPayload::ObservedDepositAddressNonce {
+                    owner,
+                    subaccount,
+                    nonce,
+                } => ET::ObservedDepositAddressNonce {
+                    account: Account {
+                        owner,
+                        subaccount: subaccount.map(|subaccount| {
+                            <[u8; 32]>::try_from(subaccount.into_vec().as_slice()).unwrap()
+                        }),
+                    },
+                    nonce: TransactionNonce::try_from(nonce).unwrap(),
+                },
                 EventPayload::AcceptedSweepRequest {
                     sweep_id,
                     destination,

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -570,10 +570,7 @@ impl GetEventsFile {
                 } => ET::AcceptedSweepRequest(SweepRequest {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
-                    token: match crate::asset::Asset::try_from(asset).unwrap() {
-                        crate::asset::Asset::Erc20(address) => address,
-                        crate::asset::Asset::Eth => panic!("BUG: no recorded sweep moves ETH yet"),
-                    },
+                    asset: asset.try_into().unwrap(),
                     items: map_authorized_sweep_items(items),
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -19,7 +19,7 @@ use crate::tx::{
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
@@ -85,6 +85,12 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::authorizations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     authorizations: BTreeMap<AuthorizationRequest, StoredAuthorization>,
+    /// The accounts whose deposit address' nonce the record can no longer vouch for, because a
+    /// sweep of that address reverted. A reverted sweep is the one sign that the record has
+    /// drifted from the chain, and until the address' nonce is read back and the record re-anchored
+    /// on it ([`Self::record_observed_deposit_address_nonce`]) any further tuple would be signed
+    /// for a guessed nonce, so the address is left out of every sweep.
+    unverified_nonces: BTreeSet<Account>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -224,6 +230,7 @@ impl AutomaticDeposits {
                 "BUG: {request:?} is not held by sweep {id:?}"
             );
             if receipt.status == TransactionStatus::Failure {
+                self.unverified_nonces.insert(account);
                 log!(
                     INFO,
                     "[record_finalized_sweep_transaction]: DROPPING {request:?} from the sweep queue: {id:?} failed and the minter does not retry. Its {:?} stays at {}, and reaching it again needs the pair armed afresh.",
@@ -249,6 +256,7 @@ impl AutomaticDeposits {
             sweep,
             attestations,
             authorizations,
+            unverified_nonces,
             sweeper_transactions,
         } = self;
 
@@ -256,6 +264,7 @@ impl AutomaticDeposits {
         ensure_eq!(sweep, &other.sweep);
         ensure_eq!(attestations, &other.attestations);
         ensure_eq!(authorizations, &other.authorizations);
+        ensure_eq!(unverified_nonces, &other.unverified_nonces);
         sweeper_transactions.is_equivalent_to(&other.sweeper_transactions)
     }
 
@@ -361,7 +370,65 @@ impl AutomaticDeposits {
         self.authorizations
             .get_mut(&request)
             .expect("BUG: a sweep carried an authorization the minter never signed")
-            .applied_by = Some(sweep_id);
+            .applied_by = Some(AppliedBy::Sweep(sweep_id));
+    }
+
+    /// Whether a reverted sweep has left the minter unable to say which of the tuples it signed
+    /// for `account`'s deposit address the chain applied, and so what nonce that address stands at.
+    pub fn has_unverified_nonce(&self, account: &Account) -> bool {
+        self.unverified_nonces.contains(account)
+    }
+
+    /// Re-anchor the record of `account`'s deposit address on `observed`, the nonce the chain says
+    /// it stands at, and mark that nonce verified again.
+    ///
+    /// The minter signs at most one tuple per `(deposit address, nonce)` and holds the address'
+    /// only key, so `observed` alone says which of them the chain applied: those signed for a nonce
+    /// below it, and no other. Where the address nonetheless holds two tuples at one nonce — state
+    /// from before that rule — the one already marked applied stays the answer; if neither is, the
+    /// observed nonce cannot tell them apart, so nothing is re-anchored and the address stays
+    /// unverified, out of every sweep, until an operator sorts it out.
+    pub fn record_observed_deposit_address_nonce(
+        &mut self,
+        account: Account,
+        observed: TransactionNonce,
+    ) {
+        let mut signed_at: BTreeMap<TransactionNonce, Vec<AuthorizationRequest>> = BTreeMap::new();
+        let mut already_applied: BTreeSet<AuthorizationRequest> = BTreeSet::new();
+        for (request, stored) in self.authorizations_of(&account) {
+            signed_at
+                .entry(request.nonce())
+                .or_default()
+                .push(request.clone());
+            if stored.applied_by.is_some() {
+                already_applied.insert(request.clone());
+            }
+        }
+
+        let mut applied = BTreeSet::new();
+        for (nonce, tuples) in signed_at.range(..observed) {
+            let Some(request) = tuple_the_chain_applied(tuples, &already_applied) else {
+                log!(
+                    INFO,
+                    "[record_observed_deposit_address_nonce]: LEAVING {account:?} out of every sweep: its deposit address stands at nonce {observed}, but the tuples signed for its nonce {nonce} are several and none is marked applied, so the observed nonce cannot say which of them the chain applied."
+                );
+                return;
+            };
+            applied.insert(request.clone());
+        }
+
+        for request in signed_at.into_values().flatten() {
+            let stored = self
+                .authorizations
+                .get_mut(&request)
+                .expect("BUG: an authorization left the store while it was being re-anchored");
+            stored.applied_by = if applied.contains(&request) {
+                stored.applied_by.or(Some(AppliedBy::ObservedNonce))
+            } else {
+                None
+            };
+        }
+        self.unverified_nonces.remove(&account);
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.
@@ -699,6 +766,7 @@ impl Default for AutomaticDeposits {
             sweep: BTreeMap::new(),
             attestations: BTreeMap::new(),
             authorizations: BTreeMap::new(),
+            unverified_nonces: BTreeSet::new(),
             sweeper_transactions: SweeperTransactionPipeline::new(TransactionNonce::ZERO),
         }
     }
@@ -821,7 +889,34 @@ impl ScanTarget<Erc20Asset> {
 #[derive(Clone, PartialEq, Debug)]
 struct StoredAuthorization {
     signature: TransactionSignature,
-    applied_by: Option<SweepId>,
+    applied_by: Option<AppliedBy>,
+}
+
+/// What tells the minter that one of the tuples it signed is installed on chain.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+enum AppliedBy {
+    /// The finalized sweep that carried the tuple while its deposit address stood at the tuple's
+    /// nonce.
+    Sweep(SweepId),
+    /// The deposit address' own nonce, read back off the chain after a reverted sweep: it stands
+    /// above the tuple's nonce, and the minter signs at most one tuple per nonce.
+    ObservedNonce,
+}
+
+/// The one of `tuples` — all signed for a single deposit address at a single nonce — that the chain
+/// must have applied to move that address past the nonce: the only tuple, or, where the address
+/// holds several, the one already marked applied. `None` when several are unapplied, which the
+/// nonce alone cannot tell apart.
+fn tuple_the_chain_applied<'a>(
+    tuples: &'a [AuthorizationRequest],
+    already_applied: &BTreeSet<AuthorizationRequest>,
+) -> Option<&'a AuthorizationRequest> {
+    match tuples {
+        [only] => Some(only),
+        _ => tuples
+            .iter()
+            .find(|request| already_applied.contains(request)),
+    }
 }
 
 /// The delegation a deposit address carries on chain.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -76,15 +76,15 @@ pub struct AutomaticDeposits {
     /// entries naming a retired helper stay behind forever. [`Self::attestations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
     attestations: BTreeMap<AttestationRequest, TransactionSignature>,
-    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed. A
-    /// signature only delegates the chain, the sweeper contract and the nonce its request names, so
-    /// re-pointing the minter at another sweeper contract misses this map rather than reusing a
-    /// tuple that delegates the old one.
+    /// Delegation authorizations the minter has signed, keyed by exactly what each one signed, each
+    /// recording whether a sweep has applied it on chain. A signature only delegates the chain, the
+    /// sweeper contract and the nonce its request names, so re-pointing the minter at another
+    /// sweeper contract misses this map rather than reusing a tuple that delegates the old one.
     ///
     /// Nothing prunes this map: it grows with the number of accounts that have ever been swept, and
     /// entries naming a retired helper stay behind forever. [`Self::authorizations_len`] is exported
     /// as a metric so that growth is visible before it needs bounding.
-    authorizations: BTreeMap<AuthorizationRequest, TransactionSignature>,
+    authorizations: BTreeMap<AuthorizationRequest, StoredAuthorization>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -189,6 +189,9 @@ impl AutomaticDeposits {
     /// leave the queue on success because the funds moved, and on failure because the minter does
     /// not retry them.
     ///
+    /// The authorizations the sweep carried are settled either way too: an EIP-7702 tuple applies
+    /// before the call it travels with runs, and stays applied when that call reverts.
+    ///
     /// # Panics
     ///
     /// If the sweep has no processed request, or a deposit it named is not queued or is held by
@@ -207,6 +210,11 @@ impl AutomaticDeposits {
             .expect("BUG: missing sweep request");
         let asset = request.asset;
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
+        let authorizations = request.authorization_requests();
+
+        for authorization in authorizations {
+            self.record_applied_authorization(authorization, id);
+        }
 
         for account in accounts {
             let request = DepositRequest::new(account, asset);
@@ -268,7 +276,9 @@ impl AutomaticDeposits {
     /// The authorization already stored for `account`, if any: signing another would cost a
     /// threshold-ECDSA signature for the same tuple.
     pub fn authorization(&self, request: &AuthorizationRequest) -> Option<&TransactionSignature> {
-        self.authorizations.get(request)
+        self.authorizations
+            .get(request)
+            .map(|stored| &stored.signature)
     }
 
     pub fn record_authorization(
@@ -276,7 +286,54 @@ impl AutomaticDeposits {
         request: AuthorizationRequest,
         signature: TransactionSignature,
     ) {
-        self.authorizations.insert(request, signature);
+        self.authorizations.insert(
+            request,
+            StoredAuthorization {
+                signature,
+                applied_by: None,
+            },
+        );
+    }
+
+    /// The delegation `account`'s deposit address carries on chain, as the authorizations applied
+    /// to it say: the delegate the highest applied nonce names, and the nonce the address has
+    /// reached. `None` while none of the minter's authorizations for the address has been applied,
+    /// which for a deposit address means it holds no delegation at all: only the minter ever
+    /// authorizes one.
+    pub fn delegation(&self, account: &Account) -> Option<Delegation> {
+        self.authorizations
+            .iter()
+            .filter(|(request, stored)| {
+                request.account() == *account && stored.applied_by.is_some()
+            })
+            .map(|(request, _stored)| request)
+            .max_by_key(|request| request.nonce())
+            .map(|request| Delegation {
+                delegate: request.delegate(),
+                nonce: request
+                    .nonce()
+                    .checked_increment()
+                    .expect("BUG: authorization nonce space exhausted"),
+            })
+    }
+
+    /// The nonce `account`'s deposit address is at, and therefore the only nonce a further
+    /// authorization of it can be signed for.
+    fn next_authorization_nonce(&self, account: &Account) -> TransactionNonce {
+        self.delegation(account)
+            .map_or(TransactionNonce::ZERO, |delegation| delegation.nonce)
+    }
+
+    /// Record that `sweep_id` applied `request`'s authorization on chain, unless the protocol
+    /// skipped it: a tuple applies only at the authority's current nonce, and applying one spends
+    /// that nonce, so a tuple signed for any other leaves the address as it was.
+    fn record_applied_authorization(&mut self, request: AuthorizationRequest, sweep_id: SweepId) {
+        if request.nonce() != self.next_authorization_nonce(&request.account()) {
+            return;
+        }
+        if let Some(stored) = self.authorizations.get_mut(&request) {
+            stored.applied_by.get_or_insert(sweep_id);
+        }
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.
@@ -526,6 +583,13 @@ impl AutomaticDeposits {
         self.authorizations.len()
     }
 
+    pub fn applied_authorizations_len(&self) -> usize {
+        self.authorizations
+            .values()
+            .filter(|stored| stored.applied_by.is_some())
+            .count()
+    }
+
     /// Where `request`'s deposit currently stands, or `None` if the pair is neither armed nor has
     /// funds queued for sweeping (so it must be registered). Reports
     /// [`DepositStage::AwaitingSweep`] once funds have been detected and queued, otherwise
@@ -721,6 +785,25 @@ impl ScanTarget<Erc20Asset> {
     pub fn token(&self) -> Address {
         self.asset.contract_address()
     }
+}
+
+/// An EIP-7702 authorization the minter has signed, and the sweep that applied it on chain if one
+/// has. Signing a tuple only makes it available to a sweep: the delegation it authorizes exists on
+/// chain only once a sweep carrying the tuple has finalized with the authority at its nonce.
+#[derive(Clone, PartialEq, Debug)]
+struct StoredAuthorization {
+    signature: TransactionSignature,
+    applied_by: Option<SweepId>,
+}
+
+/// The delegation a deposit address carries on chain.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct Delegation {
+    /// The contract the address' code points at.
+    pub delegate: Address,
+    /// The nonce the address has reached, one past the nonce of the authorization that installed
+    /// the delegation.
+    pub nonce: TransactionNonce,
 }
 
 /// A funded token awaiting sweeping at a [`DepositRequest`]'s deposit address.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -404,13 +404,29 @@ impl AutomaticDeposits {
     }
 
     /// The deposit addresses of the accounts whose nonce is waiting to be read back *and* have
-    /// funds queued for sweeping, so a tick pays for the reads it could act on and no others.
-    pub fn deposit_addresses_awaiting_a_nonce_read(&self) -> BTreeMap<Account, DepositAddress> {
-        self.sweep
+    /// funds queued for sweeping, so a tick pays for the reads it could act on and no others, at
+    /// most `batch_size` of them.
+    ///
+    /// The cap is what keeps the repair the size of a sweep: a sweeper contract that reverts every
+    /// batch leaves every address it touched waiting on a read, and a tick reading all of them at
+    /// once would turn one timer into a chain read per queued address. What a tick leaves out it
+    /// reads next tick, since a read that places an address takes it out of this set.
+    pub fn deposit_addresses_awaiting_a_nonce_read(
+        &self,
+        batch_size: usize,
+    ) -> BTreeMap<Account, DepositAddress> {
+        let mut batch = BTreeMap::new();
+        for (request, entry) in self
+            .sweep
             .iter()
             .filter(|(request, _entry)| self.unverified_nonces.contains(&request.account))
-            .map(|(request, entry)| (request.account, entry.address))
-            .collect()
+        {
+            if batch.len() == batch_size && !batch.contains_key(&request.account) {
+                break;
+            }
+            batch.insert(request.account, entry.address);
+        }
+        batch
     }
 
     pub fn unverified_nonces_len(&self) -> usize {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -411,22 +411,39 @@ impl AutomaticDeposits {
     /// batch leaves every address it touched waiting on a read, and a tick reading all of them at
     /// once would turn one timer into a chain read per queued address. What a tick leaves out it
     /// reads next tick, since a read that places an address takes it out of this set.
+    ///
+    /// An account another of whose tokens a sweep still holds is left out until that sweep
+    /// finalizes: applying its tuple moves the very marks a read re-anchors, and a count read
+    /// before it lands would undo them. Waiting costs nothing — the sweep that reverted dropped
+    /// the funds it named, so a read this tick skips is taken by a later one, off a record that no
+    /// longer moves under it. Nothing else can move that record meanwhile: an account waiting on a
+    /// read is offered no new sweep ([`Self::has_trusted_nonce`]), and the minter alone holds its
+    /// deposit key.
     pub fn deposit_addresses_awaiting_a_nonce_read(
         &self,
         batch_size: usize,
     ) -> BTreeMap<Account, DepositAddress> {
+        let swept = self.accounts_a_sweep_still_holds();
         let mut batch = BTreeMap::new();
-        for (request, entry) in self
-            .sweep
-            .iter()
-            .filter(|(request, _entry)| self.unverified_nonces.contains(&request.account))
-        {
+        for (request, entry) in self.sweep.iter().filter(|(request, _entry)| {
+            self.unverified_nonces.contains(&request.account) && !swept.contains(&request.account)
+        }) {
             if batch.len() == batch_size && !batch.contains_key(&request.account) {
                 break;
             }
             batch.insert(request.account, entry.address);
         }
         batch
+    }
+
+    /// The accounts a sweep in flight still holds queued funds of, whatever the token: finalizing
+    /// it settles which of their tuples the chain applied.
+    fn accounts_a_sweep_still_holds(&self) -> BTreeSet<Account> {
+        self.sweep
+            .iter()
+            .filter(|(_request, entry)| !entry.is_sweepable())
+            .map(|(request, _entry)| request.account)
+            .collect()
     }
 
     pub fn unverified_nonces_len(&self) -> usize {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -314,6 +314,21 @@ impl AutomaticDeposits {
             })
     }
 
+    /// The tuple already signed for `account` at `nonce` that no sweep has applied yet, whatever
+    /// delegate it names. It is the one the chain will apply at that nonce, so a sweep re-carries
+    /// it rather than signing another: the minter holds at most one signed tuple per
+    /// `(deposit address, nonce)`, and two would leave which delegate the address ends up on to
+    /// the order the sweeps carrying them happen to mine in.
+    pub fn unapplied_authorization_at(
+        &self,
+        account: &Account,
+        nonce: TransactionNonce,
+    ) -> Option<&AuthorizationRequest> {
+        self.authorizations_of(account)
+            .find(|(request, stored)| request.nonce() == nonce && stored.applied_by.is_none())
+            .map(|(request, _stored)| request)
+    }
+
     /// The authorizations signed for `account`, in key order. An [`AuthorizationRequest`] orders by
     /// its account first, so one account's authorizations are a contiguous range: reaching them
     /// costs the account's own entries rather than a scan of every account ever swept, which

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -205,11 +205,11 @@ impl AutomaticDeposits {
             .sweeper_transactions
             .get_processed_request(&id)
             .expect("BUG: missing sweep request");
-        let token = request.token;
+        let asset = request.asset;
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
 
         for account in accounts {
-            let request = DepositRequest::new(account, Asset::Erc20(token));
+            let request = DepositRequest::new(account, asset);
             let entry = self
                 .sweep
                 .remove(&request)
@@ -554,23 +554,14 @@ impl AutomaticDeposits {
         })
     }
 
-    /// The queued deposits a sweep could take next, batched by token, skipping those a sweep
+    /// The queued deposits a sweep could take next, batched by asset, skipping those a sweep
     /// already holds: taking them twice would move a balance the minter has already accounted for.
-    /// ETH entries stay queued but are never batched yet: they wait for the `sweepEthBatch` lane
-    /// (DEFI-2931).
-    pub fn requests_batch(
-        &self,
-        requested_batch_size: usize,
-    ) -> BTreeMap<Address, Vec<SweepTarget>> {
+    pub fn requests_batch(&self, requested_batch_size: usize) -> BTreeMap<Asset, Vec<SweepTarget>> {
         let mut batches = BTreeMap::new();
         for (deposit_request, sweep_entry) in
             self.sweep.iter().filter(|(_, entry)| entry.is_sweepable())
         {
-            let token = match deposit_request.asset {
-                Asset::Erc20(token) => token,
-                Asset::Eth => continue,
-            };
-            let batch: &mut Vec<_> = batches.entry(token).or_default();
+            let batch: &mut Vec<_> = batches.entry(deposit_request.asset).or_default();
             if batch.len() < requested_batch_size {
                 batch.push(SweepTarget {
                     account: deposit_request.account,
@@ -581,7 +572,7 @@ impl AutomaticDeposits {
         batches
     }
 
-    /// Record that `sweep_id` took these accounts' deposits of `token`: each leaves the pool of
+    /// Record that `sweep_id` took these accounts' deposits of `asset`: each leaves the pool of
     /// sweepable entries until the sweep is done with it.
     ///
     /// # Panics
@@ -591,11 +582,11 @@ impl AutomaticDeposits {
     pub fn record_sweep_scheduled(
         &mut self,
         sweep_id: SweepId,
-        token: Address,
+        asset: Asset,
         accounts: impl IntoIterator<Item = Account>,
     ) {
         for account in accounts {
-            let request = DepositRequest::new(account, Asset::Erc20(token));
+            let request = DepositRequest::new(account, asset);
             let entry = self
                 .sweep
                 .get_mut(&request)

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -91,6 +91,12 @@ pub struct AutomaticDeposits {
     /// on it ([`Self::record_observed_deposit_address_nonce`]) any further tuple would be signed
     /// for a guessed nonce, so the address is left out of every sweep.
     unverified_nonces: BTreeSet<Account>,
+    /// The accounts whose deposit address' nonce was read back but could not be squared with the
+    /// record. They are held apart from [`Self::unverified_nonces`] so that they are never read
+    /// again: a second read returns the same nonce and explains no more than the first, and paying
+    /// for one every tick, forever, per stuck address, is what that would cost. They stay out of
+    /// every sweep until an operator sorts them out.
+    unresolved_nonces: BTreeSet<Account>,
     /// The dedicated sweeper address' transaction pipeline: sweeps sent from the sweeper address on
     /// its own nonce sequence, independent of the main-address withdrawal pipeline.
     sweeper_transactions: SweeperTransactionPipeline,
@@ -257,6 +263,7 @@ impl AutomaticDeposits {
             attestations,
             authorizations,
             unverified_nonces,
+            unresolved_nonces,
             sweeper_transactions,
         } = self;
 
@@ -265,6 +272,7 @@ impl AutomaticDeposits {
         ensure_eq!(attestations, &other.attestations);
         ensure_eq!(authorizations, &other.authorizations);
         ensure_eq!(unverified_nonces, &other.unverified_nonces);
+        ensure_eq!(unresolved_nonces, &other.unresolved_nonces);
         sweeper_transactions.is_equivalent_to(&other.sweeper_transactions)
     }
 
@@ -323,18 +331,26 @@ impl AutomaticDeposits {
             })
     }
 
-    /// The tuple already signed for `account` at `nonce` that no sweep has applied yet, whatever
-    /// delegate it names. It is the one the chain will apply at that nonce, so a sweep re-carries
-    /// it rather than signing another: the minter holds at most one signed tuple per
-    /// `(deposit address, nonce)`, and two would leave which delegate the address ends up on to
-    /// the order the sweeps carrying them happen to mine in.
+    /// The tuple already signed for `account` on `chain_id` at `nonce` that no sweep has applied
+    /// yet, whatever delegate it names. It is the one that chain will apply at that nonce, so a
+    /// sweep re-carries it rather than signing another: the minter holds at most one signed tuple
+    /// per `(deposit address, chain, nonce)`, and two would leave which delegate the address ends
+    /// up on to the order the sweeps carrying them happen to mine in.
+    ///
+    /// A signature is only usable for the chain its tuple names, so tuples recorded for another
+    /// chain are no answer here however their nonce reads.
     pub fn unapplied_authorization_at(
         &self,
         account: &Account,
+        chain_id: u64,
         nonce: TransactionNonce,
     ) -> Option<&AuthorizationRequest> {
         self.authorizations_of(account)
-            .find(|(request, stored)| request.nonce() == nonce && stored.applied_by.is_none())
+            .find(|(request, stored)| {
+                request.chain_id() == chain_id
+                    && request.nonce() == nonce
+                    && stored.applied_by.is_none()
+            })
             .map(|(request, _stored)| request)
     }
 
@@ -374,20 +390,53 @@ impl AutomaticDeposits {
     }
 
     /// Whether a reverted sweep has left the minter unable to say which of the tuples it signed
-    /// for `account`'s deposit address the chain applied, and so what nonce that address stands at.
+    /// for `account`'s deposit address the chain applied, so that address' nonce is still to be
+    /// read back off the chain.
     pub fn has_unverified_nonce(&self, account: &Account) -> bool {
         self.unverified_nonces.contains(account)
     }
 
+    /// Whether the minter can say what nonce `account`'s deposit address stands at, which is what
+    /// every tuple it signs for that address depends on. False while the nonce is waiting to be
+    /// read back, and once a read has come back that the record cannot be squared with.
+    pub fn has_trusted_nonce(&self, account: &Account) -> bool {
+        !self.unverified_nonces.contains(account) && !self.unresolved_nonces.contains(account)
+    }
+
+    /// The deposit addresses of the accounts whose nonce is waiting to be read back *and* have
+    /// funds queued for sweeping, so a tick pays for the reads it could act on and no others.
+    pub fn deposit_addresses_awaiting_a_nonce_read(&self) -> BTreeMap<Account, DepositAddress> {
+        self.sweep
+            .iter()
+            .filter(|(request, _entry)| self.unverified_nonces.contains(&request.account))
+            .map(|(request, entry)| (request.account, entry.address))
+            .collect()
+    }
+
+    pub fn unverified_nonces_len(&self) -> usize {
+        self.unverified_nonces.len()
+    }
+
+    pub fn unresolved_nonces_len(&self) -> usize {
+        self.unresolved_nonces.len()
+    }
+
     /// Re-anchor the record of `account`'s deposit address on `observed`, the nonce the chain says
-    /// it stands at, and mark that nonce verified again.
+    /// it stands at, and trust that address' nonce again.
     ///
     /// The minter signs at most one tuple per `(deposit address, nonce)` and holds the address'
     /// only key, so `observed` alone says which of them the chain applied: those signed for a nonce
-    /// below it, and no other. Where the address nonetheless holds two tuples at one nonce — state
-    /// from before that rule — the one already marked applied stays the answer; if neither is, the
-    /// observed nonce cannot tell them apart, so nothing is re-anchored and the address stays
-    /// unverified, out of every sweep, until an operator sorts it out.
+    /// below it, and no other.
+    ///
+    /// Two observations say instead that the record is beyond arithmetic, and leave the address
+    /// *unresolved* — out of every sweep, and never read again, since a further read would report
+    /// the same nonce and explain no more:
+    ///
+    /// * a nonce above every tuple the minter signed, which nothing it did could have taken the
+    ///   address to, so the record must be missing tuples;
+    /// * two unapplied tuples at one nonce below `observed` — state from before the
+    ///   one-tuple-per-nonce rule — which the nonce cannot tell apart. Where one of them is already
+    ///   marked applied, that one stays the answer and the record is re-anchored as usual.
     pub fn record_observed_deposit_address_nonce(
         &mut self,
         account: Account,
@@ -405,13 +454,32 @@ impl AutomaticDeposits {
             }
         }
 
+        let highest_explainable =
+            signed_at
+                .keys()
+                .next_back()
+                .map_or(TransactionNonce::ZERO, |highest| {
+                    highest
+                        .checked_increment()
+                        .expect("BUG: authorization nonce space exhausted")
+                });
+        if observed > highest_explainable {
+            log!(
+                INFO,
+                "[record_observed_deposit_address_nonce]: LEAVING {account:?} unresolved: its deposit address stands at nonce {observed}, above the {highest_explainable} the tuples the minter signed for it could have reached, so the record is missing tuples."
+            );
+            self.leave_nonce_unresolved(account);
+            return;
+        }
+
         let mut applied = BTreeSet::new();
         for (nonce, tuples) in signed_at.range(..observed) {
             let Some(request) = tuple_the_chain_applied(tuples, &already_applied) else {
                 log!(
                     INFO,
-                    "[record_observed_deposit_address_nonce]: LEAVING {account:?} out of every sweep: its deposit address stands at nonce {observed}, but the tuples signed for its nonce {nonce} are several and none is marked applied, so the observed nonce cannot say which of them the chain applied."
+                    "[record_observed_deposit_address_nonce]: LEAVING {account:?} unresolved: its deposit address stands at nonce {observed}, but the tuples signed for its nonce {nonce} are several and none is marked applied, so the observed nonce cannot say which of them the chain applied."
                 );
+                self.leave_nonce_unresolved(account);
                 return;
             };
             applied.insert(request.clone());
@@ -429,6 +497,14 @@ impl AutomaticDeposits {
             };
         }
         self.unverified_nonces.remove(&account);
+        self.unresolved_nonces.remove(&account);
+    }
+
+    /// Stop reading `account`'s deposit address' nonce and keep it out of every sweep: the read
+    /// already made explains nothing the record can act on, and another would say the same.
+    fn leave_nonce_unresolved(&mut self, account: Account) {
+        self.unverified_nonces.remove(&account);
+        self.unresolved_nonces.insert(account);
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.
@@ -715,11 +791,16 @@ impl AutomaticDeposits {
 
     /// The queued deposits a sweep could take next, batched by asset, skipping those a sweep
     /// already holds: taking them twice would move a balance the minter has already accounted for.
+    ///
+    /// Deposits of an address whose nonce the minter cannot vouch for are skipped too, and take no
+    /// slot in their asset's batch: no sweep can carry them until that nonce is settled, and
+    /// leaving them in would let a handful of stuck addresses hold back every healthy one queued
+    /// behind them.
     pub fn requests_batch(&self, requested_batch_size: usize) -> BTreeMap<Asset, Vec<SweepTarget>> {
         let mut batches = BTreeMap::new();
-        for (deposit_request, sweep_entry) in
-            self.sweep.iter().filter(|(_, entry)| entry.is_sweepable())
-        {
+        for (deposit_request, sweep_entry) in self.sweep.iter().filter(|(request, entry)| {
+            entry.is_sweepable() && self.has_trusted_nonce(&request.account)
+        }) {
             let batch: &mut Vec<_> = batches.entry(deposit_request.asset).or_default();
             if batch.len() < requested_batch_size {
                 batch.push(SweepTarget {
@@ -767,6 +848,7 @@ impl Default for AutomaticDeposits {
             attestations: BTreeMap::new(),
             authorizations: BTreeMap::new(),
             unverified_nonces: BTreeSet::new(),
+            unresolved_nonces: BTreeSet::new(),
             sweeper_transactions: SweeperTransactionPipeline::new(TransactionNonce::ZERO),
         }
     }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -212,10 +212,6 @@ impl AutomaticDeposits {
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
         let authorizations = request.authorization_requests();
 
-        for authorization in authorizations {
-            self.record_applied_authorization(authorization, id);
-        }
-
         for account in accounts {
             let request = DepositRequest::new(account, asset);
             let entry = self
@@ -235,6 +231,10 @@ impl AutomaticDeposits {
                     entry.address
                 );
             }
+        }
+
+        for authorization in authorizations {
+            self.record_applied_authorization(authorization, id);
         }
         finalized
     }
@@ -301,11 +301,8 @@ impl AutomaticDeposits {
     /// which for a deposit address means it holds no delegation at all: only the minter ever
     /// authorizes one.
     pub fn delegation(&self, account: &Account) -> Option<Delegation> {
-        self.authorizations
-            .iter()
-            .filter(|(request, stored)| {
-                request.account() == *account && stored.applied_by.is_some()
-            })
+        self.authorizations_of(account)
+            .filter(|(_request, stored)| stored.applied_by.is_some())
             .map(|(request, _stored)| request)
             .max_by_key(|request| request.nonce())
             .map(|request| Delegation {
@@ -315,6 +312,21 @@ impl AutomaticDeposits {
                     .checked_increment()
                     .expect("BUG: authorization nonce space exhausted"),
             })
+    }
+
+    /// The authorizations signed for `account`, in key order. An [`AuthorizationRequest`] orders by
+    /// its account first, so one account's authorizations are a contiguous range: reaching them
+    /// costs the account's own entries rather than a scan of every account ever swept, which
+    /// matters on replay, where every finalized sweep consults them.
+    fn authorizations_of(
+        &self,
+        account: &Account,
+    ) -> impl Iterator<Item = (&AuthorizationRequest, &StoredAuthorization)> {
+        let first =
+            AuthorizationRequest::new(*account, u64::MIN, Address::ZERO, TransactionNonce::ZERO);
+        self.authorizations
+            .range(first..)
+            .take_while(move |(request, _stored)| request.account() == *account)
     }
 
     /// The nonce `account`'s deposit address is at, and therefore the only nonce a further
@@ -331,9 +343,10 @@ impl AutomaticDeposits {
         if request.nonce() != self.next_authorization_nonce(&request.account()) {
             return;
         }
-        if let Some(stored) = self.authorizations.get_mut(&request) {
-            stored.applied_by.get_or_insert(sweep_id);
-        }
+        self.authorizations
+            .get_mut(&request)
+            .expect("BUG: a sweep carried an authorization the minter never signed")
+            .applied_by = Some(sweep_id);
     }
 
     /// Arm the `(account, asset)` pair, whose deposit `address` is derived for `account`.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -34,8 +34,9 @@ use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
 
 /// A delegate other than the sweeper contract every fixture sweep names, for the tests that rotate
-/// an account onto a second one.
-const ANOTHER_DELEGATE: Address = Address::new([0x9e; 20]);
+/// an account onto a second one. Sorts before the incumbent, so a test reading the delegation off
+/// the last key rather than off the highest nonce fails.
+const ANOTHER_DELEGATE: Address = Address::new([0x1e; 20]);
 
 #[test]
 fn should_watch_a_pair_for_the_scan_window() {
@@ -1043,7 +1044,7 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
         transaction_signature(),
     );
 
-    finalize_sweep_carrying(&mut deposits, account(0), None);
+    finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
     // Signing a tuple is not applying it: an address only a sweep that left it out has swept
     // holds no delegation.
@@ -1053,17 +1054,16 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 }
 
 #[tokio::test]
-async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_it() {
+async fn should_not_mark_a_tuple_whose_nonce_the_account_has_already_spent() {
     let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
     finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
     let authorization = first.items[0].authorization.clone();
     assert!(authorization.is_some(), "the fixture must carry a tuple");
 
-    // The protocol skips a tuple whose nonce the account has already spent, so re-carrying it
-    // changes nothing on chain.
-    let second = finalize_sweep_carrying(&mut deposits, account(0), authorization);
+    // Applying the tuple spent nonce zero, so the protocol skips the very same tuple when a later
+    // sweep carries it again: the mark stays on the sweep that did apply it.
+    finalize_sweep_carrying(&mut deposits, SweepId(1), authorization);
 
-    assert_ne!(second, first.id);
     assert_eq!(
         applied_by(
             &deposits,
@@ -1081,6 +1081,45 @@ async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_i
     assert_eq!(deposits.applied_authorizations_len(), 1);
 }
 
+/// Two sweeps of the same account can be in flight at once — one per token it has queued — and
+/// both carry a tuple for nonce zero, since the minter always signs for nonce zero. Whichever
+/// lands first spends the nonce; the other is skipped, even when it names a different delegate.
+#[test]
+fn should_apply_only_the_first_of_two_sweeps_carrying_the_same_nonce() {
+    let mut deposits = AutomaticDeposits::default();
+    let incumbent = authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO);
+    let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ZERO);
+    deposits.record_authorization(incumbent.clone(), transaction_signature());
+    deposits.record_authorization(rotated.clone(), transaction_signature());
+
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&incumbent)));
+    finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
+
+    assert_eq!(applied_by(&deposits, &incumbent), Some(SweepId(0)));
+    assert_eq!(applied_by(&deposits, &rotated), None);
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 1);
+}
+
+#[test]
+fn should_not_mark_a_tuple_signed_for_a_nonce_the_account_has_not_reached() {
+    let mut deposits = AutomaticDeposits::default();
+    let ahead = authorization_request(account(0), sweeper_contract(), TransactionNonce::ONE);
+    deposits.record_authorization(ahead.clone(), transaction_signature());
+
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&ahead)));
+
+    assert_eq!(applied_by(&deposits, &ahead), None);
+    assert_eq!(deposits.delegation(&account(0)), None);
+    assert_eq!(deposits.applied_authorizations_len(), 0);
+}
+
 #[tokio::test]
 async fn should_report_the_delegate_of_the_highest_applied_authorization() {
     let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
@@ -1088,11 +1127,7 @@ async fn should_report_the_delegate_of_the_highest_applied_authorization() {
 
     let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ONE);
     deposits.record_authorization(rotated.clone(), transaction_signature());
-    finalize_sweep_carrying(
-        &mut deposits,
-        account(0),
-        Some(rotated.signed_with(transaction_signature())),
-    );
+    finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
 
     assert_eq!(
         deposits.delegation(&account(0)),
@@ -1157,24 +1192,29 @@ fn replay_of_the_event_log() -> State {
     state
 }
 
-/// Queue `account`'s USDT, hand it to a sweep of its own carrying `authorization`, and finalize
-/// that sweep. Numbered after the sweep a fixture enqueues, so it can follow one.
+/// Queue [`account(0)`]'s deposit of the token sweep `id` alone moves, hand it to that sweep
+/// carrying `authorization`, and finalize the sweep. One token per id, so several sweeps of the
+/// same account can follow one another.
 fn finalize_sweep_carrying(
     deposits: &mut AutomaticDeposits,
-    account: Account,
+    id: SweepId,
     authorization: Option<SignedAuthorization>,
-) -> SweepId {
-    let id = SweepId(1);
+) {
+    let account = account(0);
+    let token = token(id.0 as u8);
     let request = sweep_request(
         id,
-        Asset::Erc20(usdt()),
+        Asset::Erc20(token),
         vec![authorized_item(account, authorization)],
     );
-    queue(deposits, &[(account, usdt())]);
-    deposits.record_sweep_scheduled(id, Asset::Erc20(usdt()), [account]);
+    queue(deposits, &[(account, token)]);
+    deposits.record_sweep_scheduled(id, Asset::Erc20(token), [account]);
     deposits.record_sweep_request(request.clone());
     finalize_sweep(deposits, &request, TransactionStatus::Success);
-    id
+}
+
+fn signed(request: &AuthorizationRequest) -> SignedAuthorization {
+    request.signed_with(transaction_signature())
 }
 
 fn sweep_request(id: SweepId, asset: Asset, items: Vec<AuthorizedSweepItem>) -> SweepRequest {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1046,8 +1046,8 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 
     finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
-    // Signing a tuple is not applying it: an address only a sweep that left it out has swept
-    // holds no delegation.
+    // Signing a tuple is not applying it: a sweep that leaves the tuple out leaves the address
+    // without a delegation.
     assert_eq!(deposits.authorizations_len(), 1);
     assert_eq!(deposits.applied_authorizations_len(), 0);
     assert_eq!(deposits.delegation(&account(0)), None);

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1408,6 +1408,43 @@ async fn should_offer_at_most_a_batch_of_deposit_addresses_to_read_the_nonce_of(
     );
 }
 
+/// A sweep in flight applies its tuple when it finalizes, moving the marks a read re-anchors. An
+/// address one still holds is therefore not read while it is in flight: a count read before that
+/// sweep lands would undo what it left behind. It is read once the sweep is done with it.
+#[tokio::test]
+async fn should_read_no_nonce_of_an_address_a_sweep_still_holds() {
+    let (mut deposits, reverted) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    finalize_sweep(&mut deposits, &reverted, TransactionStatus::Failure);
+    rearm(&mut deposits, &[(account(0), usdc()), (account(0), usdt())]);
+    let in_flight = sweep_request(
+        SweepId(1),
+        Asset::Erc20(usdt()),
+        vec![authorized_item(account(0), None)],
+    );
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdt()), [account(0)]);
+    deposits.record_sweep_request(in_flight.clone());
+
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(10)
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![],
+        "reading the nonce now would race the tuple that sweep applies when it finalizes"
+    );
+
+    finalize_sweep(&mut deposits, &in_flight, TransactionStatus::Success);
+
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(10)
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![account(0)],
+        "the sweep has settled what it applied, so the read anchors on a record that stands still"
+    );
+}
+
 /// One read places an account's deposit address whatever that account has queued, so a second
 /// funded token of the same account may not cost the batch a slot.
 #[tokio::test]

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, DepositRequest, DepositStage,
+    AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, Delegation, DepositRequest, DepositStage,
     DepositStatusInfo, MAX_ACTIVE_DEPOSITS, MAX_ASSETS_PER_ACCOUNT, RegisterDepositError,
     SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry, SweepTarget,
 };
@@ -8,18 +8,34 @@ use crate::deposit_address::DepositAddress;
 use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
 use crate::lifecycle::EthereumNetwork;
-use crate::numeric::{BlockNumber, Erc20Value};
+use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
+use crate::state::State;
+use crate::state::audit::{EventType, apply_state_transition, process_event};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::{PipelineRequest, SweepId, SweepRequest};
+use crate::state::transactions::{
+    AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest, sweep_gas_limit,
+};
+use crate::storage::with_event_iter;
+use crate::sweeper_contract::SweepItem;
+use crate::test_fixtures::mock::MockTimeProvider;
 use crate::test_fixtures::{
-    deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, usdc, usdt,
+    deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, initial_state,
+    prepay_sweep_gas, state_with_enqueued_sweep, sweeper_contract, transaction_signature, usdc,
+    usdt,
 };
 use crate::timed_sized_map::{Entry, Timestamp};
-use crate::tx::{SignableTransaction, Signed, TransactionSignature};
+use crate::tx::{
+    AuthorizationRequest, SignableTransaction, Signed, SignedAuthorization, SweepTransaction,
+    TransactionSignature,
+};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
 use std::collections::BTreeMap;
+
+/// A delegate other than the sweeper contract every fixture sweep names, for the tests that rotate
+/// an account onto a second one.
+const ANOTHER_DELEGATE: Address = Address::new([0x9e; 20]);
 
 #[test]
 fn should_watch_a_pair_for_the_scan_window() {
@@ -947,7 +963,7 @@ async fn should_release_a_deposit_once_its_sweep_succeeds() {
     let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
     queue(&mut deposits, &[(account(1), usdc())]);
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
 
     // The swept pair is gone from the queue; the pair queued after the sweep was decided is still
     // offered.
@@ -962,7 +978,7 @@ async fn should_release_a_deposit_once_its_sweep_succeeds() {
 async fn should_drop_a_deposit_once_its_sweep_fails() {
     let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
 
     // A reverted sweep moved nothing, but the minter does not retry: the pair leaves the queue and
     // has to be armed afresh.
@@ -975,7 +991,7 @@ async fn should_release_every_account_a_sweep_held() {
     let (mut deposits, request) =
         deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
 
     assert_eq!(deposits.sweep_len(), 0);
 }
@@ -992,27 +1008,282 @@ async fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
     deposits.record_sweep_scheduled(SweepId(0), Asset::Erc20(usdc()), [account(0)]);
     deposits.record_sweep_request(request.clone());
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Success);
+}
+
+#[tokio::test]
+async fn should_mark_the_authorizations_a_finalized_sweep_carried_as_applied() {
+    // A tuple applies before the call runs and stays applied when the call reverts, so both
+    // outcomes leave the delegation installed.
+    for status in [TransactionStatus::Success, TransactionStatus::Failure] {
+        let (mut deposits, request) =
+            deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+
+        finalize_sweep(&mut deposits, &request, status);
+
+        for account in [account(0), account(1)] {
+            assert_eq!(
+                deposits.delegation(&account),
+                Some(Delegation {
+                    delegate: sweeper_contract(),
+                    nonce: TransactionNonce::ONE,
+                }),
+                "a {status:?} sweep installs the delegations it carried"
+            );
+        }
+        assert_eq!(deposits.applied_authorizations_len(), 2);
+    }
+}
+
+#[test]
+fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
+    let mut deposits = AutomaticDeposits::default();
+    deposits.record_authorization(
+        authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO),
+        transaction_signature(),
+    );
+
+    finalize_sweep_carrying(&mut deposits, account(0), None);
+
+    // Signing a tuple is not applying it: an address only a sweep that left it out has swept
+    // holds no delegation.
+    assert_eq!(deposits.authorizations_len(), 1);
+    assert_eq!(deposits.applied_authorizations_len(), 0);
+    assert_eq!(deposits.delegation(&account(0)), None);
+}
+
+#[tokio::test]
+async fn should_keep_an_applied_authorization_marked_by_the_sweep_that_applied_it() {
+    let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
+    let authorization = first.items[0].authorization.clone();
+    assert!(authorization.is_some(), "the fixture must carry a tuple");
+
+    // The protocol skips a tuple whose nonce the account has already spent, so re-carrying it
+    // changes nothing on chain.
+    let second = finalize_sweep_carrying(&mut deposits, account(0), authorization);
+
+    assert_ne!(second, first.id);
+    assert_eq!(
+        applied_by(
+            &deposits,
+            &authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO)
+        ),
+        Some(first.id)
+    );
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 1);
+}
+
+#[tokio::test]
+async fn should_report_the_delegate_of_the_highest_applied_authorization() {
+    let (mut deposits, first) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    finalize_sweep(&mut deposits, &first, TransactionStatus::Success);
+
+    let rotated = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ONE);
+    deposits.record_authorization(rotated.clone(), transaction_signature());
+    finalize_sweep_carrying(
+        &mut deposits,
+        account(0),
+        Some(rotated.signed_with(transaction_signature())),
+    );
+
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: ANOTHER_DELEGATE,
+            nonce: TransactionNonce::new(2),
+        })
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 2);
+}
+
+#[tokio::test]
+async fn should_rebuild_the_applied_marks_by_replaying_the_event_log() {
+    let (mut live, request) = state_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    let mut time_provider = MockTimeProvider::new();
+    time_provider.expect_time().return_const(0_u64);
+    for event in sweep_pipeline_events(
+        live.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Success,
+    ) {
+        process_event(&mut live, event, &time_provider);
+    }
+
+    let replayed = replay_of_the_event_log();
+
+    assert_eq!(
+        replayed.automatic_deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+    assert_eq!(
+        replayed
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(())
+    );
+
+    let mut unmarked = replayed.automatic_deposits.clone();
+    for stored in unmarked.authorizations.values_mut() {
+        stored.applied_by = None;
+    }
+    assert_ne!(
+        unmarked.is_equivalent_to(&live.automatic_deposits),
+        Ok(()),
+        "equivalence must notice which authorizations were applied"
+    );
+}
+
+/// The minter state the event log alone reconstructs. The prepaid sweep gas is not event-sourced,
+/// so it is put back by hand for the accepted sweeps in the log to draw on.
+fn replay_of_the_event_log() -> State {
+    let mut state = initial_state();
+    prepay_sweep_gas(&mut state);
+    with_event_iter(|events| {
+        for event in events {
+            apply_state_transition(&mut state, &event.payload);
+        }
+    });
+    state
+}
+
+/// Queue `account`'s USDT, hand it to a sweep of its own carrying `authorization`, and finalize
+/// that sweep. Numbered after the sweep a fixture enqueues, so it can follow one.
+fn finalize_sweep_carrying(
+    deposits: &mut AutomaticDeposits,
+    account: Account,
+    authorization: Option<SignedAuthorization>,
+) -> SweepId {
+    let id = SweepId(1);
+    let request = sweep_request(
+        id,
+        Asset::Erc20(usdt()),
+        vec![authorized_item(account, authorization)],
+    );
+    queue(deposits, &[(account, usdt())]);
+    deposits.record_sweep_scheduled(id, Asset::Erc20(usdt()), [account]);
+    deposits.record_sweep_request(request.clone());
+    finalize_sweep(deposits, &request, TransactionStatus::Success);
+    id
+}
+
+fn sweep_request(id: SweepId, asset: Asset, items: Vec<AuthorizedSweepItem>) -> SweepRequest {
+    let max_transaction_fee = gas_fee_estimate()
+        .to_price(sweep_gas_limit(&items))
+        .max_transaction_fee();
+    SweepRequest {
+        id,
+        destination: sweeper_contract(),
+        asset,
+        items,
+        max_transaction_fee,
+        created_at: 0,
+    }
+}
+
+fn authorized_item(
+    account: Account,
+    authorization: Option<SignedAuthorization>,
+) -> AuthorizedSweepItem {
+    AuthorizedSweepItem {
+        item: SweepItem {
+            deposit: deposit_address(&account),
+            account,
+            attestation: transaction_signature(),
+        },
+        authorization,
+    }
+}
+
+fn authorization_request(
+    account: Account,
+    delegate: Address,
+    nonce: TransactionNonce,
+) -> AuthorizationRequest {
+    AuthorizationRequest::new(
+        account,
+        EthereumNetwork::default().chain_id(),
+        delegate,
+        nonce,
+    )
+}
+
+fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> Option<SweepId> {
+    deposits
+        .authorizations
+        .get(request)
+        .and_then(|stored| stored.applied_by)
 }
 
 /// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.
 fn finalize_sweep(
     deposits: &mut AutomaticDeposits,
-    request: SweepRequest,
+    request: &SweepRequest,
     status: TransactionStatus,
 ) {
-    let id = request.id;
+    let sweep = sweep_pipeline_outcome(deposits.next_sweeper_transaction_nonce(), request, status);
+    deposits.record_created_sweep_transaction(request.id, sweep.transaction);
+    deposits.record_signed_sweep_transaction(sweep.signed);
+    deposits.record_finalized_sweep_transaction(request.id, &sweep.receipt);
+}
+
+/// The events the sweeper pipeline records taking the already-accepted `request` from its
+/// transaction to a receipt of `status`.
+fn sweep_pipeline_events(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> Vec<EventType> {
+    let sweep = sweep_pipeline_outcome(nonce, request, status);
+    vec![
+        EventType::CreatedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.transaction,
+        },
+        EventType::SignedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.signed,
+        },
+        EventType::FinalizedSweeperTransaction {
+            sweep_id: request.id,
+            transaction_receipt: sweep.receipt,
+        },
+    ]
+}
+
+/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction
+/// signed, and the receipt finalizing it.
+struct SweepPipelineOutcome {
+    transaction: SweepTransaction,
+    signed: Signed<SweepTransaction>,
+    receipt: TransactionReceipt,
+}
+
+fn sweep_pipeline_outcome(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> SweepPipelineOutcome {
     let transaction = request
         .create_transaction(
-            deposits.next_sweeper_transaction_nonce(),
+            nonce,
             gas_fee_estimate(),
             request.gas_limit(),
             EthereumNetwork::Sepolia,
         )
         .expect("BUG: the fixture prices the request with the estimate it creates with");
-    deposits.record_created_sweep_transaction(id, transaction.clone());
     let signed = Signed::from((
-        transaction,
+        transaction.clone(),
         TransactionSignature {
             signature_y_parity: false,
             r: Default::default(),
@@ -1027,8 +1298,11 @@ fn finalize_sweep(
         status,
         transaction_hash: signed.hash(),
     };
-    deposits.record_signed_sweep_transaction(signed);
-    deposits.record_finalized_sweep_transaction(id, &receipt);
+    SweepPipelineOutcome {
+        transaction,
+        signed,
+        receipt,
+    }
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -5,29 +5,23 @@ use super::{
 };
 use crate::asset::Asset;
 use crate::deposit_address::DepositAddress;
-use crate::eth_rpc::Hash;
-use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
 use crate::state::State;
-use crate::state::audit::{EventType, apply_state_transition, process_event};
+use crate::state::audit::{apply_state_transition, process_event};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
-use crate::state::transactions::{
-    AuthorizedSweepItem, PipelineRequest, SweepId, SweepRequest, sweep_gas_limit,
-};
+use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest, sweep_gas_limit};
 use crate::storage::with_event_iter;
 use crate::sweeper_contract::SweepItem;
 use crate::test_fixtures::mock::MockTimeProvider;
 use crate::test_fixtures::{
     deposit_address, deposits_with_enqueued_sweep, gas_fee_estimate, initial_state,
-    prepay_sweep_gas, state_with_enqueued_sweep, sweeper_contract, transaction_signature, usdc,
-    usdt,
+    prepay_sweep_gas, state_with_enqueued_sweep, sweep_pipeline_events, sweep_pipeline_outcome,
+    sweeper_contract, transaction_signature, usdc, usdt,
 };
 use crate::timed_sized_map::{Entry, Timestamp};
-use crate::tx::{
-    AuthorizationRequest, SignableTransaction, Signed, SignedAuthorization, SweepTransaction,
-    TransactionSignature,
-};
+use crate::tx::{AuthorizationRequest, SignedAuthorization};
 use candid::Principal;
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -1273,74 +1267,6 @@ fn finalize_sweep(
     deposits.record_created_sweep_transaction(request.id, sweep.transaction);
     deposits.record_signed_sweep_transaction(sweep.signed);
     deposits.record_finalized_sweep_transaction(request.id, &sweep.receipt);
-}
-
-/// The events the sweeper pipeline records taking the already-accepted `request` from its
-/// transaction to a receipt of `status`.
-fn sweep_pipeline_events(
-    nonce: TransactionNonce,
-    request: &SweepRequest,
-    status: TransactionStatus,
-) -> Vec<EventType> {
-    let sweep = sweep_pipeline_outcome(nonce, request, status);
-    vec![
-        EventType::CreatedSweeperTransaction {
-            sweep_id: request.id,
-            transaction: sweep.transaction,
-        },
-        EventType::SignedSweeperTransaction {
-            sweep_id: request.id,
-            transaction: sweep.signed,
-        },
-        EventType::FinalizedSweeperTransaction {
-            sweep_id: request.id,
-            transaction_receipt: sweep.receipt,
-        },
-    ]
-}
-
-/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction
-/// signed, and the receipt finalizing it.
-struct SweepPipelineOutcome {
-    transaction: SweepTransaction,
-    signed: Signed<SweepTransaction>,
-    receipt: TransactionReceipt,
-}
-
-fn sweep_pipeline_outcome(
-    nonce: TransactionNonce,
-    request: &SweepRequest,
-    status: TransactionStatus,
-) -> SweepPipelineOutcome {
-    let transaction = request
-        .create_transaction(
-            nonce,
-            gas_fee_estimate(),
-            request.gas_limit(),
-            EthereumNetwork::Sepolia,
-        )
-        .expect("BUG: the fixture prices the request with the estimate it creates with");
-    let signed = Signed::from((
-        transaction.clone(),
-        TransactionSignature {
-            signature_y_parity: false,
-            r: Default::default(),
-            s: Default::default(),
-        },
-    ));
-    let receipt = TransactionReceipt {
-        block_hash: Hash([0x11; 32]),
-        block_number: BlockNumber::new(4_190_269),
-        effective_gas_price: signed.transaction().max_fee_per_gas(),
-        gas_used: signed.transaction().gas_limit(),
-        status,
-        transaction_hash: signed.hash(),
-    };
-    SweepPipelineOutcome {
-        transaction,
-        signed,
-        receipt,
-    }
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1349,8 +1349,7 @@ async fn should_offer_no_sweep_of_an_address_whose_nonce_is_not_trusted() {
     let (mut deposits, request) =
         deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
     finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
-    // A reverted sweep drops the deposits it held, so queue them as a re-armed pair would be.
-    queue(&mut deposits, &[(account(0), usdc()), (account(1), usdc())]);
+    rearm(&mut deposits, &[(account(0), usdc()), (account(1), usdc())]);
     assert_eq!(accounts_in(&deposits.requests_batch(10), usdc()), vec![]);
 
     deposits.record_observed_deposit_address_nonce(account(0), TransactionNonce::ONE);
@@ -1620,6 +1619,12 @@ fn queued(pairs: &[(Account, Address)]) -> AutomaticDeposits {
     queue(&mut deposits, pairs);
     assert_eq!(deposits.sweep_len(), pairs.len());
     deposits
+}
+
+/// Queue these pairs again, as arming them afresh does. What a reverted sweep's deposits need
+/// before any test can offer them for sweeping again: failing dropped them from the queue.
+fn rearm(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {
+    queue(deposits, pairs);
 }
 
 fn queue(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -854,7 +854,7 @@ fn automatic_deposit(
 }
 
 #[test]
-fn should_keep_eth_entries_out_of_sweep_batches() {
+fn should_batch_eth_entries_alongside_tokens() {
     let mut deposits = AutomaticDeposits::default();
     deposits.record_automatic_deposit_received(&automatic_deposit(
         account(0),
@@ -873,13 +873,9 @@ fn should_keep_eth_entries_out_of_sweep_batches() {
 
     let batches = deposits.requests_batch(10);
 
-    assert_eq!(batches.len(), 1);
+    assert_eq!(batches.len(), 2);
+    assert_eq!(accounts_in(&batches, Asset::Eth), vec![account(0)]);
     assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
-    assert_eq!(
-        deposits.sweep_len(),
-        2,
-        "BUG: the ETH entry stays queued, awaiting the sweepEthBatch lane"
-    );
 }
 
 #[test]
@@ -894,7 +890,7 @@ fn should_batch_queued_deposits_by_token() {
 
     assert_eq!(
         batches.keys().copied().collect::<Vec<_>>(),
-        vec![usdc(), usdt()]
+        vec![Asset::Erc20(usdc()), Asset::Erc20(usdt())]
     );
     assert_eq!(accounts_in(&batches, usdc()), vec![account(0), account(1)]);
     assert_eq!(accounts_in(&batches, usdt()), vec![account(2)]);
@@ -909,7 +905,7 @@ fn should_batch_queued_deposits_by_token() {
 fn should_stop_offering_a_deposit_a_sweep_has_taken() {
     let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(7), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(7), Asset::Erc20(usdc()), [account(0)]);
 
     let batches = deposits.requests_batch(10);
     assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
@@ -922,8 +918,8 @@ fn should_stop_offering_a_deposit_a_sweep_has_taken() {
 fn should_offer_nothing_once_every_deposit_is_taken() {
     let mut deposits = queued(&[(account(0), usdc()), (account(1), usdt())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
-    deposits.record_sweep_scheduled(SweepId(2), usdt(), [account(1)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdt()), [account(1)]);
 
     assert!(deposits.requests_batch(10).is_empty());
     assert_eq!(deposits.sweep_len(), 2);
@@ -934,8 +930,8 @@ fn should_offer_nothing_once_every_deposit_is_taken() {
 fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
     let mut deposits = queued(&[(account(0), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
-    deposits.record_sweep_scheduled(SweepId(2), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdc()), [account(0)]);
 }
 
 #[test]
@@ -943,7 +939,7 @@ fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
 fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
     let mut deposits = queued(&[(account(0), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdt(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdt()), [account(0)]);
 }
 
 #[tokio::test]
@@ -993,7 +989,7 @@ async fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
     let (_, request) =
         deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
     let mut deposits = queued(&[(account(0), usdc())]);
-    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(0), Asset::Erc20(usdc()), [account(0)]);
     deposits.record_sweep_request(request.clone());
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Success);
@@ -1063,9 +1059,12 @@ fn queue(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {
     }
 }
 
-fn accounts_in(batches: &BTreeMap<Address, Vec<SweepTarget>>, token: Address) -> Vec<Account> {
+fn accounts_in(
+    batches: &BTreeMap<Asset, Vec<SweepTarget>>,
+    asset: impl Into<Asset>,
+) -> Vec<Account> {
     batches
-        .get(&token)
+        .get(&asset.into())
         .map(|targets| targets.iter().map(|target| target.account()).collect())
         .unwrap_or_default()
 }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1478,7 +1478,7 @@ fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> O
     deposits
         .authorizations
         .get(request)
-        .and_then(|stored| stored.applied_by.clone())
+        .and_then(|stored| stored.applied_by)
 }
 
 /// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1037,7 +1037,7 @@ async fn should_mark_the_authorizations_a_finalized_sweep_carried_as_applied() {
 }
 
 #[test]
-fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
+fn should_leave_a_tuple_unapplied_and_its_address_undelegated_when_a_sweep_leaves_it_out() {
     let mut deposits = AutomaticDeposits::default();
     deposits.record_authorization(
         authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO),
@@ -1046,8 +1046,6 @@ fn should_mark_nothing_for_a_sweep_carrying_no_authorization() {
 
     finalize_sweep_carrying(&mut deposits, SweepId(0), None);
 
-    // Signing a tuple is not applying it: a sweep that leaves the tuple out leaves the address
-    // without a delegation.
     assert_eq!(deposits.authorizations_len(), 1);
     assert_eq!(deposits.applied_authorizations_len(), 0);
     assert_eq!(deposits.delegation(&account(0)), None);

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, Delegation, DepositRequest, DepositStage,
-    DepositStatusInfo, MAX_ACTIVE_DEPOSITS, MAX_ASSETS_PER_ACCOUNT, RegisterDepositError,
-    SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry, SweepTarget,
+    AppliedBy, AutomaticDeposits, DEPOSIT_ADDRESS_SCAN_WINDOW, Delegation, DepositRequest,
+    DepositStage, DepositStatusInfo, MAX_ACTIVE_DEPOSITS, MAX_ASSETS_PER_ACCOUNT,
+    RegisterDepositError, SCAN_GAP_SECS, SECS_PER_BLOCK, ScanProgress, SweepEntry, SweepTarget,
 };
 use crate::asset::Asset;
 use crate::deposit_address::DepositAddress;
@@ -9,7 +9,7 @@ use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::lifecycle::EthereumNetwork;
 use crate::numeric::{BlockNumber, Erc20Value, TransactionNonce};
 use crate::state::State;
-use crate::state::audit::{apply_state_transition, process_event};
+use crate::state::audit::{EventType, apply_state_transition, process_event};
 use crate::state::event::{AutomaticDeposit, DepositAddressRegistration, DepositAddressRegistry};
 use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest, sweep_gas_limit};
 use crate::storage::with_event_iter;
@@ -1061,7 +1061,7 @@ async fn should_not_mark_a_tuple_whose_nonce_the_account_has_already_spent() {
             &deposits,
             &authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO)
         ),
-        Some(first.id)
+        Some(AppliedBy::Sweep(first.id))
     );
     assert_eq!(
         deposits.delegation(&account(0)),
@@ -1087,7 +1087,10 @@ fn should_apply_only_the_first_of_two_sweeps_carrying_the_same_nonce() {
     finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&incumbent)));
     finalize_sweep_carrying(&mut deposits, SweepId(1), Some(signed(&rotated)));
 
-    assert_eq!(applied_by(&deposits, &incumbent), Some(SweepId(0)));
+    assert_eq!(
+        applied_by(&deposits, &incumbent),
+        Some(AppliedBy::Sweep(SweepId(0)))
+    );
     assert_eq!(applied_by(&deposits, &rotated), None);
     assert_eq!(
         deposits.delegation(&account(0)),
@@ -1171,6 +1174,217 @@ async fn should_rebuild_the_applied_marks_by_replaying_the_event_log() {
     );
 }
 
+#[tokio::test]
+async fn should_leave_nonces_unverified_only_where_a_sweep_reverted() {
+    for (status, unverified) in [
+        (TransactionStatus::Success, false),
+        (TransactionStatus::Failure, true),
+    ] {
+        let (mut deposits, request) =
+            deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+
+        finalize_sweep(&mut deposits, &request, status);
+
+        for account in [account(0), account(1)] {
+            assert_eq!(
+                deposits.has_unverified_nonce(&account),
+                unverified,
+                "a {status:?} sweep must leave its addresses' nonces {}",
+                if unverified {
+                    "unverified"
+                } else {
+                    "as they were"
+                }
+            );
+        }
+        assert!(
+            !deposits.has_unverified_nonce(&account(2)),
+            "an address the sweep never touched keeps its nonce"
+        );
+    }
+}
+
+#[test]
+fn should_reanchor_the_applied_marks_on_the_observed_deposit_address_nonce() {
+    struct Case {
+        name: &'static str,
+        observed: TransactionNonce,
+        expected_delegation: Option<Delegation>,
+        expected_applied: usize,
+    }
+
+    for case in [
+        Case {
+            name: "the record already agreed with the chain",
+            observed: TransactionNonce::ONE,
+            expected_delegation: Some(Delegation {
+                delegate: sweeper_contract(),
+                nonce: TransactionNonce::ONE,
+            }),
+            expected_applied: 1,
+        },
+        Case {
+            name: "the chain is ahead: the tuples below the observed nonce did apply",
+            observed: TransactionNonce::new(3),
+            expected_delegation: Some(Delegation {
+                delegate: ANOTHER_DELEGATE,
+                nonce: TransactionNonce::new(3),
+            }),
+            expected_applied: 3,
+        },
+        Case {
+            name: "the chain is behind: nothing at or above the observed nonce applied",
+            observed: TransactionNonce::ZERO,
+            expected_delegation: None,
+            expected_applied: 0,
+        },
+    ] {
+        let mut deposits = deposits_with_three_rotations_of_which_one_applied();
+        let reverted = sweep_carrying(&mut deposits, SweepId(1), None);
+        finalize_sweep(&mut deposits, &reverted, TransactionStatus::Failure);
+
+        deposits.record_observed_deposit_address_nonce(account(0), case.observed);
+
+        assert_eq!(
+            deposits.delegation(&account(0)),
+            case.expected_delegation,
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            deposits.applied_authorizations_len(),
+            case.expected_applied,
+            "{}",
+            case.name
+        );
+        assert!(
+            !deposits.has_unverified_nonce(&account(0)),
+            "{}: re-anchoring the record verifies the nonce",
+            case.name
+        );
+    }
+}
+
+/// Two tuples at one nonce is state from before the minter signed at most one per nonce. The
+/// observed nonce cannot say which of them applied, so the one already marked applied stays the
+/// answer.
+#[test]
+fn should_keep_the_applied_tuple_when_two_share_a_nonce_below_the_observed_one() {
+    let mut deposits = AutomaticDeposits::default();
+    let incumbent = authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO);
+    let rival = authorization_request(account(0), ANOTHER_DELEGATE, TransactionNonce::ZERO);
+    for request in [&incumbent, &rival] {
+        deposits.record_authorization(request.clone(), transaction_signature());
+    }
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&incumbent)));
+
+    deposits.record_observed_deposit_address_nonce(account(0), TransactionNonce::ONE);
+
+    assert_eq!(
+        applied_by(&deposits, &incumbent),
+        Some(AppliedBy::Sweep(SweepId(0)))
+    );
+    assert_eq!(applied_by(&deposits, &rival), None);
+    assert_eq!(
+        deposits.delegation(&account(0)),
+        Some(Delegation {
+            delegate: sweeper_contract(),
+            nonce: TransactionNonce::ONE,
+        })
+    );
+}
+
+#[test]
+fn should_leave_the_nonce_unverified_when_two_unapplied_tuples_share_a_nonce_below_it() {
+    let mut deposits = AutomaticDeposits::default();
+    for delegate in [sweeper_contract(), ANOTHER_DELEGATE] {
+        deposits.record_authorization(
+            authorization_request(account(0), delegate, TransactionNonce::ZERO),
+            transaction_signature(),
+        );
+    }
+    let reverted = sweep_carrying(&mut deposits, SweepId(0), None);
+    finalize_sweep(&mut deposits, &reverted, TransactionStatus::Failure);
+
+    deposits.record_observed_deposit_address_nonce(account(0), TransactionNonce::ONE);
+
+    assert!(
+        deposits.has_unverified_nonce(&account(0)),
+        "an address whose record the observed nonce cannot resolve stays out of sweeps"
+    );
+    assert_eq!(deposits.applied_authorizations_len(), 0);
+    assert_eq!(deposits.delegation(&account(0)), None);
+}
+
+#[tokio::test]
+async fn should_rebuild_the_unverified_nonces_and_their_repair_by_replaying_the_event_log() {
+    let (mut live, request) = state_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    let mut time_provider = MockTimeProvider::new();
+    time_provider.expect_time().return_const(0_u64);
+    for event in sweep_pipeline_events(
+        live.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Failure,
+    ) {
+        process_event(&mut live, event, &time_provider);
+    }
+    assert!(live.automatic_deposits.has_unverified_nonce(&account(0)));
+
+    let flagged = replay_of_the_event_log();
+    assert_eq!(
+        flagged
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(())
+    );
+
+    process_event(
+        &mut live,
+        EventType::ObservedDepositAddressNonce {
+            account: account(0),
+            nonce: TransactionNonce::ONE,
+        },
+        &time_provider,
+    );
+
+    let repaired = replay_of_the_event_log();
+    assert!(
+        !repaired
+            .automatic_deposits
+            .has_unverified_nonce(&account(0))
+    );
+    assert_eq!(
+        repaired
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(())
+    );
+    assert_ne!(
+        flagged
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(()),
+        "equivalence must notice which addresses are still awaiting a nonce read"
+    );
+}
+
+/// [`account(0)`] with a tuple recorded for each of the nonces zero, one and two — the first on
+/// the sweeper contract, the two rotations onto [`ANOTHER_DELEGATE`] — of which only the first is
+/// marked applied, so the record says the address stands at nonce one on the sweeper contract.
+fn deposits_with_three_rotations_of_which_one_applied() -> AutomaticDeposits {
+    let mut deposits = AutomaticDeposits::default();
+    let installed = authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO);
+    deposits.record_authorization(installed.clone(), transaction_signature());
+    for nonce in [TransactionNonce::ONE, TransactionNonce::new(2)] {
+        deposits.record_authorization(
+            authorization_request(account(0), ANOTHER_DELEGATE, nonce),
+            transaction_signature(),
+        );
+    }
+    finalize_sweep_carrying(&mut deposits, SweepId(0), Some(signed(&installed)));
+    deposits
+}
+
 /// The minter state the event log alone reconstructs. The prepaid sweep gas is not event-sourced,
 /// so it is put back by hand for the accepted sweeps in the log to draw on.
 fn replay_of_the_event_log() -> State {
@@ -1192,6 +1406,16 @@ fn finalize_sweep_carrying(
     id: SweepId,
     authorization: Option<SignedAuthorization>,
 ) {
+    let request = sweep_carrying(deposits, id, authorization);
+    finalize_sweep(deposits, &request, TransactionStatus::Success);
+}
+
+/// [`finalize_sweep_carrying`] up to the receipt, so a test can pick the status itself.
+fn sweep_carrying(
+    deposits: &mut AutomaticDeposits,
+    id: SweepId,
+    authorization: Option<SignedAuthorization>,
+) -> SweepRequest {
     let account = account(0);
     let token = token(id.0 as u8);
     let request = sweep_request(
@@ -1202,7 +1426,7 @@ fn finalize_sweep_carrying(
     queue(deposits, &[(account, token)]);
     deposits.record_sweep_scheduled(id, Asset::Erc20(token), [account]);
     deposits.record_sweep_request(request.clone());
-    finalize_sweep(deposits, &request, TransactionStatus::Success);
+    request
 }
 
 fn signed(request: &AuthorizationRequest) -> SignedAuthorization {
@@ -1250,11 +1474,11 @@ fn authorization_request(
     )
 }
 
-fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> Option<SweepId> {
+fn applied_by(deposits: &AutomaticDeposits, request: &AuthorizationRequest) -> Option<AppliedBy> {
     deposits
         .authorizations
         .get(request)
-        .and_then(|stored| stored.applied_by)
+        .and_then(|stored| stored.applied_by.clone())
 }
 
 /// Drives the already-recorded `request` through the sweeper pipeline to a receipt of `status`.

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1363,9 +1363,73 @@ async fn should_offer_no_sweep_of_an_address_whose_nonce_is_not_trusted() {
     assert_unresolved(&deposits, account(1));
     assert!(
         deposits
-            .deposit_addresses_awaiting_a_nonce_read()
+            .deposit_addresses_awaiting_a_nonce_read(10)
             .is_empty(),
         "neither address is read again: one is placed, the other no read can place"
+    );
+}
+
+/// A tick pays for the nonce reads it takes, a batch at a time, as it does for the sweeps it
+/// sends: a delegate that reverts every batch leaves every address those sweeps touched waiting on
+/// a read, and reading all of them at once would fan one timer out into a chain read per queued
+/// address.
+#[tokio::test]
+async fn should_offer_at_most_a_batch_of_deposit_addresses_to_read_the_nonce_of() {
+    let pairs = [
+        (account(0), usdc()),
+        (account(1), usdc()),
+        (account(2), usdc()),
+    ];
+    let (mut deposits, request) = deposits_with_enqueued_sweep(&pairs).await;
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
+    rearm(&mut deposits, &pairs);
+
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(0)
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![]
+    );
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(2)
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![account(0), account(1)]
+    );
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(pairs.len())
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![account(0), account(1), account(2)],
+        "a batch wide enough for them offers every address still waiting on a read"
+    );
+}
+
+/// One read places an account's deposit address whatever that account has queued, so a second
+/// funded token of the same account may not cost the batch a slot.
+#[tokio::test]
+async fn should_offer_a_deposit_address_once_however_many_of_its_tokens_are_queued() {
+    let (mut deposits, request) =
+        deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
+    rearm(
+        &mut deposits,
+        &[
+            (account(0), usdc()),
+            (account(0), usdt()),
+            (account(1), usdc()),
+        ],
+    );
+
+    assert_eq!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read(2)
+            .into_keys()
+            .collect::<Vec<_>>(),
+        vec![account(0), account(1)]
     );
 }
 

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -1295,7 +1295,7 @@ fn should_keep_the_applied_tuple_when_two_share_a_nonce_below_the_observed_one()
 }
 
 #[test]
-fn should_leave_the_nonce_unverified_when_two_unapplied_tuples_share_a_nonce_below_it() {
+fn should_leave_the_nonce_unresolved_when_two_unapplied_tuples_share_a_nonce_below_it() {
     let mut deposits = AutomaticDeposits::default();
     for delegate in [sweeper_contract(), ANOTHER_DELEGATE] {
         deposits.record_authorization(
@@ -1308,12 +1308,102 @@ fn should_leave_the_nonce_unverified_when_two_unapplied_tuples_share_a_nonce_bel
 
     deposits.record_observed_deposit_address_nonce(account(0), TransactionNonce::ONE);
 
-    assert!(
-        deposits.has_unverified_nonce(&account(0)),
-        "an address whose record the observed nonce cannot resolve stays out of sweeps"
-    );
+    assert_unresolved(&deposits, account(0));
     assert_eq!(deposits.applied_authorizations_len(), 0);
     assert_eq!(deposits.delegation(&account(0)), None);
+}
+
+/// The minter holds the deposit address' only key, so no nonce above the tuples it signed is
+/// explainable: reading one back means the record is missing tuples, which no arithmetic recovers.
+#[test]
+fn should_leave_the_nonce_unresolved_when_the_observed_one_is_beyond_every_signed_tuple() {
+    for (observed, explainable) in [
+        (TransactionNonce::ONE, true),
+        (TransactionNonce::new(2), false),
+    ] {
+        let mut deposits = AutomaticDeposits::default();
+        deposits.record_authorization(
+            authorization_request(account(0), sweeper_contract(), TransactionNonce::ZERO),
+            transaction_signature(),
+        );
+        let reverted = sweep_carrying(&mut deposits, SweepId(0), None);
+        finalize_sweep(&mut deposits, &reverted, TransactionStatus::Failure);
+
+        deposits.record_observed_deposit_address_nonce(account(0), observed);
+
+        if explainable {
+            assert!(
+                deposits.has_trusted_nonce(&account(0)),
+                "{observed} is the nonce the one tuple the minter signed takes the address to"
+            );
+        } else {
+            assert_unresolved(&deposits, account(0));
+        }
+    }
+}
+
+/// An address the minter cannot place takes no slot in a token's sweep batch: leaving it in would
+/// let a handful of stuck addresses hold back every healthy one queued behind them.
+#[tokio::test]
+async fn should_offer_no_sweep_of_an_address_whose_nonce_is_not_trusted() {
+    let (mut deposits, request) =
+        deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+    finalize_sweep(&mut deposits, &request, TransactionStatus::Failure);
+    // A reverted sweep drops the deposits it held, so queue them as a re-armed pair would be.
+    queue(&mut deposits, &[(account(0), usdc()), (account(1), usdc())]);
+    assert_eq!(accounts_in(&deposits.requests_batch(10), usdc()), vec![]);
+
+    deposits.record_observed_deposit_address_nonce(account(0), TransactionNonce::ONE);
+    deposits.record_observed_deposit_address_nonce(account(1), TransactionNonce::new(9));
+
+    assert_eq!(
+        accounts_in(&deposits.requests_batch(10), usdc()),
+        vec![account(0)],
+        "only the address the nonce read back placed is offered for sweeping again"
+    );
+    assert_unresolved(&deposits, account(1));
+    assert!(
+        deposits
+            .deposit_addresses_awaiting_a_nonce_read()
+            .is_empty(),
+        "neither address is read again: one is placed, the other no read can place"
+    );
+}
+
+/// A signature is only usable on the chain its tuple names, so a tuple recorded for another chain
+/// is not the one this chain will apply at that nonce.
+#[test]
+fn should_not_recarry_a_tuple_signed_for_another_chain() {
+    let mut deposits = AutomaticDeposits::default();
+    deposits.record_authorization(
+        AuthorizationRequest::new(
+            account(0),
+            EthereumNetwork::default().chain_id() + 1,
+            sweeper_contract(),
+            TransactionNonce::ZERO,
+        ),
+        transaction_signature(),
+    );
+
+    assert_eq!(
+        deposits.unapplied_authorization_at(
+            &account(0),
+            EthereumNetwork::default().chain_id(),
+            TransactionNonce::ZERO
+        ),
+        None
+    );
+}
+
+fn assert_unresolved(deposits: &AutomaticDeposits, account: Account) {
+    assert!(
+        !deposits.has_trusted_nonce(&account),
+        "an address the observed nonce cannot place stays out of every sweep"
+    );
+    assert!(
+        !deposits.has_unverified_nonce(&account),
+        "re-reading a nonce that explains nothing would burn cycles every tick to no end"
+    );
 }
 
 #[tokio::test]
@@ -1348,11 +1438,7 @@ async fn should_rebuild_the_unverified_nonces_and_their_repair_by_replaying_the_
     );
 
     let repaired = replay_of_the_event_log();
-    assert!(
-        !repaired
-            .automatic_deposits
-            .has_unverified_nonce(&account(0))
-    );
+    assert!(repaired.automatic_deposits.has_trusted_nonce(&account(0)));
     assert_eq!(
         repaired
             .automatic_deposits
@@ -1365,6 +1451,41 @@ async fn should_rebuild_the_unverified_nonces_and_their_repair_by_replaying_the_
             .is_equivalent_to(&live.automatic_deposits),
         Ok(()),
         "equivalence must notice which addresses are still awaiting a nonce read"
+    );
+}
+
+/// The event that leaves an address unresolved rebuilds that on replay too, so an upgrade does not
+/// quietly put a stuck address back into sweeps.
+#[tokio::test]
+async fn should_rebuild_the_unresolved_nonces_by_replaying_the_event_log() {
+    let (mut live, request) = state_with_enqueued_sweep(&[(account(0), usdc())]).await;
+    let mut time_provider = MockTimeProvider::new();
+    time_provider.expect_time().return_const(0_u64);
+    for event in sweep_pipeline_events(
+        live.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Failure,
+    ) {
+        process_event(&mut live, event, &time_provider);
+    }
+    process_event(
+        &mut live,
+        EventType::ObservedDepositAddressNonce {
+            account: account(0),
+            nonce: TransactionNonce::new(9),
+        },
+        &time_provider,
+    );
+    assert_unresolved(&live.automatic_deposits, account(0));
+
+    let replayed = replay_of_the_event_log();
+
+    assert_unresolved(&replayed.automatic_deposits, account(0));
+    assert_eq!(
+        replayed
+            .automatic_deposits
+            .is_equivalent_to(&live.automatic_deposits),
+        Ok(())
     );
 }
 

--- a/rs/ethereum/cketh/minter/src/state/event.rs
+++ b/rs/ethereum/cketh/minter/src/state/event.rs
@@ -5,7 +5,7 @@ use crate::erc20::CkErc20Token;
 use crate::eth_logs::{EventSource, ReceivedErc20Event, ReceivedEthEvent, ReceivedEvent};
 use crate::eth_rpc_client::responses::TransactionReceipt;
 use crate::lifecycle::{init::InitArg, upgrade::UpgradeArg};
-use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, LedgerMintIndex};
+use crate::numeric::{BlockNumber, Erc20Value, LedgerBurnIndex, LedgerMintIndex, TransactionNonce};
 use crate::state::transactions::{
     Erc20WithdrawalRequest, EthWithdrawalRequest, Reimbursed, ReimbursementIndex,
     ReimbursementRequest, SweepId, SweepRequest,
@@ -17,6 +17,7 @@ use crate::tx::{
 };
 use candid::Principal;
 use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
 use minicbor::{Decode, Encode};
 
 /// The event describing the ckETH minter state transition.
@@ -249,6 +250,17 @@ pub enum EventType {
         request: AuthorizationRequest,
         #[n(1)]
         signature: TransactionSignature,
+    },
+    /// The nonce a deposit address was read to stand at, after a reverted sweep left the minter
+    /// unable to say which of the tuples it had signed for that address the chain applied. The
+    /// minter signs at most one tuple per `(deposit address, nonce)`, so the nonce alone says which
+    /// of them applied, which is what re-anchors the record on the chain.
+    #[n(35)]
+    ObservedDepositAddressNonce {
+        #[n(0)]
+        account: Account,
+        #[n(1)]
+        nonce: TransactionNonce,
     },
 }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -294,37 +294,39 @@ const SWEEP_GAS_PER_BALANCE_CHECK: GasAmount = GasAmount::new(15_000);
 const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 
 /// Gas one EIP-7702 authorization costs: 25'000 (`PER_EMPTY_ACCOUNT_COST`) charged upfront for
-/// every tuple, before any of them is looked at.
+/// every tuple, before any of them is looked at. Rounded up as its siblings are.
 ///
-/// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
-/// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
-/// matches — costs the full 25'000: the 12'500 refund for an authority the state trie already
-/// holds is granted only past the nonce check, and a tuple failing that check ends there. Rounded
-/// up as its siblings are.
+/// Budgeted for the tuples the sweep carries, which are those of the addresses it still has to
+/// delegate. A tuple the EVM skips — another sweep delegated the address in between, so the nonce
+/// it was signed for no longer matches — costs the full 25'000: the 12'500 refund for an authority
+/// the state trie already holds is granted only past the nonce check, and a tuple failing that
+/// check ends there.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
-    let addresses = u64::try_from(
+    let saturating_count = |occurrences: usize| u64::try_from(occurrences).unwrap_or(u64::MAX);
+    let addresses = saturating_count(
         items
             .iter()
             .map(|authorized| authorized.item.deposit)
             .collect::<BTreeSet<_>>()
             .len(),
-    )
-    .unwrap_or(u64::MAX);
+    );
+    let authorizations = saturating_count(
+        items
+            .iter()
+            .filter(|authorized| authorized.authorization.is_some())
+            .count(),
+    );
     [
-        SWEEP_GAS_PER_BALANCE_CHECK,
-        SWEEP_GAS_PER_TRANSFER,
-        SWEEP_GAS_PER_AUTHORIZATION,
+        (SWEEP_GAS_PER_BALANCE_CHECK, addresses),
+        (SWEEP_GAS_PER_TRANSFER, addresses),
+        (SWEEP_GAS_PER_AUTHORIZATION, authorizations),
     ]
     .into_iter()
-    .fold(SWEEP_BASE_GAS, |total, gas_per_address| {
+    .fold(SWEEP_BASE_GAS, |total, (gas_each, occurrences)| {
         total
-            .checked_add(
-                gas_per_address
-                    .checked_mul(addresses)
-                    .unwrap_or(GasAmount::MAX),
-            )
+            .checked_add(gas_each.checked_mul(occurrences).unwrap_or(GasAmount::MAX))
             .unwrap_or(GasAmount::MAX)
     })
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -19,8 +19,8 @@ use crate::numeric::{
 };
 use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::{
-    Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
-    Resubmittable, SignableTransaction, Signed, SignedAuthorization,
+    AuthorizationRequest, Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction,
+    GasFeeEstimate, Resubmittable, SignableTransaction, Signed, SignedAuthorization,
     SignedEip1559TransactionRequest, TransactionPrice,
 };
 use candid::Principal;
@@ -298,9 +298,9 @@ const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 ///
 /// Budgeted for every address the sweep touches, since every one of them carries a tuple. A tuple
 /// the EVM skips — the address is already delegated, so the nonce it was signed for no longer
-/// matches — is charged the same 25'000 and refunded 12'500 for an authority the state trie
-/// already holds. That refund lands after execution and so cannot shrink the limit the transaction
-/// had to declare, leaving 25'000 the figure to budget either way. Rounded up as its siblings are.
+/// matches — costs the full 25'000: the 12'500 refund for an authority the state trie already
+/// holds is granted only past the nonce check, and a tuple failing that check ends there. Rounded
+/// up as its siblings are.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
 pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
@@ -352,6 +352,23 @@ impl SweepRequest {
         self.items
             .iter()
             .filter_map(|item| item.authorization.clone())
+            .collect()
+    }
+
+    /// The delegations this sweep carries, each named as what its signature was signed over, which
+    /// is the key the minter stores it under.
+    pub fn authorization_requests(&self) -> Vec<AuthorizationRequest> {
+        self.items
+            .iter()
+            .filter_map(|item| {
+                let authorization = item.authorization.as_ref()?;
+                Some(AuthorizationRequest::new(
+                    item.item.account,
+                    authorization.chain_id,
+                    authorization.delegate,
+                    authorization.nonce,
+                ))
+            })
             .collect()
     }
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -5,6 +5,7 @@ pub(in crate::state) mod tests;
 
 pub use request::PipelineRequest;
 
+use crate::asset::Asset;
 use crate::endpoints::{EthTransaction, RetrieveEthStatus, TxFinalizedStatus, WithdrawalStatus};
 use crate::eth_logs::LedgerSubaccount;
 use crate::eth_rpc::Hash;
@@ -16,7 +17,7 @@ use crate::numeric::{
     CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
     TransactionNonce, Wei,
 };
-use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
+use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::{
     Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
     Resubmittable, SignableTransaction, Signed, SignedAuthorization,
@@ -229,12 +230,13 @@ pub struct SweepRequest {
     /// sweeps every delegated deposit address the sweep names.
     #[n(1)]
     pub destination: Address,
-    /// The single ERC-20 this sweep moves. One token per sweep: the delegate applies the token
-    /// list to every item it walks, so a sweep mixing tokens would check balances that cannot be
-    /// there. Holding it as one address rather than a list is what makes that an invariant of the
-    /// request instead of a property of how the batch happened to be picked.
+    /// The single asset this sweep moves: one ERC-20 token, or ETH. One asset per sweep: the
+    /// delegate applies the token list to every item it walks, so a sweep mixing tokens would
+    /// check balances that cannot be there. Holding it as one asset rather than a list is what
+    /// makes that an invariant of the request instead of a property of how the batch happened to
+    /// be picked.
     #[n(2)]
-    pub token: Address,
+    pub asset: Asset,
     /// The deposits this sweep moves, one per account. A deposit address is derived per account,
     /// so an account has one address, one attestation and one authorization however many tokens
     /// it has queued.
@@ -333,10 +335,13 @@ impl SweepRequest {
     }
 
     /// The delegate's batch call, naming every deposit address this sweep walks and the single
-    /// token it moves.
+    /// asset it moves.
     pub fn call_data(&self) -> Vec<u8> {
         let items: Vec<_> = self.items.iter().map(|item| item.item.clone()).collect();
-        encode_sweep_erc20_batch(&items, &[self.token])
+        match self.asset {
+            Asset::Erc20(token) => encode_sweep_erc20_batch(&items, &[token]),
+            Asset::Eth => encode_sweep_eth_batch(&items),
+        }
     }
 
     /// The delegations the sweep installs on the way, one per deposit address it still has to

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -3059,7 +3059,9 @@ mod sweep_lane {
         const MEASURED_TEN_DEPOSIT_SWEEP_GAS: u128 = 609_431;
 
         let items_for = |addresses: u8| -> Vec<AuthorizedSweepItem> {
-            (1..=addresses).map(|seed| sweep_item(seed, None)).collect()
+            (1..=addresses)
+                .map(|seed| sweep_item(seed, Some(authorization(seed))))
+                .collect()
         };
 
         assert_eq!(sweep_gas_limit(&items_for(1)), GasAmount::new(225_000));
@@ -3069,7 +3071,28 @@ mod sweep_lane {
         let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
         assert_eq!(
             sweep_gas_limit(&one_address_ten_times),
-            sweep_gas_limit(&items_for(1))
+            sweep_gas_limit(&[sweep_item(1, None)])
+        );
+    }
+
+    #[test]
+    fn should_budget_the_authorization_gas_only_for_the_items_carrying_a_tuple() {
+        let delegated = sweep_item(1, None);
+        let to_delegate = sweep_item(2, Some(authorization(2)));
+        let also_to_delegate = sweep_item(3, Some(authorization(3)));
+
+        assert_eq!(
+            sweep_gas_limit(std::slice::from_ref(&delegated)),
+            GasAmount::new(185_000),
+            "an address swept without a tuple costs its balance check and its transfer only"
+        );
+        assert_eq!(
+            sweep_gas_limit(&[delegated, to_delegate.clone()]),
+            GasAmount::new(350_000)
+        );
+        assert_eq!(
+            sweep_gas_limit(&[to_delegate, also_to_delegate]),
+            GasAmount::new(390_000)
         );
     }
 

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2957,6 +2957,7 @@ mod sweep_lane {
     };
 
     const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+    use crate::asset::Asset;
     use crate::sweeper_contract::SweepItem;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
@@ -2977,7 +2978,7 @@ mod sweep_lane {
         SweepRequest {
             id: SweepId(id),
             destination: Address::new([id as u8; 20]),
-            token: Address::new([0xc0; 20]),
+            asset: Asset::Erc20(Address::new([0xc0; 20])),
             items: vec![sweep_item(1, None), sweep_item(2, None)],
             max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
             created_at: 1_620_328_630_000_000_000,

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2968,6 +2968,7 @@ mod sweep_lane {
     use ethnum::u256;
     use ic_ethereum_types::Address;
     use icrc_ledger_types::icrc1::account::Account;
+    use std::slice::from_ref;
 
     const EIP1559_TX_ID: u8 = 2;
     const SET_CODE_TX_ID: u8 = 4;
@@ -3068,10 +3069,14 @@ mod sweep_lane {
         assert_eq!(sweep_gas_limit(&items_for(10)), GasAmount::new(1_710_000));
         assert!(sweep_gas_limit(&items_for(10)) > GasAmount::new(MEASURED_TEN_DEPOSIT_SWEEP_GAS));
 
-        let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
+        let one_address_ten_times: Vec<_> = (0..10)
+            .map(|_| sweep_item(1, Some(authorization(1))))
+            .collect();
         assert_eq!(
             sweep_gas_limit(&one_address_ten_times),
-            sweep_gas_limit(&[sweep_item(1, None)])
+            GasAmount::new(585_000),
+            "the balance check and the transfer collapse onto the one address walked, while every \
+             tuple in the list is charged"
         );
     }
 
@@ -3082,7 +3087,7 @@ mod sweep_lane {
         let also_to_delegate = sweep_item(3, Some(authorization(3)));
 
         assert_eq!(
-            sweep_gas_limit(std::slice::from_ref(&delegated)),
+            sweep_gas_limit(from_ref(&delegated)),
             GasAmount::new(185_000),
             "an address swept without a tuple costs its balance check and its transfer only"
         );

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -129,10 +129,13 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 /// of them at once would fan a single timer out into a chain read per queued address. The addresses
 /// a tick leaves out are read by the next one.
 ///
-/// A count is only recorded while the address is still awaiting one: a sweep of it may have
-/// finalized during the read, taking the nonce with it, and a count read before that would undo the
-/// marks that sweep left. An address whose read fails keeps its unverified nonce and so stays out
-/// of this tick's sweeps. It is not dropped: the next tick reads it again.
+/// What makes a count worth recording is that the record cannot move while it is read: an address
+/// another of whose tokens a sweep still holds is not offered until that sweep finalizes, and one
+/// waiting on a read is offered no new sweep, so no tuple of it can apply in between. The recording
+/// step re-checks that the address is still awaiting a read, since it runs after an await.
+///
+/// An address whose read fails keeps its unverified nonce and so stays out of this tick's sweeps.
+/// It is not dropped: the next tick reads it again.
 async fn verify_deposit_address_nonces<R: CanisterRuntime>(runtime: &R) {
     let unverified = read_state(|s| {
         s.automatic_deposits

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -27,8 +27,8 @@ use crate::{
         automatic_deposits::SweepTarget,
         mutate_state, read_state,
         transactions::{
-            AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepRequest,
-            sweep_gas_limit,
+            AuthorizedSweepItem, CreateSweepTransactionError, PipelineRequest, SweepId,
+            SweepRequest, sweep_gas_limit,
         },
     },
     time::TimeProvider,
@@ -38,10 +38,12 @@ use crate::{
         send_signed_transactions,
     },
 };
+use candid::Nat;
+use evm_rpc_types::TransactionReceipt as EvmTransactionReceipt;
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
@@ -470,6 +472,26 @@ async fn send_transactions_batch(
     send_signed_transactions(sender, &transactions_to_send).await;
 }
 
+/// The finalized sweeps of `receipts`, in the order the chain executed them: by block, then by
+/// position within it. The sweeper queue reschedules a sweep it cannot yet pay for, which lets a
+/// lower [`SweepId`] hold a higher transaction nonce, so id order is not chain order; the
+/// authorizations a sweep applied follow from the nonce its deposit addresses had reached when it
+/// ran, which only chain order tells.
+fn in_chain_execution_order(
+    receipts: BTreeMap<SweepId, EvmTransactionReceipt>,
+) -> Vec<(SweepId, EvmTransactionReceipt)> {
+    let mut ordered: Vec<_> = receipts.into_iter().collect();
+    ordered.sort_by(|(_, left), (_, right)| chain_position(left).cmp(&chain_position(right)));
+    ordered
+}
+
+fn chain_position(receipt: &EvmTransactionReceipt) -> (&Nat, &Nat) {
+    (
+        receipt.block_number.as_ref(),
+        receipt.transaction_index.as_ref(),
+    )
+}
+
 async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_provider: &T) {
     if read_state(|s| s.automatic_deposits.is_sent_sweep_tx_empty()) {
         return;
@@ -481,7 +503,7 @@ async fn finalize_transactions_batch<T: TimeProvider>(sender: Address, time_prov
                     .sent_sweep_transactions_to_finalize(&finalized_tx_count)
             });
             if let Some(receipts) = fetch_finalized_receipts(txs_to_finalize).await {
-                for (sweep_id, transaction_receipt) in receipts {
+                for (sweep_id, transaction_receipt) in in_chain_execution_order(receipts) {
                     mutate_state(|s| {
                         process_event(
                             s,

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -12,6 +12,7 @@
 #[cfg(test)]
 mod tests;
 
+use crate::asset::Asset;
 use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::sweeper_contract::SweepItem;
 use crate::{
@@ -69,9 +70,9 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     }
 
-    let batch_per_token =
+    let batch_per_asset =
         read_state(|s| s.automatic_deposits.requests_batch(MAX_DEPOSITS_PER_SWEEP));
-    if batch_per_token.is_empty() {
+    if batch_per_asset.is_empty() {
         return;
     }
 
@@ -83,7 +84,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     };
 
-    for (token, targets) in batch_per_token {
+    for (asset, targets) in batch_per_asset {
         let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
             log!(
                 DEBUG,
@@ -101,18 +102,18 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         };
         sign_attestations_batch(attestation_requests, runtime).await;
         sign_authorizations_batch(authorization_requests, runtime).await;
-        enqueue_sweep(token, &targets, &gas_fee_estimate, runtime);
+        enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
 
-/// Enqueues one sweep of `token` from the targets both signing passes covered, so the pipeline can
+/// Enqueues one sweep of `asset` from the targets both signing passes covered, so the pipeline can
 /// price, sign and send it.
 ///
 /// A target whose attestation or authorization is missing is left out rather than swept: its
 /// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
 /// delegate it with. It stays queued, and the next tick tries it again.
 fn enqueue_sweep<R: CanisterRuntime>(
-    token: Address,
+    asset: Asset,
     targets: &[SweepTarget],
     gas_fee_estimate: &GasFeeEstimate,
     runtime: &R,
@@ -150,7 +151,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         if items.is_empty() {
             log!(
                 INFO,
-                "[create_pending_sweeper_requests]: SKIPPING {token}: none of its queued deposits could be signed for"
+                "[create_pending_sweeper_requests]: SKIPPING {asset}: none of its queued deposits could be signed for"
             );
             return;
         }
@@ -163,7 +164,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         if max_transaction_fee > sweeper_gas {
             log!(
                 INFO,
-                "[create_pending_sweeper_requests]: SKIPPING {token}: the sweep needs \
+                "[create_pending_sweeper_requests]: SKIPPING {asset}: the sweep needs \
                  {max_transaction_fee} of gas but the sweeper holds at least {sweeper_gas}"
             );
             return;
@@ -171,7 +172,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         let request = SweepRequest {
             id: s.next_sweep_id,
             destination,
-            token,
+            asset,
             items,
             max_transaction_fee,
             created_at: runtime.time(),

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -46,7 +46,9 @@ use std::collections::BTreeSet;
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
-const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+/// Maximum number of deposits one sweep batches; a larger queue is drained over several
+/// sweeps.
+pub const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -49,6 +49,7 @@ const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
 const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+const MAX_NONCE_READS_PER_TICK: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.
@@ -123,6 +124,11 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 /// the marks it just rewrote. That is also why the read demands every provider agree
 /// ([`finalized_transaction_count`]) rather than taking the lowest count offered.
 ///
+/// The reads are taken a batch at a time, as the sweeps themselves are: a delegate that reverts
+/// every batch leaves every address those sweeps touched waiting on a read, and a tick reading all
+/// of them at once would fan a single timer out into a chain read per queued address. The addresses
+/// a tick leaves out are read by the next one.
+///
 /// A count is only recorded while the address is still awaiting one: a sweep of it may have
 /// finalized during the read, taking the nonce with it, and a count read before that would undo the
 /// marks that sweep left. An address whose read fails keeps its unverified nonce and so stays out
@@ -130,7 +136,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 async fn verify_deposit_address_nonces<R: CanisterRuntime>(runtime: &R) {
     let unverified = read_state(|s| {
         s.automatic_deposits
-            .deposit_addresses_awaiting_a_nonce_read()
+            .deposit_addresses_awaiting_a_nonce_read(MAX_NONCE_READS_PER_TICK)
     });
     if unverified.is_empty() {
         return;

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -14,6 +14,7 @@ mod tests;
 
 use crate::asset::Asset;
 use crate::attestation::{AttestationRequest, sign_attestation};
+use crate::deposit_address::DepositAddress;
 use crate::sweeper_contract::SweepItem;
 use crate::{
     deposit_address::AddressSchema,
@@ -43,6 +44,7 @@ use evm_rpc_types::TransactionReceipt as EvmTransactionReceipt;
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
+use icrc_ledger_types::icrc1::account::Account;
 use std::collections::{BTreeMap, BTreeSet};
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
@@ -86,6 +88,8 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     };
 
+    verify_deposit_address_nonces(&batch_per_asset, runtime).await;
+
     for (asset, targets) in batch_per_asset {
         let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
             log!(
@@ -108,13 +112,65 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
     }
 }
 
+/// Re-anchors on the chain the record of every deposit address in `batches` whose nonce a reverted
+/// sweep left unverified: its transaction count is what the minter's own tuples advanced, so
+/// reading it back says which of them the chain applied.
+///
+/// An address whose read fails, or whose record the nonce read back cannot resolve, keeps its
+/// unverified nonce and so stays out of this tick's sweeps. It is not dropped: the next tick tries
+/// it again.
+async fn verify_deposit_address_nonces<R: CanisterRuntime>(
+    batches: &BTreeMap<Asset, Vec<SweepTarget>>,
+    runtime: &R,
+) {
+    let unverified: BTreeMap<Account, DepositAddress> = read_state(|s| {
+        batches
+            .values()
+            .flatten()
+            .filter(|target| s.automatic_deposits.has_unverified_nonce(&target.account()))
+            .map(|target| (target.account(), target.address()))
+            .collect()
+    });
+    if unverified.is_empty() {
+        return;
+    }
+
+    let observed = join_all(unverified.into_iter().map(|(account, address)| async move {
+        (
+            account,
+            latest_transaction_count(*address.as_address()).await,
+        )
+    }))
+    .await;
+
+    for (account, transaction_count) in observed {
+        match transaction_count {
+            Some(transaction_count) => mutate_state(|s| {
+                process_event(
+                    s,
+                    EventType::ObservedDepositAddressNonce {
+                        account,
+                        nonce: transaction_count.change_units(),
+                    },
+                    runtime,
+                )
+            }),
+            None => log!(
+                INFO,
+                "[create_pending_sweeper_requests]: leaving out {account:?}: its deposit address' nonce could not be read back, so which tuples the sweep that reverted on it applied is still unknown"
+            ),
+        }
+    }
+}
+
 /// Enqueues one sweep of `asset` from the targets both signing passes covered, so the pipeline can
 /// price, sign and send it.
 ///
 /// A target whose attestation or authorization is missing is left out rather than swept: its
 /// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
 /// delegate it with. It stays queued, and the next tick tries it again. A target already delegated
-/// to the sweeper contract asks for no authorization, and is swept carrying none.
+/// to the sweeper contract asks for no authorization, and is swept carrying none; one whose nonce a
+/// reverted sweep left unverified is left out, since any tuple for it would name a guessed nonce.
 fn enqueue_sweep<R: CanisterRuntime>(
     asset: Asset,
     targets: &[SweepTarget],
@@ -145,6 +201,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
                         Some(request.signed_with(signature))
                     }
                     SweepAuthorization::AlreadyDelegated => None,
+                    SweepAuthorization::NonceUnverified => return None,
                 };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
@@ -231,11 +288,12 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
 }
 
 /// Signs the authorizations `authorizations` requires and the minter has not signed before,
-/// recording each so a later sweep of the same address reuses it. An address already delegated
-/// requires none, and so costs no threshold signature.
+/// recording each so a later sweep of the same address reuses it. An address already delegated to
+/// the configured sweeper contract, and one whose nonce is unverified, require none and so cost no
+/// threshold signature.
 ///
 /// A request names the chain, the delegate and the nonce it authorizes, so re-pointing the minter
-/// at another sweeper contract misses the recorded ones and signs afresh.
+/// at another sweeper contract misses the recorded ones and signs the rotation afresh.
 async fn sign_authorizations_batch<R: CanisterRuntime>(
     authorizations: Vec<SweepAuthorization>,
     runtime: &R,
@@ -245,7 +303,7 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
             .into_iter()
             .filter_map(|authorization| match authorization {
                 SweepAuthorization::Required(request) => Some(request),
-                SweepAuthorization::AlreadyDelegated => None,
+                SweepAuthorization::AlreadyDelegated | SweepAuthorization::NonceUnverified => None,
             })
             .filter(|request| s.automatic_deposits.authorization(request).is_none())
             .collect()

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -14,7 +14,6 @@ mod tests;
 
 use crate::asset::Asset;
 use crate::attestation::{AttestationRequest, sign_attestation};
-use crate::deposit_address::DepositAddress;
 use crate::sweeper_contract::SweepItem;
 use crate::{
     deposit_address::AddressSchema,
@@ -44,7 +43,6 @@ use evm_rpc_types::TransactionReceipt as EvmTransactionReceipt;
 use futures::future::join_all;
 use ic_canister_log::log;
 use ic_ethereum_types::Address;
-use icrc_ledger_types::icrc1::account::Account;
 use std::collections::{BTreeMap, BTreeSet};
 
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
@@ -74,6 +72,10 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     }
 
+    // Before the batch is built, not after: an address whose nonce is unverified is left out of
+    // it, so a queue holding nothing else would otherwise never be read back and never recover.
+    verify_deposit_address_nonces(runtime).await;
+
     let batch_per_asset =
         read_state(|s| s.automatic_deposits.requests_batch(MAX_DEPOSITS_PER_SWEEP));
     if batch_per_asset.is_empty() {
@@ -87,8 +89,6 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         );
         return;
     };
-
-    verify_deposit_address_nonces(&batch_per_asset, runtime).await;
 
     for (asset, targets) in batch_per_asset {
         let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
@@ -112,24 +112,21 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
     }
 }
 
-/// Re-anchors on the chain the record of every deposit address in `batches` whose nonce a reverted
-/// sweep left unverified: its transaction count is what the minter's own tuples advanced, so
-/// reading it back says which of them the chain applied.
+/// Re-anchors on the chain the record of every queued deposit address whose nonce a reverted sweep
+/// left unverified: its transaction count is what the minter's own tuples advanced, so reading it
+/// back says which of them the chain applied.
 ///
-/// An address whose read fails, or whose record the nonce read back cannot resolve, keeps its
-/// unverified nonce and so stays out of this tick's sweeps. It is not dropped: the next tick tries
-/// it again.
-async fn verify_deposit_address_nonces<R: CanisterRuntime>(
-    batches: &BTreeMap<Asset, Vec<SweepTarget>>,
-    runtime: &R,
-) {
-    let unverified: BTreeMap<Account, DepositAddress> = read_state(|s| {
-        batches
-            .values()
-            .flatten()
-            .filter(|target| s.automatic_deposits.has_unverified_nonce(&target.account()))
-            .map(|target| (target.account(), target.address()))
-            .collect()
+/// The count is read at `finalized`, not `latest`: every other mark on the record comes from a
+/// finalized receipt, so an anchor read one block deeper than those could be reorged out from under
+/// the marks it just rewrote. That is also why the read demands every provider agree
+/// ([`finalized_transaction_count`]) rather than taking the lowest count offered.
+///
+/// An address whose read fails keeps its unverified nonce and so stays out of this tick's sweeps.
+/// It is not dropped: the next tick reads it again.
+async fn verify_deposit_address_nonces<R: CanisterRuntime>(runtime: &R) {
+    let unverified = read_state(|s| {
+        s.automatic_deposits
+            .deposit_addresses_awaiting_a_nonce_read()
     });
     if unverified.is_empty() {
         return;
@@ -138,14 +135,19 @@ async fn verify_deposit_address_nonces<R: CanisterRuntime>(
     let observed = join_all(unverified.into_iter().map(|(account, address)| async move {
         (
             account,
-            latest_transaction_count(*address.as_address()).await,
+            finalized_transaction_count(*address.as_address()).await,
         )
     }))
     .await;
 
     for (account, transaction_count) in observed {
         match transaction_count {
-            Some(transaction_count) => mutate_state(|s| {
+            Ok(transaction_count) => mutate_state(|s| {
+                // A sweep of this address may have finalized while the read was in flight, taking
+                // the nonce with it; recording a count read before that would undo its marks.
+                if !s.automatic_deposits.has_unverified_nonce(&account) {
+                    return;
+                }
                 process_event(
                     s,
                     EventType::ObservedDepositAddressNonce {
@@ -155,9 +157,9 @@ async fn verify_deposit_address_nonces<R: CanisterRuntime>(
                     runtime,
                 )
             }),
-            None => log!(
+            Err(e) => log!(
                 INFO,
-                "[create_pending_sweeper_requests]: leaving out {account:?}: its deposit address' nonce could not be read back, so which tuples the sweep that reverted on it applied is still unknown"
+                "[create_pending_sweeper_requests]: leaving out {account:?}: its deposit address' nonce could not be read back ({e:?}), so which tuples the sweep that reverted on it applied is still unknown"
             ),
         }
     }
@@ -201,7 +203,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
                         Some(request.signed_with(signature))
                     }
                     SweepAuthorization::AlreadyDelegated => None,
-                    SweepAuthorization::NonceUnverified => return None,
+                    SweepAuthorization::NonceUnknown => return None,
                 };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
@@ -303,7 +305,7 @@ async fn sign_authorizations_batch<R: CanisterRuntime>(
             .into_iter()
             .filter_map(|authorization| match authorization {
                 SweepAuthorization::Required(request) => Some(request),
-                SweepAuthorization::AlreadyDelegated | SweepAuthorization::NonceUnverified => None,
+                SweepAuthorization::AlreadyDelegated | SweepAuthorization::NonceUnknown => None,
             })
             .filter(|request| s.automatic_deposits.authorization(request).is_none())
             .collect()

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -103,7 +103,11 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             return;
         };
         sign_attestations_batch(attestation_requests, runtime).await;
-        sign_authorizations_batch(authorization_requests, runtime).await;
+        sign_authorizations_batch(
+            authorization_requests.into_iter().flatten().collect(),
+            runtime,
+        )
+        .await;
         enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
@@ -113,7 +117,8 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 ///
 /// A target whose attestation or authorization is missing is left out rather than swept: its
 /// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
-/// delegate it with. It stays queued, and the next tick tries it again.
+/// delegate it with. It stays queued, and the next tick tries it again. A target already delegated
+/// to the sweeper contract asks for no authorization, and is swept carrying none.
 fn enqueue_sweep<R: CanisterRuntime>(
     asset: Asset,
     targets: &[SweepTarget],
@@ -138,14 +143,20 @@ fn enqueue_sweep<R: CanisterRuntime>(
             .zip(authorization_requests)
             .filter_map(|((target, attestation_request), authorization_request)| {
                 let attestation = s.automatic_deposits.attestation(&attestation_request)?;
-                let authorization = s.automatic_deposits.authorization(&authorization_request)?;
+                let authorization = match authorization_request {
+                    Some(request) => {
+                        let signature = s.automatic_deposits.authorization(&request)?.clone();
+                        Some(request.signed_with(signature))
+                    }
+                    None => None,
+                };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
                         deposit: target.address(),
                         account: target.account(),
                         attestation: attestation.clone(),
                     },
-                    authorization: Some(authorization_request.signed_with(authorization.clone())),
+                    authorization,
                 })
             })
             .collect();

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     numeric::TransactionCount,
     runtime::CanisterRuntime,
     state::{
-        State, TaskType,
+        State, SweepAuthorization, TaskType,
         audit::{EventType, process_event},
         automatic_deposits::SweepTarget,
         mutate_state, read_state,
@@ -32,7 +32,7 @@ use crate::{
         },
     },
     time::TimeProvider,
-    tx::{AuthorizationRequest, GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
+    tx::{GasFeeEstimate, lazy_refresh_gas_fee_estimate, sign_digest},
     withdraw::{
         fetch_finalized_receipts, finalized_transaction_count, latest_transaction_count,
         send_signed_transactions,
@@ -103,11 +103,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
             return;
         };
         sign_attestations_batch(attestation_requests, runtime).await;
-        sign_authorizations_batch(
-            authorization_requests.into_iter().flatten().collect(),
-            runtime,
-        )
-        .await;
+        sign_authorizations_batch(authorization_requests, runtime).await;
         enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
@@ -141,14 +137,14 @@ fn enqueue_sweep<R: CanisterRuntime>(
             .iter()
             .zip(attestation_requests)
             .zip(authorization_requests)
-            .filter_map(|((target, attestation_request), authorization_request)| {
+            .filter_map(|((target, attestation_request), sweep_authorization)| {
                 let attestation = s.automatic_deposits.attestation(&attestation_request)?;
-                let authorization = match authorization_request {
-                    Some(request) => {
+                let authorization = match sweep_authorization {
+                    SweepAuthorization::Required(request) => {
                         let signature = s.automatic_deposits.authorization(&request)?.clone();
                         Some(request.signed_with(signature))
                     }
-                    None => None,
+                    SweepAuthorization::AlreadyDelegated => None,
                 };
                 Some(AuthorizedSweepItem {
                     item: SweepItem {
@@ -234,18 +230,23 @@ async fn sign_attestations_batch<R: CanisterRuntime>(
     }
 }
 
-/// Signs the authorizations in `requests` that the minter has not signed before, recording each so
-/// a later sweep of the same address reuses it.
+/// Signs the authorizations `authorizations` requires and the minter has not signed before,
+/// recording each so a later sweep of the same address reuses it. An address already delegated
+/// requires none, and so costs no threshold signature.
 ///
 /// A request names the chain, the delegate and the nonce it authorizes, so re-pointing the minter
 /// at another sweeper contract misses the recorded ones and signs afresh.
 async fn sign_authorizations_batch<R: CanisterRuntime>(
-    requests: Vec<AuthorizationRequest>,
+    authorizations: Vec<SweepAuthorization>,
     runtime: &R,
 ) {
     let requests_to_sign: BTreeSet<_> = read_state(|s| {
-        requests
+        authorizations
             .into_iter()
+            .filter_map(|authorization| match authorization {
+                SweepAuthorization::Required(request) => Some(request),
+                SweepAuthorization::AlreadyDelegated => None,
+            })
             .filter(|request| s.automatic_deposits.authorization(request).is_none())
             .collect()
     });

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -46,9 +46,7 @@ use std::collections::BTreeSet;
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
-/// Maximum number of deposits one sweep batches; a larger queue is drained over several
-/// sweeps.
-pub const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -72,8 +72,6 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     }
 
-    // Before the batch is built, not after: an address whose nonce is unverified is left out of
-    // it, so a queue holding nothing else would otherwise never be read back and never recover.
     verify_deposit_address_nonces(runtime).await;
 
     let batch_per_asset =
@@ -116,13 +114,19 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
 /// left unverified: its transaction count is what the minter's own tuples advanced, so reading it
 /// back says which of them the chain applied.
 ///
+/// Runs before the sweep batch is built rather than over it: such an address is left out of that
+/// batch, so a queue holding nothing else would produce an empty one, and a tick that gave up on
+/// an empty batch would never read the nonce back and never recover.
+///
 /// The count is read at `finalized`, not `latest`: every other mark on the record comes from a
 /// finalized receipt, so an anchor read one block deeper than those could be reorged out from under
 /// the marks it just rewrote. That is also why the read demands every provider agree
 /// ([`finalized_transaction_count`]) rather than taking the lowest count offered.
 ///
-/// An address whose read fails keeps its unverified nonce and so stays out of this tick's sweeps.
-/// It is not dropped: the next tick reads it again.
+/// A count is only recorded while the address is still awaiting one: a sweep of it may have
+/// finalized during the read, taking the nonce with it, and a count read before that would undo the
+/// marks that sweep left. An address whose read fails keeps its unverified nonce and so stays out
+/// of this tick's sweeps. It is not dropped: the next tick reads it again.
 async fn verify_deposit_address_nonces<R: CanisterRuntime>(runtime: &R) {
     let unverified = read_state(|s| {
         s.automatic_deposits
@@ -143,8 +147,6 @@ async fn verify_deposit_address_nonces<R: CanisterRuntime>(runtime: &R) {
     for (account, transaction_count) in observed {
         match transaction_count {
             Ok(transaction_count) => mutate_state(|s| {
-                // A sweep of this address may have finalized while the read was in flight, taking
-                // the nonce with it; recording a count read before that would undo its marks.
                 if !s.automatic_deposits.has_unverified_nonce(&account) {
                     return;
                 }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -1,6 +1,7 @@
 use crate::asset::Asset;
 use crate::attestation::AttestationRequest;
 use crate::deposit_address::AddressSchema;
+use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::management::{CallError, Reason};
 use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
@@ -13,9 +14,12 @@ use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep, usdc, usdt,
+    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
+    sweep_pipeline_outcome, usdc, usdt,
 };
-use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
+use crate::tx::{
+    Authorization, AuthorizationRequest, GasFeeEstimate, SignableTransaction, TransactionSignature,
+};
 use ethnum::u256;
 use evm_rpc_types::{
     Hex20, Hex32, Hex256, HexByte, Nat256, TransactionReceipt as EvmTransactionReceipt,
@@ -29,6 +33,7 @@ use std::collections::BTreeMap;
 const NOW: u64 = 1_620_328_630_000_000_000;
 const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
 const DEPOSIT_HELPER: Address = Address::new([0xde; 20]);
+const SET_CODE_TX_ID: u8 = 4;
 const SWEEPER_CONTRACT: Address = Address::new([0x5e; 20]);
 const ANOTHER_SWEEPER_CONTRACT: Address = Address::new([0x99; 20]);
 const CHAIN_CODE: [u8; 32] = [0_u8; 32];
@@ -120,7 +125,7 @@ async fn should_sign_and_record_one_authorization_for_every_account() {
             .count(),
         1
     );
-    assert!(stored_authorization(SWEEPER_CONTRACT).is_some());
+    assert!(stored_authorization(account(), SWEEPER_CONTRACT).is_some());
 }
 
 #[tokio::test]
@@ -153,7 +158,7 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
-    let first = stored_authorization(SWEEPER_CONTRACT);
+    let first = stored_authorization(account(), SWEEPER_CONTRACT);
     assert!(first.is_some());
 
     mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
@@ -162,10 +167,10 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     queue_deposit(&account(), &usdt());
 
     create_pending_sweeper_requests(&runtime).await;
-    let second = stored_authorization(ANOTHER_SWEEPER_CONTRACT);
+    let second = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT);
     assert!(second.is_some());
     assert_ne!(first, second);
-    assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
+    assert_eq!(stored_authorization(account(), SWEEPER_CONTRACT), first);
 }
 
 #[tokio::test]
@@ -208,12 +213,48 @@ async fn should_authorize_at_nonce_zero_an_address_delegated_to_another_contract
 
     create_pending_sweeper_requests(&runtime).await;
 
+    let signature = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT)
+        .expect("BUG: the sweep must have signed a tuple for the new sweeper contract");
     assert_eq!(
         swept_item(Asset::Erc20(usdt())).authorization,
-        stored_authorization(ANOTHER_SWEEPER_CONTRACT).map(|signature| authorization_request(
-            ANOTHER_SWEEPER_CONTRACT
-        )
-        .signed_with(signature))
+        Some(authorization_request(account(), ANOTHER_SWEEPER_CONTRACT).signed_with(signature))
+    );
+}
+
+#[tokio::test]
+async fn should_batch_a_delegated_and_a_fresh_address_into_one_sweep() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+    queue_deposit(&account(), &usdt());
+    queue_deposit(&another_account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    let [sweep] = <[SweepRequest; 1]>::try_from(pending_sweeps())
+        .expect("BUG: expected the two deposits of one token to become one sweep");
+    let [delegated, fresh] = <[AuthorizedSweepItem; 2]>::try_from(sweep.items.clone())
+        .expect("BUG: expected the sweep to hold both deposits");
+    assert_eq!(delegated.item.account, account());
+    assert_eq!(fresh.item.account, another_account());
+    assert_eq!(
+        delegated.authorization, None,
+        "the address the earlier sweep delegated must be swept carrying no tuple"
+    );
+    let signature = stored_authorization(another_account(), SWEEPER_CONTRACT)
+        .expect("BUG: the sweep must have signed a tuple for the address it still has to delegate");
+    assert_eq!(
+        fresh.authorization,
+        Some(authorization_request(another_account(), SWEEPER_CONTRACT).signed_with(signature)),
+        "the tuple must be the one signed for the fresh address, at nonce zero"
+    );
+    assert_eq!(
+        sweep_pipeline_outcome(TransactionNonce::ZERO, &sweep, TransactionStatus::Success)
+            .transaction
+            .transaction_type(),
+        SET_CODE_TX_ID,
+        "a sweep still delegating one of its addresses rides an EIP-7702 transaction"
     );
 }
 
@@ -279,10 +320,10 @@ async fn should_carry_the_signed_attestation_and_authorization_of_every_swept_ac
         item.authorization,
         read_state(|s| s
             .automatic_deposits
-            .authorization(&authorization_request(SWEEPER_CONTRACT))
-            .map(
-                |signature| authorization_request(SWEEPER_CONTRACT).signed_with(signature.clone())
-            ))
+            .authorization(&authorization_request(account(), SWEEPER_CONTRACT))
+            .map(|signature| {
+                authorization_request(account(), SWEEPER_CONTRACT).signed_with(signature.clone())
+            }))
     );
 }
 
@@ -444,17 +485,17 @@ fn sign_digest_with_derived_key(
 /// Spelled out rather than taken from `delegation_authorization`, so that changing the tuple the
 /// minter signs — its delegate, or the nonce 0 that makes a stale authorization skip harmlessly
 /// rather than sink the sweep — fails here.
-fn stored_authorization(delegate: Address) -> Option<TransactionSignature> {
+fn stored_authorization(account: Account, delegate: Address) -> Option<TransactionSignature> {
     read_state(|s| {
         s.automatic_deposits
-            .authorization(&authorization_request(delegate))
+            .authorization(&authorization_request(account, delegate))
             .cloned()
     })
 }
 
-fn authorization_request(delegate: Address) -> AuthorizationRequest {
+fn authorization_request(account: Account, delegate: Address) -> AuthorizationRequest {
     AuthorizationRequest::new(
-        account(),
+        account,
         initial_state().ethereum_network.chain_id(),
         delegate,
         TransactionNonce::ZERO,

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -3,7 +3,7 @@ use crate::attestation::AttestationRequest;
 use crate::deposit_address::AddressSchema;
 use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::management::{CallError, Reason};
-use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
+use crate::numeric::{BlockNumber, TransactionNonce, Wei};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::automatic_deposits::SweepTarget;
 use crate::state::eth_logs_scraping::LogScrapings;
@@ -18,9 +18,7 @@ use crate::test_fixtures::{
     initial_state, prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
     sweep_pipeline_events, sweep_pipeline_outcome, usdc, usdt,
 };
-use crate::tx::{
-    Authorization, AuthorizationRequest, GasFeeEstimate, SignableTransaction, TransactionSignature,
-};
+use crate::tx::{Authorization, AuthorizationRequest, SignableTransaction, TransactionSignature};
 use ethnum::u256;
 use evm_rpc_types::{
     Hex20, Hex32, Hex256, HexByte, Nat256, TransactionReceipt as EvmTransactionReceipt,
@@ -153,50 +151,6 @@ async fn should_reuse_the_recorded_authorization_on_a_later_sweep() {
             .filter(|event| matches!(event, EventType::AuthorizedDepositAddress { .. }))
             .count(),
         1
-    );
-}
-
-#[tokio::test]
-async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
-    init_state(state_ready_to_sign(&[(account(), usdc())]));
-    let mut runtime = mock();
-    runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, TransactionNonce::ZERO);
-    expect_authorization_signing(
-        &mut runtime,
-        ANOTHER_SWEEPER_CONTRACT,
-        TransactionNonce::ZERO,
-    );
-    expect_signing(&mut runtime);
-
-    create_pending_sweeper_requests(&runtime).await;
-    let first = stored_authorization(&authorization_request(
-        account(),
-        SWEEPER_CONTRACT,
-        TransactionNonce::ZERO,
-    ));
-    assert!(first.is_some());
-
-    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
-    // The first sweep took the account's USDC, so give the second pass its USDT to batch. Same
-    // account, hence the same authorization but for the delegate, which is what must miss.
-    queue_deposit(&account(), &usdt());
-
-    create_pending_sweeper_requests(&runtime).await;
-    let second = stored_authorization(&authorization_request(
-        account(),
-        ANOTHER_SWEEPER_CONTRACT,
-        TransactionNonce::ZERO,
-    ));
-    assert!(second.is_some());
-    assert_ne!(first, second);
-    assert_eq!(
-        stored_authorization(&authorization_request(
-            account(),
-            SWEEPER_CONTRACT,
-            TransactionNonce::ZERO
-        )),
-        first
     );
 }
 
@@ -711,13 +665,8 @@ fn state_ready_to_sign(deposits: &[(Account, Address)]) -> State {
 fn state_ready_to_sign_with_unfunded_sweeper(deposits: &[(Account, Address)]) -> State {
     let mut state = state_with_deposit_helper(DEPOSIT_HELPER);
     state.sweeper_contract_address = Some(SWEEPER_CONTRACT);
-    state.last_transaction_price_estimate = Some((
-        NOW - GAS_FEE_ESTIMATE_AGE_NANOS,
-        GasFeeEstimate {
-            base_fee_per_gas: WeiPerGas::ONE,
-            max_priority_fee_per_gas: WeiPerGas::ONE,
-        },
-    ));
+    state.last_transaction_price_estimate =
+        Some((NOW - GAS_FEE_ESTIMATE_AGE_NANOS, gas_fee_estimate()));
     for (account, token) in deposits {
         apply_state_transition(&mut state, &deposit_received(account, token));
     }

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -179,8 +179,8 @@ async fn should_enqueue_one_sweep_per_token() {
 
     let enqueued = pending_sweeps();
     assert_eq!(
-        enqueued.iter().map(|r| r.token).collect::<Vec<_>>(),
-        vec![usdc(), usdt()]
+        enqueued.iter().map(|r| r.asset).collect::<Vec<_>>(),
+        vec![Asset::Erc20(usdc()), Asset::Erc20(usdt())]
     );
     assert_eq!(
         enqueued.iter().map(|r| r.id).collect::<Vec<_>>(),

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -4,7 +4,7 @@ use crate::deposit_address::AddressSchema;
 use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::management::{CallError, Reason};
 use crate::numeric::{BlockNumber, TransactionNonce, Wei};
-use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::audit::{EventType, apply_state_transition, process_event};
 use crate::state::automatic_deposits::SweepTarget;
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
@@ -15,8 +15,8 @@ use crate::sweep::{create_pending_sweeper_requests, enqueue_sweep, in_chain_exec
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, gas_fee_estimate, init_state,
-    initial_state, prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
-    sweep_pipeline_events, sweep_pipeline_outcome, usdc, usdt,
+    initial_state, prepay_sweep_gas, state_with_deposit_helper, state_with_enqueued_sweep,
+    state_with_finalized_sweep, sweep_pipeline_events, sweep_pipeline_outcome, usdc, usdt,
 };
 use crate::tx::{Authorization, AuthorizationRequest, SignableTransaction, TransactionSignature};
 use ethnum::u256;
@@ -282,21 +282,34 @@ async fn should_rotate_at_the_next_nonce_once_the_recarried_tuple_has_applied() 
 /// A reverted sweep leaves the minter unable to say which of the tuples it signed for the
 /// addresses that sweep touched the chain applied, so their nonce is no longer known — and a tuple
 /// signed for a guessed nonce is at best wasted gas. They stay out of sweeps until the nonce is
-/// read back off the chain.
+/// read back off the chain, and they are dropped at both the batching and the enqueueing step: the
+/// batch is taken a signing round before the sweep is built, and a sweep can revert in between.
 #[tokio::test]
 async fn should_leave_out_an_address_whose_nonce_a_reverted_sweep_left_unverified() {
-    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Failure).await;
+    state_with_enqueued_sweep(&[(account(), usdc())]).await;
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
     queue_deposit(&account(), &usdt());
+    let taken_before_the_revert = targets_of(Asset::Erc20(usdt()));
+    assert_eq!(
+        taken_before_the_revert.len(),
+        1,
+        "the address is offered while its nonce is still trusted"
+    );
 
+    finalize_pending_sweeps(TransactionStatus::Failure);
+
+    assert!(
+        targets_of(Asset::Erc20(usdt())).is_empty(),
+        "a batch offering an address whose nonce is unverified would let it take a slot no sweep \
+         can use"
+    );
     enqueue_sweep(
         Asset::Erc20(usdt()),
-        &targets_of(Asset::Erc20(usdt())),
+        &taken_before_the_revert,
         &gas_fee_estimate(),
         &runtime,
     );
-
     assert_eq!(
         pending_sweeps(),
         vec![],
@@ -311,12 +324,13 @@ async fn should_sweep_again_once_the_deposit_address_nonce_has_been_read_back() 
     runtime.expect_time().return_const(NOW);
     queue_deposit(&account(), &usdt());
     mutate_state(|s| {
-        apply_state_transition(
+        process_event(
             s,
-            &EventType::ObservedDepositAddressNonce {
+            EventType::ObservedDepositAddressNonce {
                 account: account(),
                 nonce: TransactionNonce::ONE,
             },
+            &runtime,
         )
     });
 

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -6,14 +6,14 @@ use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::{SweepId, SweepRequest};
+use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
 use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    prepay_sweep_gas, state_with_deposit_helper, usdc, usdt,
+    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep, usdc, usdt,
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
@@ -166,6 +166,55 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     assert!(second.is_some());
     assert_ne!(first, second);
     assert_eq!(stored_authorization(SWEEPER_CONTRACT), first);
+}
+
+#[tokio::test]
+async fn should_sweep_without_a_tuple_an_address_an_earlier_sweep_delegated() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    queue_deposit(&account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        None,
+        "an address the earlier sweep delegated to the sweeper contract needs no further tuple"
+    );
+    assert_eq!(
+        recorded_events()
+            .into_iter()
+            .filter(|event| matches!(event, EventType::AuthorizedDepositAddress { .. }))
+            .count(),
+        1,
+        "signing another tuple for a delegated address would pay for a threshold signature the \
+         sweep cannot use"
+    );
+}
+
+/// Re-pointing the minter at another sweeper contract makes an address delegated to the old one
+/// authorize afresh, still at nonce zero — a tuple the chain skips, since applying the first one
+/// spent that nonce. Rotating a delegation onto another contract takes more than this.
+#[tokio::test]
+async fn should_authorize_at_nonce_zero_an_address_delegated_to_another_contract() {
+    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, ANOTHER_SWEEPER_CONTRACT, 1);
+    expect_signing(&mut runtime);
+    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+    queue_deposit(&account(), &usdt());
+
+    create_pending_sweeper_requests(&runtime).await;
+
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        stored_authorization(ANOTHER_SWEEPER_CONTRACT).map(|signature| authorization_request(
+            ANOTHER_SWEEPER_CONTRACT
+        )
+        .signed_with(signature))
+    );
 }
 
 #[tokio::test]
@@ -335,6 +384,20 @@ fn should_order_finalized_sweeps_as_the_chain_executed_them() {
 
 fn pending_sweeps() -> Vec<SweepRequest> {
     read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
+}
+
+/// The one item of the one pending sweep of `asset`.
+fn swept_item(asset: Asset) -> AuthorizedSweepItem {
+    let [sweep] = <[SweepRequest; 1]>::try_from(
+        pending_sweeps()
+            .into_iter()
+            .filter(|sweep| sweep.asset == asset)
+            .collect::<Vec<_>>(),
+    )
+    .expect("BUG: expected exactly one pending sweep of the asset");
+    let [item] = <[AuthorizedSweepItem; 1]>::try_from(sweep.items)
+        .expect("BUG: expected the sweep to hold exactly one item");
+    item
 }
 
 /// Expects `times` signatures over the authorization tuple every deposit address delegates with:

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -5,17 +5,18 @@ use crate::eth_rpc_client::responses::TransactionStatus;
 use crate::management::{CallError, Reason};
 use crate::numeric::{BlockNumber, TransactionNonce, Wei, WeiPerGas};
 use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::automatic_deposits::SweepTarget;
 use crate::state::eth_logs_scraping::LogScrapings;
 use crate::state::event::AutomaticDeposit;
 use crate::state::transactions::{AuthorizedSweepItem, SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
-use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
+use crate::sweep::{create_pending_sweeper_requests, enqueue_sweep, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
-    account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
-    prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
-    sweep_pipeline_outcome, usdc, usdt,
+    account, another_account, automatic_deposit, deposit_address, gas_fee_estimate, init_state,
+    initial_state, prepay_sweep_gas, state_with_deposit_helper, state_with_finalized_sweep,
+    sweep_pipeline_events, sweep_pipeline_outcome, usdc, usdt,
 };
 use crate::tx::{
     Authorization, AuthorizationRequest, GasFeeEstimate, SignableTransaction, TransactionSignature,
@@ -113,7 +114,7 @@ async fn should_sign_and_record_one_authorization_for_every_account() {
     ]));
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, TransactionNonce::ZERO);
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
@@ -125,7 +126,14 @@ async fn should_sign_and_record_one_authorization_for_every_account() {
             .count(),
         1
     );
-    assert!(stored_authorization(account(), SWEEPER_CONTRACT).is_some());
+    assert!(
+        stored_authorization(&authorization_request(
+            account(),
+            SWEEPER_CONTRACT,
+            TransactionNonce::ZERO
+        ))
+        .is_some()
+    );
 }
 
 #[tokio::test]
@@ -133,7 +141,7 @@ async fn should_reuse_the_recorded_authorization_on_a_later_sweep() {
     init_state(state_ready_to_sign(&[(account(), usdc())]));
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, TransactionNonce::ZERO);
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
@@ -153,12 +161,20 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     init_state(state_ready_to_sign(&[(account(), usdc())]));
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, 1);
-    expect_authorization_signing(&mut runtime, ANOTHER_SWEEPER_CONTRACT, 1);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, TransactionNonce::ZERO);
+    expect_authorization_signing(
+        &mut runtime,
+        ANOTHER_SWEEPER_CONTRACT,
+        TransactionNonce::ZERO,
+    );
     expect_signing(&mut runtime);
 
     create_pending_sweeper_requests(&runtime).await;
-    let first = stored_authorization(account(), SWEEPER_CONTRACT);
+    let first = stored_authorization(&authorization_request(
+        account(),
+        SWEEPER_CONTRACT,
+        TransactionNonce::ZERO,
+    ));
     assert!(first.is_some());
 
     mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
@@ -167,15 +183,26 @@ async fn should_sign_a_fresh_authorization_when_the_sweeper_contract_changes() {
     queue_deposit(&account(), &usdt());
 
     create_pending_sweeper_requests(&runtime).await;
-    let second = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT);
+    let second = stored_authorization(&authorization_request(
+        account(),
+        ANOTHER_SWEEPER_CONTRACT,
+        TransactionNonce::ZERO,
+    ));
     assert!(second.is_some());
     assert_ne!(first, second);
-    assert_eq!(stored_authorization(account(), SWEEPER_CONTRACT), first);
+    assert_eq!(
+        stored_authorization(&authorization_request(
+            account(),
+            SWEEPER_CONTRACT,
+            TransactionNonce::ZERO
+        )),
+        first
+    );
 }
 
 #[tokio::test]
 async fn should_sweep_without_a_tuple_an_address_an_earlier_sweep_delegated() {
-    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Success).await;
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
     queue_deposit(&account(), &usdt());
@@ -198,32 +225,165 @@ async fn should_sweep_without_a_tuple_an_address_an_earlier_sweep_delegated() {
     );
 }
 
-/// Re-pointing the minter at another sweeper contract makes an address delegated to the old one
-/// authorize afresh, still at nonce zero — a tuple the chain skips, since applying the first one
-/// spent that nonce. Rotating a delegation onto another contract takes more than this.
+/// Re-pointing the minter at another sweeper contract rotates the addresses delegated to the old
+/// one. The rotation tuple is signed for the nonce the address has reached, which is the only
+/// nonce the protocol applies it at: a tuple for nonce zero would be skipped, since applying the
+/// first one spent that nonce.
 #[tokio::test]
-async fn should_authorize_at_nonce_zero_an_address_delegated_to_another_contract() {
-    state_with_finalized_sweep(&[(account(), usdc())]).await;
+async fn should_rotate_a_delegated_address_onto_the_newly_configured_contract() {
+    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Success).await;
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
-    expect_authorization_signing(&mut runtime, ANOTHER_SWEEPER_CONTRACT, 1);
+    expect_authorization_signing(
+        &mut runtime,
+        ANOTHER_SWEEPER_CONTRACT,
+        TransactionNonce::ONE,
+    );
     expect_signing(&mut runtime);
     mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
     queue_deposit(&account(), &usdt());
 
     create_pending_sweeper_requests(&runtime).await;
 
-    let signature = stored_authorization(account(), ANOTHER_SWEEPER_CONTRACT)
-        .expect("BUG: the sweep must have signed a tuple for the new sweeper contract");
+    let rotation =
+        authorization_request(account(), ANOTHER_SWEEPER_CONTRACT, TransactionNonce::ONE);
+    let signature = stored_authorization(&rotation)
+        .expect("BUG: the sweep must have signed the rotation tuple");
     assert_eq!(
         swept_item(Asset::Erc20(usdt())).authorization,
-        Some(authorization_request(account(), ANOTHER_SWEEPER_CONTRACT).signed_with(signature))
+        Some(rotation.signed_with(signature))
+    );
+    assert_eq!(
+        stored_authorization(&authorization_request(
+            account(),
+            ANOTHER_SWEEPER_CONTRACT,
+            TransactionNonce::ZERO
+        )),
+        None,
+        "a tuple at a nonce the address has already spent is skipped on chain, and pays the full \
+         gas of a tuple for nothing"
+    );
+}
+
+/// The tuple a sweep already in flight carries is the one the chain will apply, whatever the
+/// minter has since been re-pointed at: signing a second tuple for the same nonce would leave the
+/// delegate the address ends up on to the order the two sweeps happen to mine in.
+#[tokio::test]
+async fn should_recarry_an_unapplied_tuple_signed_for_another_delegate() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_authorization_signing(&mut runtime, SWEEPER_CONTRACT, TransactionNonce::ZERO);
+    expect_signing(&mut runtime);
+    create_pending_sweeper_requests(&runtime).await;
+
+    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+    queue_deposit(&account(), &usdt());
+    create_pending_sweeper_requests(&runtime).await;
+
+    let in_flight = authorization_request(account(), SWEEPER_CONTRACT, TransactionNonce::ZERO);
+    let signature =
+        stored_authorization(&in_flight).expect("BUG: the first sweep must have signed a tuple");
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        Some(in_flight.signed_with(signature)),
+        "the second sweep must carry the tuple the first one is still delegating with"
+    );
+    assert_eq!(
+        stored_authorization(&authorization_request(
+            account(),
+            ANOTHER_SWEEPER_CONTRACT,
+            TransactionNonce::ZERO
+        )),
+        None,
+        "at most one tuple may be signed per (address, nonce), whatever delegate it names"
+    );
+}
+
+#[tokio::test]
+async fn should_rotate_at_the_next_nonce_once_the_recarried_tuple_has_applied() {
+    init_state(state_ready_to_sign(&[(account(), usdc())]));
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    expect_signing(&mut runtime);
+    create_pending_sweeper_requests(&runtime).await;
+    mutate_state(|s| s.sweeper_contract_address = Some(ANOTHER_SWEEPER_CONTRACT));
+    queue_deposit(&account(), &usdt());
+    create_pending_sweeper_requests(&runtime).await;
+
+    finalize_pending_sweeps(TransactionStatus::Success);
+    queue_deposit(&account(), &token(0xcc));
+    create_pending_sweeper_requests(&runtime).await;
+
+    let rotation =
+        authorization_request(account(), ANOTHER_SWEEPER_CONTRACT, TransactionNonce::ONE);
+    let signature = stored_authorization(&rotation)
+        .expect("BUG: the rotation must be retried once the carried tuple has applied");
+    assert_eq!(
+        swept_item(Asset::Erc20(token(0xcc))).authorization,
+        Some(rotation.signed_with(signature))
+    );
+}
+
+/// A reverted sweep leaves the minter unable to say which of the tuples it signed for the
+/// addresses that sweep touched the chain applied, so their nonce is no longer known — and a tuple
+/// signed for a guessed nonce is at best wasted gas. They stay out of sweeps until the nonce is
+/// read back off the chain.
+#[tokio::test]
+async fn should_leave_out_an_address_whose_nonce_a_reverted_sweep_left_unverified() {
+    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Failure).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    queue_deposit(&account(), &usdt());
+
+    enqueue_sweep(
+        Asset::Erc20(usdt()),
+        &targets_of(Asset::Erc20(usdt())),
+        &gas_fee_estimate(),
+        &runtime,
+    );
+
+    assert_eq!(
+        pending_sweeps(),
+        vec![],
+        "no sweep may be enqueued while the address' nonce is unverified"
+    );
+}
+
+#[tokio::test]
+async fn should_sweep_again_once_the_deposit_address_nonce_has_been_read_back() {
+    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Failure).await;
+    let mut runtime = mock();
+    runtime.expect_time().return_const(NOW);
+    queue_deposit(&account(), &usdt());
+    mutate_state(|s| {
+        apply_state_transition(
+            s,
+            &EventType::ObservedDepositAddressNonce {
+                account: account(),
+                nonce: TransactionNonce::ONE,
+            },
+        )
+    });
+
+    enqueue_sweep(
+        Asset::Erc20(usdt()),
+        &targets_of(Asset::Erc20(usdt())),
+        &gas_fee_estimate(),
+        &runtime,
+    );
+
+    assert_eq!(
+        swept_item(Asset::Erc20(usdt())).authorization,
+        None,
+        "the nonce read back says the reverted sweep did apply its tuple, so the address is \
+         delegated and needs none"
     );
 }
 
 #[tokio::test]
 async fn should_batch_a_delegated_and_a_fresh_address_into_one_sweep() {
-    state_with_finalized_sweep(&[(account(), usdc())]).await;
+    state_with_finalized_sweep(&[(account(), usdc())], TransactionStatus::Success).await;
     let mut runtime = mock();
     runtime.expect_time().return_const(NOW);
     expect_signing(&mut runtime);
@@ -242,11 +402,13 @@ async fn should_batch_a_delegated_and_a_fresh_address_into_one_sweep() {
         delegated.authorization, None,
         "the address the earlier sweep delegated must be swept carrying no tuple"
     );
-    let signature = stored_authorization(another_account(), SWEEPER_CONTRACT)
+    let fresh_tuple =
+        authorization_request(another_account(), SWEEPER_CONTRACT, TransactionNonce::ZERO);
+    let signature = stored_authorization(&fresh_tuple)
         .expect("BUG: the sweep must have signed a tuple for the address it still has to delegate");
     assert_eq!(
         fresh.authorization,
-        Some(authorization_request(another_account(), SWEEPER_CONTRACT).signed_with(signature)),
+        Some(fresh_tuple.signed_with(signature)),
         "the tuple must be the one signed for the fresh address, at nonce zero"
     );
     assert_eq!(
@@ -316,14 +478,10 @@ async fn should_carry_the_signed_attestation_and_authorization_of_every_swept_ac
         item.item.attestation,
         expected_signature(&attestation_request(account()))
     );
+    let tuple = authorization_request(account(), SWEEPER_CONTRACT, TransactionNonce::ZERO);
     assert_eq!(
         item.authorization,
-        read_state(|s| s
-            .automatic_deposits
-            .authorization(&authorization_request(account(), SWEEPER_CONTRACT))
-            .map(|signature| {
-                authorization_request(account(), SWEEPER_CONTRACT).signed_with(signature.clone())
-            }))
+        stored_authorization(&tuple).map(|signature| tuple.signed_with(signature))
     );
 }
 
@@ -427,6 +585,31 @@ fn pending_sweeps() -> Vec<SweepRequest> {
     read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
 }
 
+/// The queued deposits of `asset` a sweep could take next.
+fn targets_of(asset: Asset) -> Vec<SweepTarget> {
+    read_state(|s| {
+        s.automatic_deposits
+            .requests_batch(usize::MAX)
+            .get(&asset)
+            .cloned()
+            .unwrap_or_default()
+    })
+}
+
+/// Drives every enqueued sweep through the sweeper pipeline to a receipt of `status`.
+fn finalize_pending_sweeps(status: TransactionStatus) {
+    for sweep in pending_sweeps() {
+        let nonce = read_state(|s| s.automatic_deposits.next_sweeper_transaction_nonce());
+        for event in sweep_pipeline_events(nonce, &sweep, status) {
+            mutate_state(|s| apply_state_transition(s, &event));
+        }
+    }
+}
+
+fn token(byte: u8) -> Address {
+    Address::new([byte; 20])
+}
+
 /// The one item of the one pending sweep of `asset`.
 fn swept_item(asset: Asset) -> AuthorizedSweepItem {
     let [sweep] = <[SweepRequest; 1]>::try_from(
@@ -441,22 +624,21 @@ fn swept_item(asset: Asset) -> AuthorizedSweepItem {
     item
 }
 
-/// Expects `times` signatures over the authorization tuple every deposit address delegates with:
-/// the minter's chain, `delegate`, and nonce 0, signed along the deposit address' own derivation
-/// path.
+/// Expects exactly one signature over the authorization tuple `(the minter's chain, `delegate`,
+/// `nonce`)`, signed along the deposit address' own derivation path.
 fn expect_authorization_signing(
     runtime: &mut MockCanisterRuntime,
     delegate: Address,
-    times: usize,
+    nonce: TransactionNonce,
 ) {
-    let digest = authorization_digest(delegate);
+    let digest = authorization_digest(delegate, nonce);
     let path = derivation_path_bytes();
     runtime
         .expect_sign_with_ecdsa()
         .withf(move |_, derivation_path, message_hash| {
             *message_hash == digest && *derivation_path == path
         })
-        .times(times)
+        .times(1)
         .returning(sign_digest_with_derived_key);
 }
 
@@ -482,31 +664,31 @@ fn sign_digest_with_derived_key(
         .sign_digest_with_ecdsa(&message_hash))
 }
 
-/// Spelled out rather than taken from `delegation_authorization`, so that changing the tuple the
-/// minter signs — its delegate, or the nonce 0 that makes a stale authorization skip harmlessly
-/// rather than sink the sweep — fails here.
-fn stored_authorization(account: Account, delegate: Address) -> Option<TransactionSignature> {
-    read_state(|s| {
-        s.automatic_deposits
-            .authorization(&authorization_request(account, delegate))
-            .cloned()
-    })
+fn stored_authorization(request: &AuthorizationRequest) -> Option<TransactionSignature> {
+    read_state(|s| s.automatic_deposits.authorization(request).cloned())
 }
 
-fn authorization_request(account: Account, delegate: Address) -> AuthorizationRequest {
+/// Spelled out rather than taken from the minter's own request builder, so that changing the tuple
+/// the minter signs — its delegate, or the nonce that decides whether the protocol applies it or
+/// skips it — fails here.
+fn authorization_request(
+    account: Account,
+    delegate: Address,
+    nonce: TransactionNonce,
+) -> AuthorizationRequest {
     AuthorizationRequest::new(
         account,
         initial_state().ethereum_network.chain_id(),
         delegate,
-        TransactionNonce::ZERO,
+        nonce,
     )
 }
 
-fn authorization_digest(delegate: Address) -> [u8; 32] {
+fn authorization_digest(delegate: Address, nonce: TransactionNonce) -> [u8; 32] {
     Authorization {
         chain_id: initial_state().ethereum_network.chain_id(),
         delegate,
-        nonce: TransactionNonce::ZERO,
+        nonce,
     }
     .hash()
     .0

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -9,7 +9,7 @@ use crate::state::event::AutomaticDeposit;
 use crate::state::transactions::{SweepId, SweepRequest};
 use crate::state::{State, mutate_state, read_state};
 use crate::storage::with_event_iter;
-use crate::sweep::create_pending_sweeper_requests;
+use crate::sweep::{create_pending_sweeper_requests, in_chain_execution_order};
 use crate::test_fixtures::mock::MockCanisterRuntime;
 use crate::test_fixtures::{
     account, another_account, automatic_deposit, deposit_address, init_state, initial_state,
@@ -17,10 +17,14 @@ use crate::test_fixtures::{
 };
 use crate::tx::{Authorization, AuthorizationRequest, GasFeeEstimate, TransactionSignature};
 use ethnum::u256;
+use evm_rpc_types::{
+    Hex20, Hex32, Hex256, HexByte, Nat256, TransactionReceipt as EvmTransactionReceipt,
+};
 use ic_cdk_management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
 use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey};
 use icrc_ledger_types::icrc1::account::Account;
+use std::collections::BTreeMap;
 
 const NOW: u64 = 1_620_328_630_000_000_000;
 const GAS_FEE_ESTIMATE_AGE_NANOS: u64 = 1_000_000_000;
@@ -307,6 +311,28 @@ async fn should_leave_out_a_deposit_whose_attestation_could_not_be_signed() {
     assert_eq!(read_state(|s| s.automatic_deposits.sweep_len()), 2);
 }
 
+#[test]
+fn should_order_finalized_sweeps_as_the_chain_executed_them() {
+    let earliest = receipt_mined_at(7, 3);
+    let second = receipt_mined_at(8, 0);
+    let latest = receipt_mined_at(8, 1);
+    let receipts = BTreeMap::from([
+        (SweepId(0), latest.clone()),
+        (SweepId(1), earliest.clone()),
+        (SweepId(2), second.clone()),
+    ]);
+
+    assert_eq!(
+        in_chain_execution_order(receipts),
+        vec![
+            (SweepId(1), earliest),
+            (SweepId(2), second),
+            (SweepId(0), latest),
+        ],
+        "a sweep mined earlier must be finalized first, whatever its id"
+    );
+}
+
 fn pending_sweeps() -> Vec<SweepRequest> {
     read_state(|s| s.automatic_deposits.sweep_requests_batch(usize::MAX))
 }
@@ -481,6 +507,26 @@ fn expected_signature(request: &AttestationRequest) -> TransactionSignature {
 
 fn recorded_events() -> Vec<EventType> {
     with_event_iter(|events| events.map(|event| event.payload).collect())
+}
+
+fn receipt_mined_at(block_number: u64, transaction_index: u64) -> EvmTransactionReceipt {
+    EvmTransactionReceipt {
+        block_hash: Hex32::from([0_u8; 32]),
+        block_number: Nat256::from(block_number),
+        effective_gas_price: Nat256::ZERO,
+        gas_used: Nat256::ZERO,
+        cumulative_gas_used: Nat256::ZERO,
+        status: Some(Nat256::from(1_u8)),
+        root: None,
+        transaction_hash: Hex32::from([0_u8; 32]),
+        contract_address: None,
+        from: Hex20::from([0_u8; 20]),
+        logs: vec![],
+        logs_bloom: Hex256::from([0_u8; 256]),
+        to: None,
+        transaction_index: Nat256::from(transaction_index),
+        tx_type: HexByte::from(2_u8),
+    }
 }
 
 fn mock() -> MockCanisterRuntime {

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
@@ -18,6 +18,10 @@ use minicbor::{Decode, Encode};
 /// keccak256("sweepErc20Batch((address,bytes32,bytes32,bytes32,bytes32,uint8)[],address[])").
 const SWEEP_ERC20_BATCH_SELECTOR: [u8; 4] = hex_literal::hex!("3a7ce054");
 
+/// First 4 bytes of
+/// keccak256("sweepEthBatch((address,bytes32,bytes32,bytes32,bytes32,uint8)[])").
+const SWEEP_ETH_BATCH_SELECTOR: [u8; 4] = hex_literal::hex!("509181f7");
+
 /// A 6-word ABI head: `(address, bytes32, bytes32, bytes32, bytes32, uint8)`. Every component is
 /// static, so the elements of a `SweepItem[]` are encoded inline rather than behind offsets.
 const WORDS_PER_ITEM: usize = 6;
@@ -59,21 +63,46 @@ pub fn encode_sweep_erc20_batch(items: &[SweepItem], tokens: &[Address]) -> Vec<
 
     data.extend(word(items.len()));
     for item in items {
-        data.extend(<[u8; 32]>::from(item.deposit.as_address()));
-        data.extend(encode_principal(&item.account.owner));
-        data.extend(item.account.effective_subaccount());
-        data.extend(item.attestation.r.to_be_bytes());
-        data.extend(item.attestation.s.to_be_bytes());
-        // `ecrecover` wants v as 27 or 28, where the signature carries the parity bit.
-        data.extend(word(usize::from(
-            27 + u8::from(item.attestation.signature_y_parity),
-        )));
+        data.extend(encode_item(item));
     }
 
     data.extend(word(tokens.len()));
     for token in tokens {
         data.extend(<[u8; 32]>::from(token));
     }
+    data
+}
+
+/// Encode `sweepEthBatch(SweepItem[] items)` on the deployed delegate, which sweeps the whole
+/// ETH balance held by every `item`'s deposit address to the minter's main address through the
+/// deposit helper.
+///
+/// The single argument is dynamic, so the head holds one offset and the items block follows.
+pub fn encode_sweep_eth_batch(items: &[SweepItem]) -> Vec<u8> {
+    let head_len = WORD;
+    let items_block_len = WORD + items.len() * WORDS_PER_ITEM * WORD;
+
+    let mut data = Vec::with_capacity(SWEEP_ETH_BATCH_SELECTOR.len() + head_len + items_block_len);
+    data.extend(SWEEP_ETH_BATCH_SELECTOR);
+    data.extend(word(head_len));
+    data.extend(word(items.len()));
+    for item in items {
+        data.extend(encode_item(item));
+    }
+    data
+}
+
+fn encode_item(item: &SweepItem) -> Vec<u8> {
+    let mut data = Vec::with_capacity(WORDS_PER_ITEM * WORD);
+    data.extend(<[u8; 32]>::from(item.deposit.as_address()));
+    data.extend(encode_principal(&item.account.owner));
+    data.extend(item.account.effective_subaccount());
+    data.extend(item.attestation.r.to_be_bytes());
+    data.extend(item.attestation.s.to_be_bytes());
+    // `ecrecover` wants v as 27 or 28, where the signature carries the parity bit.
+    data.extend(word(usize::from(
+        27 + u8::from(item.attestation.signature_y_parity),
+    )));
     data
 }
 

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/tests.rs
@@ -1,6 +1,6 @@
 use crate::deposit_address::DepositAddress;
 use crate::eth_logs::encode_principal;
-use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
+use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::TransactionSignature;
 use candid::Principal;
 use ethnum::u256;
@@ -93,6 +93,65 @@ fn should_encode_an_empty_batch() {
     assert_eq!(data.len(), 4 + 64 + 32 + 32);
     assert_eq!(&data[4 + 64..4 + 96], &word(0));
     assert_eq!(&data[4 + 96..], &word(0));
+}
+
+const ETH_SIGNATURE: &str = "sweepEthBatch((address,bytes32,bytes32,bytes32,bytes32,uint8)[])";
+
+#[test]
+fn should_call_the_eth_function_the_delegate_exposes() {
+    let (items, _tokens) = sweep();
+
+    let data = encode_sweep_eth_batch(&items);
+
+    assert_eq!(
+        &data[..4],
+        &ic_sha3::Keccak256::hash(ETH_SIGNATURE.as_bytes())[..4]
+    );
+}
+
+#[test]
+fn should_encode_an_eth_batch_sweep() {
+    use alloy_primitives::{Address, B256};
+    use alloy_sol_types::{SolValue, sol};
+
+    sol! {
+        struct EthSweepItem {
+            address deposit;
+            bytes32 principal;
+            bytes32 subaccount;
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+        }
+    }
+
+    let (items, _tokens) = sweep();
+
+    let data = encode_sweep_eth_batch(&items);
+
+    let expected_arguments = (items
+        .iter()
+        .map(|item| EthSweepItem {
+            deposit: Address::from(item.deposit.as_address().into_bytes()),
+            principal: B256::from(encode_principal(&item.account.owner)),
+            subaccount: B256::from(item.account.effective_subaccount()),
+            r: B256::from(item.attestation.r.to_be_bytes()),
+            s: B256::from(item.attestation.s.to_be_bytes()),
+            v: 27 + u8::from(item.attestation.signature_y_parity),
+        })
+        .collect::<Vec<_>>(),)
+        .abi_encode_params();
+
+    assert_eq!(&data[4..], expected_arguments.as_slice());
+}
+
+#[test]
+fn should_encode_an_empty_eth_batch() {
+    let data = encode_sweep_eth_batch(&[]);
+
+    assert_eq!(data.len(), 4 + 32 + 32);
+    assert_eq!(&data[4..4 + 32], &word(32));
+    assert_eq!(&data[4 + 32..], &word(0));
 }
 
 fn sweep() -> (Vec<SweepItem>, Vec<Address>) {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -5,6 +5,7 @@ use crate::deposit_address::DepositAddress;
 use crate::eth_logs::LedgerSubaccount;
 use crate::eth_rpc::Hash;
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
+use crate::lifecycle::EthereumNetwork;
 use crate::lifecycle::init::InitArg;
 use crate::numeric::{
     BlockNumber, Erc20Value, GasAmount, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas,
@@ -13,12 +14,12 @@ use crate::state::audit::{EventType, process_event};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::event::AutomaticDeposit;
-use crate::state::transactions::{EthWithdrawalRequest, SweepRequest};
-use crate::state::{State, read_state};
+use crate::state::transactions::{EthWithdrawalRequest, PipelineRequest, SweepRequest};
+use crate::state::{State, mutate_state, read_state};
 use crate::sweep::create_pending_sweeper_requests;
 use crate::tx::{
     AccessList, AuthorizationRequest, Eip1559TransactionRequest, FinalizedEip1559Transaction,
-    GasFeeEstimate, Signed, TransactionSignature,
+    GasFeeEstimate, SignableTransaction, Signed, SweepTransaction, TransactionSignature,
 };
 use candid::{Nat, Principal};
 use ethnum::u256;
@@ -202,14 +203,15 @@ pub fn prepay_sweep_gas(state: &mut State) {
         ));
 }
 
+/// When every sweep fixture decides its sweep, and the age its gas fee estimate is fresh at.
+const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
+
 /// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
 /// the sweep is assembled by the production path without the runtime signing anything, and the log
 /// alone reconstructs the state the fixture hands back.
 pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
-    const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
-
     let mut runtime = mock::MockCanisterRuntime::new();
     runtime.expect_time().return_const(SWEEP_DECIDED_AT);
     let mut state = state_with_deposit_helper(deposit_helper());
@@ -267,6 +269,91 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
                 .expect("BUG: expected the pairs to become exactly one sweep");
         (s.clone(), request)
     })
+}
+
+/// [`state_with_enqueued_sweep`]'s state once the sweeper pipeline has taken that sweep all the way
+/// to a successful receipt, so every address it swept holds the delegation the tuple it carried
+/// installed.
+pub async fn state_with_finalized_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
+    let (state, request) = state_with_enqueued_sweep(pairs).await;
+    let mut time_provider = mock::MockTimeProvider::new();
+    time_provider.expect_time().return_const(SWEEP_DECIDED_AT);
+    for event in sweep_pipeline_events(
+        state.automatic_deposits.next_sweeper_transaction_nonce(),
+        &request,
+        TransactionStatus::Success,
+    ) {
+        mutate_state(|s| process_event(s, event, &time_provider));
+    }
+    (read_state(State::clone), request)
+}
+
+/// The events the sweeper pipeline records taking the already-accepted `request` from its
+/// transaction to a receipt of `status`.
+pub fn sweep_pipeline_events(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> Vec<EventType> {
+    let sweep = sweep_pipeline_outcome(nonce, request, status);
+    vec![
+        EventType::CreatedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.transaction,
+        },
+        EventType::SignedSweeperTransaction {
+            sweep_id: request.id,
+            transaction: sweep.signed,
+        },
+        EventType::FinalizedSweeperTransaction {
+            sweep_id: request.id,
+            transaction_receipt: sweep.receipt,
+        },
+    ]
+}
+
+/// What the sweeper pipeline makes of a sweep: the transaction it creates, that transaction signed,
+/// and the receipt finalizing it.
+pub struct SweepPipelineOutcome {
+    pub transaction: SweepTransaction,
+    pub signed: Signed<SweepTransaction>,
+    pub receipt: TransactionReceipt,
+}
+
+pub fn sweep_pipeline_outcome(
+    nonce: TransactionNonce,
+    request: &SweepRequest,
+    status: TransactionStatus,
+) -> SweepPipelineOutcome {
+    let transaction = request
+        .create_transaction(
+            nonce,
+            gas_fee_estimate(),
+            request.gas_limit(),
+            EthereumNetwork::Sepolia,
+        )
+        .expect("BUG: the fixture prices the request with the estimate it creates with");
+    let signed = Signed::from((
+        transaction.clone(),
+        TransactionSignature {
+            signature_y_parity: false,
+            r: Default::default(),
+            s: Default::default(),
+        },
+    ));
+    let receipt = TransactionReceipt {
+        block_hash: Hash([0x11; 32]),
+        block_number: BlockNumber::new(4_190_269),
+        effective_gas_price: signed.transaction().max_fee_per_gas(),
+        gas_used: signed.transaction().gas_limit(),
+        status,
+        transaction_hash: signed.hash(),
+    };
+    SweepPipelineOutcome {
+        transaction,
+        signed,
+        receipt,
+    }
 }
 
 pub fn sweeper_contract() -> Address {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -9,7 +9,7 @@ use crate::lifecycle::init::InitArg;
 use crate::numeric::{
     BlockNumber, Erc20Value, GasAmount, LedgerBurnIndex, TransactionNonce, Wei, WeiPerGas,
 };
-use crate::state::audit::{EventType, apply_state_transition};
+use crate::state::audit::{EventType, process_event};
 use crate::state::automatic_deposits::AutomaticDeposits;
 use crate::state::eth_logs_scraping::LogScrapingId;
 use crate::state::event::AutomaticDeposit;
@@ -205,25 +205,29 @@ pub fn prepay_sweep_gas(state: &mut State) {
 /// A [`State`] whose sweep queue holds exactly these funded pairs, all taken by the one sweep
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
-/// the sweep is assembled by the production path without the runtime signing anything.
+/// the sweep is assembled by the production path without the runtime signing anything, and the log
+/// alone reconstructs the state the fixture hands back.
 pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
     const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
 
+    let mut runtime = mock::MockCanisterRuntime::new();
+    runtime.expect_time().return_const(SWEEP_DECIDED_AT);
     let mut state = state_with_deposit_helper(deposit_helper());
     prepay_sweep_gas(&mut state);
     state.sweeper_contract_address = Some(sweeper_contract());
     state.last_transaction_price_estimate = Some((SWEEP_DECIDED_AT, gas_fee_estimate()));
     let chain_id = state.ethereum_network.chain_id();
     for (account, token) in pairs {
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AutomaticDepositReceived(AutomaticDeposit {
+            EventType::AutomaticDepositReceived(AutomaticDeposit {
                 owner: account.owner,
                 subaccount: account.subaccount,
                 address: deposit_address(account),
                 asset: Asset::Erc20(*token),
                 ..automatic_deposit()
             }),
+            &runtime,
         );
     }
     for account in pairs
@@ -231,16 +235,17 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
         .map(|(account, _token)| *account)
         .collect::<BTreeSet<_>>()
     {
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AttestedDepositAddress {
+            EventType::AttestedDepositAddress {
                 request: AttestationRequest::new(chain_id, deposit_helper(), account),
                 signature: transaction_signature(),
             },
+            &runtime,
         );
-        apply_state_transition(
+        process_event(
             &mut state,
-            &EventType::AuthorizedDepositAddress {
+            EventType::AuthorizedDepositAddress {
                 request: AuthorizationRequest::new(
                     account,
                     chain_id,
@@ -249,11 +254,10 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
                 ),
                 signature: transaction_signature(),
             },
+            &runtime,
         );
     }
     init_state(state);
-    let mut runtime = mock::MockCanisterRuntime::new();
-    runtime.expect_time().return_const(SWEEP_DECIDED_AT);
 
     create_pending_sweeper_requests(&runtime).await;
 

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -272,16 +272,20 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
 }
 
 /// [`state_with_enqueued_sweep`]'s state once the sweeper pipeline has taken that sweep all the way
-/// to a successful receipt, so every address it swept holds the delegation the tuple it carried
-/// installed.
-pub async fn state_with_finalized_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
+/// to a receipt of `status`, so every address it swept holds the delegation the tuple it carried
+/// installed: a tuple applies before the call it travels with runs, and stays applied when that
+/// call reverts.
+pub async fn state_with_finalized_sweep(
+    pairs: &[(Account, Address)],
+    status: TransactionStatus,
+) -> (State, SweepRequest) {
     let (state, request) = state_with_enqueued_sweep(pairs).await;
     let mut time_provider = mock::MockTimeProvider::new();
     time_provider.expect_time().return_const(SWEEP_DECIDED_AT);
     for event in sweep_pipeline_events(
         state.automatic_deposits.next_sweeper_transaction_nonce(),
         &request,
-        TransactionStatus::Success,
+        status,
     ) {
         mutate_state(|s| process_event(s, event, &time_provider));
     }

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -89,6 +89,10 @@ impl AuthorizationRequest {
         self.account
     }
 
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
     pub fn delegate(&self) -> Address {
         self.delegate
     }

--- a/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
+++ b/rs/ethereum/cketh/minter/src/tx/eip_7702.rs
@@ -89,6 +89,14 @@ impl AuthorizationRequest {
         self.account
     }
 
+    pub fn delegate(&self) -> Address {
+        self.delegate
+    }
+
+    pub fn nonce(&self) -> TransactionNonce {
+        self.nonce
+    }
+
     pub fn derivation_path(&self) -> Vec<ByteBuf> {
         AddressSchema::Deposit(self.account).derivation_path()
     }

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -406,12 +406,9 @@ mod deposit_erc20 {
 
     /// Number of `AutomaticDepositReceived` events currently in the minter's audit log.
     fn count_automatic_deposits_received(ckerc20: &CkErc20Setup) -> usize {
-        ckerc20
-            .cketh
-            .get_all_events()
-            .into_iter()
-            .filter(|event| matches!(event.payload, EventPayload::AutomaticDepositReceived { .. }))
-            .count()
+        ckerc20.cketh.minter_count_events(|event| {
+            matches!(event.payload, EventPayload::AutomaticDepositReceived { .. })
+        })
     }
 
     /// EIP-55 address string of the first supported ckERC20 token.

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1368,7 +1368,8 @@ fn should_export_the_stored_attestation_and_authorization_metrics() {
     CkEthSetup::default()
         .check_minter_metrics()
         .assert_contains_metric_matching(r"cketh_minter_stored_attestations 0 \d+")
-        .assert_contains_metric_matching(r"cketh_minter_stored_authorizations 0 \d+");
+        .assert_contains_metric_matching(r"cketh_minter_stored_authorizations 0 \d+")
+        .assert_contains_metric_matching(r"cketh_minter_applied_authorizations 0 \d+");
 }
 
 /// Tests with the EVM RPC canister

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -20,7 +20,7 @@ use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
-use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, LiveSetup};
+use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 use ic_ethereum_types::Address;
 
@@ -432,6 +432,43 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
         .assert_sweeper_spent_gas(&sweeper, funded_gas);
 
     setup.expect_mints(&deposits);
+}
+
+#[test]
+fn should_credit_an_eth_cex_deposit_through_a_sweep() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
+    const DEPOSIT_WEI: u128 = 20_000_000_000_000_000;
+
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+    let sweeper = setup.await_sweeper_address();
+    let owner = setup.depositor(1);
+
+    let (setup, deposits) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: DEPOSIT_WEI,
+        }])
+        .expect_deposit_responses();
+
+    let setup = setup
+        .credit_eth_deposits_from_cex(&deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+
+    let (setup, _sweeps) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_all_delegating_sweeps();
+
+    setup
+        .assert_eth_addresses_swept_empty(&deposits)
+        .expect_cketh_mints(&deposits);
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -549,7 +549,8 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let sweeper = setup.await_sweeper_address();
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
-    let mints_before = count_cketh_mints(&setup);
+    let mints_before = setup
+        .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }));
     let owner = setup.depositor(1);
 
     let (setup, first_deposits) = setup
@@ -623,18 +624,12 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
         .assert_minter_received_swept_eth_total(&all_deposits, minter_eth_before)
         .expect_cketh_mints(&all_deposits);
     assert_eq!(
-        count_cketh_mints(&setup) - mints_before,
+        setup
+            .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
+            - mints_before,
         2,
         "each deposit flow must be credited exactly once"
     );
-}
-
-fn count_cketh_mints(setup: &LiveSetup<CkErc20Setup>) -> usize {
-    setup
-        .minter_events()
-        .into_iter()
-        .filter(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
-        .count()
 }
 
 #[test]
@@ -730,10 +725,7 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         .assert_minter_holds_swept_totals(&all_deposits)
         .expect_mints(&all_deposits);
     let mints = setup
-        .minter_events()
-        .into_iter()
-        .filter(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }))
-        .count();
+        .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }));
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
 }
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -851,6 +851,138 @@ fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authori
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
 }
 
+/// Replacing the sweeper delegate re-delegates lazily the addresses already carrying the old one:
+/// the rotation tuple rides the sweep that would happen anyway, signed for the nonce the address
+/// has reached rather than for zero — which the protocol would skip — and once it has applied the
+/// address is on the new delegate and needs no further tuple.
+#[test]
+fn should_rotate_a_delegated_address_onto_a_newly_configured_delegate() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [9; 32];
+
+    let (setup, current_delegate) = LiveSetup::<CkErc20Setup>::on_legacy_delegate();
+    let legacy_delegate = setup.sweep_contracts().delegate;
+    assert_ne!(
+        legacy_delegate, current_delegate,
+        "the two delegate versions must be distinct deployments for the rotation to mean anything"
+    );
+    let setup = setup
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let [usdc, _usdt]: [Erc20Token; 2] = setup
+        .supported_erc20_tokens_owned()
+        .try_into()
+        .expect("expected exactly 2 supported tokens");
+    let usdc_minimum = setup.minimum_deposit_amount(&usdc);
+    let owner = setup.depositor(1);
+
+    let (setup, first_deposits) = setup
+        .call_minter_deposit_erc20([DepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            token: usdc.clone(),
+            amount: 4 * usdc_minimum,
+        }])
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_deposits_from_cex(&first_deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+    let (setup, first_sweeps) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_all_delegating_sweeps();
+    assert_eq!(
+        setup.anvil().authorization_nonces(&first_sweeps[0].hash),
+        vec![0],
+        "the first sweep of an address delegates it at nonce 0"
+    );
+    let address = first_deposits[0].address;
+    let setup = setup
+        .expect_sweeps_finalized(1)
+        .assert_delegations_installed(&first_deposits, &legacy_delegate)
+        .expect_mints(&first_deposits);
+    assert_eq!(setup.anvil().transaction_count(&address), 1);
+
+    setup.rotate_delegate_to(&current_delegate);
+
+    let second_deposits = [CexDeposit {
+        amount: 3 * usdc_minimum,
+        ..first_deposits[0].clone()
+    }];
+    let setup = setup
+        .credit_deposits_from_cex(&second_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let (setup, second_registrations) = setup
+        .call_minter_deposit_erc20([DepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            token: usdc.clone(),
+            amount: second_deposits[0].amount,
+        }])
+        .expect_deposit_responses();
+    assert_eq!(second_registrations[0].address, address);
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+    ]);
+    assert_eq!(
+        setup.anvil().authorization_nonces(&sweeps[1].hash),
+        vec![1],
+        "the rotation must be signed for the nonce the first sweep left the address at, since the \
+         protocol applies a tuple only at the authority's current nonce"
+    );
+    let both_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];
+    let setup = setup
+        .expect_sweeps_finalized(2)
+        .assert_delegations_installed(&second_deposits, &current_delegate)
+        .assert_addresses_swept_empty(&second_deposits)
+        .assert_minter_holds_swept_totals(&both_deposits)
+        .expect_mints(&both_deposits);
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        2,
+        "applying the rotation tuple spends the address' nonce 1"
+    );
+
+    let third_deposits = [CexDeposit {
+        amount: 2 * usdc_minimum,
+        ..first_deposits[0].clone()
+    }];
+    let setup = setup
+        .credit_deposits_from_cex(&third_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let (setup, _third_registrations) = setup
+        .call_minter_deposit_erc20([DepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            token: usdc.clone(),
+            amount: third_deposits[0].amount,
+        }])
+        .expect_deposit_responses();
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 3).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        PLAIN_SWEEP_TRANSACTION_TYPE,
+    ]);
+    assert_eq!(
+        setup.anvil().authorization_nonces(&sweeps[2].hash),
+        Vec::<u64>::new(),
+        "a rotated address is delegated to the configured contract and needs no further tuple"
+    );
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        2,
+        "sweeping without a tuple leaves the address at the nonce the rotation spent"
+    );
+}
+
 fn assert_eth_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
     const ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS: u64 = 413_076;
     const GAS_BAND_PERCENT: u64 = 10;

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -20,7 +20,9 @@ use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
-use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
+use ic_cketh_test_utils::live::{
+    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
+};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 
 const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
@@ -537,7 +539,112 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
 }
 
 #[test]
-fn should_sweep_a_second_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
+
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+    // The fee-account funding above minted ckETH too, so the deposit mints are counted
+    // against this baseline.
+    let mints_before = count_cketh_mints(&setup);
+    let owner = setup.depositor(1);
+
+    let (setup, first_deposits) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: 3 * MINIMUM_ETH_DEPOSIT_WEI,
+        }])
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_eth_deposits_from_cex(&first_deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+    let (setup, _first_sweeps) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_all_delegating_sweeps();
+    let setup = setup
+        .expect_sweeps_finalized(1)
+        .expect_cketh_mints(&first_deposits);
+    let address = first_deposits[0].address;
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        1,
+        "applying the first sweep's authorization must spend the deposit address' nonce 0"
+    );
+
+    let second_deposits = [EthCexDeposit {
+        amount: 2 * MINIMUM_ETH_DEPOSIT_WEI,
+        ..first_deposits[0].clone()
+    }];
+    let setup = setup
+        .credit_eth_deposits_from_cex(&second_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let (setup, second_registrations) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: second_deposits[0].amount,
+        }])
+        .expect_deposit_responses();
+    assert_eq!(
+        second_registrations[0].address, address,
+        "re-registering the pair must yield the same deposit address"
+    );
+    assert_matches!(
+        setup.await_eth_detection(owner, DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == second_deposits[0].amount
+    );
+
+    let (setup, sweeps) = setup
+        .await_sweeps(&sweeper, 2)
+        .expect_all_delegating_sweeps();
+    let second_sweep = &sweeps[1];
+    assert_eq!(
+        setup.anvil().authorization_nonces(&second_sweep.hash),
+        vec![0],
+        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+    );
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        1,
+        "a skipped stale authorization must not advance the deposit address' nonce"
+    );
+
+    let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];
+    let setup = setup
+        .assert_eth_delegations_installed(&all_deposits, &delegate)
+        .assert_eth_addresses_swept_empty(&second_deposits)
+        .assert_minter_received_swept_eth_total(&all_deposits, minter_eth_before)
+        .expect_cketh_mints(&all_deposits);
+    assert_eq!(
+        count_cketh_mints(&setup) - mints_before,
+        2,
+        "each deposit flow must be credited exactly once"
+    );
+}
+
+fn count_cketh_mints(setup: &LiveSetup<CkErc20Setup>) -> usize {
+    setup
+        .minter_events()
+        .into_iter()
+        .filter(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
+        .count()
+}
+
+#[test]
+fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -21,7 +21,8 @@ use ic_cketh_test_utils::anvil::{
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{
-    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
+    CexDeposit, DELEGATING_SWEEP_TRANSACTION_TYPE, DepositPlan, EthCexDeposit, EthDepositPlan,
+    LiveSetup, PLAIN_SWEEP_TRANSACTION_TYPE,
 };
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 
@@ -642,7 +643,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
 }
 
 #[test]
-fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()
@@ -709,19 +710,20 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
             if detected.scanned_balance == second_deposits[0].amount
     );
 
-    let (setup, sweeps) = setup
-        .await_sweeps(&sweeper, 2)
-        .expect_all_delegating_sweeps();
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        PLAIN_SWEEP_TRANSACTION_TYPE,
+    ]);
     let second_sweep = &sweeps[1];
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
-        vec![0],
-        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+        Vec::<u64>::new(),
+        "an address already delegated is swept without any authorization to install"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
         1,
-        "a skipped stale authorization must not advance the deposit address' nonce"
+        "sweeping without a tuple must leave the deposit address at the nonce the first sweep spent"
     );
 
     let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];
@@ -740,7 +742,7 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
 }
 
 #[test]
-fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()
@@ -810,19 +812,20 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == second_deposits[0].amount
     );
 
-    let (setup, sweeps) = setup
-        .await_sweeps(&sweeper, 2)
-        .expect_all_delegating_sweeps();
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).expect_sweeps_of_types(&[
+        DELEGATING_SWEEP_TRANSACTION_TYPE,
+        PLAIN_SWEEP_TRANSACTION_TYPE,
+    ]);
     let second_sweep = &sweeps[1];
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
-        vec![0],
-        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+        Vec::<u64>::new(),
+        "an address already delegated is swept without any authorization to install"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
         1,
-        "a skipped stale authorization must not advance the deposit address' nonce"
+        "sweeping without a tuple must leave the deposit address at the nonce the first sweep spent"
     );
 
     let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -353,6 +353,113 @@ fn should_flag_only_erc20_deposits_at_or_above_the_per_token_minimum() {
 }
 
 #[test]
+fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let funded_gas = setup.anvil_eth_balance(&sweeper);
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+    let [usdc, usdt]: [Erc20Token; 2] = setup
+        .supported_erc20_tokens_owned()
+        .try_into()
+        .expect("expected exactly 2 supported tokens");
+
+    let erc20_only = (setup.depositor(1), [1_u8; 32]);
+    let both_assets = (setup.depositor(2), [2_u8; 32]);
+    let eth_only = (setup.depositor(3), [3_u8; 32]);
+    let usdc_amount = 3 * setup.minimum_deposit_amount(&usdc);
+    let usdt_amount = 5 * setup.minimum_deposit_amount(&usdt);
+    let both_eth_amount = 4 * MINIMUM_ETH_DEPOSIT_WEI;
+    let eth_only_amount = 7 * MINIMUM_ETH_DEPOSIT_WEI;
+
+    let (setup, erc20_deposits) = setup
+        .call_minter_deposit_erc20([
+            DepositPlan {
+                owner: erc20_only.0,
+                subaccount: erc20_only.1,
+                token: usdc.clone(),
+                amount: usdc_amount,
+            },
+            DepositPlan {
+                owner: both_assets.0,
+                subaccount: both_assets.1,
+                token: usdt.clone(),
+                amount: usdt_amount,
+            },
+        ])
+        .expect_deposit_responses();
+    let (setup, eth_deposits) = setup
+        .call_minter_deposit_eth([
+            EthDepositPlan {
+                owner: both_assets.0,
+                subaccount: both_assets.1,
+                amount: both_eth_amount,
+            },
+            EthDepositPlan {
+                owner: eth_only.0,
+                subaccount: eth_only.1,
+                amount: eth_only_amount,
+            },
+        ])
+        .expect_deposit_responses();
+    assert_eq!(
+        erc20_deposits[1].address, eth_deposits[0].address,
+        "one account deposits both assets at one address"
+    );
+
+    let setup = setup
+        .credit_deposits_from_cex(&erc20_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let setup = setup
+        .credit_eth_deposits_from_cex(&eth_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+
+    assert_matches!(
+        setup.await_detection(erc20_only.0, erc20_only.1, &usdc).status,
+        DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == usdc_amount
+    );
+    assert_matches!(
+        setup.await_detection(both_assets.0, both_assets.1, &usdt).status,
+        DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == usdt_amount
+    );
+    assert_matches!(
+        setup.await_eth_detection(both_assets.0, both_assets.1).status,
+        DepositEthStatus::AwaitingSweep(detected) if detected.scanned_balance == both_eth_amount
+    );
+    assert_matches!(
+        setup.await_eth_detection(eth_only.0, eth_only.1).status,
+        DepositEthStatus::AwaitingSweep(detected) if detected.scanned_balance == eth_only_amount
+    );
+
+    let (setup, _sweeps) = setup
+        .await_sweeps(&sweeper, 3)
+        .expect_all_delegating_sweeps();
+
+    let setup = setup
+        .assert_sweeps_batched_per_token(&erc20_deposits)
+        .assert_eth_sweeps_batched(&[2])
+        .assert_addresses_swept_empty(&erc20_deposits)
+        .assert_eth_addresses_swept_empty(&eth_deposits)
+        .assert_minter_holds_swept_totals(&erc20_deposits)
+        .assert_minter_received_swept_eth_total(&eth_deposits, minter_eth_before)
+        .assert_delegations_installed(&erc20_deposits, &delegate)
+        .assert_eth_delegations_installed(&eth_deposits, &delegate)
+        .assert_sweeper_spent_gas(&sweeper, funded_gas);
+
+    let setup = setup.expect_mints(&erc20_deposits);
+    setup.expect_cketh_mints(&eth_deposits);
+}
+
+#[test]
 fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -672,9 +672,14 @@ fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authoriza
         .credit_eth_deposits_from_cex(&first_deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
-    let (setup, _first_sweeps) = setup
+    let (setup, first_sweeps) = setup
         .await_sweeps(&sweeper, 1)
         .expect_all_delegating_sweeps();
+    assert_eq!(
+        setup.anvil().authorization_nonces(&first_sweeps[0].hash),
+        vec![0],
+        "the first sweep of an address must carry the tuple delegating it, signed for nonce 0"
+    );
     let setup = setup
         .expect_sweeps_finalized(1)
         .expect_cketh_mints(&first_deposits);
@@ -718,7 +723,8 @@ fn should_sweep_a_second_eth_deposit_of_a_delegated_address_without_an_authoriza
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
         Vec::<u64>::new(),
-        "an address already delegated is swept without any authorization to install"
+        "the type-2 transaction above is what proves no tuple was sent: an address already \
+         delegated is swept carrying none"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),
@@ -774,9 +780,14 @@ fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authori
         .credit_deposits_from_cex(&first_deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
-    let (setup, _first_sweeps) = setup
+    let (setup, first_sweeps) = setup
         .await_sweeps(&sweeper, 1)
         .expect_all_delegating_sweeps();
+    assert_eq!(
+        setup.anvil().authorization_nonces(&first_sweeps[0].hash),
+        vec![0],
+        "the first sweep of an address must carry the tuple delegating it, signed for nonce 0"
+    );
     let setup = setup
         .expect_sweeps_finalized(1)
         .expect_mints(&first_deposits);
@@ -820,7 +831,8 @@ fn should_sweep_a_second_erc20_deposit_of_a_delegated_address_without_an_authori
     assert_eq!(
         setup.anvil().authorization_nonces(&second_sweep.hash),
         Vec::<u64>::new(),
-        "an address already delegated is swept without any authorization to install"
+        "the type-2 transaction above is what proves no tuple was sent: an address already \
+         delegated is swept carrying none"
     );
     assert_eq!(
         setup.anvil().transaction_count(&address),

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -366,7 +366,7 @@ fn should_fund_the_sweeper_address_by_burning_cketh_from_the_fee_account() {
 }
 
 #[test]
-fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
+fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
     /// Ten depositors per token, so each sweep is a ten-deposit single-token batch — directly
     /// comparable with `deposit_from_cex_demo`'s measured scenarios.
     const DEPOSITORS_PER_TOKEN: u64 = 10;
@@ -435,9 +435,9 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
 }
 
 #[test]
-fn should_credit_an_eth_cex_deposit_through_a_sweep() {
-    const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
-    const DEPOSIT_WEI: u128 = 20_000_000_000_000_000;
+fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
+    const DEPOSITORS: u64 = 20;
+    const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 
     let setup = LiveSetup::<CkErc20Setup>::new()
         .fund_fee_account()
@@ -446,29 +446,47 @@ fn should_credit_an_eth_cex_deposit_through_a_sweep() {
         .expect_sweeper_address_derived()
         .expect_eth_received()
         .expect_funding_finalized();
+
     let sweeper = setup.await_sweeper_address();
-    let owner = setup.depositor(1);
+    let funded_gas = setup.anvil_eth_balance(&sweeper);
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+
+    // Every depositor gets a distinct principal and a distinct subaccount, so no two share a
+    // deposit address, and a distinct amount, so a positional mixup in the batch cannot cancel
+    // out in the totals.
+    let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
+        .map(|index| EthDepositPlan {
+            owner: setup.depositor(index),
+            subaccount: [u8::try_from(index).unwrap(); 32],
+            amount: (u128::from(index) + 2) * MINIMUM_ETH_DEPOSIT_WEI,
+        })
+        .collect();
 
     let (setup, deposits) = setup
-        .call_minter_deposit_eth([EthDepositPlan {
-            owner,
-            subaccount: DEPOSIT_SUBACCOUNT,
-            amount: DEPOSIT_WEI,
-        }])
+        .call_minter_deposit_eth(plans)
         .expect_deposit_responses();
+    let setup = setup.assert_eth_deposit_addresses_bare(&deposits);
 
+    // The CEX withdrawals: a plain ETH transfer to each address, carrying no calldata.
     let setup = setup
         .credit_eth_deposits_from_cex(&deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
+    // Two full ten-deposit sweeps, and nothing more.
     let (setup, _sweeps) = setup
-        .await_sweeps(&sweeper, 1)
+        .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
 
-    setup
+    let setup = setup
+        .assert_eth_sweeps_batched(&[10, 10])
         .assert_eth_addresses_swept_empty(&deposits)
-        .expect_cketh_mints(&deposits);
+        .assert_minter_received_swept_eth_total(&deposits, minter_eth_before)
+        .assert_eth_delegations_installed(&deposits, &delegate)
+        .assert_sweeper_spent_gas(&sweeper, funded_gas);
+
+    setup.expect_cketh_mints(&deposits);
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -446,7 +446,7 @@ fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
 
     let setup = setup
         .assert_sweeps_batched_per_token(&erc20_deposits)
-        .assert_eth_sweeps_batched(&[2])
+        .assert_eth_sweeps_batched(&eth_deposits)
         .assert_addresses_swept_empty(&erc20_deposits)
         .assert_eth_addresses_swept_empty(&eth_deposits)
         .assert_minter_holds_swept_totals(&erc20_deposits)
@@ -632,7 +632,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     assert_eth_sweep_gas_near_demo(&sweeps, 10);
 
     let setup = setup
-        .assert_eth_sweeps_batched(&[10, 10])
+        .assert_eth_sweeps_batched(&deposits)
         .assert_eth_addresses_swept_empty(&deposits)
         .assert_minter_received_swept_eth_total(&deposits, minter_eth_before)
         .assert_eth_delegations_installed(&deposits, &delegate)

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -13,8 +13,8 @@ use ic_cketh_minter::balance_scan::batcher::{
     encode_eth_balance_batch,
 };
 use ic_cketh_minter::deposit_address::DepositAddress;
-use ic_cketh_minter::endpoints::DepositStatus;
 use ic_cketh_minter::endpoints::events::EventPayload;
+use ic_cketh_minter::endpoints::{DepositEthStatus, DepositStatus};
 use ic_cketh_minter::numeric::Erc20Value;
 use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
@@ -22,6 +22,8 @@ use ic_cketh_test_utils::anvil::{
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
+
+const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 use ic_ethereum_types::Address;
 
 #[test]
@@ -294,7 +296,7 @@ fn should_revert_the_whole_call_when_a_token_is_not_a_contract() {
 /// tokens and must apply the per-token minimum to each. Only the two at-or-above-minimum deposits
 /// are flagged as candidates; the below-minimum deposit is scanned but not flagged.
 #[test]
-fn should_flag_only_deposits_at_or_above_the_per_token_minimum() {
+fn should_flag_only_erc20_deposits_at_or_above_the_per_token_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new();
@@ -344,6 +346,52 @@ fn should_flag_only_deposits_at_or_above_the_per_token_minimum() {
     assert_matches!(
         setup.await_scan(setup.depositor(3), DEPOSIT_SUBACCOUNT, &usdt).status,
         DepositStatus::Scanning { scan_count, last_scanned_block, .. }
+            if scan_count >= 1 && last_scanned_block.is_some()
+    );
+}
+
+#[test]
+fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
+
+    let setup = LiveSetup::<CkErc20Setup>::new();
+    let above_minimum = 2 * MINIMUM_ETH_DEPOSIT_WEI;
+    let at_minimum = MINIMUM_ETH_DEPOSIT_WEI;
+    let below_minimum = MINIMUM_ETH_DEPOSIT_WEI / 10;
+    let plans = [
+        (setup.depositor(1), above_minimum),
+        (setup.depositor(2), at_minimum),
+        (setup.depositor(3), below_minimum),
+    ]
+    .map(|(owner, amount)| EthDepositPlan {
+        owner,
+        subaccount: DEPOSIT_SUBACCOUNT,
+        amount,
+    });
+
+    let (setup, deposits) = setup
+        .call_minter_deposit_eth(plans)
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_eth_deposits_from_cex(&deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(1), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == above_minimum
+                && detected.detected_at_block > 0_u8
+    );
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(2), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == at_minimum
+                && detected.detected_at_block > 0_u8
+    );
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(3), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::Scanning { scan_count, last_scanned_block, .. }
             if scan_count >= 1 && last_scanned_block.is_some()
     );
 }
@@ -437,7 +485,6 @@ fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
 #[test]
 fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     const DEPOSITORS: u64 = 20;
-    const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 
     let setup = LiveSetup::<CkErc20Setup>::new()
         .fund_fee_account()

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -989,6 +989,9 @@ fn should_rotate_a_delegated_address_onto_a_newly_configured_delegate() {
 /// finalized a failure, so it can no longer say which of the tuples it signed the chain installed.
 /// Before either address is swept again the minter must read the deposit address' nonce back off
 /// the chain, record it, and rotate from there.
+///
+/// The reverted sweep moved nothing, so the balance is still sitting at the deposit address:
+/// re-registering the pair is all it takes for the minter to see it again.
 #[test]
 fn should_repair_a_reverted_sweep_by_reading_the_deposit_address_nonce_back() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
@@ -1040,13 +1043,10 @@ fn should_repair_a_reverted_sweep_by_reading_the_deposit_address_nonce_back() {
 
     setup.rotate_delegate_to(&current_delegate);
 
-    // The reverted sweep moved nothing, so the balance is still at the address: re-arming the pair
-    // is all it takes for the minter to see it again.
     let (setup, re_registrations) = setup
         .call_minter_deposit_erc20([plan])
         .expect_deposit_responses();
     assert_eq!(re_registrations[0].address, address);
-    // Only the second sweep is asserted on here: the first is the one that reverted.
     let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).into_sweeps();
     let repair = &sweeps[1];
     assert_eq!(repair.transaction_type, DELEGATING_SWEEP_TRANSACTION_TYPE);

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -519,9 +519,10 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
-    let (setup, _sweeps) = setup
+    let (setup, sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
+    assert_eth_sweep_gas_near_demo(&sweeps, 10);
 
     let setup = setup
         .assert_eth_sweeps_batched(&[10, 10])
@@ -734,6 +735,28 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         .filter(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }))
         .count();
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
+}
+
+fn assert_eth_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
+    const ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS: u64 = 413_076;
+    const GAS_BAND_PERCENT: u64 = 10;
+
+    assert_eq!(
+        deposits_per_sweep, 10,
+        "the demo baseline is measured for ten-deposit sweeps"
+    );
+    for sweep in sweeps {
+        assert!(
+            sweep
+                .gas_used
+                .abs_diff(ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS)
+                * 100
+                <= ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS * GAS_BAND_PERCENT,
+            "a ten-deposit ETH sweep used {} gas, more than {GAS_BAND_PERCENT}% away from the \
+             demo-measured {ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS}: {sweep:?}",
+            sweep.gas_used,
+        );
+    }
 }
 
 fn assert_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -501,9 +501,6 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
 
-    // Every depositor gets a distinct principal and a distinct subaccount, so no two share a
-    // deposit address, and a distinct amount, so a positional mixup in the batch cannot cancel
-    // out in the totals.
     let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
         .map(|index| EthDepositPlan {
             owner: setup.depositor(index),
@@ -517,13 +514,11 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
         .expect_deposit_responses();
     let setup = setup.assert_eth_deposit_addresses_bare(&deposits);
 
-    // The CEX withdrawals: a plain ETH transfer to each address, carrying no calldata.
     let setup = setup
         .credit_eth_deposits_from_cex(&deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
-    // Two full ten-deposit sweeps, and nothing more.
     let (setup, _sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
@@ -553,8 +548,6 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let sweeper = setup.await_sweeper_address();
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
-    // The fee-account funding above minted ckETH too, so the deposit mints are counted
-    // against this baseline.
     let mints_before = count_cketh_mints(&setup);
     let owner = setup.depositor(1);
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -17,7 +17,7 @@ use ic_cketh_minter::endpoints::events::EventPayload;
 use ic_cketh_minter::endpoints::{DepositEthStatus, DepositStatus};
 use ic_cketh_minter::numeric::Erc20Value;
 use ic_cketh_test_utils::anvil::{
-    Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
+    Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, delegation_designator, deploy_mock_erc20,
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{
@@ -980,6 +980,108 @@ fn should_rotate_a_delegated_address_onto_a_newly_configured_delegate() {
         setup.anvil().transaction_count(&address),
         2,
         "sweeping without a tuple leaves the address at the nonce the rotation spent"
+    );
+}
+
+/// The repair path, end to end: a sweep whose configured delegate has no `sweepErc20Batch` reverts
+/// *after* its
+/// EIP-7702 tuples have applied, which is exactly the drift the record cannot see — the minter
+/// finalized a failure, so it can no longer say which of the tuples it signed the chain installed.
+/// Before either address is swept again the minter must read the deposit address' nonce back off
+/// the chain, record it, and rotate from there.
+#[test]
+fn should_repair_a_reverted_sweep_by_reading_the_deposit_address_nonce_back() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
+
+    let (setup, current_delegate) =
+        LiveSetup::<CkErc20Setup>::on_delegate_without_sweep_entry_points();
+    let broken_delegate = setup.sweep_contracts().delegate;
+    let setup = setup
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let [usdc, _usdt]: [Erc20Token; 2] = setup
+        .supported_erc20_tokens_owned()
+        .try_into()
+        .expect("expected exactly 2 supported tokens");
+    let usdc_minimum = setup.minimum_deposit_amount(&usdc);
+    let owner = setup.depositor(1);
+    let plan = DepositPlan {
+        owner,
+        subaccount: DEPOSIT_SUBACCOUNT,
+        token: usdc.clone(),
+        amount: 4 * usdc_minimum,
+    };
+
+    let (setup, deposits) = setup
+        .call_minter_deposit_erc20([plan.clone()])
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_deposits_from_cex(&deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+    let (setup, _reverted) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_reverted_sweeps_of_types(&[DELEGATING_SWEEP_TRANSACTION_TYPE]);
+    let address = deposits[0].address;
+    assert_eq!(
+        setup.anvil().code(&address),
+        delegation_designator(&broken_delegate),
+        "an EIP-7702 tuple applies before the call it travels with runs, and stays applied when \
+         that call reverts"
+    );
+    assert_eq!(setup.anvil().transaction_count(&address), 1);
+    let setup = setup.expect_sweeps_settled(1);
+
+    setup.rotate_delegate_to(&current_delegate);
+
+    // The reverted sweep moved nothing, so the balance is still at the address: re-arming the pair
+    // is all it takes for the minter to see it again.
+    let (setup, re_registrations) = setup
+        .call_minter_deposit_erc20([plan])
+        .expect_deposit_responses();
+    assert_eq!(re_registrations[0].address, address);
+    // Only the second sweep is asserted on here: the first is the one that reverted.
+    let (setup, sweeps) = setup.await_sweeps(&sweeper, 2).into_sweeps();
+    let repair = &sweeps[1];
+    assert_eq!(repair.transaction_type, DELEGATING_SWEEP_TRANSACTION_TYPE);
+    assert!(
+        repair.succeeded,
+        "the sweep after the repair must go through: {repair:?}"
+    );
+    assert_eq!(
+        setup.anvil().authorization_nonces(&repair.hash),
+        vec![1],
+        "the sweep after the repair must rotate from the nonce the chain reported"
+    );
+    let observed: Vec<String> = setup
+        .minter_events()
+        .into_iter()
+        .filter_map(|event| match event.payload {
+            EventPayload::ObservedDepositAddressNonce { nonce, .. } => Some(nonce.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        observed,
+        vec!["1".to_string()],
+        "the minter must read the reverted sweep's deposit address' nonce back exactly once"
+    );
+
+    let setup = setup
+        .assert_delegations_installed(&deposits, &current_delegate)
+        .assert_addresses_swept_empty(&deposits)
+        .assert_minter_holds_swept_totals(&deposits)
+        .expect_mints(&deposits);
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        2,
+        "applying the rotation tuple spends the nonce the reverted sweep left the address at"
     );
 }
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -146,6 +146,97 @@ const ATTESTED_SCENARIOS: [BatchScenario; 3] = [
     },
 ];
 
+const ETH_ATTESTED_SCENARIOS: [BatchScenario; 3] = [
+    BatchScenario {
+        deposits: 1,
+        eip7702_total_gas_used: 63_283,
+        eip7702_average_gas_used: 63_283,
+        eip1559_total_gas_used: 53_283,
+        eip1559_average_gas_used: 53_283,
+    },
+    BatchScenario {
+        deposits: 10,
+        eip7702_total_gas_used: 413_076,
+        eip7702_average_gas_used: 41_307,
+        eip1559_total_gas_used: 291_345,
+        eip1559_average_gas_used: 29_134,
+    },
+    BatchScenario {
+        deposits: 20,
+        eip7702_total_gas_used: 804_603,
+        eip7702_average_gas_used: 40_230,
+        eip1559_total_gas_used: 555_753,
+        eip1559_average_gas_used: 27_787,
+    },
+];
+
+#[test]
+fn batched_eth_sweep_amortizes_gas_across_the_batch() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter = eth_address(&key_from_hex(MINTER_PRIVATE_KEY).public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+    let relayer_key = key_from_hex(RELAYER_PRIVATE_KEY);
+
+    let contracts = deploy_contracts(&anvil, &minter, &cex);
+
+    let mut previous_average = u64::MAX;
+    for scenario in ETH_ATTESTED_SCENARIOS {
+        let gas = sweep_eth_batch_attested(
+            &anvil,
+            chain_id,
+            &relayer_key,
+            &minter,
+            &cex,
+            &contracts,
+            scenario.deposits,
+        );
+        let deposits = scenario.deposits as u64;
+        let eip7702_average = gas.eip7702 / deposits;
+        let eip1559_average = gas.eip1559 / deposits;
+        println!(
+            "attested ETH batch of {}: EIP-7702 {} ({eip7702_average}/deposit), EIP-1559 {} ({eip1559_average}/deposit)",
+            scenario.deposits, gas.eip7702, gas.eip1559
+        );
+        assert_gas(
+            gas.eip7702,
+            scenario.eip7702_total_gas_used,
+            &format!("attested ETH batch of {} EIP-7702 total", scenario.deposits),
+        );
+        assert_gas(
+            eip7702_average,
+            scenario.eip7702_average_gas_used,
+            &format!(
+                "attested ETH batch of {} EIP-7702 average",
+                scenario.deposits
+            ),
+        );
+        assert_gas(
+            gas.eip1559,
+            scenario.eip1559_total_gas_used,
+            &format!("attested ETH batch of {} EIP-1559 total", scenario.deposits),
+        );
+        assert_gas(
+            eip1559_average,
+            scenario.eip1559_average_gas_used,
+            &format!(
+                "attested ETH batch of {} EIP-1559 average",
+                scenario.deposits
+            ),
+        );
+        assert!(
+            gas.eip1559 < gas.eip7702,
+            "an already-delegated (EIP-1559) sweep must cost less than one installing the delegation (EIP-7702)"
+        );
+        assert!(
+            eip7702_average < previous_average,
+            "per-deposit gas should shrink as the batch grows"
+        );
+        previous_average = eip7702_average;
+    }
+}
+
 #[test]
 fn batched_sweep_amortizes_gas_across_the_batch() {
     let anvil = Anvil::start();
@@ -986,6 +1077,122 @@ fn assert_batch_swept(
     assert_eq!(
         anvil.usdt_balance(usdt, minter),
         minter_before + DEPOSIT_AMOUNT * deposits.len() as u128,
+        "minter did not receive every deposit"
+    );
+    gas_used(receipt)
+}
+
+fn sweep_eth_batch_attested(
+    anvil: &Anvil,
+    chain_id: u64,
+    sender_key: &PrivateKey,
+    minter: &Address,
+    cex: &Address,
+    contracts: &Contracts,
+    n: usize,
+) -> BatchGas {
+    let Contracts {
+        helper, attested, ..
+    } = contracts;
+
+    let principals: Vec<Principal> = (0..n)
+        .map(|i| Principal::self_authenticating([0xE1, n as u8, i as u8]))
+        .collect();
+    let keys: Vec<PrivateKey> = principals.iter().map(derive_deposit_key).collect();
+    let deposits: Vec<Address> = keys.iter().map(|k| eth_address(&k.public_key())).collect();
+
+    let items: Vec<SweepItem> = keys
+        .iter()
+        .zip(&deposits)
+        .zip(&principals)
+        .map(|((key, deposit), principal)| {
+            let a = attest(key, chain_id, helper, principal, &[0_u8; 32]);
+            SweepItem {
+                deposit: alloy_address(deposit),
+                principal: B256::from(encode_principal(principal)),
+                subaccount: B256::ZERO,
+                r: B256::from(a.r),
+                s: B256::from(a.s),
+                v: a.v,
+            }
+        })
+        .collect();
+    let sweep_call = ICkSweeperAttested::sweepEthBatchCall { items }.abi_encode();
+
+    fund_eth(anvil, cex, &deposits);
+    let minter_before = anvil.balance(minter);
+    let authorizations: Vec<SignedAuthorization> = keys
+        .iter()
+        .map(|key| sign_authorization(key, chain_id, attested, 0))
+        .collect();
+    let receipt = anvil.send_eip7702(
+        sender_key,
+        chain_id,
+        attested,
+        sweep_call.clone(),
+        authorizations,
+    );
+    let eip7702 = assert_eth_batch_swept(
+        anvil,
+        &receipt,
+        contracts,
+        minter,
+        &deposits,
+        &principals,
+        minter_before,
+    );
+
+    fund_eth(anvil, cex, &deposits);
+    let minter_before = anvil.balance(minter);
+    let receipt = anvil.send_eip1559(sender_key, chain_id, attested, sweep_call);
+    let eip1559 = assert_eth_batch_swept(
+        anvil,
+        &receipt,
+        contracts,
+        minter,
+        &deposits,
+        &principals,
+        minter_before,
+    );
+
+    BatchGas { eip7702, eip1559 }
+}
+
+fn fund_eth(anvil: &Anvil, cex: &Address, deposits: &[Address]) {
+    for deposit in deposits {
+        let receipt = anvil.send_eth(cex, deposit, ETH_DEPOSIT_AMOUNT, None);
+        assert!(status_ok(&receipt), "CEX ETH transfer failed");
+    }
+}
+
+fn assert_eth_batch_swept(
+    anvil: &Anvil,
+    receipt: &Value,
+    contracts: &Contracts,
+    minter: &Address,
+    deposits: &[Address],
+    principals: &[Principal],
+    minter_before: u128,
+) -> u64 {
+    let Contracts { helper, .. } = contracts;
+    assert!(status_ok(receipt), "batch ETH sweep reverted");
+    let events = received_events(receipt, helper);
+    assert_eq!(
+        events.len(),
+        deposits.len(),
+        "one ReceivedEthOrErc20 event per deposit"
+    );
+    for (event, (deposit, principal)) in events.iter().zip(deposits.iter().zip(principals)) {
+        assert_eq!(event.owner, *deposit);
+        assert_eq!(event.principal, encode_principal(principal));
+        assert_eq!(event.amount, ETH_DEPOSIT_AMOUNT);
+    }
+    for deposit in deposits {
+        assert_eq!(anvil.balance(deposit), 0, "deposit not swept");
+    }
+    assert_eq!(
+        anvil.balance(minter),
+        minter_before + ETH_DEPOSIT_AMOUNT * deposits.len() as u128,
         "minter did not receive every deposit"
     );
     gas_used(receipt)

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo/CkSweeperAttestedLegacy.sol
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo/CkSweeperAttestedLegacy.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+interface ICkDeposit {
+    function depositErc20(address erc20Address, uint256 amount, bytes32 principal, bytes32 subaccount) external;
+}
+
+interface IErc20Balance {
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/// One deposit address to sweep, with its attested IC account and the (r, s, v)
+/// attestation signature. Grouping the parallel arrays into a struct array keeps
+/// the batch loop within the EVM stack limit.
+struct SweepItem {
+    address deposit;
+    bytes32 principal;
+    bytes32 subaccount;
+    bytes32 r;
+    bytes32 s;
+    uint8 v;
+}
+
+/// EIP-7702 delegate variant with *permissionless* sweeping (the proposed
+/// one-time self-attestation design, see docs/deposit_from_cex.md). Anyone may
+/// submit a sweep, but each sweep must carry an attestation: a secp256k1
+/// signature by the deposit address' own key (produced by the minter via
+/// threshold ECDSA) over a domain-separated digest binding the address to its IC
+/// account. Running as a delegate, `address(this)` is the deposit EOA, so the
+/// digest recovers to it only for the signature by that address' key — a caller
+/// supplying their own principal fails the check. The attestation is passed as
+/// its (r, s, v) components.
+contract CkSweeperAttestedLegacy {
+    address private immutable HELPER;
+
+    constructor(address helper) {
+        HELPER = helper;
+    }
+
+    /// The attestation digest: keccak256 over a fixed-length, domain-separated
+    /// preimage. The ASCII prefix (first byte 0x63) cannot collide with typed
+    /// transactions (0x00-0x04), EIP-7702 authorizations (0x05), EIP-191/712
+    /// (0x19) or legacy-transaction RLP (>= 0xc0).
+    function _attestationDigest(bytes32 principal, bytes32 subaccount) private view returns (bytes32) {
+        return keccak256(abi.encodePacked("ck-deposit-owner", block.chainid, HELPER, principal, subaccount));
+    }
+
+    function sweepErc20(
+        address[] calldata tokens,
+        bytes32 principal,
+        bytes32 subaccount,
+        bytes32 r,
+        bytes32 s,
+        uint8 v
+    ) external {
+        require(
+            ecrecover(_attestationDigest(principal, subaccount), v, r, s) == address(this),
+            "invalid attestation"
+        );
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            uint256 balance = IErc20Balance(tokens[i]).balanceOf(address(this));
+            if (balance > 0) {
+                _safeApprove(tokens[i], HELPER, balance);
+                ICkDeposit(HELPER).depositErc20(tokens[i], balance, principal, subaccount);
+            }
+        }
+    }
+
+    /// Permissionless batch entry point: sweeps many delegated deposit EOAs in a
+    /// single transaction, each with its own attestation.
+    function sweepErc20Batch(SweepItem[] calldata items, address[] calldata tokens) external {
+        for (uint256 i = 0; i < items.length; ++i) {
+            SweepItem calldata item = items[i];
+            CkSweeperAttestedLegacy(item.deposit).sweepErc20(
+                tokens, item.principal, item.subaccount, item.r, item.s, item.v
+            );
+        }
+    }
+
+    /// Tolerates non-standard ERC-20s such as USDT whose approve returns no value.
+    function _safeApprove(address token, address spender, uint256 value) private {
+        (bool ok, bytes memory data) =
+            token.call(abi.encodeWithSignature("approve(address,uint256)", spender, value));
+        require(ok && (data.length == 0 || abi.decode(data, (bool))), "approve failed");
+    }
+}

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -20,6 +20,7 @@ use ic_cketh_minter::eth_logs::{
 };
 use ic_cketh_minter::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
 use ic_cketh_minter::lifecycle::EthereumNetwork;
+use ic_cketh_minter::numeric::TransactionNonce;
 use ic_cketh_minter::state::audit::EventType as ET;
 use ic_cketh_minter::state::event::Event;
 use ic_cketh_minter::state::transactions::{
@@ -495,6 +496,19 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
                     },
                 }
             }
+            EventPayload::ObservedDepositAddressNonce {
+                owner,
+                subaccount,
+                nonce,
+            } => ET::ObservedDepositAddressNonce {
+                account: Account {
+                    owner,
+                    subaccount: subaccount.map(|subaccount| {
+                        <[u8; 32]>::try_from(subaccount.into_vec().as_slice()).unwrap()
+                    }),
+                },
+                nonce: TransactionNonce::try_from(nonce).unwrap(),
+            },
             EventPayload::AcceptedSweepRequest {
                 sweep_id,
                 destination,

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -505,12 +505,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
             } => ET::AcceptedSweepRequest(SweepRequest {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
-                token: match ic_cketh_minter::asset::Asset::try_from(asset).unwrap() {
-                    ic_cketh_minter::asset::Asset::Erc20(address) => address,
-                    ic_cketh_minter::asset::Asset::Eth => {
-                        panic!("BUG: no recorded sweep moves ETH yet")
-                    }
-                },
+                asset: asset.try_into().unwrap(),
                 items: map_authorized_sweep_items(items),
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -620,6 +620,19 @@ pub struct SweepContracts {
     pub delegate: Address,
 }
 
+/// Compiles and deploys the superseded delegate (`CkSweeperAttestedLegacy.sol`, the version before
+/// `receive()`, `sweepEth` and `sweepEthBatch` were added) against the same helper, so a test can
+/// start the minter on it and rotate the addresses it delegated onto the current one.
+pub fn deploy_legacy_delegate(anvil: &Anvil, helper: &Address) -> Address {
+    anvil.deploy(
+        &address_from_hex(DEV_ACCOUNT),
+        &deploy_code(
+            &compile("CKSWEEPER_ATTESTED_LEGACY_SOL", "CkSweeperAttestedLegacy"),
+            &alloy_address(helper).abi_encode(),
+        ),
+    )
+}
+
 /// Compiles and deploys the real deposit helper and the attested sweeper delegate, wiring the
 /// delegate to that helper exactly as production does.
 pub fn deploy_sweep_contracts(anvil: &Anvil, minter: &Address) -> SweepContracts {

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -385,15 +385,19 @@ impl Anvil {
             .unwrap_or_else(|e| panic!("not a u64 transaction count {count}: {e}"))
     }
 
+    /// The nonces of the EIP-7702 tuples `tx_hash` carries, in the order it lists them. Empty for a
+    /// transaction carrying no authorization list at all, which is what a sweep of addresses that
+    /// are all delegated already is.
     pub fn authorization_nonces(&self, tx_hash: &str) -> Vec<u64> {
         let transaction = self.rpc("eth_getTransactionByHash", serde_json::json!([tx_hash]));
         assert!(
             !transaction.is_null(),
             "no transaction {tx_hash} on the chain"
         );
-        transaction["authorizationList"]
-            .as_array()
-            .unwrap_or_else(|| panic!("transaction {tx_hash} carries no authorization list"))
+        let Some(tuples) = transaction["authorizationList"].as_array() else {
+            return Vec::new();
+        };
+        tuples
             .iter()
             .map(|tuple| {
                 let nonce = tuple["nonce"].as_str().unwrap_or_else(|| {

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -464,6 +464,13 @@ impl CkEthSetup {
         .unwrap()
     }
 
+    pub fn minter_count_events(&self, filter: impl Fn(&Event) -> bool) -> usize {
+        self.get_all_events()
+            .into_iter()
+            .filter(|event| filter(event))
+            .count()
+    }
+
     pub fn get_all_events(&self) -> Vec<Event> {
         const FIRST_BATCH_SIZE: u64 = 100;
         let GetEventsResult {

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -54,8 +54,8 @@ use ic_cketh_minter::endpoints::events::{
     Asset as EventAsset, Event, EventPayload, TransactionStatus,
 };
 use ic_cketh_minter::endpoints::{
-    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode,
-    DepositStatus, MinterInfo,
+    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositEthArg,
+    DepositEthError, DepositEthResponse, DepositEthStatus, DepositMode, DepositStatus, MinterInfo,
 };
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
@@ -148,6 +148,20 @@ pub struct CexDeposit {
     pub owner: Principal,
     pub subaccount: [u8; 32],
     pub token: Erc20Token,
+    pub amount: u128,
+    pub address: Address,
+}
+
+pub struct EthDepositPlan {
+    pub owner: Principal,
+    pub subaccount: [u8; 32],
+    pub amount: u128,
+}
+
+#[derive(Clone)]
+pub struct EthCexDeposit {
+    pub owner: Principal,
+    pub subaccount: [u8; 32],
     pub amount: u128,
     pub address: Address,
 }
@@ -263,6 +277,28 @@ impl LiveSetup<CkErc20Setup> {
             token.contract.address
         );
         nat_to_u128(minimum.minimum_deposit_amount)
+    }
+
+    /// Calls `deposit_eth` as `caller`, which registers (idempotently) that user's
+    /// `(address, ETH)` pair for balance scanning and reports its scan progress.
+    fn deposit_eth(&self, caller: Principal, subaccount: [u8; 32]) -> DepositEthResponse {
+        let arg = DepositEthArg {
+            mode: DepositMode::Unsponsored {
+                subaccount: Some(subaccount),
+            },
+        };
+        let reply = self
+            .env()
+            .update_call(
+                self.minter_id(),
+                caller,
+                "deposit_eth",
+                Encode!(&arg).unwrap(),
+            )
+            .expect("BUG: deposit_eth was rejected");
+        Decode!(&reply, Result<DepositEthResponse, DepositEthError>)
+            .unwrap()
+            .expect("BUG: deposit_eth returned an error")
     }
 
     /// Calls `deposit_erc20` as `caller`, which registers (idempotently) that user's
@@ -397,6 +433,28 @@ impl LiveSetup<CkErc20Setup> {
         )
     }
 
+    pub fn await_eth_detection(
+        &self,
+        caller: Principal,
+        subaccount: [u8; 32],
+    ) -> DepositEthResponse {
+        let mut reached = None;
+        self.drive_until_with(
+            SCAN_TICK,
+            SCAN_TICKS,
+            |_| "the ETH deposit was not detected".to_string(),
+            |setup| {
+                let progress = setup.deposit_eth(caller, subaccount);
+                let done = matches!(progress.status, DepositEthStatus::AwaitingSweep(_));
+                if done {
+                    reached = Some(progress);
+                }
+                done
+            },
+        );
+        reached.expect("drive_until_with returns only once observe held")
+    }
+
     fn await_deposit_status(
         &self,
         caller: Principal,
@@ -467,6 +525,61 @@ impl LiveSetup<CkErc20Setup> {
             },
             |setup| setup.balance_of_ledger(ledger_id, account) == credited,
         );
+    }
+
+    pub fn call_minter_deposit_eth(
+        self,
+        plans: impl IntoIterator<Item = EthDepositPlan>,
+    ) -> DepositEthCalls {
+        let responses = plans
+            .into_iter()
+            .map(|plan| {
+                let response = self.deposit_eth(plan.owner, plan.subaccount);
+                (plan, response)
+            })
+            .collect();
+        DepositEthCalls {
+            setup: self,
+            responses,
+        }
+    }
+
+    /// Funds each ETH deposit with a plain transfer from the CEX-style dev account, the shape an
+    /// exchange withdrawal has: no calldata, no principal, just value.
+    pub fn credit_eth_deposits_from_cex(self, deposits: &[EthCexDeposit]) -> EthCexCredit<'_> {
+        let cex = address_from_hex(DEV_ACCOUNT);
+        for deposit in deposits {
+            self.anvil.send_eth(&cex, &deposit.address, deposit.amount);
+        }
+        EthCexCredit {
+            setup: self,
+            deposits,
+        }
+    }
+
+    pub fn expect_cketh_mints(self, deposits: &[EthCexDeposit]) -> Self {
+        let ledger_id = self.fixture.cketh_ledger_id();
+        let mut credits: BTreeMap<(Principal, Option<[u8; 32]>), u128> = BTreeMap::new();
+        for deposit in deposits {
+            *credits
+                .entry((deposit.owner, Some(deposit.subaccount)))
+                .or_default() += deposit.amount;
+        }
+        for ((owner, subaccount), amount) in credits {
+            self.await_credited(ledger_id, Account { owner, subaccount }, amount);
+        }
+        self
+    }
+
+    pub fn assert_eth_addresses_swept_empty(self, deposits: &[EthCexDeposit]) -> Self {
+        for deposit in deposits {
+            assert_eq!(
+                self.anvil.balance(&deposit.address),
+                0,
+                "the swept deposit address must hold no ETH"
+            );
+        }
+        self
     }
 
     pub fn call_minter_deposit_erc20(
@@ -1167,6 +1280,86 @@ impl DepositErc20Calls {
             "every account must get its own deposit address"
         );
         (self.setup, deposits)
+    }
+}
+
+#[must_use]
+pub struct DepositEthCalls {
+    setup: LiveSetup<CkErc20Setup>,
+    responses: Vec<(EthDepositPlan, DepositEthResponse)>,
+}
+
+impl DepositEthCalls {
+    pub fn expect_deposit_responses(self) -> (LiveSetup<CkErc20Setup>, Vec<EthCexDeposit>) {
+        let deposits: Vec<EthCexDeposit> = self
+            .responses
+            .into_iter()
+            .map(|(plan, response)| {
+                let minimum = nat_to_u128(response.minimum_deposit_amount);
+                assert!(
+                    plan.amount >= minimum,
+                    "the planned deposit of {} wei is below the reported minimum of {minimum} wei",
+                    plan.amount
+                );
+                EthCexDeposit {
+                    address: Address::from_str(&response.address)
+                        .expect("BUG: minter returned an invalid deposit address"),
+                    owner: plan.owner,
+                    subaccount: plan.subaccount,
+                    amount: plan.amount,
+                }
+            })
+            .collect();
+        (self.setup, deposits)
+    }
+}
+
+#[must_use]
+pub struct EthCexCredit<'a> {
+    setup: LiveSetup<CkErc20Setup>,
+    deposits: &'a [EthCexDeposit],
+}
+
+impl<'a> EthCexCredit<'a> {
+    pub fn expect_deposit_balances_on_anvil(self) -> EthDetectionWatch<'a> {
+        for deposit in self.deposits {
+            assert_eq!(
+                self.setup.anvil.balance(&deposit.address),
+                deposit.amount,
+                "the deposited ETH should be readable on anvil"
+            );
+        }
+        EthDetectionWatch {
+            setup: self.setup,
+            deposits: self.deposits,
+        }
+    }
+}
+
+#[must_use]
+pub struct EthDetectionWatch<'a> {
+    pub setup: LiveSetup<CkErc20Setup>,
+    deposits: &'a [EthCexDeposit],
+}
+
+impl EthDetectionWatch<'_> {
+    pub fn expect_each_awaiting_sweep(self) -> LiveSetup<CkErc20Setup> {
+        for deposit in self.deposits {
+            let detected = match self
+                .setup
+                .await_eth_detection(deposit.owner, deposit.subaccount)
+                .status
+            {
+                DepositEthStatus::AwaitingSweep(detected) => detected,
+                status => panic!("BUG: await_eth_detection returned {status:?}"),
+            };
+            assert_eq!(
+                detected.scanned_balance,
+                Nat::from(deposit.amount),
+                "the detected balance must match the deposited amount"
+            );
+        }
+        self.setup
     }
 }
 

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -136,6 +136,14 @@ const CREDIT_TICKS: u32 = 6;
 
 const FUNDING_TICKS: u32 = 6;
 
+/// The EIP-2718 type of a sweep that still installs a delegation, and so carries an EIP-7702
+/// authorization list.
+pub const DELEGATING_SWEEP_TRANSACTION_TYPE: u64 = 4;
+
+/// The EIP-2718 type of a sweep of addresses all delegated already, which carries no authorization
+/// and so is a plain EIP-1559 transaction.
+pub const PLAIN_SWEEP_TRANSACTION_TYPE: u64 = 2;
+
 pub struct DepositPlan {
     pub owner: Principal,
     pub subaccount: [u8; 32],
@@ -1539,12 +1547,30 @@ pub struct SweepsSent {
 }
 
 impl SweepsSent {
+    /// Asserts every sweep succeeded riding a type-4 transaction, as a sweep still installing a
+    /// delegation must.
     pub fn expect_all_delegating_sweeps(self) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
-        for sweep in &self.sweeps {
+        let delegating = vec![DELEGATING_SWEEP_TRANSACTION_TYPE; self.sweeps.len()];
+        self.expect_sweeps_of_types(&delegating)
+    }
+
+    /// Asserts every sweep succeeded riding the transaction type its position in `expected` names:
+    /// type 4 while it still delegates an address it sweeps, type 2 once they are all delegated.
+    pub fn expect_sweeps_of_types(
+        self,
+        expected: &[u64],
+    ) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
+        assert_eq!(
+            self.sweeps.len(),
+            expected.len(),
+            "expected {} sweeps, got {:?}",
+            expected.len(),
+            self.sweeps
+        );
+        for (sweep, expected_type) in self.sweeps.iter().zip(expected) {
             assert_eq!(
-                sweep.transaction_type, 4,
-                "a sweep here always carries its EIP-7702 authorizations, installed or re-sent, \
-                 so it must be a type-4 transaction: {sweep:?}"
+                sweep.transaction_type, *expected_type,
+                "the sweep did not ride the expected transaction type: {sweep:?}"
             );
             assert!(sweep.succeeded, "the sweep reverted: {sweep:?}");
         }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -60,6 +60,7 @@ use ic_cketh_minter::endpoints::{
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
 use ic_cketh_minter::numeric::Erc20Value;
+use ic_cketh_minter::sweep::MAX_DEPOSITS_PER_SWEEP;
 use ic_cketh_minter::{BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -607,8 +608,8 @@ impl LiveSetup<CkErc20Setup> {
         self
     }
 
-    pub fn assert_eth_sweeps_batched(self, expected_item_counts: &[usize]) -> Self {
-        let batched: Vec<usize> = self
+    pub fn assert_eth_sweeps_batched(self, deposits: &[EthCexDeposit]) -> Self {
+        let batches: Vec<Vec<Address>> = self
             .minter_events()
             .into_iter()
             .filter_map(|event| match event.payload {
@@ -616,13 +617,37 @@ impl LiveSetup<CkErc20Setup> {
                     asset: EventAsset::Eth,
                     items,
                     ..
-                } => Some(items.len()),
+                } => Some(
+                    items
+                        .iter()
+                        .map(|item| {
+                            Address::from_str(&item.deposit)
+                                .expect("BUG: the sweep names an invalid deposit address")
+                        })
+                        .collect(),
+                ),
                 _ => None,
             })
             .collect();
+
+        let mut expected_sizes = Vec::new();
+        let mut remaining = deposits.len();
+        while remaining > 0 {
+            let batch = remaining.min(MAX_DEPOSITS_PER_SWEEP);
+            expected_sizes.push(batch);
+            remaining -= batch;
+        }
         assert_eq!(
-            batched, expected_item_counts,
-            "the ETH deposits must be swept in full batches, oldest first"
+            batches.iter().map(Vec::len).collect::<Vec<_>>(),
+            expected_sizes,
+            "the ETH deposits must be swept in full batches"
+        );
+
+        let swept: BTreeSet<Address> = batches.into_iter().flatten().collect();
+        let expected: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
+        assert_eq!(
+            swept, expected,
+            "every ETH deposit address must appear in exactly one sweep"
         );
         self
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -946,6 +946,10 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
         self.cketh().get_all_events()
     }
 
+    pub fn minter_count_events(&self, filter: impl Fn(&Event) -> bool) -> usize {
+        self.cketh().minter_count_events(filter)
+    }
+
     pub fn get_minter_info(&self) -> MinterInfo {
         self.cketh().get_minter_info()
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -71,8 +71,8 @@ use std::time::{Duration, Instant};
 
 use crate::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, SweepContracts, address_from_hex, delegation_designator,
-    deploy_deposit_helper, deploy_mock_erc20, deploy_sweep_contracts, deposit_eth,
-    erc20_balance_slot, u256_be,
+    deploy_deposit_helper, deploy_legacy_delegate, deploy_mock_erc20, deploy_sweep_contracts,
+    deposit_eth, erc20_balance_slot, u256_be,
 };
 use crate::ckerc20::{CkErc20Setup, Erc20Token};
 use crate::{CkEthSetup, EthereumBackend, MINTER_ADDRESS, minter_wasm, switch_to_live};
@@ -215,6 +215,13 @@ impl LiveSetup<CkErc20Setup> {
         // installed. It is only ever read back out of the helper event, never by the helper
         // itself, so the deployment can name the address the test asserts against.
         let contracts = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
+        Self::with_sweep_contracts(anvil, contracts)
+    }
+
+    /// Builds the full [`CkErc20Setup`] fixture against `anvil` — minter, EVM RPC canister,
+    /// orchestrator, and the ckUSDC/ckUSDT ledger and index canisters it spawns — with the minter
+    /// installed knowing `contracts`. Then switches the instance to live outcalls.
+    fn with_sweep_contracts(anvil: Arc<Anvil>, contracts: SweepContracts) -> Self {
         let cketh = CkEthSetup::new(EthereumBackend::Anvil {
             anvil: Arc::clone(&anvil),
             sweep_contracts: Some(contracts),
@@ -232,6 +239,30 @@ impl LiveSetup<CkErc20Setup> {
         setup.sweep_contracts = Some(contracts);
         setup.deposit_helper = Some(contracts.helper);
         setup
+    }
+
+    /// As [`Self::new`], but with the minter installed on the superseded delegate
+    /// (`CkSweeperAttestedLegacy.sol`), so a test can sweep addresses onto it and then rotate them.
+    /// Returns the harness along with the current delegate to rotate to; the legacy one the minter
+    /// runs against is [`Self::sweep_contracts`]' `delegate`.
+    pub fn on_legacy_delegate() -> (Self, Address) {
+        let anvil = Arc::new(Anvil::start_mainnet_like());
+        let current = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
+        let legacy = SweepContracts {
+            delegate: deploy_legacy_delegate(&anvil, &current.helper),
+            ..current
+        };
+        (Self::with_sweep_contracts(anvil, legacy), current.delegate)
+    }
+
+    /// Points the minter at `delegate`, as an operator replacing the sweeper contract does. The
+    /// addresses already delegated to the old one are re-delegated lazily, by the sweeps that
+    /// happen anyway.
+    pub fn rotate_delegate_to(&self, delegate: &Address) {
+        self.upgrade_minter_with(UpgradeArg {
+            ethereum_sweeper_contract_address: Some(delegate.to_string()),
+            ..Default::default()
+        });
     }
 
     /// The ckERC20 token the orchestrator spawned for `symbol`, whose ledger the mint lands on.

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -144,6 +144,7 @@ pub const DELEGATING_SWEEP_TRANSACTION_TYPE: u64 = 4;
 /// and so is a plain EIP-1559 transaction.
 pub const PLAIN_SWEEP_TRANSACTION_TYPE: u64 = 2;
 
+#[derive(Clone)]
 pub struct DepositPlan {
     pub owner: Principal,
     pub subaccount: [u8; 32],
@@ -246,13 +247,40 @@ impl LiveSetup<CkErc20Setup> {
     /// Returns the harness along with the current delegate to rotate to; the legacy one the minter
     /// runs against is [`Self::sweep_contracts`]' `delegate`.
     pub fn on_legacy_delegate() -> (Self, Address) {
+        Self::on_delegate(|anvil, current| deploy_legacy_delegate(anvil, &current.helper))
+    }
+
+    /// As [`Self::new`], but with the minter pointed at a contract that is no sweeper delegate: a
+    /// second deployment of the deposit helper, which has neither `sweepErc20Batch` nor a fallback
+    /// (a second deployment because the minter refuses to run with its helper and its sweeper
+    /// contract at one address). The batch call reverts on the unknown selector while the EIP-7702
+    /// tuples riding with it still apply — a mined sweep the minter finalizes as a failure whose
+    /// addresses are nonetheless delegated, which is the drift the repair path exists for.
+    ///
+    /// Returns the harness along with the real delegate to rotate to once the sweep has reverted.
+    pub fn on_delegate_without_sweep_entry_points() -> (Self, Address) {
+        Self::on_delegate(|anvil, _current| {
+            deploy_deposit_helper(
+                anvil,
+                &address_from_hex(DEV_ACCOUNT),
+                &address_from_hex(MINTER_ADDRESS),
+            )
+        })
+    }
+
+    /// The harness of [`Self::new`] with the minter installed on the delegate `choose` deploys or
+    /// picks, alongside the current sweeper contract, which is returned to rotate to.
+    fn on_delegate(choose: impl FnOnce(&Anvil, &SweepContracts) -> Address) -> (Self, Address) {
         let anvil = Arc::new(Anvil::start_mainnet_like());
         let current = deploy_sweep_contracts(&anvil, &address_from_hex(MINTER_ADDRESS));
-        let legacy = SweepContracts {
-            delegate: deploy_legacy_delegate(&anvil, &current.helper),
+        let installed = SweepContracts {
+            delegate: choose(&anvil, &current),
             ..current
         };
-        (Self::with_sweep_contracts(anvil, legacy), current.delegate)
+        (
+            Self::with_sweep_contracts(anvil, installed),
+            current.delegate,
+        )
     }
 
     /// Points the minter at `delegate`, as an operator replacing the sweeper contract does. The
@@ -864,6 +892,37 @@ impl LiveSetup<CkErc20Setup> {
             self.await_credited(ledger_id, Account { owner, subaccount }, amount);
         }
         self
+    }
+
+    /// Waits until the minter has finalized `expected` sweeps, whichever way each went. What
+    /// [`Self::expect_sweeps_finalized`] is for a test whose sweep is expected to revert: a
+    /// reverted sweep releases the deposits it held just the same, and only then can the pair be
+    /// armed afresh.
+    pub fn expect_sweeps_settled(self, expected: usize) -> Self {
+        self.drive_until(
+            SWEEP_TICKS,
+            |setup| {
+                format!(
+                    "the minter finalized {} of {expected} sweeps (stages: {})",
+                    setup.settled_sweeps(),
+                    setup.sweep_stages(),
+                )
+            },
+            |setup| setup.settled_sweeps() == expected,
+        );
+        self
+    }
+
+    fn settled_sweeps(&self) -> usize {
+        self.minter_events()
+            .iter()
+            .filter(|event| {
+                matches!(
+                    &event.payload,
+                    EventPayload::FinalizedSweeperTransaction { .. }
+                )
+            })
+            .count()
     }
 
     /// Waits until the minter has finalized `expected` sweeps successfully. A swept pair only leaves
@@ -1591,6 +1650,30 @@ impl SweepsSent {
         self,
         expected: &[u64],
     ) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
+        self.expect_sweeps(expected, true)
+    }
+
+    /// The sweeps sent, with nothing asserted about them beyond the count
+    /// [`LiveSetup::await_sweeps`] already waited for: for a test whose sweeps did not all end the
+    /// same way, and which therefore asserts on each of them itself.
+    pub fn into_sweeps(self) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
+        (self.setup, self.sweeps)
+    }
+
+    /// As [`Self::expect_sweeps_of_types`], for sweeps expected to revert: the transaction is mined
+    /// and its tuples apply, but the call it carries fails.
+    pub fn expect_reverted_sweeps_of_types(
+        self,
+        expected: &[u64],
+    ) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
+        self.expect_sweeps(expected, false)
+    }
+
+    fn expect_sweeps(
+        self,
+        expected: &[u64],
+        succeeded: bool,
+    ) -> (LiveSetup<CkErc20Setup>, Vec<SentTransaction>) {
         assert_eq!(
             self.sweeps.len(),
             expected.len(),
@@ -1603,7 +1686,10 @@ impl SweepsSent {
                 sweep.transaction_type, *expected_type,
                 "the sweep did not ride the expected transaction type: {sweep:?}"
             );
-            assert!(sweep.succeeded, "the sweep reverted: {sweep:?}");
+            assert_eq!(
+                sweep.succeeded, succeeded,
+                "the sweep did not end as expected: {sweep:?}"
+            );
         }
         (self.setup, self.sweeps)
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -438,14 +438,50 @@ impl LiveSetup<CkErc20Setup> {
         caller: Principal,
         subaccount: [u8; 32],
     ) -> DepositEthResponse {
+        self.await_eth_deposit_status(caller, subaccount, "the ETH deposit was not detected", {
+            |status| matches!(status, DepositEthStatus::AwaitingSweep(_))
+        })
+    }
+
+    /// The ETH pendant of [`Self::await_scan`]: waits until the pair was scanned at a block
+    /// where its funding is visible, observed through `deposit_eth`'s own status.
+    pub fn await_eth_scan(&self, caller: Principal, subaccount: [u8; 32]) -> DepositEthResponse {
+        let funded_by = Nat::from(self.anvil.block_number());
+        self.await_eth_deposit_status(
+            caller,
+            subaccount,
+            &format!("the ETH deposit address was not scanned at or past block {funded_by}"),
+            |status| match status {
+                DepositEthStatus::Scanning {
+                    scan_count,
+                    last_scanned_block,
+                    ..
+                } => {
+                    *scan_count >= 1
+                        && last_scanned_block
+                            .as_ref()
+                            .is_some_and(|block| *block >= funded_by)
+                }
+                DepositEthStatus::AwaitingSweep(_) => true,
+            },
+        )
+    }
+
+    fn await_eth_deposit_status(
+        &self,
+        caller: Principal,
+        subaccount: [u8; 32],
+        what: &str,
+        is_done: impl Fn(&DepositEthStatus) -> bool,
+    ) -> DepositEthResponse {
         let mut reached = None;
         self.drive_until_with(
             SCAN_TICK,
             SCAN_TICKS,
-            |_| "the ETH deposit was not detected".to_string(),
+            |_| what.to_string(),
             |setup| {
                 let progress = setup.deposit_eth(caller, subaccount);
-                let done = matches!(progress.status, DepositEthStatus::AwaitingSweep(_));
+                let done = is_done(&progress.status);
                 if done {
                     reached = Some(progress);
                 }
@@ -1359,20 +1395,12 @@ impl DepositEthCalls {
         let deposits: Vec<EthCexDeposit> = self
             .responses
             .into_iter()
-            .map(|(plan, response)| {
-                let minimum = nat_to_u128(response.minimum_deposit_amount);
-                assert!(
-                    plan.amount >= minimum,
-                    "the planned deposit of {} wei is below the reported minimum of {minimum} wei",
-                    plan.amount
-                );
-                EthCexDeposit {
-                    address: Address::from_str(&response.address)
-                        .expect("BUG: minter returned an invalid deposit address"),
-                    owner: plan.owner,
-                    subaccount: plan.subaccount,
-                    amount: plan.amount,
-                }
+            .map(|(plan, response)| EthCexDeposit {
+                address: Address::from_str(&response.address)
+                    .expect("BUG: minter returned an invalid deposit address"),
+                owner: plan.owner,
+                subaccount: plan.subaccount,
+                amount: plan.amount,
             })
             .collect();
         let accounts: BTreeSet<(Principal, [u8; 32])> = deposits

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -60,7 +60,6 @@ use ic_cketh_minter::endpoints::{
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
 use ic_cketh_minter::numeric::Erc20Value;
-use ic_cketh_minter::sweep::MAX_DEPOSITS_PER_SWEEP;
 use ic_cketh_minter::{BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -609,7 +608,7 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_eth_sweeps_batched(self, deposits: &[EthCexDeposit]) -> Self {
-        let batches: Vec<Vec<Address>> = self
+        let swept: BTreeSet<Address> = self
             .minter_events()
             .into_iter()
             .filter_map(|event| match event.payload {
@@ -624,26 +623,13 @@ impl LiveSetup<CkErc20Setup> {
                             Address::from_str(&item.deposit)
                                 .expect("BUG: the sweep names an invalid deposit address")
                         })
-                        .collect(),
+                        .collect::<Vec<_>>(),
                 ),
                 _ => None,
             })
+            .flatten()
             .collect();
 
-        let mut expected_sizes = Vec::new();
-        let mut remaining = deposits.len();
-        while remaining > 0 {
-            let batch = remaining.min(MAX_DEPOSITS_PER_SWEEP);
-            expected_sizes.push(batch);
-            remaining -= batch;
-        }
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            expected_sizes,
-            "the ETH deposits must be swept in full batches"
-        );
-
-        let swept: BTreeSet<Address> = batches.into_iter().flatten().collect();
         let expected: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
         assert_eq!(
             swept, expected,

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -571,6 +571,47 @@ impl LiveSetup<CkErc20Setup> {
         self
     }
 
+    pub fn assert_eth_sweeps_batched(self, expected_item_counts: &[usize]) -> Self {
+        let batched: Vec<usize> = self
+            .minter_events()
+            .into_iter()
+            .filter_map(|event| match event.payload {
+                EventPayload::AcceptedSweepRequest {
+                    asset: EventAsset::Eth,
+                    items,
+                    ..
+                } => Some(items.len()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            batched, expected_item_counts,
+            "the ETH deposits must be swept in full batches, oldest first"
+        );
+        self
+    }
+
+    /// The minter's main address ETH balance, as a baseline for
+    /// [`Self::assert_minter_received_swept_eth_total`]: the address also holds the residue of
+    /// the funding deposit, so only the delta attributes the swept ETH.
+    pub fn minter_eth_balance(&self) -> u128 {
+        self.anvil.balance(&self.minter_address)
+    }
+
+    pub fn assert_minter_received_swept_eth_total(
+        self,
+        deposits: &[EthCexDeposit],
+        balance_before: u128,
+    ) -> Self {
+        let total: u128 = deposits.iter().map(|deposit| deposit.amount).sum();
+        assert_eq!(
+            self.anvil.balance(&self.minter_address),
+            balance_before + total,
+            "the minter's main address should have received all swept ETH"
+        );
+        self
+    }
+
     pub fn assert_eth_addresses_swept_empty(self, deposits: &[EthCexDeposit]) -> Self {
         for deposit in deposits {
             assert_eq!(
@@ -600,13 +641,21 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_deposit_addresses_bare(self, deposits: &[CexDeposit]) -> Self {
-        for deposit in deposits {
+        self.assert_addresses_bare(deposits.iter().map(|deposit| deposit.address))
+    }
+
+    pub fn assert_eth_deposit_addresses_bare(self, deposits: &[EthCexDeposit]) -> Self {
+        self.assert_addresses_bare(deposits.iter().map(|deposit| deposit.address))
+    }
+
+    fn assert_addresses_bare(self, addresses: impl IntoIterator<Item = Address>) -> Self {
+        for address in addresses {
             assert!(
-                self.anvil.code(&deposit.address).is_empty(),
+                self.anvil.code(&address).is_empty(),
                 "a deposit address starts with no code"
             );
             assert_eq!(
-                self.anvil.balance(&deposit.address),
+                self.anvil.balance(&address),
                 0,
                 "a deposit address never needs ETH of its own"
             );
@@ -673,10 +722,26 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_delegations_installed(self, deposits: &[CexDeposit], delegate: &Address) -> Self {
+        self.assert_delegations_installed_at(deposits.iter().map(|d| d.address), delegate)
+    }
+
+    pub fn assert_eth_delegations_installed(
+        self,
+        deposits: &[EthCexDeposit],
+        delegate: &Address,
+    ) -> Self {
+        self.assert_delegations_installed_at(deposits.iter().map(|d| d.address), delegate)
+    }
+
+    fn assert_delegations_installed_at(
+        self,
+        addresses: impl IntoIterator<Item = Address>,
+        delegate: &Address,
+    ) -> Self {
         let designator = delegation_designator(delegate);
-        for deposit in deposits {
+        for address in addresses {
             assert_eq!(
-                self.anvil.code(&deposit.address),
+                self.anvil.code(&address),
                 designator,
                 "the sweep should have installed the delegation"
             );
@@ -1310,6 +1375,16 @@ impl DepositEthCalls {
                 }
             })
             .collect();
+        let accounts: BTreeSet<(Principal, [u8; 32])> = deposits
+            .iter()
+            .map(|deposit| (deposit.owner, deposit.subaccount))
+            .collect();
+        let addresses: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
+        assert_eq!(
+            addresses.len(),
+            accounts.len(),
+            "every account must get its own deposit address"
+        );
         (self.setup, deposits)
     }
 }


### PR DESCRIPTION
### Why

* The sweeper delegate has changed once already (#11449) and will change again. Pointing the minter at a new delegate is not enough: an address already delegated skips a fresh nonce-0 tuple and stays on the old code. ERC-20 sweeps keep working through it, which hides the problem, while any entry point the old delegate lacks reverts the whole batch.
* Design: `R18` and "Changing the sweeper delegate" in #11491.

### What

* An address whose recorded delegation names another sweeper contract is re-delegated by its next sweep, with a tuple for the configured contract signed at the nonce the address has reached.
* At most one tuple is ever signed per address and nonce, whatever the delegate. While an earlier tuple for that nonce is still unapplied, the sweep re-carries it instead of signing a competing one, and the rotation follows at the next nonce.
* A reverted sweep marks its addresses as nonce-unverified. The read-back is per address, whichever asset lane queued it, since the nonce is a property of the address. Before such an address is swept again, its nonce is read from the chain and recorded as a new audit event, which re-anchors the applied marks on replay.
* A live anvil test installs the minter on the pre-#11449 delegate, upgrades to the current one, and checks that the next sweep flips the designator and the one after that carries no tuple.

Last PR of this stack, stacked on #11501. ETH entry-point gating is left to the Phase 2 ETH work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X44H4nAU65nAexEUvG15MK
