### PR TITLE
chore: fix assorted typos in packages/ doc comments and messages

### DIFF
--- a/packages/ic-ed25519/src/lib.rs
+++ b/packages/ic-ed25519/src/lib.rs
@@ -609,7 +609,7 @@ impl PublicKey {
     /// Deserialize a public key in raw format
     ///
     /// This is just the 32 byte encoding of the public point,
-    /// cooresponding to Self::serialize_raw
+    /// corresponding to Self::serialize_raw
     ///
     /// # Warning
     ///
@@ -654,7 +654,7 @@ impl PublicKey {
 
     /// Deserialize the DER encoded public key
     ///
-    /// See RFC 8410 for details on the format. This cooresponds to
+    /// See RFC 8410 for details on the format. This corresponds to
     /// Self::serialize_rfc8410_der
     ///
     /// # Warning
@@ -670,7 +670,7 @@ impl PublicKey {
 
     /// Deserialize the PEM encoded public key
     ///
-    /// See RFC 8410 for details on the format. This cooresponds to
+    /// See RFC 8410 for details on the format. This corresponds to
     /// Self::serialize_rfc8410_pem
     ///
     /// # Warning

--- a/packages/ic-hpke/src/lib.rs
+++ b/packages/ic-hpke/src/lib.rs
@@ -30,7 +30,7 @@
 //! used is also authentic, and is associated with that ciphertext message. If the
 //! encryptor and decryptor disagree on the `associated_data` field, then decryption will
 //! fail. Commonly, the `associated_data` is used to bind additional information about the
-//! context which both the sender and receiver will know, for example a protocol identifer.
+//! context which both the sender and receiver will know, for example a protocol identifier.
 //! If no such information is available, the associated data can be set to an empty slice.
 //!
 //! # Example (Authenticated Encryption)
@@ -171,7 +171,7 @@ macro_rules! check_header {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-/// An error occured while deserializing a key
+/// An error occurred while deserializing a key
 pub enum KeyDeserializationError {
     /// The protocol identifier or version field was unknown to us
     UnknownMagic,
@@ -320,7 +320,7 @@ impl PublicKey {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-/// An error occured while decrypting a message
+/// An error occurred while decrypting a message
 pub enum DecryptionError {
     /// The protocol identifier/version field did not match
     UnknownMagic,

--- a/packages/ic-secp256k1/src/lib.rs
+++ b/packages/ic-secp256k1/src/lib.rs
@@ -891,7 +891,7 @@ impl PublicKey {
         use k256::pkcs8::EncodePublicKey;
         self.key
             .to_public_key_der()
-            .expect("Encoding is infalliable as long as key is valid")
+            .expect("Encoding is infallible as long as key is valid")
             .as_ref()
             .to_vec()
     }
@@ -901,7 +901,7 @@ impl PublicKey {
         use k256::pkcs8::EncodePublicKey;
         self.key
             .to_public_key_pem(k256::pkcs8::LineEnding::CRLF)
-            .expect("Encoding is infalliable as long as key is valid")
+            .expect("Encoding is infallible as long as key is valid")
     }
 
     /// Deprecated alias of verify_ecdsa_signature

--- a/packages/ic-secp256k1/tests/tests.rs
+++ b/packages/ic-secp256k1/tests/tests.rs
@@ -551,10 +551,10 @@ fn should_match_slip10_derivation_test_data() {
 fn should_handle_short_len_prehashed() {
     // k256 somewhat arbitrarily rejects prehashed digests under 128
     // bits. This is somewhat ok, since we hopefully don't ever do
-    // this, but it makes an otherwise infalliable function fallible,
+    // this, but it makes an otherwise infallible function fallible,
     // which is unfortunate. So we perform the (correct/standard)
     // prefixing of zero padding the digest in order to make the
-    // function infalliable. Test this using a short input generated
+    // function infallible. Test this using a short input generated
     // by another ECDSA implementation
 
     let pk = PublicKey::deserialize_sec1(&hex!(

--- a/packages/icrc-ledger-types/src/icrc/generic_value_predicate.rs
+++ b/packages/icrc-ledger-types/src/icrc/generic_value_predicate.rs
@@ -60,7 +60,7 @@ impl ValuePredicateFailures {
             And(failures) => {
                 writeln!(
                     f,
-                    "{:width$}Expected all of the following validators to be successfull:",
+                    "{:width$}Expected all of the following validators to be successful:",
                     "",
                     width = indent
                 )?;
@@ -71,7 +71,7 @@ impl ValuePredicateFailures {
             Or(failures) => {
                 writeln!(
                     f,
-                    "{:width$}Expected at least one of the following validators to be successfull:",
+                    "{:width$}Expected at least one of the following validators to be successful:",
                     "",
                     width = indent
                 )?;

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1648,7 +1648,7 @@ impl PocketIc {
     /// to be retrievable here.
     /// Note that, unless a PocketIC instance is in auto progress mode,
     /// a response to the pending canister HTTP outcalls
-    /// must be produced by the test driver and passed on to the PocketIC instace
+    /// must be produced by the test driver and passed on to the PocketIC instance
     /// using `PocketIc::mock_canister_http_response`, or, for a *flexible* outcall
     /// (`CanisterHttpReplication::Flexible`), using
     /// `PocketIc::mock_flexible_canister_http_response`.
@@ -2311,7 +2311,7 @@ pub struct StartServerParams {
     /// The server stops gracefully if no request has been received for the duration of its TTL
     /// after the last request finished and if there are no more pending requests.
     /// A default value of TTL is used if no `ttl` is specified here.
-    /// Note: The TTL might not be overriden if the same test process sets `reuse` to `true`
+    /// Note: The TTL might not be overridden if the same test process sets `reuse` to `true`
     /// and passes different values of `ttl`.
     pub ttl: Option<Duration>,
     /// Hard TTL for the PocketIC server.
@@ -2319,7 +2319,7 @@ pub struct StartServerParams {
     /// since its launch.
     /// If no `hard_ttl` is specified here, then the PocketIC server
     /// does not use any default hard TTL.
-    /// Note: The hard TTL might not be overriden if the same test process sets `reuse` to `true`
+    /// Note: The hard TTL might not be overridden if the same test process sets `reuse` to `true`
     /// and passes different values of `hard_ttl`.
     pub hard_ttl: Option<Duration>,
 }

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1872,7 +1872,7 @@ impl PocketIc {
     /// to be retrievable here.
     /// Note that, unless a PocketIC instance is in auto progress mode,
     /// a response to the pending canister HTTP outcalls
-    /// must be produced by the test driver and passed on to the PocketIC instace
+    /// must be produced by the test driver and passed on to the PocketIC instance
     /// using `PocketIc::mock_canister_http_response`, or, for a *flexible* outcall
     /// (`CanisterHttpReplication::Flexible`), using
     /// `PocketIc::mock_flexible_canister_http_response`.

--- a/packages/pocket-ic/tests/canister_snapshots.rs
+++ b/packages/pocket-ic/tests/canister_snapshots.rs
@@ -184,7 +184,7 @@ fn test_canister_snapshot_download_upload(
 
     // Compare snapshot metadata.
     // The source and timestamps are expected to differ and
-    // thus they are overwritten before comparision.
+    // thus they are overwritten before comparison.
     let downloaded_metadata_path = downloaded_snapshot_dir.join("metadata.json");
     let downloaded_metadata_bytes = std::fs::read(downloaded_metadata_path).unwrap();
     let downloaded_metadata: ReadCanisterSnapshotMetadataResponse =


### PR DESCRIPTION
## What

Fixes 17 spelling mistakes across five `packages/` crates. All changes are in
doc comments, test comments, one `.expect()` panic message, and the
user-facing `writeln!` output of `ValuePredicateFailures` — **text only, no
code / API / behavior changes**.

| Crate | Fix |
| --- | --- |
| `ic-ed25519` | `cooresponding` / `cooresponds` → `corresponding` / `corresponds` |
| `ic-hpke` | `identifer` → `identifier`, `occured` → `occurred` |
| `ic-secp256k1` | `infalliable` → `infallible` |
| `icrc-ledger-types` | `successfull` → `successful` (pretty-print output) |
| `pocket-ic` | `instace` → `instance`, `overriden` → `overridden`, `comparision` → `comparison` |

## Notes

- Found with `codespell`; each hit was reviewed individually.
- No `CHANGELOG.md` files touched — the one remaining `infalliable` in
  `ic-ed25519/CHANGELOG.md` sits under the already-released `0.6.0` heading and
  is left as-is.
- No dependency changes, so no Bazel repin needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)