### PR TITLE
feat(cketh): scan and detect ETH deposits

### DIFF
--- a/rs/ethereum/cketh/minter/src/asset/mod.rs
+++ b/rs/ethereum/cketh/minter/src/asset/mod.rs
@@ -31,6 +31,37 @@ impl From<Address> for Asset {
     }
 }
 
+/// The ETH asset, as a type: code generic over the asset kind uses this and [`Erc20Asset`]
+/// where mixing the kinds up must not compile, and [`Asset`] where both are handled alike.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct EthAsset;
+
+/// An ERC-20 token, as a type: the compile-time counterpart of [`Asset::Erc20`].
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct Erc20Asset(Address);
+
+impl Erc20Asset {
+    pub fn new(contract_address: Address) -> Self {
+        Self(contract_address)
+    }
+
+    pub fn contract_address(&self) -> Address {
+        self.0
+    }
+}
+
+impl From<EthAsset> for Asset {
+    fn from(_: EthAsset) -> Self {
+        Asset::Eth
+    }
+}
+
+impl From<Erc20Asset> for Asset {
+    fn from(token: Erc20Asset) -> Self {
+        Asset::Erc20(token.contract_address())
+    }
+}
+
 impl Display for Asset {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
@@ -53,7 +53,7 @@ const MAX_CODE_SIZE: usize = 24_576;
 /// [EIP-3860]: https://eips.ethereum.org/EIPS/eip-3860
 const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 
-/// Maximum number of `balanceOf` sub-calls in a single deployless-batcher `eth_call`.
+/// Maximum number of balance reads in a single deployless-batcher `eth_call`, for both batchers.
 ///
 /// A create-style `eth_call` is bounded at both ends: the initcode it carries is rejected beyond
 /// [`MAX_INITCODE_SIZE`] (EIP-3860), and the blob the program `RETURN`s is rejected beyond
@@ -73,6 +73,12 @@ const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
 /// registered pairs into chunks of this size and advances each chunk all-or-nothing, so a
 /// whole-call failure re-does that chunk on the next tick — and a chunk that always exceeds a
 /// provider limit fails *every* time, permanently stalling its pairs.
+///
+/// The value is derived from the ERC-20 encoding, yet it caps [`ETH_BATCHER_INITCODE`] batches
+/// too, with margin on both ends. The returned-blob term is shared — both programs return one
+/// word per entry — so the cap can never exceed `MAX_CODE_SIZE / WORD`; and the ETH initcode
+/// side is far looser than the ERC-20 one (one word per entry after a 78-byte program, so 1532
+/// reads) and never binds. `full_batch_of_eth_balance_reads_fits_both_node_limits` pins this.
 pub const MAX_CALLS_PER_BATCH: usize = {
     let by_initcode_size = (MAX_INITCODE_SIZE - BATCHER_INITCODE.len() - WORD) / (2 * WORD);
     let by_returned_code_size = MAX_CODE_SIZE / WORD;

--- a/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
@@ -83,6 +83,26 @@ pub const MAX_CALLS_PER_BATCH: usize = {
     }
 };
 
+/// Deployless ETH balance-batcher creation bytecode.
+///
+/// The native-ETH sibling of [`BATCHER_INITCODE`], executed the same way (create-style
+/// `eth_call`, `to` omitted). It reads its inputs from the calldata appended right after this
+/// bytecode (`[n][ holder x n ]`, one 32-byte word each) and, for each holder, reads its ETH
+/// balance with the `BALANCE` opcode — no sub-calls, so unlike the ERC-20 batcher nothing here
+/// can fail and the program has no revert path. On success it returns the balances as a flat
+/// `n x 32`-byte array (no ABI array header), decoded positionally by [`decode_balance_batch`].
+///
+/// The program is fixed regardless of `n` (only the appended args grow). It was assembled from
+/// the opcode listing in `eth_initcode_matches_readable_assembly` and validated against a live
+/// anvil node; see `rs/ethereum/cketh/minter/tests/deposit_from_cex.rs`.
+pub const ETH_BATCHER_INITCODE: [u8; 78] = [
+    0x60, 0x20, 0x61, 0x00, 0x4e, 0x60, 0x00, 0x39, 0x60, 0x00, 0x60, 0x20, 0x52, 0x5b, 0x60, 0x00,
+    0x51, 0x60, 0x20, 0x51, 0x10, 0x15, 0x61, 0x00, 0x44, 0x57, 0x60, 0x20, 0x60, 0x20, 0x51, 0x60,
+    0x20, 0x02, 0x61, 0x00, 0x6e, 0x01, 0x60, 0x40, 0x39, 0x60, 0x40, 0x51, 0x31, 0x60, 0x20, 0x51,
+    0x60, 0x20, 0x02, 0x60, 0x60, 0x01, 0x52, 0x60, 0x20, 0x51, 0x60, 0x01, 0x01, 0x60, 0x20, 0x52,
+    0x61, 0x00, 0x0d, 0x56, 0x5b, 0x60, 0x00, 0x51, 0x60, 0x20, 0x02, 0x60, 0x60, 0xf3,
+];
+
 /// Function selector for `balanceOf(address)`, i.e. `keccak256("balanceOf(address)")[..4]`.
 /// Embedded in [`BATCHER_INITCODE`] right after its leading `PUSH32` opcode; asserted by tests.
 #[cfg(test)]
@@ -111,6 +131,18 @@ pub fn encode_balance_batch(calls: &[BalanceOfCall]) -> Vec<u8> {
     for call in calls {
         out.extend_from_slice(&left_padded_address(&call.token));
         out.extend_from_slice(&left_padded_address(call.holder.as_address()));
+    }
+    out
+}
+
+/// Build the create-call `input` for a batch of ETH balance reads:
+/// `ETH_BATCHER_INITCODE ++ [n] ++ [ holder x n ]`, every value a 32-byte word.
+pub fn encode_eth_balance_batch(holders: &[DepositAddress]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(ETH_BATCHER_INITCODE.len() + WORD * (1 + holders.len()));
+    out.extend_from_slice(&ETH_BATCHER_INITCODE);
+    out.extend_from_slice(&word_from_usize(holders.len()));
+    for holder in holders {
+        out.extend_from_slice(&left_padded_address(holder.as_address()));
     }
     out
 }

--- a/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/batcher/mod.rs
@@ -153,13 +153,14 @@ pub fn encode_eth_balance_batch(holders: &[DepositAddress]) -> Vec<u8> {
     out
 }
 
-/// Decode the flat `n x 32`-byte return blob into `n` balances, in call order.
+/// Decode the flat `n x 32`-byte return blob of either batcher into `n` balances, in call order.
 ///
-/// Every entry is a genuine `balanceOf` result: the batcher reverts the whole
-/// call if any sub-call fails, so a successful return means all `n` balances are
-/// present (a failed batch surfaces as an `eth_call` error upstream, never as a
-/// `0` here). Returns `Err` if the blob length is not exactly `n` words; never
-/// panics.
+/// Every entry is a genuine balance, never a `0` standing in for a failure, because neither
+/// program can return a partial result: [`BATCHER_INITCODE`] reverts the whole call if any
+/// `balanceOf` sub-call fails, and [`ETH_BATCHER_INITCODE`] has no failure path at all — the
+/// `BALANCE` opcode makes no sub-calls. A failed batch therefore surfaces as an `eth_call` error
+/// upstream, never as a `0` here. Returns `Err` if the blob length is not exactly `n` words;
+/// never panics.
 pub fn decode_balance_batch(ret: &[u8], n: usize) -> Result<Vec<Erc20Value>, BatcherDecodeError> {
     let expected = n * WORD;
     if ret.len() != expected {

--- a/rs/ethereum/cketh/minter/src/balance_scan/batcher/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/batcher/tests.rs
@@ -196,6 +196,18 @@ fn full_batch_fits_the_initcode_limit_and_one_more_call_does_not() {
 }
 
 #[test]
+fn full_batch_of_eth_balance_reads_fits_both_node_limits() {
+    let holders: Vec<DepositAddress> = (0..MAX_CALLS_PER_BATCH)
+        .map(|index| DepositAddress::new(Address::new([index as u8; 20])))
+        .collect();
+
+    let returned_blob_size = holders.len() * WORD;
+
+    assert!(encode_eth_balance_batch(&holders).len() <= MAX_INITCODE_SIZE);
+    assert!(returned_blob_size <= MAX_CODE_SIZE);
+}
+
+#[test]
 fn decode_round_trip() {
     let mut ret = Vec::new();
     for v in [1_000_000_u64, 0, u64::MAX] {

--- a/rs/ethereum/cketh/minter/src/balance_scan/batcher/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/batcher/tests.rs
@@ -73,6 +73,77 @@ fn initcode_matches_readable_assembly() {
 }
 
 #[test]
+fn eth_initcode_matches_readable_assembly() {
+    use Op::*;
+
+    // The byte-for-byte source of truth for ETH_BATCHER_INITCODE, as a commented EVM assembly
+    // listing. A create-style `eth_call` runs this as init code; it reads its args appended
+    // right after the code (`[n][ holder x n ]`, from code offset ARGS_START) and RETURNs each
+    // holder's ETH balance, read with the BALANCE opcode. No sub-calls, so unlike the ERC-20
+    // batcher nothing here can fail: the program has no revert path.
+    //
+    // Memory layout (all offsets in bytes):
+    //   [0x00] n    [0x20] loop counter i    [0x40] holder (rewritten per iteration)
+    //   [OUTPUT..]  returned balances (n x 32 bytes)
+    const ARGS_START: u16 = 0x4e; // == ETH_BATCHER_INITCODE.len(): the `n` word sits right after the code
+    const FIRST_HOLDER: u16 = 0x6e; // == ARGS_START + WORD: first holder word
+    const OUTPUT: u8 = 0x60; // start of the returned balances region in memory
+    const LOOP: u16 = 0x0d; // JUMPDEST at the top of the per-holder loop
+    const DONE: u16 = 0x44; // JUMPDEST for the RETURN path
+
+    #[rustfmt::skip]
+    let program = assemble(&[
+        // mem[0x00] = n  (one word copied from code[ARGS_START])
+        Push1(0x20), Push2(ARGS_START), Push1(0x00), Codecopy,
+        // mem[0x20] = i = 0
+        Push1(0x00), Push1(0x20), Mstore,
+        Jumpdest, // LOOP
+        // if !(i < n) goto DONE
+        Push1(0x00), Mload, Push1(0x20), Mload, Lt, IsZero, Push2(DONE), Jumpi,
+        // mem[0x40] = holder = code[FIRST_HOLDER + i * 0x20]
+        Push1(0x20), Push1(0x20), Mload, Push1(0x20), Mul, Push2(FIRST_HOLDER), Add,
+        Push1(0x40), Codecopy,
+        // mem[OUTPUT + i * 0x20] = BALANCE(holder)
+        Push1(0x40), Mload, Balance,
+        Push1(0x20), Mload, Push1(0x20), Mul, Push1(OUTPUT), Add, Mstore,
+        // i += 1; goto LOOP
+        Push1(0x20), Mload, Push1(0x01), Add, Push1(0x20), Mstore, Push2(LOOP), Jump,
+        Jumpdest, // DONE: RETURN(OUTPUT, n * 0x20)
+        Push1(0x00), Mload, Push1(0x20), Mul, Push1(OUTPUT), Return,
+    ]);
+
+    assert_eq!(program, ETH_BATCHER_INITCODE);
+    // Offsets baked into the code must match the actual layout.
+    assert_eq!(ARGS_START as usize, ETH_BATCHER_INITCODE.len());
+    assert_eq!(FIRST_HOLDER, ARGS_START + WORD as u16);
+}
+
+#[test]
+fn encode_eth_single_holder_golden_vector() {
+    let encoded = encode_eth_balance_batch(&[HOLDER0]);
+
+    assert_eq!(encoded.len(), ETH_BATCHER_INITCODE.len() + 2 * WORD);
+    assert_eq!(
+        &encoded[..ETH_BATCHER_INITCODE.len()],
+        &ETH_BATCHER_INITCODE
+    );
+    let args = &encoded[ETH_BATCHER_INITCODE.len()..];
+    assert_eq!(&args[0..32], &word(1)); // n
+    assert_eq!(&args[32..64], &left_padded_address(HOLDER0.as_address()));
+}
+
+#[test]
+fn encode_eth_two_holders_layout() {
+    let encoded = encode_eth_balance_batch(&[HOLDER0, HOLDER1]);
+
+    assert_eq!(encoded.len(), ETH_BATCHER_INITCODE.len() + WORD * (1 + 2));
+    let args = &encoded[ETH_BATCHER_INITCODE.len()..];
+    assert_eq!(&args[0..32], &word(2));
+    assert_eq!(&args[32..64], &left_padded_address(HOLDER0.as_address()));
+    assert_eq!(&args[64..96], &left_padded_address(HOLDER1.as_address()));
+}
+
+#[test]
 fn encode_single_call_golden_vector() {
     let encoded = encode_balance_batch(&[BalanceOfCall {
         token: TOKEN0,
@@ -178,6 +249,7 @@ enum Op {
     Gas,
     Mload,
     Mstore,
+    Balance,
     Jump,
     Jumpi,
     Jumpdest,
@@ -205,6 +277,7 @@ fn assemble(ops: &[Op]) -> Vec<u8> {
             Op::Lt => out.push(0x10),
             Op::Eq => out.push(0x14),
             Op::IsZero => out.push(0x15),
+            Op::Balance => out.push(0x31),
             Op::Codecopy => out.push(0x39),
             Op::Gas => out.push(0x5a),
             Op::Mload => out.push(0x51),

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -3,7 +3,7 @@ pub mod batcher;
 #[cfg(test)]
 mod tests;
 
-use crate::asset::Asset;
+use crate::asset::{Asset, Erc20Asset, EthAsset};
 use crate::deposit_address::DepositAddress;
 use crate::eth_rpc_client::{AnyOf, MIN_ATTACHED_CYCLES, ToReducedWithStrategy, rpc_client};
 use crate::guard::TimerGuard;
@@ -48,18 +48,13 @@ async fn scan<R: Runtime, T: TimeProvider>(
             return;
         }
     };
-    let (erc20_targets, eth_targets, watchlist_len) = read_state(|s| {
-        let mut erc20 = Vec::new();
-        let mut eth = Vec::new();
-        for target in s.automatic_deposits.scan_targets_iter(now, latest_block) {
-            match target.asset() {
-                Asset::Erc20(token) => erc20.push((target, token)),
-                Asset::Eth => eth.push(target),
-            }
-        }
-        (erc20, eth, s.automatic_deposits.watchlist_len())
+    let (targets, watchlist_len) = read_state(|s| {
+        (
+            s.automatic_deposits.due_scan_targets(now, latest_block),
+            s.automatic_deposits.watchlist_len(),
+        )
     });
-    if erc20_targets.is_empty() && eth_targets.is_empty() {
+    if targets.is_empty() {
         log!(
             DEBUG,
             "[balance_scan] SKIPPING: 0/{watchlist_len} deposits ready to be scanned"
@@ -67,9 +62,9 @@ async fn scan<R: Runtime, T: TimeProvider>(
         return;
     }
 
-    let outcomes = scan_balances(&erc20_targets, latest_block, &client).await;
+    let outcomes = scan_balances(&targets.erc20, latest_block, &client).await;
     apply_scan_outcomes(outcomes, now, latest_block, time_provider);
-    let outcomes = scan_eth_balances(&eth_targets, latest_block, &client).await;
+    let outcomes = scan_eth_balances(&targets.eth, latest_block, &client).await;
     apply_scan_outcomes(outcomes, now, latest_block, time_provider);
 }
 
@@ -114,7 +109,7 @@ enum ScanOutcome {
 /// Pairs whose chunk failed yield no outcome at all, so a failed chunk is retried next tick rather
 /// than silently advanced until its next scheduled slot.
 async fn scan_balances<R: Runtime>(
-    due: &[(ScanTarget, Address)],
+    due: &[ScanTarget<Erc20Asset>],
     latest_block: BlockNumber,
     client: &EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
 ) -> Vec<ScanOutcome> {
@@ -126,8 +121,8 @@ async fn scan_balances<R: Runtime>(
     for chunk in due.chunks(MAX_CALLS_PER_BATCH) {
         let calls: Vec<BalanceOfCall> = chunk
             .iter()
-            .map(|(target, token)| BalanceOfCall {
-                token: *token,
+            .map(|target| BalanceOfCall {
+                token: target.token(),
                 holder: target.address(),
             })
             .collect();
@@ -135,7 +130,7 @@ async fn scan_balances<R: Runtime>(
         if let Some(balances) =
             chunk_balances(input, calls.len(), latest_block, client, &mut errors).await
         {
-            for ((target, _token), balance) in chunk.iter().zip(balances) {
+            for (target, balance) in chunk.iter().zip(balances) {
                 outcomes.push(scan_outcome(target, balance, latest_block));
             }
         }
@@ -146,7 +141,7 @@ async fn scan_balances<R: Runtime>(
 }
 
 async fn scan_eth_balances<R: Runtime>(
-    due: &[ScanTarget],
+    due: &[ScanTarget<EthAsset>],
     latest_block: BlockNumber,
     client: &EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
 ) -> Vec<ScanOutcome> {
@@ -222,8 +217,8 @@ fn log_scan_summary(kind: &str, outcomes: &[ScanOutcome], errors: &ScanErrors) {
 /// Classify one pair's scanned `balance`: a [`ScanOutcome::Detected`] built entirely from the
 /// pre-scan `target` when the balance is at or above the token's minimum, otherwise
 /// [`ScanOutcome::NothingFound`].
-fn scan_outcome(
-    target: &ScanTarget,
+fn scan_outcome<A: Copy + Into<Asset>>(
+    target: &ScanTarget<A>,
     balance: Erc20Value,
     latest_block: BlockNumber,
 ) -> ScanOutcome {

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -67,14 +67,25 @@ async fn scan<R: Runtime, T: TimeProvider>(
         return;
     }
 
-    // Await every balance read first, then apply the outcomes in a single `mutate_state`: the state
-    // borrow must never span an await, and re-reading the watchlist after the outcalls is what this
-    // scan deliberately avoids (a concurrent registration can evict a pair whose window closed
-    // mid-scan, which would drop funds already observed on-chain). See `scan_balances`. Both scans
-    // read at the same `latest_block`, so an address' assets are observed at one block.
-    let mut outcomes = scan_balances(&erc20_targets, latest_block, &client).await;
-    outcomes.extend(scan_eth_balances(&eth_targets, latest_block, &client).await);
+    // Each batch's outcomes are applied in a single `mutate_state` before the next batch is
+    // awaited: the state borrow must never span an await, re-reading the watchlist after the
+    // outcalls is what this scan deliberately avoids (a concurrent registration can evict a pair
+    // whose window closed mid-scan, which would drop funds already observed on-chain — see
+    // `scan_balances`), and outcomes already in hand are recorded durably rather than hinging on
+    // a later await resuming. Both scans read at the same `latest_block`, so an address' assets
+    // are observed at one block.
+    let outcomes = scan_balances(&erc20_targets, latest_block, &client).await;
+    apply_scan_outcomes(outcomes, now, latest_block, time_provider);
+    let outcomes = scan_eth_balances(&eth_targets, latest_block, &client).await;
+    apply_scan_outcomes(outcomes, now, latest_block, time_provider);
+}
 
+fn apply_scan_outcomes<T: TimeProvider>(
+    outcomes: Vec<ScanOutcome>,
+    now: Timestamp,
+    latest_block: BlockNumber,
+    time_provider: &T,
+) {
     mutate_state(|s| {
         for outcome in outcomes {
             match outcome {

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -67,13 +67,6 @@ async fn scan<R: Runtime, T: TimeProvider>(
         return;
     }
 
-    // Each batch's outcomes are applied in a single `mutate_state` before the next batch is
-    // awaited: the state borrow must never span an await, re-reading the watchlist after the
-    // outcalls is what this scan deliberately avoids (a concurrent registration can evict a pair
-    // whose window closed mid-scan, which would drop funds already observed on-chain — see
-    // `scan_balances`), and outcomes already in hand are recorded durably rather than hinging on
-    // a later await resuming. Both scans read at the same `latest_block`, so an address' assets
-    // are observed at one block.
     let outcomes = scan_balances(&erc20_targets, latest_block, &client).await;
     apply_scan_outcomes(outcomes, now, latest_block, time_provider);
     let outcomes = scan_eth_balances(&eth_targets, latest_block, &client).await;

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -4,6 +4,7 @@ pub mod batcher;
 mod tests;
 
 use crate::asset::Asset;
+use crate::deposit_address::DepositAddress;
 use crate::eth_rpc_client::{AnyOf, MIN_ATTACHED_CYCLES, ToReducedWithStrategy, rpc_client};
 use crate::guard::TimerGuard;
 use crate::logs::{DEBUG, INFO};
@@ -47,15 +48,18 @@ async fn scan<R: Runtime, T: TimeProvider>(
             return;
         }
     };
-    let (targets, watchlist_len) = read_state(|s| {
-        (
-            s.automatic_deposits
-                .scan_targets_iter(now, latest_block)
-                .collect::<Vec<_>>(),
-            s.automatic_deposits.watchlist_len(),
-        )
+    let (erc20_targets, eth_targets, watchlist_len) = read_state(|s| {
+        let mut erc20 = Vec::new();
+        let mut eth = Vec::new();
+        for target in s.automatic_deposits.scan_targets_iter(now, latest_block) {
+            match target.asset() {
+                Asset::Erc20(token) => erc20.push((target, token)),
+                Asset::Eth => eth.push(target),
+            }
+        }
+        (erc20, eth, s.automatic_deposits.watchlist_len())
     });
-    if targets.is_empty() {
+    if erc20_targets.is_empty() && eth_targets.is_empty() {
         log!(
             DEBUG,
             "[balance_scan] SKIPPING: 0/{watchlist_len} deposits ready to be scanned"
@@ -65,9 +69,11 @@ async fn scan<R: Runtime, T: TimeProvider>(
 
     // Await every balance read first, then apply the outcomes in a single `mutate_state`: the state
     // borrow must never span an await, and re-reading the watchlist after the outcalls is what this
-    // scan deliberately avoids (a concurrent `deposit_erc20` can evict a pair whose window closed
-    // mid-scan, which would drop funds already observed on-chain). See `scan_balances`.
-    let outcomes = scan_balances(&targets, latest_block, client).await;
+    // scan deliberately avoids (a concurrent registration can evict a pair whose window closed
+    // mid-scan, which would drop funds already observed on-chain). See `scan_balances`. Both scans
+    // read at the same `latest_block`, so an address' assets are observed at one block.
+    let mut outcomes = scan_balances(&erc20_targets, latest_block, &client).await;
+    outcomes.extend(scan_eth_balances(&eth_targets, latest_block, &client).await);
 
     mutate_state(|s| {
         for outcome in outcomes {
@@ -104,60 +110,113 @@ enum ScanOutcome {
 /// Pairs whose chunk failed yield no outcome at all, so a failed chunk is retried next tick rather
 /// than silently advanced until its next scheduled slot.
 async fn scan_balances<R: Runtime>(
-    due: &[ScanTarget],
+    due: &[(ScanTarget, Address)],
     latest_block: BlockNumber,
-    client: EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
+    client: &EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
 ) -> Vec<ScanOutcome> {
     let mut outcomes = Vec::new();
-    let mut decode_errors = 0_usize;
-    let mut call_errors = 0_usize;
+    let mut errors = ScanErrors::default();
 
     // Each pair is one `balanceOf` call, so chunks split at any pair boundary; a chunk yields its
     // outcomes together once it succeeds.
     for chunk in due.chunks(MAX_CALLS_PER_BATCH) {
         let calls: Vec<BalanceOfCall> = chunk
             .iter()
-            .map(|target| BalanceOfCall {
-                token: target.token(),
+            .map(|(target, token)| BalanceOfCall {
+                token: *token,
                 holder: target.address(),
             })
             .collect();
         let input = batcher::encode_balance_batch(&calls);
-        match client
-            .call(call_args(input, latest_block))
-            .with_cycles(MIN_ATTACHED_CYCLES)
-            .try_send()
-            .await
-            .reduce_with_strategy(AnyOf)
+        if let Some(balances) =
+            chunk_balances(input, calls.len(), latest_block, client, &mut errors).await
         {
-            Ok(hex) => match batcher::decode_balance_batch(hex.as_ref(), calls.len()) {
-                Ok(balances) => {
-                    for (target, balance) in chunk.iter().zip(balances) {
-                        outcomes.push(scan_outcome(target, balance, latest_block));
-                    }
-                }
-                Err(e) => {
-                    decode_errors += 1;
-                    log!(INFO, "balance scan decode error: {e:?}");
-                }
-            },
-            Err(e) => {
-                call_errors += 1;
-                log!(INFO, "balance scan eth_call error: {e:?}");
+            for ((target, _token), balance) in chunk.iter().zip(balances) {
+                outcomes.push(scan_outcome(target, balance, latest_block));
             }
         }
     }
 
+    log_scan_summary("token", &outcomes, &errors);
+    outcomes
+}
+
+/// The ETH counterpart of [`scan_balances`]: one batched `BALANCE` read per chunk of `due`
+/// `(address, ETH)` pairs, at the same `latest_block` the ERC-20 scan is pinned to.
+async fn scan_eth_balances<R: Runtime>(
+    due: &[ScanTarget],
+    latest_block: BlockNumber,
+    client: &EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
+) -> Vec<ScanOutcome> {
+    let mut outcomes = Vec::new();
+    let mut errors = ScanErrors::default();
+
+    for chunk in due.chunks(MAX_CALLS_PER_BATCH) {
+        let holders: Vec<DepositAddress> = chunk.iter().map(ScanTarget::address).collect();
+        let input = batcher::encode_eth_balance_batch(&holders);
+        if let Some(balances) =
+            chunk_balances(input, holders.len(), latest_block, client, &mut errors).await
+        {
+            for (target, balance) in chunk.iter().zip(balances) {
+                outcomes.push(scan_outcome(target, balance, latest_block));
+            }
+        }
+    }
+
+    log_scan_summary("ETH", &outcomes, &errors);
+    outcomes
+}
+
+#[derive(Default)]
+struct ScanErrors {
+    decode: usize,
+    call: usize,
+}
+
+/// Send one deployless-batcher `input` pinned at `latest_block` and decode its `n` balances,
+/// counting a failed call or an undecodable return in `errors` instead of yielding balances.
+async fn chunk_balances<R: Runtime>(
+    input: Vec<u8>,
+    n: usize,
+    latest_block: BlockNumber,
+    client: &EvmRpcClient<R, CandidResponseConverter, DoubleCycles>,
+    errors: &mut ScanErrors,
+) -> Option<Vec<Erc20Value>> {
+    match client
+        .call(call_args(input, latest_block))
+        .with_cycles(MIN_ATTACHED_CYCLES)
+        .try_send()
+        .await
+        .reduce_with_strategy(AnyOf)
+    {
+        Ok(hex) => match batcher::decode_balance_batch(hex.as_ref(), n) {
+            Ok(balances) => Some(balances),
+            Err(e) => {
+                errors.decode += 1;
+                log!(INFO, "balance scan decode error: {e:?}");
+                None
+            }
+        },
+        Err(e) => {
+            errors.call += 1;
+            log!(INFO, "balance scan eth_call error: {e:?}");
+            None
+        }
+    }
+}
+
+fn log_scan_summary(kind: &str, outcomes: &[ScanOutcome], errors: &ScanErrors) {
     let candidates_found = outcomes
         .iter()
         .filter(|o| matches!(o, ScanOutcome::Detected(_)))
         .count();
     log!(
         INFO,
-        "[balance_scan]: scanned {} (address, token) pair(s), found {candidates_found} candidate(s), {decode_errors} decode error(s), {call_errors} call error(s)",
+        "[balance_scan]: scanned {} (address, {kind}) pair(s), found {candidates_found} candidate(s), {} decode error(s), {} call error(s)",
         outcomes.len(),
+        errors.decode,
+        errors.call,
     );
-    outcomes
 }
 
 /// Classify one pair's scanned `balance`: a [`ScanOutcome::Detected`] built entirely from the
@@ -168,14 +227,14 @@ fn scan_outcome(
     balance: Erc20Value,
     latest_block: BlockNumber,
 ) -> ScanOutcome {
-    if balance < min_deposit(&Asset::Erc20(target.token())) {
+    if balance < min_deposit(&target.asset()) {
         return ScanOutcome::NothingFound(target.request());
     }
     ScanOutcome::Detected(AutomaticDeposit {
         owner: target.account().owner,
         subaccount: target.account().subaccount,
         address: target.address(),
-        asset: Asset::Erc20(target.token()),
+        asset: target.asset(),
         last_scanned_block: latest_block,
         scan_count: target.scan_count().saturating_add(1),
         scanned_balance: balance,

--- a/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/mod.rs
@@ -145,8 +145,6 @@ async fn scan_balances<R: Runtime>(
     outcomes
 }
 
-/// The ETH counterpart of [`scan_balances`]: one batched `BALANCE` read per chunk of `due`
-/// `(address, ETH)` pairs, at the same `latest_block` the ERC-20 scan is pinned to.
 async fn scan_eth_balances<R: Runtime>(
     due: &[ScanTarget],
     latest_block: BlockNumber,
@@ -177,8 +175,6 @@ struct ScanErrors {
     call: usize,
 }
 
-/// Send one deployless-batcher `input` pinned at `latest_block` and decode its `n` balances,
-/// counting a failed call or an undecodable return in `errors` instead of yielding balances.
 async fn chunk_balances<R: Runtime>(
     input: Vec<u8>,
     n: usize,

--- a/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
@@ -350,16 +350,8 @@ async fn should_yield_no_outcome_for_a_pair_whose_chunk_failed() {
     assert!(outcomes.is_empty(), "a failed chunk must yield no outcome");
 }
 
-fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<(ScanTarget, Address)> {
-    read_state(|s| {
-        s.automatic_deposits
-            .scan_targets_iter(now, latest)
-            .map(|target| match target.asset() {
-                Asset::Erc20(token) => (target, token),
-                Asset::Eth => panic!("BUG: these tests only seed ERC-20 pairs"),
-            })
-            .collect()
-    })
+fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<ScanTarget<Erc20Asset>> {
+    read_state(|s| s.automatic_deposits.due_scan_targets(now, latest).erc20)
 }
 
 #[tokio::test]

--- a/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
+++ b/rs/ethereum/cketh/minter/src/balance_scan/tests.rs
@@ -295,7 +295,7 @@ async fn should_detect_a_funded_pair_from_pre_scan_targets_even_after_eviction()
 
     // The funded pair is still detected: scan_balances works off the captured targets alone, so the
     // detection is never lost to a mid-scan eviction.
-    let outcomes = scan_balances(&targets, latest, stub_client(vec![ok_balances(&[min])])).await;
+    let outcomes = scan_balances(&targets, latest, &stub_client(vec![ok_balances(&[min])])).await;
 
     assert_eq!(
         outcomes,
@@ -321,7 +321,7 @@ async fn should_yield_nothing_found_for_a_below_minimum_pair() {
     seed_state(Some(latest), token, &[holder], now);
 
     let targets = due_targets(now, latest);
-    let outcomes = scan_balances(&targets, latest, stub_client(vec![ok_balances(&[below])])).await;
+    let outcomes = scan_balances(&targets, latest, &stub_client(vec![ok_balances(&[below])])).await;
 
     assert_eq!(
         outcomes,
@@ -343,17 +343,21 @@ async fn should_yield_no_outcome_for_a_pair_whose_chunk_failed() {
     let outcomes = scan_balances(
         &targets,
         latest,
-        stub_client(vec![Err(IcError::CallPerformFailed)]),
+        &stub_client(vec![Err(IcError::CallPerformFailed)]),
     )
     .await;
 
     assert!(outcomes.is_empty(), "a failed chunk must yield no outcome");
 }
 
-fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<ScanTarget> {
+fn due_targets(now: Timestamp, latest: BlockNumber) -> Vec<(ScanTarget, Address)> {
     read_state(|s| {
         s.automatic_deposits
             .scan_targets_iter(now, latest)
+            .map(|target| match target.asset() {
+                Asset::Erc20(token) => (target, token),
+                Asset::Eth => panic!("BUG: these tests only seed ERC-20 pairs"),
+            })
             .collect()
     })
 }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -375,9 +375,6 @@ impl AutomaticDeposits {
     /// latest block height, using elapsed blocks as a proxy for elapsed time against the
     /// backoff schedule. `now` filters expired entries.
     ///
-    /// ETH pairs are armed but yield no target yet: the balance batcher cannot read an ETH
-    /// balance until it gains its ETH slot, so an ETH pair stays on the watchlist unscanned.
-    ///
     /// Each target carries everything a scan of it needs (address, scan count), so the scanner
     /// never looks the entry up again: a scan spans several await points, and a concurrent
     /// [`Self::watch_deposit`] can evict an entry whose window closed at any of them — re-reading
@@ -407,13 +404,8 @@ impl AutomaticDeposits {
                     }
                 }
             };
-            let token = match request.asset {
-                Asset::Erc20(token) => token,
-                Asset::Eth => return None,
-            };
             due.then_some(ScanTarget {
                 request: *request,
-                token,
                 address: progress.address,
                 scan_count: progress.scan_count,
             })
@@ -554,6 +546,8 @@ impl AutomaticDeposits {
 
     /// The queued deposits a sweep could take next, batched by token, skipping those a sweep
     /// already holds: taking them twice would move a balance the minter has already accounted for.
+    /// ETH entries stay queued but are never batched yet: they wait for the `sweepEthBatch` lane
+    /// (DEFI-2931).
     pub fn requests_batch(
         &self,
         requested_batch_size: usize,
@@ -564,7 +558,7 @@ impl AutomaticDeposits {
         {
             let token = match deposit_request.asset {
                 Asset::Erc20(token) => token,
-                Asset::Eth => todo!("DEFI-2931: sweep ETH deposits via sweepEthBatch"),
+                Asset::Eth => continue,
             };
             let batch: &mut Vec<_> = batches.entry(token).or_default();
             if batch.len() < requested_batch_size {
@@ -679,7 +673,6 @@ pub enum RegisterDepositError {
 #[derive(Clone, Copy, Debug)]
 pub struct ScanTarget {
     request: DepositRequest,
-    token: Address,
     address: DepositAddress,
     scan_count: u32,
 }
@@ -693,8 +686,8 @@ impl ScanTarget {
         self.request.account
     }
 
-    pub fn token(&self) -> Address {
-        self.token
+    pub fn asset(&self) -> Asset {
+        self.request.asset
     }
 
     pub fn address(&self) -> DepositAddress {

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::asset::Asset;
+use crate::asset::{Asset, Erc20Asset, EthAsset};
 use crate::attestation::AttestationRequest;
 use crate::deposit_address::DepositAddress;
 use crate::eth_rpc::Hash;
@@ -371,22 +371,19 @@ impl AutomaticDeposits {
         self.watchlist = TimedSizedMap::from_ordered_entries(ttl, capacity, entries);
     }
 
-    /// Iterate the live [`ScanTarget`]s that are due for a balance scan as of the given
-    /// latest block height, using elapsed blocks as a proxy for elapsed time against the
-    /// backoff schedule. `now` filters expired entries.
+    /// The live [`ScanTarget`]s that are due for a balance scan as of the given latest block
+    /// height, using elapsed blocks as a proxy for elapsed time against the backoff schedule,
+    /// partitioned by the asset kind whose batcher can read them. `now` filters expired entries.
     ///
     /// Each target carries everything a scan of it needs (address, scan count), so the scanner
     /// never looks the entry up again: a scan spans several await points, and a concurrent
     /// [`Self::watch_deposit`] can evict an entry whose window closed at any of them — re-reading
     /// it could come back empty and drop funds already observed on-chain.
-    pub fn scan_targets_iter(
-        &self,
-        now: Timestamp,
-        latest_block: BlockNumber,
-    ) -> impl Iterator<Item = ScanTarget> + '_ {
-        self.watchlist.iter().filter_map(move |(request, entry)| {
+    pub fn due_scan_targets(&self, now: Timestamp, latest_block: BlockNumber) -> ScanTargets {
+        let mut targets = ScanTargets::default();
+        for (request, entry) in self.watchlist.iter() {
             if entry.expires_at < now {
-                return None;
+                continue;
             }
             let progress = &entry.value;
             let due = match progress.last_scanned_block {
@@ -404,12 +401,25 @@ impl AutomaticDeposits {
                     }
                 }
             };
-            due.then_some(ScanTarget {
-                request: *request,
-                address: progress.address,
-                scan_count: progress.scan_count,
-            })
-        })
+            if !due {
+                continue;
+            }
+            match request.asset {
+                Asset::Erc20(token) => targets.erc20.push(ScanTarget {
+                    account: request.account,
+                    asset: Erc20Asset::new(token),
+                    address: progress.address,
+                    scan_count: progress.scan_count,
+                }),
+                Asset::Eth => targets.eth.push(ScanTarget {
+                    account: request.account,
+                    asset: EthAsset,
+                    address: progress.address,
+                    scan_count: progress.scan_count,
+                }),
+            }
+        }
+        targets
     }
 
     /// The live watchlist entry for the `(account, token)` pair, or `None` if the pair is not
@@ -666,28 +676,45 @@ pub enum RegisterDepositError {
     KeyNotInitialized,
 }
 
-/// A [`DepositRequest`] due for a balance scan, carrying everything a scan of it needs read off the
+/// The due targets of one balance-scan tick, partitioned by asset kind: each vector can only
+/// be fed to the batcher that reads its kind's balances.
+#[derive(Default, Debug)]
+pub struct ScanTargets {
+    pub erc20: Vec<ScanTarget<Erc20Asset>>,
+    pub eth: Vec<ScanTarget<EthAsset>>,
+}
+
+impl ScanTargets {
+    pub fn is_empty(&self) -> bool {
+        self.erc20.is_empty() && self.eth.is_empty()
+    }
+}
+
+/// A deposit pair due for a balance scan, carrying everything a scan of it needs read off the
 /// watchlist up front: the deposit `address` derived for its account and the `scan_count` before
 /// this scan. Self-contained so the scanner never re-reads the watchlist (which a concurrent
-/// arming could have evicted from) after its outcalls.
+/// arming could have evicted from) after its outcalls. The asset is carried as a type
+/// ([`EthAsset`] or [`Erc20Asset`]), so a target cannot reach the wrong batcher, and only
+/// [`AutomaticDeposits::due_scan_targets`] constructs one.
 #[derive(Clone, Copy, Debug)]
-pub struct ScanTarget {
-    request: DepositRequest,
+pub struct ScanTarget<A> {
+    account: Account,
+    asset: A,
     address: DepositAddress,
     scan_count: u32,
 }
 
-impl ScanTarget {
+impl<A: Copy + Into<Asset>> ScanTarget<A> {
     pub fn request(&self) -> DepositRequest {
-        self.request
+        DepositRequest::new(self.account, self.asset.into())
     }
 
     pub fn account(&self) -> Account {
-        self.request.account
+        self.account
     }
 
     pub fn asset(&self) -> Asset {
-        self.request.asset
+        self.asset.into()
     }
 
     pub fn address(&self) -> DepositAddress {
@@ -696,6 +723,12 @@ impl ScanTarget {
 
     pub fn scan_count(&self) -> u32 {
         self.scan_count
+    }
+}
+
+impl ScanTarget<Erc20Asset> {
+    pub fn token(&self) -> Address {
+        self.asset.contract_address()
     }
 }
 

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -322,27 +322,27 @@ mod scan_targets_iter {
     };
 
     #[test]
-    fn should_yield_a_target_for_an_eth_pair() {
+    fn should_partition_due_targets_by_asset_kind() {
         let deposits = deposits_from(vec![
             scan_state(account(0), Asset::Eth, ts(window_nanos()), None, 0),
             scan_state(account(0), usdc(), ts(window_nanos()), None, 0),
         ]);
 
-        let due: Vec<_> = deposits
-            .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .map(|t| (t.account(), t.asset(), t.address()))
-            .collect();
+        let due = deposits.due_scan_targets(ts(0), BlockNumber::new(1_000));
 
         assert_eq!(
-            due,
-            vec![
-                (account(0), Asset::Eth, deposit_address(&account(0))),
-                (
-                    account(0),
-                    Asset::Erc20(usdc()),
-                    deposit_address(&account(0))
-                ),
-            ]
+            due.eth
+                .iter()
+                .map(|t| (t.account(), t.address()))
+                .collect::<Vec<_>>(),
+            vec![(account(0), deposit_address(&account(0)))]
+        );
+        assert_eq!(
+            due.erc20
+                .iter()
+                .map(|t| (t.account(), t.token(), t.address()))
+                .collect::<Vec<_>>(),
+            vec![(account(0), usdc(), deposit_address(&account(0)))]
         );
     }
 
@@ -356,18 +356,15 @@ mod scan_targets_iter {
             0,
         )]);
 
-        let due: Vec<_> = deposits
-            .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .map(|t| (t.account(), t.asset(), t.address()))
-            .collect();
+        let due = deposits.due_scan_targets(ts(0), BlockNumber::new(1_000));
 
+        assert!(due.eth.is_empty());
         assert_eq!(
-            due,
-            vec![(
-                account(0),
-                Asset::Erc20(usdc()),
-                deposit_address(&account(0))
-            )]
+            due.erc20
+                .iter()
+                .map(|t| (t.account(), t.token(), t.address()))
+                .collect::<Vec<_>>(),
+            vec![(account(0), usdc(), deposit_address(&account(0)))]
         );
     }
 
@@ -397,15 +394,16 @@ mod scan_targets_iter {
             let just_before = BlockNumber::new(1_000 + u128::from(gap_blocks) - 1);
             let at_boundary = BlockNumber::new(1_000 + u128::from(gap_blocks));
 
-            assert_eq!(
-                deposits.scan_targets_iter(ts(0), just_before).count(),
-                0,
+            assert!(
+                deposits.due_scan_targets(ts(0), just_before).is_empty(),
                 "scan_count {}: not due one block before the gap elapses",
                 case.scan_count
             );
             assert_eq!(
                 deposits
-                    .scan_targets_iter(ts(0), at_boundary)
+                    .due_scan_targets(ts(0), at_boundary)
+                    .erc20
+                    .iter()
                     .map(|t| (t.account(), t.address()))
                     .collect::<Vec<_>>(),
                 vec![(account(0), deposit_address(&account(0)))],
@@ -419,11 +417,10 @@ mod scan_targets_iter {
     fn should_never_yield_an_expired_entry() {
         let deposits = deposits_from(vec![scan_state(account(0), usdc(), ts(100), None, 0)]);
 
-        assert_eq!(
+        assert!(
             deposits
-                .scan_targets_iter(ts(101), BlockNumber::new(1_000_000))
-                .count(),
-            0
+                .due_scan_targets(ts(101), BlockNumber::new(1_000_000))
+                .is_empty()
         );
     }
 
@@ -439,11 +436,10 @@ mod scan_targets_iter {
             SCAN_GAP_SECS.len() as u32 + 1,
         )]);
 
-        assert_eq!(
+        assert!(
             deposits
-                .scan_targets_iter(ts(0), BlockNumber::new(u128::MAX))
-                .count(),
-            0
+                .due_scan_targets(ts(0), BlockNumber::new(u128::MAX))
+                .is_empty()
         );
     }
 }
@@ -568,8 +564,9 @@ fn record_scan_advances_the_schedule() {
     // Never scanned -> due immediately.
     assert_eq!(
         deposits
-            .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .count(),
+            .due_scan_targets(ts(0), BlockNumber::new(1_000))
+            .erc20
+            .len(),
         1
     );
 
@@ -584,16 +581,16 @@ fn record_scan_advances_the_schedule() {
     assert_eq!(snapshot.registrations[0].scan_count, 1);
 
     // Not due at the just-scanned block; due again well after the next gap.
-    assert_eq!(
+    assert!(
         deposits
-            .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .count(),
-        0
+            .due_scan_targets(ts(0), BlockNumber::new(1_000))
+            .is_empty()
     );
     assert_eq!(
         deposits
-            .scan_targets_iter(ts(0), BlockNumber::new(2_000))
-            .count(),
+            .due_scan_targets(ts(0), BlockNumber::new(2_000))
+            .erc20
+            .len(),
         1
     );
 }

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -322,7 +322,7 @@ mod scan_targets_iter {
     };
 
     #[test]
-    fn should_not_yield_a_target_for_an_eth_pair() {
+    fn should_yield_a_target_for_an_eth_pair() {
         let deposits = deposits_from(vec![
             scan_state(account(0), Asset::Eth, ts(window_nanos()), None, 0),
             scan_state(account(0), usdc(), ts(window_nanos()), None, 0),
@@ -330,13 +330,19 @@ mod scan_targets_iter {
 
         let due: Vec<_> = deposits
             .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .map(|t| (t.account(), t.token(), t.address()))
+            .map(|t| (t.account(), t.asset(), t.address()))
             .collect();
 
         assert_eq!(
             due,
-            vec![(account(0), usdc(), deposit_address(&account(0)))],
-            "BUG: the ETH pair is not scannable until the batcher can read ETH balances"
+            vec![
+                (account(0), Asset::Eth, deposit_address(&account(0))),
+                (
+                    account(0),
+                    Asset::Erc20(usdc()),
+                    deposit_address(&account(0))
+                ),
+            ]
         );
     }
 
@@ -352,12 +358,16 @@ mod scan_targets_iter {
 
         let due: Vec<_> = deposits
             .scan_targets_iter(ts(0), BlockNumber::new(1_000))
-            .map(|t| (t.account(), t.token(), t.address()))
+            .map(|t| (t.account(), t.asset(), t.address()))
             .collect();
 
         assert_eq!(
             due,
-            vec![(account(0), usdc(), deposit_address(&account(0)))]
+            vec![(
+                account(0),
+                Asset::Erc20(usdc()),
+                deposit_address(&account(0))
+            )]
         );
     }
 
@@ -830,7 +840,7 @@ fn request(account: Account, token: Address) -> DepositRequest {
 
 fn automatic_deposit(
     account: Account,
-    token: Address,
+    asset: impl Into<Asset>,
     scanned_balance: u128,
     last_scanned_block: BlockNumber,
     scan_count: u32,
@@ -839,11 +849,40 @@ fn automatic_deposit(
         owner: account.owner,
         subaccount: account.subaccount,
         address: deposit_address(&account),
-        asset: Asset::Erc20(token),
+        asset: asset.into(),
         last_scanned_block,
         scan_count,
         scanned_balance: Erc20Value::new(scanned_balance),
     }
+}
+
+#[test]
+fn should_keep_eth_entries_out_of_sweep_batches() {
+    let mut deposits = AutomaticDeposits::default();
+    deposits.record_automatic_deposit_received(&automatic_deposit(
+        account(0),
+        Asset::Eth,
+        10,
+        BlockNumber::new(900),
+        3,
+    ));
+    deposits.record_automatic_deposit_received(&automatic_deposit(
+        account(1),
+        usdc(),
+        10,
+        BlockNumber::new(900),
+        3,
+    ));
+
+    let batches = deposits.requests_batch(10);
+
+    assert_eq!(batches.len(), 1);
+    assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
+    assert_eq!(
+        deposits.sweep_len(),
+        2,
+        "BUG: the ETH entry stays queued, awaiting the sweepEthBatch lane"
+    );
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -147,7 +147,7 @@ fn should_mint_with_ckerc20_setup() {
 
 mod deposit_eth {
     use assert_matches::assert_matches;
-    use candid::Principal;
+    use candid::{Nat, Principal};
     use ic_cketh_minter::endpoints::events::{Asset as EventAsset, EventPayload};
     use ic_cketh_minter::endpoints::{DepositEthStatus, DepositStatus};
     use ic_cketh_minter::state::automatic_deposits::DEPOSIT_ADDRESS_SCAN_WINDOW;
@@ -278,6 +278,7 @@ mod deposit_eth {
             .expect_deposit_response();
 
         let scanned_at = 4_500_000_u64;
+        let scanned_at_block = Nat::from(scanned_at);
         ckerc20.refresh_latest_block(scanned_at);
         ckerc20.run_balance_scan_with_eth(
             &[(armed.address.as_str(), 1)],
@@ -290,7 +291,7 @@ mod deposit_eth {
         assert_matches!(
             erc20_response.status,
             DepositStatus::Scanning { scan_count: 1, last_scanned_block: Some(ref block), .. }
-                if *block == candid::Nat::from(scanned_at)
+                if *block == scanned_at_block
         );
 
         let (_ckerc20, eth_response) = ckerc20
@@ -299,7 +300,7 @@ mod deposit_eth {
         assert_matches!(
             eth_response.status,
             DepositEthStatus::Scanning { scan_count: 1, last_scanned_block: Some(ref block), .. }
-                if *block == candid::Nat::from(scanned_at)
+                if *block == scanned_at_block
         );
     }
 

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -302,6 +302,54 @@ mod deposit_eth {
     }
 
     #[test]
+    fn should_record_erc20_outcomes_before_awaiting_the_eth_scan() {
+        let ckerc20 = CkErc20Setup::default().add_supported_erc20_tokens();
+        let caller = ckerc20.caller();
+        let token =
+            format_ethereum_address_to_eip_55(&ckerc20.supported_erc20_tokens[0].contract.address);
+
+        let (ckerc20, _) = ckerc20
+            .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
+            .expect_deposit_response();
+        let (ckerc20, _) = ckerc20
+            .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token.clone())
+            .expect_deposit_response();
+
+        ckerc20.refresh_latest_block(4_500_000);
+        ckerc20.answer_erc20_balance_scan(&[1_u128]);
+
+        // The tick is still suspended on its unanswered ETH batch, yet the ERC-20 outcome is
+        // already recorded: funds observed on-chain must not hinge on a later await resuming.
+        let (ckerc20, erc20_response) = ckerc20
+            .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
+            .expect_deposit_response();
+        assert_matches!(
+            erc20_response.status,
+            DepositStatus::Scanning { scan_count: 1, .. }
+        );
+        let (ckerc20, eth_response) = ckerc20
+            .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
+            .expect_deposit_response();
+        assert_matches!(
+            eth_response.status,
+            DepositStatus::Scanning {
+                scan_count: 0,
+                last_scanned_block: None,
+                ..
+            }
+        );
+
+        ckerc20.answer_eth_balance_scan(&[1_u128]);
+        let (_ckerc20, eth_response) = ckerc20
+            .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
+            .expect_deposit_response();
+        assert_matches!(
+            eth_response.status,
+            DepositStatus::Scanning { scan_count: 1, .. }
+        );
+    }
+
+    #[test]
     fn should_derive_same_address_as_deposit_erc20() {
         let mut ckerc20 = CkErc20Setup::default()
             .add_supported_erc20_tokens()

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -218,7 +218,7 @@ mod deposit_eth {
 
         let scanned_at = 4_500_000_u64;
         ckerc20.refresh_latest_block(scanned_at);
-        ckerc20.run_balance_scan(&[MINIMUM_ETH_DEPOSIT_WEI as u128]);
+        ckerc20.run_balance_scan(&[(before.address.as_str(), MINIMUM_ETH_DEPOSIT_WEI as u128)]);
 
         let received: Vec<_> = ckerc20
             .cketh
@@ -270,7 +270,7 @@ mod deposit_eth {
         let token =
             format_ethereum_address_to_eip_55(&ckerc20.supported_erc20_tokens[0].contract.address);
 
-        let (ckerc20, _) = ckerc20
+        let (ckerc20, armed) = ckerc20
             .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
             .expect_deposit_response();
         let (ckerc20, _) = ckerc20
@@ -279,7 +279,10 @@ mod deposit_eth {
 
         let scanned_at = 4_500_000_u64;
         ckerc20.refresh_latest_block(scanned_at);
-        ckerc20.run_balance_scan_with_eth(&[1_u128], &[1_u128]);
+        ckerc20.run_balance_scan_with_eth(
+            &[(armed.address.as_str(), 1)],
+            &[(armed.address.as_str(), 1)],
+        );
 
         let (ckerc20, erc20_response) = ckerc20
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
@@ -307,7 +310,7 @@ mod deposit_eth {
         let token =
             format_ethereum_address_to_eip_55(&ckerc20.supported_erc20_tokens[0].contract.address);
 
-        let (ckerc20, _) = ckerc20
+        let (ckerc20, armed) = ckerc20
             .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
             .expect_deposit_response();
         let (ckerc20, _) = ckerc20
@@ -315,7 +318,7 @@ mod deposit_eth {
             .expect_deposit_response();
 
         ckerc20.refresh_latest_block(4_500_000);
-        ckerc20.answer_erc20_balance_scan(&[1_u128]);
+        ckerc20.answer_erc20_balance_scan(&[(armed.address.as_str(), 1)]);
 
         let (ckerc20, erc20_response) = ckerc20
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
@@ -329,20 +332,20 @@ mod deposit_eth {
             .expect_deposit_response();
         assert_matches!(
             eth_response.status,
-            DepositStatus::Scanning {
+            DepositEthStatus::Scanning {
                 scan_count: 0,
                 last_scanned_block: None,
                 ..
             }
         );
 
-        ckerc20.answer_eth_balance_scan(&[1_u128]);
+        ckerc20.answer_eth_balance_scan(&[(armed.address.as_str(), 1)]);
         let (_ckerc20, eth_response) = ckerc20
             .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
             .expect_deposit_response();
         assert_matches!(
             eth_response.status,
-            DepositStatus::Scanning { scan_count: 1, .. }
+            DepositEthStatus::Scanning { scan_count: 1, .. }
         );
     }
 
@@ -657,7 +660,7 @@ mod deposit_erc20 {
         // pair (one balance; the value is irrelevant to scan progress).
         let scanned_at = 4_500_000_u64;
         ckerc20.refresh_latest_block(scanned_at);
-        ckerc20.run_balance_scan(&[2_000_000_u128]);
+        ckerc20.run_balance_scan(&[(before.address.as_str(), 2_000_000)]);
 
         // deposit_erc20 now reports the pair as scanned once, at that block height.
         let (ckerc20, after) = ckerc20
@@ -697,7 +700,7 @@ mod deposit_erc20 {
         // it is moved out of the watchlist into the sweep queue.
         let scanned_at = 4_500_000_u64;
         ckerc20.refresh_latest_block(scanned_at);
-        ckerc20.run_balance_scan(&[1_000_000_000_u128]);
+        ckerc20.run_balance_scan(&[(before.address.as_str(), 1_000_000_000)]);
 
         // The move is event-sourced (metrics are deferred to DEFI-2965, so get_events is the sole
         // observable): a single AutomaticDepositReceived event for the scanned (account, token) pair,

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -148,6 +148,7 @@ fn should_mint_with_ckerc20_setup() {
 mod deposit_eth {
     use assert_matches::assert_matches;
     use candid::Principal;
+    use ic_cketh_minter::endpoints::events::{Asset as EventAsset, EventPayload};
     use ic_cketh_minter::endpoints::{DepositEthStatus, DepositStatus};
     use ic_cketh_minter::state::automatic_deposits::DEPOSIT_ADDRESS_SCAN_WINDOW;
     use ic_cketh_test_utils::ckerc20::{CkErc20Setup, ckwbtc};
@@ -207,7 +208,63 @@ mod deposit_eth {
     }
 
     #[test]
-    fn should_not_scan_the_eth_pair() {
+    fn should_detect_eth_deposit() {
+        let ckerc20 = CkErc20Setup::default().add_supported_erc20_tokens();
+        let caller = ckerc20.caller();
+
+        let (ckerc20, before) = ckerc20
+            .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
+            .expect_deposit_response();
+
+        let scanned_at = 4_500_000_u64;
+        ckerc20.refresh_latest_block(scanned_at);
+        ckerc20.run_balance_scan(&[MINIMUM_ETH_DEPOSIT_WEI as u128]);
+
+        let received: Vec<_> = ckerc20
+            .cketh
+            .get_all_events()
+            .into_iter()
+            .filter_map(|event| match event.payload {
+                EventPayload::AutomaticDepositReceived {
+                    owner,
+                    subaccount,
+                    address,
+                    asset,
+                    scanned_balance,
+                    ..
+                } => Some((owner, subaccount, address, asset, scanned_balance)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            received.len(),
+            1,
+            "one AutomaticDepositReceived event for the funded ETH pair"
+        );
+        let (owner, subaccount, address, asset, scanned_balance) = &received[0];
+        assert_eq!(*owner, caller);
+        assert_eq!(*subaccount, Some(DEFAULT_USER_SUBACCOUNT));
+        assert_eq!(*address, before.address);
+        assert_eq!(*asset, EventAsset::Eth);
+        assert_eq!(*scanned_balance, candid::Nat::from(MINIMUM_ETH_DEPOSIT_WEI));
+
+        let (_ckerc20, detected) = ckerc20
+            .call_minter_deposit_eth(caller, Some(DEFAULT_USER_SUBACCOUNT))
+            .expect_deposit_response();
+        assert_eq!(detected.address, before.address);
+        let deposit = match &detected.status {
+            DepositEthStatus::AwaitingSweep(deposit) => deposit.clone(),
+            other => panic!("BUG: expected AwaitingSweep, got {other:?}"),
+        };
+        assert_eq!(
+            deposit.scanned_balance,
+            candid::Nat::from(MINIMUM_ETH_DEPOSIT_WEI)
+        );
+        assert_eq!(deposit.detected_at_block, candid::Nat::from(scanned_at));
+    }
+
+    #[test]
+    fn should_scan_eth_and_erc20_pairs_in_one_tick() {
         let ckerc20 = CkErc20Setup::default().add_supported_erc20_tokens();
         let caller = ckerc20.caller();
         let token =
@@ -220,16 +277,18 @@ mod deposit_eth {
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token.clone())
             .expect_deposit_response();
 
-        ckerc20.refresh_latest_block(4_500_000);
-        ckerc20.run_balance_scan(&[1_000_000_000_u128]);
+        // Balances below both minimums: both pairs are scanned, neither is detected.
+        let scanned_at = 4_500_000_u64;
+        ckerc20.refresh_latest_block(scanned_at);
+        ckerc20.run_balance_scan_with_eth(&[1_u128], &[1_u128]);
 
         let (ckerc20, erc20_response) = ckerc20
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
             .expect_deposit_response();
         assert_matches!(
             erc20_response.status,
-            DepositStatus::AwaitingSweep(_),
-            "BUG: the funded ERC-20 pair should have been detected by the scan"
+            DepositStatus::Scanning { scan_count: 1, last_scanned_block: Some(ref block), .. }
+                if *block == candid::Nat::from(scanned_at)
         );
 
         let (_ckerc20, eth_response) = ckerc20
@@ -237,12 +296,8 @@ mod deposit_eth {
             .expect_deposit_response();
         assert_matches!(
             eth_response.status,
-            DepositEthStatus::Scanning {
-                scan_count: 0,
-                last_scanned_block: None,
-                ..
-            },
-            "BUG: the ETH pair must stay armed and unscanned until the batcher can read ETH balances"
+            DepositEthStatus::Scanning { scan_count: 1, last_scanned_block: Some(ref block), .. }
+                if *block == candid::Nat::from(scanned_at)
         );
     }
 

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -277,7 +277,6 @@ mod deposit_eth {
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token.clone())
             .expect_deposit_response();
 
-        // Balances below both minimums: both pairs are scanned, neither is detected.
         let scanned_at = 4_500_000_u64;
         ckerc20.refresh_latest_block(scanned_at);
         ckerc20.run_balance_scan_with_eth(&[1_u128], &[1_u128]);
@@ -318,8 +317,6 @@ mod deposit_eth {
         ckerc20.refresh_latest_block(4_500_000);
         ckerc20.answer_erc20_balance_scan(&[1_u128]);
 
-        // The tick is still suspended on its unanswered ETH batch, yet the ERC-20 outcome is
-        // already recorded: funds observed on-chain must not hinge on a later await resuming.
         let (ckerc20, erc20_response) = ckerc20
             .call_minter_deposit_erc20(caller, Some(DEFAULT_USER_SUBACCOUNT), token)
             .expect_deposit_response();

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -10,6 +10,7 @@
 use assert_matches::assert_matches;
 use ic_cketh_minter::balance_scan::batcher::{
     BalanceOfCall, MAX_CALLS_PER_BATCH, decode_balance_batch, encode_balance_batch,
+    encode_eth_balance_batch,
 };
 use ic_cketh_minter::deposit_address::DepositAddress;
 use ic_cketh_minter::endpoints::DepositStatus;
@@ -168,6 +169,78 @@ fn should_scan_a_full_batch_in_a_single_call() {
         error.to_lowercase().contains("initcode"),
         "expected an EIP-3860 initcode limit error, got: {error}"
     );
+}
+
+#[test]
+fn should_read_eth_balances_across_holders() {
+    let anvil = Anvil::start();
+    let dev = address_from_hex(DEV_ACCOUNT);
+
+    let h1 = Address::new([0x11; 20]);
+    let h2 = Address::new([0x22; 20]);
+    let h3 = Address::new([0x33; 20]); // never funded -> balance 0
+
+    anvil.send_eth(&dev, &h1, 5_000_000_000_000_000); // the 0.005 ETH minimum deposit
+    anvil.send_eth(&dev, &h2, 1_234_567_890_123_456_789);
+
+    let holders = vec![
+        DepositAddress::new(h1),
+        DepositAddress::new(h2),
+        DepositAddress::new(h3),
+    ];
+    let out = anvil
+        .eth_call_create(&dev, &encode_eth_balance_batch(&holders))
+        .expect("the ETH balance batch must not revert");
+    let balances = decode_balance_batch(&out, holders.len()).expect("decode failed");
+
+    assert_eq!(
+        balances,
+        vec![
+            Erc20Value::new(5_000_000_000_000_000),
+            Erc20Value::new(1_234_567_890_123_456_789),
+            Erc20Value::new(0),
+        ]
+    );
+
+    // The batcher must agree with anvil's own view of every balance.
+    for holder in &holders {
+        let expected = anvil.balance(holder.as_address());
+        let single = anvil
+            .eth_call_create(
+                &dev,
+                &encode_eth_balance_batch(std::slice::from_ref(holder)),
+            )
+            .expect("single-holder batch reverted");
+        assert_eq!(
+            decode_balance_batch(&single, 1).unwrap()[0],
+            Erc20Value::new(expected)
+        );
+    }
+}
+
+#[test]
+fn should_read_many_eth_balances_in_a_single_call() {
+    let anvil = Anvil::start();
+    let dev = address_from_hex(DEV_ACCOUNT);
+
+    // A single create-style eth_call carrying many BALANCE reads, to exercise
+    // the loop and the per-holder CODECOPY offset arithmetic at scale.
+    const N: u64 = 32;
+    let holders: Vec<Address> = (0..N).map(holder_at).collect();
+    for (i, holder) in holders.iter().enumerate() {
+        anvil.send_eth(&dev, holder, (i as u128 + 1) * 1_000);
+    }
+
+    let batch: Vec<DepositAddress> = holders.iter().copied().map(DepositAddress::new).collect();
+    let out = anvil
+        .eth_call_create(&dev, &encode_eth_balance_batch(&batch))
+        .expect("the ETH balance batch must not revert");
+    let balances = decode_balance_batch(&out, batch.len()).expect("decode failed");
+
+    let expected: Vec<Erc20Value> = (0..N)
+        .map(|i| Erc20Value::new((i as u128 + 1) * 1_000))
+        .collect();
+    assert_eq!(balances, expected);
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -178,15 +178,15 @@ fn should_read_eth_balances_across_holders() {
 
     let h1 = Address::new([0x11; 20]);
     let h2 = Address::new([0x22; 20]);
-    let h3 = Address::new([0x33; 20]); // never funded -> balance 0
+    let never_funded = Address::new([0x33; 20]);
 
-    anvil.send_eth(&dev, &h1, 5_000_000_000_000_000); // the 0.005 ETH minimum deposit
+    anvil.send_eth(&dev, &h1, 5_000_000_000_000_000);
     anvil.send_eth(&dev, &h2, 1_234_567_890_123_456_789);
 
     let holders = vec![
         DepositAddress::new(h1),
         DepositAddress::new(h2),
-        DepositAddress::new(h3),
+        DepositAddress::new(never_funded),
     ];
     let out = anvil
         .eth_call_create(&dev, &encode_eth_balance_batch(&holders))
@@ -223,8 +223,6 @@ fn should_read_many_eth_balances_in_a_single_call() {
     let anvil = Anvil::start();
     let dev = address_from_hex(DEV_ACCOUNT);
 
-    // A single create-style eth_call carrying many BALANCE reads, to exercise
-    // the loop and the per-holder CODECOPY offset arithmetic at scale.
     const N: u64 = 32;
     let holders: Vec<Address> = (0..N).map(holder_at).collect();
     for (i, holder) in holders.iter().enumerate() {

--- a/rs/ethereum/cketh/test_utils/src/anvil.rs
+++ b/rs/ethereum/cketh/test_utils/src/anvil.rs
@@ -243,6 +243,12 @@ impl Anvil {
         self.send_transaction_with_value(from, to, data, 0)
     }
 
+    /// A plain ETH transfer of `value` wei, mined before returning.
+    pub fn send_eth(&self, from: &Address, to: &Address, value: u128) {
+        let tx = self.send_transaction_with_value(from, Some(to), &[], value);
+        assert!(status_ok(&self.await_receipt(&tx)), "ETH transfer failed");
+    }
+
     fn send_transaction_with_value(
         &self,
         from: &Address,

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -4,7 +4,8 @@ use crate::flow::{
     ProcessWithdrawal, encode_principal,
 };
 use crate::mock::{
-    JsonRpcMethod, JsonRpcRequestMatcher, MockJsonRpcProviders, MockJsonRpcProvidersBuilder,
+    JsonRpcMethod, JsonRpcRequestMatcher, MatchRequestParams, MockJsonRpcProviders,
+    MockJsonRpcProvidersBuilder,
 };
 use crate::response::{balance_scan_response, block_response, empty_logs, fee_history};
 use crate::{
@@ -44,7 +45,7 @@ use num_traits::ToPrimitive;
 use pocket_ic::common::rest::RawMessageId;
 use pocket_ic::{ErrorCode, PocketIc};
 use serde_json::json;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::convert::identity;
 use std::iter::{once, zip};
 use std::str::FromStr;
@@ -238,7 +239,9 @@ impl CkErc20Setup {
     fn answer_balance_scan_batch(&self, kind: Option<ScanBatchKind>, balances: &[(&str, u128)]) {
         let request =
             JsonRpcRequestMatcher::new(JsonRpcProvider::Provider1, JsonRpcMethod::EthCall)
-                .with_eth_call_input_prefix(kind.map(ScanBatchKind::initcode))
+                .with_request_params(
+                    kind.map(|kind| EthCallInputStartsWith::batcher(kind).into_filter()),
+                )
                 .find_rpc_call(&self.env)
                 .expect("BUG: no balance-scan eth_call pending");
         let (kind, holders) = parse_scan_batch(&eth_call_input_bytes(&request));
@@ -247,7 +250,7 @@ impl CkErc20Setup {
             .map(|holder| scanned_balance(balances, holder))
             .collect();
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .with_eth_call_input_prefix(kind.initcode())
+            .with_request_params_filter(EthCallInputStartsWith::batcher(kind))
             .respond_for_all_with(balance_scan_response(&response))
             .build()
             .expect_rpc_calls(self);
@@ -1066,12 +1069,15 @@ impl RefreshGasFeeEstimate {
     }
 
     pub fn expect_no_refresh_gas_fee_estimate(self) -> Erc20WithdrawalFlow {
-        assert_eq!(
+        let providers_with_pending_call: Vec<JsonRpcProvider> =
             JsonRpcRequestMatcher::new_for_all_providers(JsonRpcMethod::EthFeeHistory)
-                .iter()
+                .into_iter()
                 .filter(|(_provider, matcher)| matcher.find_rpc_call(&self.setup.env).is_some())
-                .collect::<BTreeMap<_, _>>(),
-            BTreeMap::new(),
+                .map(|(provider, _matcher)| provider)
+                .collect();
+        assert_eq!(
+            providers_with_pending_call,
+            Vec::new(),
             "BUG: unexpected EthFeeHistory RPC call"
         );
 
@@ -1214,11 +1220,37 @@ impl ScanBatchKind {
     }
 }
 
+/// Matches an `eth_call` whose `input` calldata starts with the given bytes, e.g. one of the
+/// deployless balance-batcher programs.
+#[derive(Debug)]
+struct EthCallInputStartsWith(String);
+
+impl EthCallInputStartsWith {
+    fn batcher(kind: ScanBatchKind) -> Self {
+        Self(format!("0x{}", hex::encode(kind.initcode())))
+    }
+
+    fn into_filter(self) -> Arc<dyn MatchRequestParams> {
+        Arc::new(self)
+    }
+}
+
+impl MatchRequestParams for EthCallInputStartsWith {
+    fn matches(&self, params: &serde_json::Value) -> bool {
+        eth_call_input(params)
+            .map(|input| input.to_lowercase().starts_with(&self.0))
+            .unwrap_or(false)
+    }
+}
+
+fn eth_call_input(params: &serde_json::Value) -> Option<&str> {
+    params.get(0)?.get("input")?.as_str()
+}
+
 fn eth_call_input_bytes(request: &pocket_ic::common::rest::CanisterHttpRequest) -> Vec<u8> {
     let body: serde_json::Value =
         serde_json::from_slice(&request.body).expect("BUG: request body is not JSON");
-    let input =
-        crate::mock::eth_call_input(&body["params"]).expect("BUG: eth_call request without input");
+    let input = eth_call_input(&body["params"]).expect("BUG: eth_call request without input");
     hex::decode(input.trim_start_matches("0x")).expect("BUG: input is not hex")
 }
 

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -11,14 +11,16 @@ use crate::{
     CkEthSetup, DEFAULT_DEPOSIT_FROM_ADDRESS, DEFAULT_ERC20_DEPOSIT_LOG_INDEX,
     DEFAULT_ERC20_DEPOSIT_TRANSACTION_HASH, DEFAULT_PRINCIPAL_ID,
     DEPOSIT_WITH_SUBACCOUNT_HELPER_CONTRACT_ADDRESS, ERC20_HELPER_CONTRACT_ADDRESS,
-    ETH_HELPER_CONTRACT_ADDRESS, LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL, LedgerBalance, MAX_TICKS,
-    RECEIVED_ERC20_EVENT_TOPIC, RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC, assert_reply,
+    ETH_HELPER_CONTRACT_ADDRESS, JsonRpcProvider, LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL,
+    LedgerBalance, MAX_TICKS, RECEIVED_ERC20_EVENT_TOPIC,
+    RECEIVED_ETH_OR_ERC20_WITH_SUBACCOUNT_EVENT_TOPIC, assert_reply,
     format_ethereum_address_to_eip_55,
 };
 use assert_matches::assert_matches;
 use candid::{Decode, Encode, Nat, Principal};
 use evm_rpc_types::Hex32;
 use ic_base_types::PrincipalId;
+use ic_cketh_minter::balance_scan::batcher::{BATCHER_INITCODE, ETH_BATCHER_INITCODE};
 use ic_cketh_minter::endpoints::ckerc20::{
     RetrieveErc20Request, WithdrawErc20Arg, WithdrawErc20Error,
 };
@@ -198,26 +200,24 @@ impl CkErc20Setup {
         }
     }
 
-    /// Advance the balance-scan timer and answer the resulting deployless-batcher `eth_call` with
-    /// `balances` — one entry per scanned `(deposit address, asset)` pair, in scan order. Fits a
-    /// tick where a single batch goes out (only ERC-20 pairs or only ETH pairs are due); for a
-    /// mixed tick use [`Self::run_balance_scan_with_eth`]. Settles the reply so the per-address
-    /// scan schedule is advanced before returning.
-    pub fn run_balance_scan(&self, balances: &[u128]) {
+    /// Advance the balance-scan timer and answer the tick's single batch — the pending
+    /// `eth_call`'s calldata says which batcher program it runs — with each scanned address'
+    /// balance looked up in `balances` by address (an address absent from `balances` reports 0).
+    /// Settles the reply so the per-address scan schedule is advanced before returning. For a
+    /// tick where both ERC-20 and ETH pairs are due use [`Self::run_balance_scan_with_eth`].
+    pub fn run_balance_scan(&self, balances: &[(&str, u128)]) {
         self.env.advance_time(BALANCE_SCAN_INTERVAL);
-        MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(balances))
-            .build()
-            .expect_rpc_calls(self);
-        for _ in 0..MAX_TICKS {
-            self.env.tick();
-        }
+        self.answer_balance_scan_batch(None, balances);
     }
 
     /// Like [`Self::run_balance_scan`], but for a tick where both ERC-20 and ETH pairs are
-    /// due: the scanner sends the ERC-20 batch first and the ETH batch second, each answered
-    /// with its own balances.
-    pub fn run_balance_scan_with_eth(&self, erc20_balances: &[u128], eth_balances: &[u128]) {
+    /// due: each batch is identified by the batcher program in its calldata and answered from
+    /// its own balances.
+    pub fn run_balance_scan_with_eth(
+        &self,
+        erc20_balances: &[(&str, u128)],
+        eth_balances: &[(&str, u128)],
+    ) {
         self.answer_erc20_balance_scan(erc20_balances);
         self.answer_eth_balance_scan(eth_balances);
     }
@@ -225,26 +225,34 @@ impl CkErc20Setup {
     /// Advance the balance-scan timer and answer only the ERC-20 batch of a mixed tick,
     /// leaving the scanner suspended on its ETH batch until
     /// [`Self::answer_eth_balance_scan`] runs.
-    pub fn answer_erc20_balance_scan(&self, balances: &[u128]) {
+    pub fn answer_erc20_balance_scan(&self, balances: &[(&str, u128)]) {
         self.env.advance_time(BALANCE_SCAN_INTERVAL);
-        MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(balances))
-            .build()
-            .expect_rpc_calls(self);
-        for _ in 0..MAX_TICKS {
-            self.env.tick();
-        }
+        self.answer_balance_scan_batch(Some(ScanBatchKind::Erc20), balances);
     }
 
     /// Answer the ETH batch a mixed tick is suspended on and settle the reply.
-    pub fn answer_eth_balance_scan(&self, balances: &[u128]) {
+    pub fn answer_eth_balance_scan(&self, balances: &[(&str, u128)]) {
+        self.answer_balance_scan_batch(Some(ScanBatchKind::Eth), balances);
+    }
+
+    fn answer_balance_scan_batch(&self, kind: Option<ScanBatchKind>, balances: &[(&str, u128)]) {
+        let request =
+            JsonRpcRequestMatcher::new(JsonRpcProvider::Provider1, JsonRpcMethod::EthCall)
+                .with_eth_call_input_prefix(kind.map(ScanBatchKind::initcode))
+                .find_rpc_call(&self.env)
+                .expect("BUG: no balance-scan eth_call pending");
+        let (kind, holders) = parse_scan_batch(&eth_call_input_bytes(&request));
+        let response: Vec<u128> = holders
+            .iter()
+            .map(|holder| scanned_balance(balances, holder))
+            .collect();
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(balances))
+            .with_eth_call_input_prefix(kind.initcode())
+            .respond_for_all_with(balance_scan_response(&response))
             .build()
             .expect_rpc_calls(self);
-        for _ in 0..MAX_TICKS {
-            self.env.tick();
-        }
+        self.env.tick();
+        self.env.tick();
     }
 
     pub fn check_events(self) -> MinterEventAssert<Self> {
@@ -1175,6 +1183,73 @@ impl DepositErc20Flow {
         )
         .unwrap()
     }
+}
+
+#[derive(Clone, Copy)]
+enum ScanBatchKind {
+    Erc20,
+    Eth,
+}
+
+impl ScanBatchKind {
+    fn initcode(self) -> &'static [u8] {
+        match self {
+            ScanBatchKind::Erc20 => &BATCHER_INITCODE,
+            ScanBatchKind::Eth => &ETH_BATCHER_INITCODE,
+        }
+    }
+
+    fn words_per_entry(self) -> usize {
+        match self {
+            ScanBatchKind::Erc20 => 2,
+            ScanBatchKind::Eth => 1,
+        }
+    }
+
+    fn holder_word_index(self) -> usize {
+        match self {
+            ScanBatchKind::Erc20 => 1,
+            ScanBatchKind::Eth => 0,
+        }
+    }
+}
+
+fn eth_call_input_bytes(request: &pocket_ic::common::rest::CanisterHttpRequest) -> Vec<u8> {
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("BUG: request body is not JSON");
+    let input =
+        crate::mock::eth_call_input(&body["params"]).expect("BUG: eth_call request without input");
+    hex::decode(input.trim_start_matches("0x")).expect("BUG: input is not hex")
+}
+
+fn parse_scan_batch(input: &[u8]) -> (ScanBatchKind, Vec<String>) {
+    let kind = if input.starts_with(&BATCHER_INITCODE) {
+        ScanBatchKind::Erc20
+    } else if input.starts_with(&ETH_BATCHER_INITCODE) {
+        ScanBatchKind::Eth
+    } else {
+        panic!("BUG: eth_call input is not a balance-scan batch");
+    };
+    let args = &input[kind.initcode().len()..];
+    let n = u64::from_be_bytes(args[24..32].try_into().unwrap()) as usize;
+    let holders = (0..n)
+        .map(|i| {
+            let word = 32 * (1 + i * kind.words_per_entry() + kind.holder_word_index());
+            format_ethereum_address_to_eip_55(&format!(
+                "0x{}",
+                hex::encode(&args[word + 12..word + 32])
+            ))
+        })
+        .collect();
+    (kind, holders)
+}
+
+fn scanned_balance(balances: &[(&str, u128)], holder: &str) -> u128 {
+    balances
+        .iter()
+        .find(|(address, _)| address.eq_ignore_ascii_case(holder))
+        .map(|(_, balance)| *balance)
+        .unwrap_or(0)
 }
 
 pub fn erc20_transfer_data(expected_address: &Address, expected_amount: &Erc20Value) -> Vec<u8> {

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -218,13 +218,28 @@ impl CkErc20Setup {
     /// due: the scanner sends the ERC-20 batch first and the ETH batch second, each answered
     /// with its own balances.
     pub fn run_balance_scan_with_eth(&self, erc20_balances: &[u128], eth_balances: &[u128]) {
+        self.answer_erc20_balance_scan(erc20_balances);
+        self.answer_eth_balance_scan(eth_balances);
+    }
+
+    /// Advance the balance-scan timer and answer only the ERC-20 batch of a mixed tick,
+    /// leaving the scanner suspended on its ETH batch until
+    /// [`Self::answer_eth_balance_scan`] runs.
+    pub fn answer_erc20_balance_scan(&self, balances: &[u128]) {
         self.env.advance_time(BALANCE_SCAN_INTERVAL);
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(erc20_balances))
+            .respond_for_all_with(balance_scan_response(balances))
             .build()
             .expect_rpc_calls(self);
+        for _ in 0..MAX_TICKS {
+            self.env.tick();
+        }
+    }
+
+    /// Answer the ETH batch a mixed tick is suspended on and settle the reply.
+    pub fn answer_eth_balance_scan(&self, balances: &[u128]) {
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
-            .respond_for_all_with(balance_scan_response(eth_balances))
+            .respond_for_all_with(balance_scan_response(balances))
             .build()
             .expect_rpc_calls(self);
         for _ in 0..MAX_TICKS {

--- a/rs/ethereum/cketh/test_utils/src/ckerc20.rs
+++ b/rs/ethereum/cketh/test_utils/src/ckerc20.rs
@@ -199,13 +199,32 @@ impl CkErc20Setup {
     }
 
     /// Advance the balance-scan timer and answer the resulting deployless-batcher `eth_call` with
-    /// `balances` — one entry per scanned `(deposit address, supported token)` pair, in scan order
-    /// (i.e. `live-due addresses × supported tokens`). Settles the reply so the per-address scan
-    /// schedule is advanced before returning.
+    /// `balances` — one entry per scanned `(deposit address, asset)` pair, in scan order. Fits a
+    /// tick where a single batch goes out (only ERC-20 pairs or only ETH pairs are due); for a
+    /// mixed tick use [`Self::run_balance_scan_with_eth`]. Settles the reply so the per-address
+    /// scan schedule is advanced before returning.
     pub fn run_balance_scan(&self, balances: &[u128]) {
         self.env.advance_time(BALANCE_SCAN_INTERVAL);
         MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
             .respond_for_all_with(balance_scan_response(balances))
+            .build()
+            .expect_rpc_calls(self);
+        for _ in 0..MAX_TICKS {
+            self.env.tick();
+        }
+    }
+
+    /// Like [`Self::run_balance_scan`], but for a tick where both ERC-20 and ETH pairs are
+    /// due: the scanner sends the ERC-20 batch first and the ETH batch second, each answered
+    /// with its own balances.
+    pub fn run_balance_scan_with_eth(&self, erc20_balances: &[u128], eth_balances: &[u128]) {
+        self.env.advance_time(BALANCE_SCAN_INTERVAL);
+        MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
+            .respond_for_all_with(balance_scan_response(erc20_balances))
+            .build()
+            .expect_rpc_calls(self);
+        MockJsonRpcProviders::when(JsonRpcMethod::EthCall)
+            .respond_for_all_with(balance_scan_response(eth_balances))
             .build()
             .expect_rpc_calls(self);
         for _ in 0..MAX_TICKS {

--- a/rs/ethereum/cketh/test_utils/src/mock.rs
+++ b/rs/ethereum/cketh/test_utils/src/mock.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use strum::IntoEnumIterator;
 
@@ -75,13 +77,25 @@ impl FromStr for JsonRpcRequest {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+/// How a [`JsonRpcRequestMatcher`] decides whether a request's JSON-RPC `params` match.
+/// [`serde_json::Value`] implements it as exact equality; callers plug in their own filters
+/// for anything protocol-specific.
+pub trait MatchRequestParams: Debug {
+    fn matches(&self, params: &serde_json::Value) -> bool;
+}
+
+impl MatchRequestParams for serde_json::Value {
+    fn matches(&self, params: &serde_json::Value) -> bool {
+        self == params
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct JsonRpcRequestMatcher {
     http_method: CanisterHttpMethod,
     provider: JsonRpcProvider,
     json_rpc_method: JsonRpcMethod,
-    match_request_params: Option<serde_json::Value>,
-    match_eth_call_input_prefix: Option<String>,
+    match_request_params: Option<Arc<dyn MatchRequestParams>>,
     max_response_bytes: Option<u64>,
 }
 
@@ -92,7 +106,6 @@ impl JsonRpcRequestMatcher {
             provider,
             json_rpc_method: method,
             match_request_params: None,
-            match_eth_call_input_prefix: None,
             max_response_bytes: None,
         }
     }
@@ -103,15 +116,8 @@ impl JsonRpcRequestMatcher {
             .collect()
     }
 
-    pub fn with_request_params(mut self, params: Option<serde_json::Value>) -> Self {
+    pub fn with_request_params(mut self, params: Option<Arc<dyn MatchRequestParams>>) -> Self {
         self.match_request_params = params;
-        self
-    }
-
-    /// Match only `eth_call` requests whose `input` calldata starts with `prefix`, e.g. one of
-    /// the deployless balance-batcher programs.
-    pub fn with_eth_call_input_prefix(mut self, prefix: Option<&[u8]>) -> Self {
-        self.match_eth_call_input_prefix = prefix.map(|p| format!("0x{}", hex::encode(p)));
         self
     }
 
@@ -165,26 +171,12 @@ impl Matcher for JsonRpcRequestMatcher {
             && self
                 .match_request_params
                 .as_ref()
-                .map(|expected_params| expected_params == &json_rpc_request.params)
-                .unwrap_or(true)
-            && self
-                .match_eth_call_input_prefix
-                .as_ref()
-                .map(|prefix| {
-                    eth_call_input(&json_rpc_request.params)
-                        .map(|input| input.to_lowercase().starts_with(prefix))
-                        .unwrap_or(false)
-                })
+                .map(|params| params.matches(&json_rpc_request.params))
                 .unwrap_or(true)
     }
 }
 
-/// The `input` calldata of an `eth_call`'s JSON-RPC `params`, if the params have that shape.
-pub fn eth_call_input(params: &serde_json::Value) -> Option<&str> {
-    params.get(0)?.get("input")?.as_str()
-}
-
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 struct StubOnce {
     matcher: JsonRpcRequestMatcher,
     response_result: serde_json::Value,
@@ -263,7 +255,6 @@ impl MockJsonRpcProviders {
         MockJsonRpcProvidersBuilder {
             json_rpc_method,
             json_rpc_params: None,
-            eth_call_input_prefix: None,
             max_response_bytes: None,
             responses: Default::default(),
         }
@@ -286,20 +277,18 @@ impl MockJsonRpcProviders {
 
 pub struct MockJsonRpcProvidersBuilder {
     json_rpc_method: JsonRpcMethod,
-    json_rpc_params: Option<serde_json::Value>,
-    eth_call_input_prefix: Option<Vec<u8>>,
+    json_rpc_params: Option<Arc<dyn MatchRequestParams>>,
     max_response_bytes: Option<u64>,
     responses: BTreeMap<JsonRpcProvider, serde_json::Value>,
 }
 
 impl MockJsonRpcProvidersBuilder {
-    pub fn with_request_params(mut self, params: serde_json::Value) -> Self {
-        self.json_rpc_params = Some(params);
-        self
+    pub fn with_request_params(self, params: serde_json::Value) -> Self {
+        self.with_request_params_filter(params)
     }
 
-    pub fn with_eth_call_input_prefix(mut self, prefix: &[u8]) -> Self {
-        self.eth_call_input_prefix = Some(prefix.to_vec());
+    pub fn with_request_params_filter(mut self, filter: impl MatchRequestParams + 'static) -> Self {
+        self.json_rpc_params = Some(Arc::new(filter));
         self
     }
 
@@ -363,7 +352,6 @@ impl MockJsonRpcProvidersBuilder {
             stubs.push(StubOnce {
                 matcher: JsonRpcRequestMatcher::new(provider, self.json_rpc_method.clone())
                     .with_request_params(self.json_rpc_params.clone())
-                    .with_eth_call_input_prefix(self.eth_call_input_prefix.as_deref())
                     .with_max_response_bytes(self.max_response_bytes),
                 response_result: response,
             });

--- a/rs/ethereum/cketh/test_utils/src/mock.rs
+++ b/rs/ethereum/cketh/test_utils/src/mock.rs
@@ -81,6 +81,7 @@ pub struct JsonRpcRequestMatcher {
     provider: JsonRpcProvider,
     json_rpc_method: JsonRpcMethod,
     match_request_params: Option<serde_json::Value>,
+    match_eth_call_input_prefix: Option<String>,
     max_response_bytes: Option<u64>,
 }
 
@@ -91,6 +92,7 @@ impl JsonRpcRequestMatcher {
             provider,
             json_rpc_method: method,
             match_request_params: None,
+            match_eth_call_input_prefix: None,
             max_response_bytes: None,
         }
     }
@@ -103,6 +105,13 @@ impl JsonRpcRequestMatcher {
 
     pub fn with_request_params(mut self, params: Option<serde_json::Value>) -> Self {
         self.match_request_params = params;
+        self
+    }
+
+    /// Match only `eth_call` requests whose `input` calldata starts with `prefix`, e.g. one of
+    /// the deployless balance-batcher programs.
+    pub fn with_eth_call_input_prefix(mut self, prefix: Option<&[u8]>) -> Self {
+        self.match_eth_call_input_prefix = prefix.map(|p| format!("0x{}", hex::encode(p)));
         self
     }
 
@@ -158,7 +167,21 @@ impl Matcher for JsonRpcRequestMatcher {
                 .as_ref()
                 .map(|expected_params| expected_params == &json_rpc_request.params)
                 .unwrap_or(true)
+            && self
+                .match_eth_call_input_prefix
+                .as_ref()
+                .map(|prefix| {
+                    eth_call_input(&json_rpc_request.params)
+                        .map(|input| input.to_lowercase().starts_with(prefix))
+                        .unwrap_or(false)
+                })
+                .unwrap_or(true)
     }
+}
+
+/// The `input` calldata of an `eth_call`'s JSON-RPC `params`, if the params have that shape.
+pub fn eth_call_input(params: &serde_json::Value) -> Option<&str> {
+    params.get(0)?.get("input")?.as_str()
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -240,6 +263,7 @@ impl MockJsonRpcProviders {
         MockJsonRpcProvidersBuilder {
             json_rpc_method,
             json_rpc_params: None,
+            eth_call_input_prefix: None,
             max_response_bytes: None,
             responses: Default::default(),
         }
@@ -263,6 +287,7 @@ impl MockJsonRpcProviders {
 pub struct MockJsonRpcProvidersBuilder {
     json_rpc_method: JsonRpcMethod,
     json_rpc_params: Option<serde_json::Value>,
+    eth_call_input_prefix: Option<Vec<u8>>,
     max_response_bytes: Option<u64>,
     responses: BTreeMap<JsonRpcProvider, serde_json::Value>,
 }
@@ -270,6 +295,11 @@ pub struct MockJsonRpcProvidersBuilder {
 impl MockJsonRpcProvidersBuilder {
     pub fn with_request_params(mut self, params: serde_json::Value) -> Self {
         self.json_rpc_params = Some(params);
+        self
+    }
+
+    pub fn with_eth_call_input_prefix(mut self, prefix: &[u8]) -> Self {
+        self.eth_call_input_prefix = Some(prefix.to_vec());
         self
     }
 
@@ -333,6 +363,7 @@ impl MockJsonRpcProvidersBuilder {
             stubs.push(StubOnce {
                 matcher: JsonRpcRequestMatcher::new(provider, self.json_rpc_method.clone())
                     .with_request_params(self.json_rpc_params.clone())
+                    .with_eth_call_input_prefix(self.eth_call_input_prefix.as_deref())
                     .with_max_response_bytes(self.max_response_bytes),
                 response_result: response,
             });


### PR DESCRIPTION
Stacked on #11499. Third step of the `deposit_eth` flow per the [spec](https://github.com/dfinity/ic/pull/11491): an armed `(account, ETH)` pair is now actually scanned and, when funded with at least 0.005 ETH, detected and queued for sweeping — `deposit_eth` reports `AwaitingSweep`.

* A dedicated 78-byte deployless batcher program reads ETH balances with the `BALANCE` opcode and returns them in the same flat layout as the ERC-20 batcher, so the decoder is shared. The validated ERC-20 program is byte-identical — chosen over extending it with a zero-token-slot branch, which would have re-assembled the whole program. Validated against a live anvil node, including agreement with the node's own view of every balance.
* The scan tick partitions its due pairs by asset kind at the watchlist — the one place the runtime `Asset` is read — into `ScanTarget<Erc20Asset>` and `ScanTarget<EthAsset>`, so a pair cannot reach the wrong batcher by construction. Both batches are pinned to the same latest block under the same timer guard, and each batch's outcomes are recorded before the next batch is awaited, so funds already observed on-chain never hinge on a later await resuming.
* Queued ETH entries are not batched into sweeps yet: the `sweepEthBatch` lane comes in a follow-up (behind the delegation-record work per the spec's delivery order), which is also why the sweep-batching `todo!` became an explicit skip. The spec's phase-2 wording (zero address in the token slot) needs a small amendment in #11491 to record the separate-program choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9