### PR TITLE
fix: Relax the condition on routing refunds into streams

### DIFF
--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -45,8 +45,8 @@ struct StreamBuilderMetrics {
     /// Output queues skipped because this subnet or their destination subnet was
     /// cooling down.
     pub cooling_down_skipped_queues: IntCounter,
-    /// Refunds skipped because this subnet or their destination subnet was cooling
-    /// down.
+    /// Refunds skipped because their destination subnet was cooling down while this
+    /// subnet was not.
     pub cooling_down_skipped_refunds: IntCounter,
     /// Critical error for payloads above the maximum supported size.
     pub critical_error_payload_too_large: IntCounter,
@@ -142,9 +142,9 @@ impl StreamBuilderMetrics {
         );
         let cooling_down_skipped_refunds = metrics_registry.int_counter(
             METRIC_COOLING_DOWN_SKIPPED_REFUNDS,
-            "Refunds skipped because this subnet or their destination subnet was cooling \
-            down. Counted once per refund per round, so the same refund is counted \
-            repeatedly for as long as either subnet keeps cooling down.",
+            "Refunds skipped because their destination subnet was cooling down while this \
+            subnet was not. Counted once per refund per round, so the same refund is counted \
+            repeatedly for as long as the destination subnet keeps cooling down.",
         );
         let critical_error_payload_too_large =
             metrics_registry.error_counter(CRITICAL_ERROR_PAYLOAD_TOO_LARGE);
@@ -818,8 +818,8 @@ impl StreamBuilderImpl {
     /// Routes up to `refund_limit` refunds per stream from `state` into `streams`.
     ///
     /// Refunds that could not be routed due to reaching the per stream limit, or
-    /// because this subnet or their destination subnet is cooling down, are retained
-    /// in `state`.
+    /// because their destination subnet is cooling down while this subnet is not, are
+    /// retained in `state`.
     fn route_refunds(
         &self,
         state: &mut ReplicatedState,
@@ -838,13 +838,18 @@ impl StreamBuilderImpl {
                     let dst_subnet_topology = network_topology.subnets().get(&dst_subnet_id);
                     let dst_subnet_type = dst_subnet_topology.map(|topology| topology.subnet_type);
 
-                    // No refunds are routed while either this subnet (the source) or the
-                    // destination subnet is cooling down; not even into the loopback stream.
-                    // Retain them in the refund pool until neither subnet is cooling down
-                    // anymore, rather than dropping them (which would lose their cycles).
+                    // Refunds are routed under the same conditions as subnet output
+                    // responses: always, unless this subnet (the source) is not cooling down
+                    // while the destination subnet is. This way a cooling down subnet can
+                    // still hand back the cycles it holds (before it is deleted), while no new
+                    // cycles are pushed onto a subnet that is cooling down.
+                    //
+                    // Retain the skipped refunds in the refund pool until the destination
+                    // subnet stops cooling down, rather than dropping them (which would lose
+                    // their cycles).
                     let dst_subnet_is_cooling_down =
                         dst_subnet_topology.is_some_and(|topology| topology.cooling_down);
-                    if own_subnet_is_cooling_down || dst_subnet_is_cooling_down {
+                    if !own_subnet_is_cooling_down && dst_subnet_is_cooling_down {
                         self.metrics.cooling_down_skipped_refunds.inc();
                         return false;
                     }

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -144,7 +144,8 @@ impl StreamBuilderMetrics {
             METRIC_COOLING_DOWN_SKIPPED_REFUNDS,
             "Refunds skipped because their destination subnet was cooling down while this \
             subnet was not. Counted once per refund per round, so the same refund is counted \
-            repeatedly for as long as the destination subnet keeps cooling down.",
+            repeatedly for as long as that remains the case, i.e. until the destination subnet \
+            stops cooling down or this subnet starts.",
         );
         let critical_error_payload_too_large =
             metrics_registry.error_counter(CRITICAL_ERROR_PAYLOAD_TOO_LARGE);
@@ -841,12 +842,12 @@ impl StreamBuilderImpl {
                     // Refunds are routed under the same conditions as subnet output
                     // responses: always, unless this subnet (the source) is not cooling down
                     // while the destination subnet is. This way a cooling down subnet can
-                    // still hand back the cycles it holds (before it is deleted), while no new
-                    // cycles are pushed onto a subnet that is cooling down.
+                    // still hand back the cycles it holds (before it is deleted), while a
+                    // subnet that is not cooling down pushes no new cycles onto one that is.
                     //
-                    // Retain the skipped refunds in the refund pool until the destination
-                    // subnet stops cooling down, rather than dropping them (which would lose
-                    // their cycles).
+                    // Retain the skipped refunds in the refund pool until this no longer holds
+                    // (the destination subnet stops cooling down, or this subnet starts),
+                    // rather than dropping them (which would lose their cycles).
                     let dst_subnet_is_cooling_down =
                         dst_subnet_topology.is_some_and(|topology| topology.cooling_down);
                     if !own_subnet_is_cooling_down && dst_subnet_is_cooling_down {

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -1707,73 +1707,26 @@ mod cooling_down {
     }
 
     /// Tests that a refund to a canister hosted by a cooling down subnet is retained
-    /// in the refund pool -- rather than routed or dropped -- and that it is routed as
-    /// soon as the destination subnet stops cooling down.
+    /// in the refund pool -- rather than routed or dropped -- while `LOCAL_SUBNET` is
+    /// not cooling down; and that it is routed as soon as the destination subnet stops
+    /// cooling down.
     ///
-    /// Exercised twice: with a remote subnet cooling down; and with `LOCAL_SUBNET`
-    /// itself cooling down, i.e. the loopback stream is not exempt either (which also
-    /// covers a cooling down source subnet, the source and the destination subnet
-    /// being one and the same for a loopback refund).
+    /// Contrast with `build_streams_routes_refunds_while_cooling_down()`, where
+    /// `LOCAL_SUBNET` is cooling down and the refund is routed regardless.
     #[test]
     fn build_streams_retains_refunds_to_cooling_down_subnet() {
-        for cooling_down_subnet in [COOLING_DOWN_SUBNET, LOCAL_SUBNET] {
-            with_test_replica_logger(|log| {
-                let (stream_builder, mut provided_state, metrics_registry) =
-                    if cooling_down_subnet == LOCAL_SUBNET {
-                        new_local_cooling_down_fixture(&log)
-                    } else {
-                        new_cooling_down_fixture(&log)
-                    };
-                provided_state.add_refund(COOLING_DOWN_CANISTER, ONE_TRILLION_CYCLES);
-
-                let mut result_state = stream_builder.build_streams(provided_state);
-
-                // Nothing was routed into the stream to the cooling down subnet and the
-                // refund is still in the refund pool.
-                assert_no_messages_routed(&result_state, cooling_down_subnet);
-                assert_eq!(
-                    vec![one_trillion_refund(COOLING_DOWN_CANISTER)],
-                    pooled_refunds(&result_state)
-                );
-
-                assert_routed_messages_eq(MetricVec::new(), &metrics_registry);
-                assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
-                assert_eq_critical_errors(0, 0, 0, &metrics_registry);
-
-                // And it is routed as soon as the subnet stops cooling down.
-                clear_cooling_down(&mut result_state, cooling_down_subnet);
-                let result_state = stream_builder.build_streams(result_state);
-                assert_eq!(
-                    vec![StreamMessage::from(one_trillion_refund(
-                        COOLING_DOWN_CANISTER
-                    ))],
-                    routed_messages(&result_state, cooling_down_subnet)
-                );
-                assert!(result_state.refunds().is_empty());
-                // The refund was not skipped again in this round.
-                assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
-            });
-        }
-    }
-
-    /// Tests that a refund to a canister hosted by a subnet that is not cooling down
-    /// is nevertheless retained in the refund pool while `LOCAL_SUBNET` (the source
-    /// subnet) is cooling down; and that it is routed as soon as `LOCAL_SUBNET` stops
-    /// cooling down.
-    #[test]
-    fn build_streams_retains_refunds_from_cooling_down_subnet() {
         with_test_replica_logger(|log| {
             let (stream_builder, mut provided_state, metrics_registry) =
-                new_local_cooling_down_fixture(&log);
-            provided_state.add_refund(OTHER_CANISTER, ONE_TRILLION_CYCLES);
+                new_cooling_down_fixture(&log);
+            provided_state.add_refund(COOLING_DOWN_CANISTER, ONE_TRILLION_CYCLES);
 
             let mut result_state = stream_builder.build_streams(provided_state);
 
-            // Nothing was routed into the stream to `OTHER_SUBNET` and the refund is
-            // still in the refund pool.
-            assert_no_messages_routed(&result_state, OTHER_SUBNET);
+            // Nothing was routed into the stream to the cooling down subnet and the
+            // refund is still in the refund pool.
+            assert_no_messages_routed(&result_state, COOLING_DOWN_SUBNET);
             assert_eq!(
-                vec![one_trillion_refund(OTHER_CANISTER)],
+                vec![one_trillion_refund(COOLING_DOWN_CANISTER)],
                 pooled_refunds(&result_state)
             );
 
@@ -1781,17 +1734,68 @@ mod cooling_down {
             assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
             assert_eq_critical_errors(0, 0, 0, &metrics_registry);
 
-            // And it is routed as soon as the source subnet stops cooling down.
-            clear_cooling_down(&mut result_state, LOCAL_SUBNET);
+            // And it is routed as soon as the destination subnet stops cooling down.
+            clear_cooling_down(&mut result_state, COOLING_DOWN_SUBNET);
             let result_state = stream_builder.build_streams(result_state);
             assert_eq!(
-                vec![StreamMessage::from(one_trillion_refund(OTHER_CANISTER))],
-                routed_messages(&result_state, OTHER_SUBNET)
+                vec![StreamMessage::from(one_trillion_refund(
+                    COOLING_DOWN_CANISTER
+                ))],
+                routed_messages(&result_state, COOLING_DOWN_SUBNET)
             );
             assert!(result_state.refunds().is_empty());
             // The refund was not skipped again in this round.
             assert_eq!(1, fetch_cooling_down_skipped_refunds(&metrics_registry));
         });
+    }
+
+    /// Tests that a refund is routed while `LOCAL_SUBNET` (the source subnet) is
+    /// cooling down -- so that a cooling down subnet can still hand back the cycles it
+    /// holds before it is deleted -- whether or not the destination subnet is cooling
+    /// down, the loopback stream included.
+    ///
+    /// I.e. refunds are routed under the same conditions as the responses in the
+    /// subnet's own output queues; see
+    /// `build_streams_routes_subnet_messages_while_cooling_down()`.
+    #[test]
+    fn build_streams_routes_refunds_while_cooling_down() {
+        for (recipient, dst_subnet) in [
+            // A canister hosted by `OTHER_SUBNET`, which is not cooling down.
+            (OTHER_CANISTER, OTHER_SUBNET),
+            // A canister hosted by the remote `COOLING_DOWN_SUBNET`.
+            (COOLING_DOWN_CANISTER, COOLING_DOWN_SUBNET),
+            // A canister hosted by `LOCAL_SUBNET` itself, i.e. the loopback stream;
+            // and `LOCAL_SUBNET` is cooling down.
+            (SENDER_CANISTER, LOCAL_SUBNET),
+        ] {
+            with_test_replica_logger(|log| {
+                let (stream_builder, mut provided_state, metrics_registry) =
+                    new_cooling_down_fixture(&log);
+                mark_cooling_down(&mut provided_state, LOCAL_SUBNET);
+                provided_state.add_refund(recipient, ONE_TRILLION_CYCLES);
+
+                let result_state = stream_builder.build_streams(provided_state);
+
+                assert_eq!(
+                    vec![StreamMessage::from(one_trillion_refund(recipient))],
+                    routed_messages(&result_state, dst_subnet)
+                );
+                assert!(result_state.refunds().is_empty());
+
+                assert_routed_messages_eq(
+                    metric_vec(&[(
+                        &[
+                            (LABEL_TYPE, LABEL_VALUE_TYPE_REFUND),
+                            (LABEL_STATUS, LABEL_VALUE_STATUS_SUCCESS),
+                        ],
+                        1,
+                    )]),
+                    &metrics_registry,
+                );
+                assert_eq!(0, fetch_cooling_down_skipped_refunds(&metrics_registry));
+                assert_eq_critical_errors(0, 0, 0, &metrics_registry);
+            });
+        }
     }
 
     /// Tests that only the refunds to the cooling down subnet are held back: refunds


### PR DESCRIPTION
Refunds are now routed under the same conditions as the responses in a subnet's own output queues: always, unless the source subnet is not cooling down while the destination subnet is.

Previously no refunds were routed while *either* the source or the destination subnet was cooling down. That held back the refunds of a cooling down subnet, even though such a subnet should be able to hand back the cycles it holds before it is deleted -- just like it is allowed to deliver the responses to the calls it has already accepted.

Tests: `build_streams_retains_refunds_to_cooling_down_subnet` now only covers the remote-cooling-down case (with the local subnet not cooling down); `build_streams_retains_refunds_from_cooling_down_subnet` is replaced by `build_streams_routes_refunds_while_cooling_down`, which asserts that a cooling down local subnet routes refunds to a subnet that is not cooling down, to one that is, and into the loopback stream -- mirroring `build_streams_routes_subnet_messages_while_cooling_down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)