### PR TITLE
fix(registry): enforce that a canister's cycles cost schedule never changes

### DIFF
--- a/rs/registry/canister/canbench/canbench_results.yml
+++ b/rs/registry/canister/canbench/canbench_results.yml
@@ -2,129 +2,129 @@ benches:
   get_subnet_for_canister_100_times_100:
     total:
       calls: 1
-      instructions: 29074351
+      instructions: 29119278
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_subnet_for_canister_100_times_10k:
     total:
       calls: 1
-      instructions: 681252530
+      instructions: 681431748
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_subnet_for_canister_100_times_1k:
     total:
       calls: 1
-      instructions: 87859085
+      instructions: 87912415
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   measure_routing_table_invariant_checks_shards_and_unsharded:
     total:
       calls: 1
-      instructions: 234549424
+      instructions: 235090409
       heap_increase: 140
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_1000_individual_entries:
     total:
       calls: 1
-      instructions: 20676121
+      instructions: 20634268
       heap_increase: 2
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_100_000_individual_entries:
     total:
       calls: 1
-      instructions: 3580780340
+      instructions: 3576601359
       heap_increase: 177
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_100_segments_of_1000_entries:
     total:
       calls: 1
-      instructions: 6435356
+      instructions: 6431854
       heap_increase: 30
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_1_segment_of_1000_entries:
     total:
       calls: 1
-      instructions: 53945
+      instructions: 53828
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   migrate_canisters_10_times_100:
     total:
       calls: 1
-      instructions: 136465769
+      instructions: 143027050
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   migrate_canisters_10_times_10k:
     total:
       calls: 1
-      instructions: 8744932063
+      instructions: 8819175432
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   migrate_canisters_10_times_1k:
     total:
       calls: 1
-      instructions: 887181882
+      instructions: 899268781
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   upgrade_with_routing_table_100:
     total:
       calls: 1
-      instructions: 184252861
+      instructions: 184342696
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 183366849
+        instructions: 183455405
         heap_increase: 4
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 669329
+        instructions: 670457
         heap_increase: 3
         stable_memory_increase: 0
   upgrade_with_routing_table_10k:
     total:
       calls: 1
-      instructions: 5464195851
+      instructions: 5467702559
       heap_increase: 348
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 5442067820
+        instructions: 5445563400
         heap_increase: 223
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 16603867
+        instructions: 16605010
         heap_increase: 125
         stable_memory_increase: 0
   upgrade_with_routing_table_1k:
     total:
       calls: 1
-      instructions: 669963522
+      instructions: 670368355
       heap_increase: 37
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 667091694
+        instructions: 667494284
         heap_increase: 22
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 2202738
+        instructions: 2203877
         heap_increase: 15
         stable_memory_increase: 0
 version: 0.6.0

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -13,9 +13,10 @@ use crate::{
         replica_version::check_replica_version_invariants,
         routing_table::{check_canister_migrations_invariants, check_routing_table_invariants},
         standard_engine_replica_version::check_standard_engine_replica_version_invariants,
-        subnet::check_subnet_invariants,
+        subnet::{check_subnet_cost_schedule_immutability, check_subnet_invariants},
         unassigned_nodes_config::check_unassigned_nodes_config_invariants,
     },
+    mutations::common::normalized_canister_cycles_cost_schedule,
     registry::Registry,
     storage::with_chunks,
 };
@@ -23,10 +24,14 @@ use crate::{
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
 use ic_nervous_system_string::clamp_debug_len;
+use ic_protobuf::registry::subnet::v1::{CanisterCyclesCostSchedule, SubnetRecord};
 use ic_registry_canister_chunkify::dechunkify;
+use ic_registry_keys::SUBNET_RECORD_KEY_PREFIX;
 use ic_registry_transport::pb::v1::{
     RegistryMutation, high_capacity_registry_value, registry_mutation::Type,
 };
+use prost::Message;
+use std::collections::BTreeMap;
 
 impl Registry {
     pub fn check_changelog_version_invariants(&self) {
@@ -71,6 +76,7 @@ impl Registry {
             )
         );
 
+        let previous_subnet_cost_schedules = self.latest_subnet_cost_schedules();
         let snapshot = self.take_latest_snapshot_with_mutations(mutations);
 
         // Node invariants
@@ -96,6 +102,10 @@ impl Registry {
 
         // Subnet invariants
         result = result.and(check_subnet_invariants(&snapshot));
+        result = result.and(check_subnet_cost_schedule_immutability(
+            &previous_subnet_cost_schedules,
+            &snapshot,
+        ));
 
         // Replica version invariants
         result = result.and(check_replica_version_invariants(&snapshot));
@@ -127,6 +137,29 @@ impl Registry {
                 LOG_PREFIX, e.msg
             );
         }
+    }
+
+    /// Returns the cycles cost schedule of every subnet in the registry as of the
+    /// latest version, i.e. before the mutations under check are applied, keyed by the
+    /// registry key of the subnet record.
+    ///
+    /// Unlike `take_latest_snapshot`, this only decodes the subnet records, of which
+    /// there are few, so that `check_subnet_cost_schedule_immutability` does not
+    /// require a second snapshot of the whole registry.
+    fn latest_subnet_cost_schedules(&self) -> BTreeMap<Vec<u8>, CanisterCyclesCostSchedule> {
+        let version = self.latest_version();
+        self.store
+            .keys()
+            .filter(|key| key.starts_with(SUBNET_RECORD_KEY_PREFIX.as_bytes()))
+            .filter_map(|key| {
+                let value = self.get(key, version)?;
+                let subnet_record = SubnetRecord::decode(value.value.as_slice()).ok()?;
+                Some((
+                    key.clone(),
+                    normalized_canister_cycles_cost_schedule(&subnet_record),
+                ))
+            })
+            .collect()
     }
 
     fn take_latest_snapshot_with_mutations(
@@ -184,7 +217,13 @@ impl Registry {
 
 #[cfg(test)]
 mod tests {
-    use crate::registry::EncodedVersion;
+    use crate::{
+        common::test_helpers::{
+            add_fake_subnet, get_invariant_compliant_subnet_record, invariant_compliant_registry,
+            prepare_registry_with_nodes,
+        },
+        registry::EncodedVersion,
+    };
 
     use super::*;
     use ic_base_types::CanisterId;
@@ -197,12 +236,14 @@ mod tests {
     };
     use ic_registry_keys::{
         make_canister_migrations_record_key, make_canister_ranges_key,
-        make_node_operator_record_key,
+        make_node_operator_record_key, make_subnet_record_key,
     };
     use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
+    use ic_registry_subnet_type::SubnetType;
     use ic_registry_transport::{
         delete, insert,
         pb::v1::{RegistryAtomicMutateRequest, RegistryMutation},
+        update,
     };
     use ic_test_utilities_types::ids::subnet_test_id;
     use maplit::btreemap;
@@ -370,6 +411,37 @@ mod tests {
         let snapshot = registry.take_latest_snapshot_with_mutations(&mutations);
         let snapshot_data = snapshot.get(key.as_bytes());
         assert!(snapshot_data.is_none());
+    }
+
+    /// The cycles cost schedule of a subnet must not change, whichever mutation would
+    /// change it; see `check_subnet_cost_schedule_immutability`.
+    #[test]
+    #[should_panic(expected = "changes its cycles cost schedule from Normal to Free")]
+    fn subnet_cost_schedule_change_invariants_check_panic() {
+        let mut registry = invariant_compliant_registry(0);
+
+        // Add an application subnet: `check_subnet_invariants` permits either cost
+        // schedule for those, so this invariant is the one under test.
+        let (mutate_request, node_ids_and_dkg_pks) = prepare_registry_with_nodes(1, 1);
+        registry.maybe_apply_mutation_internal(mutate_request.mutations);
+        let mut subnet_list_record = registry.get_subnet_list_record();
+        let mut subnet_record =
+            get_invariant_compliant_subnet_record(node_ids_and_dkg_pks.keys().copied().collect());
+        subnet_record.subnet_type = i32::from(SubnetType::Application);
+        let subnet_id = subnet_test_id(1000);
+        let subnet_mutation = add_fake_subnet(
+            subnet_id,
+            &mut subnet_list_record,
+            subnet_record.clone(),
+            &node_ids_and_dkg_pks,
+        );
+        registry.maybe_apply_mutation_internal(subnet_mutation);
+
+        subnet_record.canister_cycles_cost_schedule = i32::from(CanisterCyclesCostSchedule::Free);
+        registry.maybe_apply_mutation_internal(vec![update(
+            make_subnet_record_key(subnet_id).as_bytes(),
+            subnet_record.encode_to_vec(),
+        )]);
     }
 }
 

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::LOG_PREFIX,
+    common::{LOG_PREFIX, key_family::get_key_family_iter},
     invariants::{
         api_boundary_node::check_api_boundary_node_invariants,
         assignment::check_node_assignment_invariants,
@@ -11,7 +11,10 @@ use crate::{
         node_operator::check_node_operator_invariants,
         node_record::check_node_record_invariants,
         replica_version::check_replica_version_invariants,
-        routing_table::{check_canister_migrations_invariants, check_routing_table_invariants},
+        routing_table::{
+            check_canister_cost_schedule_invariants, check_canister_migrations_invariants,
+            check_routing_table_invariants,
+        },
         standard_engine_replica_version::check_standard_engine_replica_version_invariants,
         subnet::{check_subnet_cost_schedule_immutability, check_subnet_invariants},
         unassigned_nodes_config::check_unassigned_nodes_config_invariants,
@@ -30,7 +33,6 @@ use ic_registry_keys::SUBNET_RECORD_KEY_PREFIX;
 use ic_registry_transport::pb::v1::{
     RegistryMutation, high_capacity_registry_value, registry_mutation::Type,
 };
-use prost::Message;
 use std::collections::BTreeMap;
 
 impl Registry {
@@ -77,6 +79,7 @@ impl Registry {
         );
 
         let previous_subnet_cost_schedules = self.latest_subnet_cost_schedules();
+        let previous_routing_table = self.get_routing_table_or_panic(self.latest_version());
         let snapshot = self.take_latest_snapshot_with_mutations(mutations);
 
         // Node invariants
@@ -96,6 +99,11 @@ impl Registry {
 
         // Routing Table invariants
         result = result.and(check_routing_table_invariants(&snapshot));
+        result = result.and(check_canister_cost_schedule_invariants(
+            &previous_routing_table,
+            &previous_subnet_cost_schedules,
+            &snapshot,
+        ));
 
         // Canister migrations invariants
         result = result.and(check_canister_migrations_invariants(&snapshot));
@@ -141,23 +149,18 @@ impl Registry {
 
     /// Returns the cycles cost schedule of every subnet in the registry as of the
     /// latest version, i.e. before the mutations under check are applied, keyed by the
-    /// registry key of the subnet record.
+    /// registry key of the subnet record (as in `get_subnet_records_map`).
     ///
-    /// Unlike `take_latest_snapshot`, this only decodes the subnet records, of which
+    /// Unlike `take_latest_snapshot`, this only visits the subnet records, of which
     /// there are few, so that `check_subnet_cost_schedule_immutability` does not
     /// require a second snapshot of the whole registry.
     fn latest_subnet_cost_schedules(&self) -> BTreeMap<Vec<u8>, CanisterCyclesCostSchedule> {
-        let version = self.latest_version();
-        self.store
-            .keys()
-            .filter(|key| key.starts_with(SUBNET_RECORD_KEY_PREFIX.as_bytes()))
-            .filter_map(|key| {
-                let value = self.get(key, version)?;
-                let subnet_record = SubnetRecord::decode(value.value.as_slice()).ok()?;
-                Some((
-                    key.clone(),
+        get_key_family_iter::<SubnetRecord>(self, SUBNET_RECORD_KEY_PREFIX)
+            .map(|(subnet_id, subnet_record)| {
+                (
+                    format!("{SUBNET_RECORD_KEY_PREFIX}{subnet_id}").into_bytes(),
                     normalized_canister_cycles_cost_schedule(&subnet_record),
-                ))
+                )
             })
             .collect()
     }

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -38,7 +38,7 @@ use ic_registry_transport::pb::v1::{
     RegistryMutation, high_capacity_registry_value, registry_mutation::Type,
 };
 use prost::Message;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 impl Registry {
     pub fn check_changelog_version_invariants(&self) {
@@ -119,11 +119,13 @@ impl Registry {
                 .key
                 .starts_with(SUBNET_RECORD_KEY_PREFIX.as_bytes())
         });
+        // A set: the same shard can be mutated more than once by a single batch, and
+        // decoding one of them twice would produce duplicate routing table entries.
         let mutated_canister_ranges_shards = mutations
             .iter()
             .filter(|mutation| mutation.key.starts_with(CANISTER_RANGES_PREFIX.as_bytes()))
             .map(|mutation| mutation.key.clone())
-            .collect::<Vec<Vec<u8>>>();
+            .collect::<BTreeSet<Vec<u8>>>();
         if mutates_subnet_record || !mutated_canister_ranges_shards.is_empty() {
             let previous_subnet_cost_schedules = self.latest_subnet_cost_schedules();
             if mutates_subnet_record {
@@ -195,7 +197,10 @@ impl Registry {
     /// Returns the routing table restricted to the given canister ranges shards, as of
     /// the latest version, i.e. before the mutations under check are applied. A shard
     /// that those mutations create is simply absent.
-    fn latest_canister_ranges(&self, shard_keys: &[Vec<u8>]) -> RoutingTable {
+    ///
+    /// The shards are given as a set: decoding one of them twice would produce duplicate
+    /// entries, which `RoutingTable` rejects.
+    fn latest_canister_ranges(&self, shard_keys: &BTreeSet<Vec<u8>>) -> RoutingTable {
         let version = self.latest_version();
         let shards = shard_keys
             .iter()
@@ -271,6 +276,7 @@ mod tests {
 
     use super::*;
     use ic_base_types::CanisterId;
+    use ic_base_types::{PrincipalId, SubnetId};
     use ic_nervous_system_common_test_keys::TEST_USER1_PRINCIPAL;
     use ic_protobuf::registry::{
         node_operator::v1::NodeOperatorRecord,
@@ -489,6 +495,35 @@ mod tests {
             subnet_record.encode_to_vec(),
         )]);
     }
+    /// A single batch may mutate the same canister ranges shard more than once. The
+    /// cost schedule check decodes only the shards a batch mutates, so it must not
+    /// mistake a shard mutated twice for duplicate routing table entries.
+    #[test]
+    fn repeatedly_mutated_canister_ranges_shard_passes_invariants_check() {
+        let mut registry = invariant_compliant_registry(0);
+        let subnet_id = SubnetId::from(
+            PrincipalId::try_from(registry.get_subnet_list_record().subnets.first().unwrap())
+                .unwrap(),
+        );
+
+        let mut routing_table = registry.get_routing_table_or_panic(registry.latest_version());
+        routing_table
+            .insert(
+                CanisterIdRange {
+                    start: CanisterId::from_u64(0x1000),
+                    end: CanisterId::from_u64(0x10ff),
+                },
+                subnet_id,
+            )
+            .unwrap();
+        let mut mutations = routing_table_into_registry_mutation(&registry, routing_table);
+        assert!(!mutations.is_empty());
+        let repeated_mutations = mutations.clone();
+        mutations.extend(repeated_mutations);
+
+        registry.maybe_apply_mutation_internal(mutations);
+    }
+
     /// The cycles cost schedule a canister is charged under must not change by moving
     /// its canister ID range to a subnet on a different cost schedule; see
     /// `check_canister_cost_schedule_invariants`. This also covers that a mutation of

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -12,8 +12,8 @@ use crate::{
         node_record::check_node_record_invariants,
         replica_version::check_replica_version_invariants,
         routing_table::{
-            check_canister_cost_schedule_invariants, check_canister_migrations_invariants,
-            check_routing_table_invariants,
+            canister_ranges_from_snapshot, check_canister_cost_schedule_invariants,
+            check_canister_migrations_invariants, check_routing_table_invariants,
         },
         standard_engine_replica_version::check_standard_engine_replica_version_invariants,
         subnet::{check_subnet_cost_schedule_immutability, check_subnet_invariants},
@@ -27,12 +27,17 @@ use crate::{
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
 use ic_nervous_system_string::clamp_debug_len;
-use ic_protobuf::registry::subnet::v1::{CanisterCyclesCostSchedule, SubnetRecord};
+use ic_protobuf::registry::{
+    routing_table::v1::RoutingTable as pbRoutingTable,
+    subnet::v1::{CanisterCyclesCostSchedule, SubnetRecord},
+};
 use ic_registry_canister_chunkify::dechunkify;
-use ic_registry_keys::SUBNET_RECORD_KEY_PREFIX;
+use ic_registry_keys::{CANISTER_RANGES_PREFIX, SUBNET_RECORD_KEY_PREFIX};
+use ic_registry_routing_table::RoutingTable;
 use ic_registry_transport::pb::v1::{
     RegistryMutation, high_capacity_registry_value, registry_mutation::Type,
 };
+use prost::Message;
 use std::collections::BTreeMap;
 
 impl Registry {
@@ -78,8 +83,6 @@ impl Registry {
             )
         );
 
-        let previous_subnet_cost_schedules = self.latest_subnet_cost_schedules();
-        let previous_routing_table = self.get_routing_table_or_panic(self.latest_version());
         let snapshot = self.take_latest_snapshot_with_mutations(mutations);
 
         // Node invariants
@@ -99,21 +102,45 @@ impl Registry {
 
         // Routing Table invariants
         result = result.and(check_routing_table_invariants(&snapshot));
-        result = result.and(check_canister_cost_schedule_invariants(
-            &previous_routing_table,
-            &previous_subnet_cost_schedules,
-            &snapshot,
-        ));
 
         // Canister migrations invariants
         result = result.and(check_canister_migrations_invariants(&snapshot));
 
         // Subnet invariants
         result = result.and(check_subnet_invariants(&snapshot));
-        result = result.and(check_subnet_cost_schedule_immutability(
-            &previous_subnet_cost_schedules,
-            &snapshot,
-        ));
+
+        // Cycles cost schedule invariants. Reading the subnet records and the routing
+        // table is not free, so only the mutations that could change the cost schedule
+        // a canister is charged under pay for these checks: a subnet record can change
+        // the cost schedule of a subnet, and a canister ranges shard can move a canister
+        // to a subnet on a different one.
+        let mutates_subnet_record = mutations.iter().any(|mutation| {
+            mutation
+                .key
+                .starts_with(SUBNET_RECORD_KEY_PREFIX.as_bytes())
+        });
+        let mutated_canister_ranges_shards = mutations
+            .iter()
+            .filter(|mutation| mutation.key.starts_with(CANISTER_RANGES_PREFIX.as_bytes()))
+            .map(|mutation| mutation.key.clone())
+            .collect::<Vec<Vec<u8>>>();
+        if mutates_subnet_record || !mutated_canister_ranges_shards.is_empty() {
+            let previous_subnet_cost_schedules = self.latest_subnet_cost_schedules();
+            if mutates_subnet_record {
+                result = result.and(check_subnet_cost_schedule_immutability(
+                    &previous_subnet_cost_schedules,
+                    &snapshot,
+                ));
+            }
+            if !mutated_canister_ranges_shards.is_empty() {
+                result = result.and(check_canister_cost_schedule_invariants(
+                    &self.latest_canister_ranges(&mutated_canister_ranges_shards),
+                    &canister_ranges_from_snapshot(&mutated_canister_ranges_shards, &snapshot),
+                    &previous_subnet_cost_schedules,
+                    &snapshot,
+                ));
+            }
+        }
 
         // Replica version invariants
         result = result.and(check_replica_version_invariants(&snapshot));
@@ -163,6 +190,19 @@ impl Registry {
                 )
             })
             .collect()
+    }
+
+    /// Returns the routing table restricted to the given canister ranges shards, as of
+    /// the latest version, i.e. before the mutations under check are applied. A shard
+    /// that those mutations create is simply absent.
+    fn latest_canister_ranges(&self, shard_keys: &[Vec<u8>]) -> RoutingTable {
+        let version = self.latest_version();
+        let shards = shard_keys
+            .iter()
+            .filter_map(|key| self.get(key, version))
+            .map(|value| pbRoutingTable::decode(value.value.as_slice()).unwrap())
+            .collect::<Vec<_>>();
+        RoutingTable::try_from(shards).unwrap()
     }
 
     fn take_latest_snapshot_with_mutations(
@@ -225,6 +265,7 @@ mod tests {
             add_fake_subnet, get_invariant_compliant_subnet_record, invariant_compliant_registry,
             prepare_registry_with_nodes,
         },
+        mutations::routing_table::routing_table_into_registry_mutation,
         registry::EncodedVersion,
     };
 
@@ -241,7 +282,9 @@ mod tests {
         make_canister_migrations_record_key, make_canister_ranges_key,
         make_node_operator_record_key, make_subnet_record_key,
     };
-    use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
+    use ic_registry_routing_table::{
+        CanisterIdRange, CanisterIdRanges, CanisterMigrations, RoutingTable,
+    };
     use ic_registry_subnet_type::SubnetType;
     use ic_registry_transport::{
         delete, insert,
@@ -445,6 +488,65 @@ mod tests {
             make_subnet_record_key(subnet_id).as_bytes(),
             subnet_record.encode_to_vec(),
         )]);
+    }
+    /// The cycles cost schedule a canister is charged under must not change by moving
+    /// its canister ID range to a subnet on a different cost schedule; see
+    /// `check_canister_cost_schedule_invariants`. This also covers that a mutation of
+    /// the routing table alone is checked, i.e. that the check is not skipped for want
+    /// of a subnet record mutation.
+    #[test]
+    #[should_panic(expected = "changes its cycles cost schedule")]
+    fn canister_range_moved_across_cost_schedules_invariants_check_panic() {
+        let mut registry = invariant_compliant_registry(0);
+
+        // Two application subnets, one on each cycles cost schedule: a rental subnet is
+        // an application subnet on the free one.
+        let (mutate_request, node_ids_and_dkg_pks) = prepare_registry_with_nodes(1, 2);
+        registry.maybe_apply_mutation_internal(mutate_request.mutations);
+        let mut subnet_list_record = registry.get_subnet_list_record();
+        let mut subnet_ids = vec![];
+        for (index, (node_id, dkg_pk)) in node_ids_and_dkg_pks.into_iter().enumerate() {
+            let mut subnet_record = get_invariant_compliant_subnet_record(vec![node_id]);
+            subnet_record.subnet_type = i32::from(SubnetType::Application);
+            if index == 1 {
+                subnet_record.canister_cycles_cost_schedule =
+                    i32::from(CanisterCyclesCostSchedule::Free);
+            }
+            let subnet_id = subnet_test_id(1000 + index as u64);
+            let subnet_mutation = add_fake_subnet(
+                subnet_id,
+                &mut subnet_list_record,
+                subnet_record,
+                &btreemap! { node_id => dkg_pk },
+            );
+            registry.maybe_apply_mutation_internal(subnet_mutation);
+            subnet_ids.push(subnet_id);
+        }
+
+        // Host a canister ID range on the subnet on the normal cost schedule, which is
+        // fine as no subnet hosted it before, ...
+        let range = CanisterIdRange {
+            start: CanisterId::from_u64(0x1000),
+            end: CanisterId::from_u64(0x10ff),
+        };
+        let mut routing_table = registry.get_routing_table_or_panic(registry.latest_version());
+        routing_table.insert(range, subnet_ids[0]).unwrap();
+        registry.maybe_apply_mutation_internal(routing_table_into_registry_mutation(
+            &registry,
+            routing_table.clone(),
+        ));
+
+        // ... and then move it to the one on the free cost schedule, which is not.
+        routing_table
+            .assign_ranges(
+                CanisterIdRanges::try_from(vec![range]).unwrap(),
+                subnet_ids[1],
+            )
+            .unwrap();
+        registry.maybe_apply_mutation_internal(routing_table_into_registry_mutation(
+            &registry,
+            routing_table,
+        ));
     }
 }
 

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -55,6 +55,14 @@ pub(crate) fn check_routing_table_invariants(
 /// - changing the cost schedule of the subnet hosting the canister, which
 ///   `check_subnet_cost_schedule_immutability` rules out outright.
 ///
+/// The two routing tables are restricted to the canister ranges shards that the
+/// mutations under check touch, as reading the whole routing table on every mutation
+/// is not free. That is sound: a canister ID whose covering entry did not change is
+/// still assigned to the same subnet, and the cost schedule of that subnet cannot have
+/// changed either, which `check_subnet_cost_schedule_immutability` enforces. Note that
+/// an entry can move between shards, e.g. when two adjacent ranges are merged into one,
+/// which mutates the shard it leaves as well as the shard it lands in.
+///
 /// `previous_cost_schedules` maps the registry key of a subnet record to the cost
 /// schedule that subnet had before the mutations under check were applied. A canister
 /// ID whose cost schedule is unknown on either side is skipped: a subnet without a
@@ -81,6 +89,7 @@ pub(crate) fn check_routing_table_invariants(
 /// subnet on a different cost schedule.
 pub(crate) fn check_canister_cost_schedule_invariants(
     previous_routing_table: &RoutingTable,
+    routing_table: &RoutingTable,
     previous_cost_schedules: &BTreeMap<Vec<u8>, CanisterCyclesCostSchedule>,
     snapshot: &RegistrySnapshot,
 ) -> Result<(), InvariantCheckError> {
@@ -105,7 +114,7 @@ pub(crate) fn check_canister_cost_schedule_invariants(
     // single sweep over both routing tables finds every pair of overlapping ranges,
     // i.e. every set of canister IDs that is hosted in both states.
     let previous_entries = as_entries(previous_routing_table);
-    let entries = as_entries(&get_routing_table(snapshot));
+    let entries = as_entries(routing_table);
     let (mut previous_index, mut index) = (0, 0);
     while previous_index < previous_entries.len() && index < entries.len() {
         let (previous_range, previous_subnet_id) = previous_entries[previous_index];
@@ -154,6 +163,20 @@ pub(crate) fn check_canister_cost_schedule_invariants(
     }
 
     Ok(())
+}
+
+/// Returns the routing table restricted to the given canister ranges shards, as held
+/// by `snapshot`. A shard that the mutations under check deleted is simply absent.
+pub(crate) fn canister_ranges_from_snapshot(
+    shard_keys: &[Vec<u8>],
+    snapshot: &RegistrySnapshot,
+) -> RoutingTable {
+    let shards = shard_keys
+        .iter()
+        .filter_map(|key| snapshot.get(key))
+        .map(|value| pbRoutingTable::decode(value.as_slice()).unwrap())
+        .collect::<Vec<_>>();
+    RoutingTable::try_from(shards).unwrap()
 }
 
 fn as_entries(routing_table: &RoutingTable) -> Vec<(CanisterIdRange, SubnetId)> {
@@ -323,10 +346,10 @@ mod tests {
             (range(0x100, 0x1ff), free_subnet_id),
         ]);
 
-        let check = |entries: Vec<(CanisterIdRange, SubnetId)>, snapshot: &mut RegistrySnapshot| {
-            insert_routing_table_to_snapshot(routing_table(entries), snapshot);
+        let check = |entries: Vec<(CanisterIdRange, SubnetId)>, snapshot: &RegistrySnapshot| {
             check_canister_cost_schedule_invariants(
                 &previous_routing_table,
+                &routing_table(entries),
                 &previous_cost_schedules,
                 snapshot,
             )
@@ -338,7 +361,7 @@ mod tests {
                 (range(0x0, 0xff), normal_subnet_id),
                 (range(0x100, 0x1ff), free_subnet_id),
             ],
-            &mut snapshot,
+            &snapshot,
         )
         .unwrap();
         // ... as is moving a range to a subnet on the same cost schedule, splitting it
@@ -349,11 +372,11 @@ mod tests {
                 (range(0x80, 0xff), other_normal_subnet_id),
                 (range(0x100, 0x1ff), free_subnet_id),
             ],
-            &mut snapshot,
+            &snapshot,
         )
         .unwrap();
         // ... dropping a range, ...
-        check(vec![(range(0x100, 0x1ff), free_subnet_id)], &mut snapshot).unwrap();
+        check(vec![(range(0x100, 0x1ff), free_subnet_id)], &snapshot).unwrap();
         // ... or assigning a range that was not hosted by any subnet before.
         check(
             vec![
@@ -361,7 +384,7 @@ mod tests {
                 (range(0x100, 0x1ff), free_subnet_id),
                 (range(0x200, 0x2ff), free_subnet_id),
             ],
-            &mut snapshot,
+            &snapshot,
         )
         .unwrap();
 
@@ -397,7 +420,7 @@ mod tests {
             // second one all along, so only the first one changes its cost schedule.
             (vec![(range(0x0, 0x1ff), free_subnet_id)], range(0x0, 0xff)),
         ] {
-            let err = check(entries, &mut snapshot)
+            let err = check(entries, &snapshot)
                 .expect_err("Expected the move across cost schedules to be rejected");
             assert!(
                 err.msg.contains("changes its cycles cost schedule"),
@@ -423,7 +446,7 @@ mod tests {
                 (range(0x0, 0xff), normal_subnet_id),
                 (range(0x100, 0x1ff), free_subnet_id),
             ],
-            &mut snapshot,
+            &snapshot,
         )
         .expect_err("Expected the change of the cost schedule to be rejected");
         assert!(

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -48,10 +48,13 @@ pub(crate) fn check_routing_table_invariants(
 /// in any combination, and hence every mutation that could:
 ///
 /// - moving the canister to a subnet on a different cost schedule, be it with
-///   `reroute_canister_ranges` (the second step of a canister migration prepared by
-///   `prepare_canister_migration`), `merge_subnets` or `do_migrate_canisters`. The
-///   former two validate the cost schedules themselves, so that a proposal is rejected
-///   with an error rather than trapping here;
+///   `reroute_canister_ranges` (the second step of a canister migration),
+///   `merge_subnets` or `do_migrate_canisters`. The latter two compare the cost
+///   schedules themselves, as does `prepare_canister_migration`, on which
+///   `reroute_canister_ranges` relies: rerouting compares nothing of its own, it only
+///   reroutes ranges that an already validated canister migration covers. Those
+///   comparisons report which subnets, or which canister, are at fault, whereas this
+///   invariant only names the affected canister ID range;
 /// - changing the cost schedule of the subnet hosting the canister, which
 ///   `check_subnet_cost_schedule_immutability` rules out outright.
 ///

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -6,7 +6,10 @@ use crate::{
     mutations::common::normalized_canister_cycles_cost_schedule,
 };
 
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+};
 
 use ic_base_types::{CanisterId, SubnetId};
 use ic_protobuf::registry::{
@@ -170,8 +173,11 @@ pub(crate) fn check_canister_cost_schedule_invariants(
 
 /// Returns the routing table restricted to the given canister ranges shards, as held
 /// by `snapshot`. A shard that the mutations under check deleted is simply absent.
+///
+/// The shards are given as a set: decoding one of them twice would produce duplicate
+/// entries, which `RoutingTable` rejects.
 pub(crate) fn canister_ranges_from_snapshot(
-    shard_keys: &[Vec<u8>],
+    shard_keys: &BTreeSet<Vec<u8>>,
     snapshot: &RegistrySnapshot,
 ) -> RoutingTable {
     let shards = shard_keys

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -59,6 +59,26 @@ pub(crate) fn check_routing_table_invariants(
 /// schedule that subnet had before the mutations under check were applied. A canister
 /// ID whose cost schedule is unknown on either side is skipped: a subnet without a
 /// record in the corresponding state hosts no canister.
+///
+/// # Limitation: canister IDs that pass through an unrouted state
+///
+/// An unrouted canister ID has no cost schedule, so this only covers the canister IDs
+/// that are routed both before and after the mutations under check. A canister ID is
+/// unrouted by `do_migrate_canisters` when the target subnet is absent from the
+/// routing table, and by `remove_subnet_from_routing_table` when its subnet is
+/// deleted; `do_migrate_canisters` then supports routing it to a subnet again, which
+/// is how a canister whose subnet was deleted is migrated
+/// (`test_migrate_canisters_succeeds_if_source_subnet_deleted`). Two such mutations in
+/// a row move a canister ID between subnets on different cost schedules without either
+/// this invariant or `Registry::validate_cost_schedules` ever seeing two schedules to
+/// compare, and unrouting a canister ID does not destroy the canister state, callbacks
+/// included.
+///
+/// Closing that gap would take either persistent knowledge of the cost schedule each
+/// unrouted canister ID last had, or making unrouting terminal, which would break the
+/// migration of a canister off a deleted subnet. It is left open: reaching it takes a
+/// canister migration orchestrator that unroutes a canister and then routes it to a
+/// subnet on a different cost schedule.
 pub(crate) fn check_canister_cost_schedule_invariants(
     previous_routing_table: &RoutingTable,
     previous_cost_schedules: &BTreeMap<Vec<u8>, CanisterCyclesCostSchedule>,

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -1,13 +1,24 @@
-use crate::invariants::common::{InvariantCheckError, RegistrySnapshot};
-
-use std::convert::TryFrom;
-
-use ic_base_types::CanisterId;
-use ic_protobuf::registry::routing_table::v1::{
-    CanisterMigrations as pbCanisterMigrations, RoutingTable as pbRoutingTable,
+use crate::{
+    invariants::{
+        common::{InvariantCheckError, RegistrySnapshot},
+        subnet::get_subnet_records_map,
+    },
+    mutations::common::normalized_canister_cycles_cost_schedule,
 };
-use ic_registry_keys::{make_canister_migrations_record_key, make_canister_ranges_key};
-use ic_registry_routing_table::{CanisterMigrations, RoutingTable};
+
+use std::{collections::BTreeMap, convert::TryFrom};
+
+use ic_base_types::{CanisterId, SubnetId};
+use ic_protobuf::registry::{
+    routing_table::v1::{
+        CanisterMigrations as pbCanisterMigrations, RoutingTable as pbRoutingTable,
+    },
+    subnet::v1::CanisterCyclesCostSchedule,
+};
+use ic_registry_keys::{
+    make_canister_migrations_record_key, make_canister_ranges_key, make_subnet_record_key,
+};
+use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
 use prost::Message;
 
 /// Routing table invariants hold if reading and conversion succeed.
@@ -16,6 +27,113 @@ pub(crate) fn check_routing_table_invariants(
 ) -> Result<(), InvariantCheckError> {
     get_routing_table(snapshot);
     Ok(())
+}
+
+/// Checks that the cycles cost schedule that a canister is charged under never
+/// changes.
+///
+/// That schedule has to stay put for as long as the canister has calls in flight: the
+/// cycles prepaid for a response execution are settled against the cycles that
+/// execution requires, derived when the response is executed
+/// (`CyclesAccountManager::adjust_prepayment_for_response_execution`), and the two
+/// amounts are only comparable if both were derived under the same cost schedule. An
+/// amount that is free under the free cost schedule has a zero real part but a
+/// non-zero nominal one, so settling across a switch either forfeits the real part of
+/// the prepayment or credits real cycles that were never withdrawn.
+///
+/// A canister is charged under the cost schedule of the subnet that the routing table
+/// assigns its canister ID to, so this compares, for every canister ID hosted before
+/// and after the mutations under check, the cost schedule of the subnet that hosted it
+/// with the one of the subnet that hosts it now. That covers both ways of changing it,
+/// in any combination, and hence every mutation that could:
+///
+/// - moving the canister to a subnet on a different cost schedule, be it with
+///   `reroute_canister_ranges` (the second step of a canister migration prepared by
+///   `prepare_canister_migration`), `merge_subnets` or `do_migrate_canisters`. The
+///   former two validate the cost schedules themselves, so that a proposal is rejected
+///   with an error rather than trapping here;
+/// - changing the cost schedule of the subnet hosting the canister, which
+///   `check_subnet_cost_schedule_immutability` rules out outright.
+///
+/// `previous_cost_schedules` maps the registry key of a subnet record to the cost
+/// schedule that subnet had before the mutations under check were applied. A canister
+/// ID whose cost schedule is unknown on either side is skipped: a subnet without a
+/// record in the corresponding state hosts no canister.
+pub(crate) fn check_canister_cost_schedule_invariants(
+    previous_routing_table: &RoutingTable,
+    previous_cost_schedules: &BTreeMap<Vec<u8>, CanisterCyclesCostSchedule>,
+    snapshot: &RegistrySnapshot,
+) -> Result<(), InvariantCheckError> {
+    let cost_schedules: BTreeMap<Vec<u8>, CanisterCyclesCostSchedule> =
+        get_subnet_records_map(snapshot)
+            .iter()
+            .map(|(key, subnet_record)| {
+                (
+                    key.clone(),
+                    normalized_canister_cycles_cost_schedule(subnet_record),
+                )
+            })
+            .collect();
+    let cost_schedule = |cost_schedules: &BTreeMap<Vec<u8>, CanisterCyclesCostSchedule>,
+                         subnet_id: SubnetId| {
+        cost_schedules
+            .get(&make_subnet_record_key(subnet_id).into_bytes())
+            .copied()
+    };
+
+    // The ranges of a routing table are disjoint and listed in ascending order, so a
+    // single sweep over both routing tables finds every pair of overlapping ranges,
+    // i.e. every set of canister IDs that is hosted in both states.
+    let previous_entries = as_entries(previous_routing_table);
+    let entries = as_entries(&get_routing_table(snapshot));
+    let (mut previous_index, mut index) = (0, 0);
+    while previous_index < previous_entries.len() && index < entries.len() {
+        let (previous_range, previous_subnet_id) = previous_entries[previous_index];
+        let (range, subnet_id) = entries[index];
+
+        if previous_range.end < range.start {
+            previous_index += 1;
+            continue;
+        }
+        if range.end < previous_range.start {
+            index += 1;
+            continue;
+        }
+
+        // The two ranges overlap: the canisters in the intersection were hosted by
+        // `previous_subnet_id` and are hosted by `subnet_id` as of this snapshot.
+        if let Some(previous_cost_schedule) =
+            cost_schedule(previous_cost_schedules, previous_subnet_id)
+            && let Some(cost_schedule) = cost_schedule(&cost_schedules, subnet_id)
+            && previous_cost_schedule != cost_schedule
+        {
+            return Err(InvariantCheckError {
+                msg: format!(
+                    "canister ID range {range:?} changes its cycles cost schedule from \
+                    {previous_cost_schedule:?} on subnet {previous_subnet_id} to \
+                    {cost_schedule:?} on subnet {subnet_id}"
+                ),
+                source: None,
+            });
+        }
+
+        // Advance past the range that ends first: the other one may still overlap the
+        // next range of the routing table it does not belong to.
+        if previous_range.end <= range.end {
+            previous_index += 1;
+        } else {
+            index += 1;
+        }
+    }
+
+    Ok(())
+}
+
+fn as_entries(routing_table: &RoutingTable) -> Vec<(CanisterIdRange, SubnetId)> {
+    routing_table
+        .iter()
+        .map(|(range, subnet_id)| (*range, *subnet_id))
+        .collect()
 }
 
 // Return routing table from snapshot
@@ -91,16 +209,36 @@ mod tests {
     use crate::invariants::routing_table::{
         check_canister_migrations_invariants, check_routing_table_invariants,
     };
+    use crate::mutations::common::normalized_canister_cycles_cost_schedule as normalized_cost_schedule;
     use ic_base_types::CanisterId;
     use ic_protobuf::registry::routing_table::v1::{
         CanisterMigrations as PbCanisterMigrations, RoutingTable as PbRoutingTable,
     };
+    use ic_protobuf::registry::subnet::v1::SubnetRecord;
     use ic_registry_keys::make_canister_migrations_record_key;
     use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
     use ic_test_utilities_types::ids::subnet_test_id;
     use maplit::btreemap;
     use prost::Message;
     use std::convert::TryFrom;
+
+    fn subnet_record(cost_schedule: CanisterCyclesCostSchedule) -> SubnetRecord {
+        SubnetRecord {
+            canister_cycles_cost_schedule: i32::from(cost_schedule),
+            ..Default::default()
+        }
+    }
+
+    fn insert_subnet_record_to_snapshot(
+        subnet_id: SubnetId,
+        cost_schedule: CanisterCyclesCostSchedule,
+        snapshot: &mut RegistrySnapshot,
+    ) {
+        snapshot.insert(
+            make_subnet_record_key(subnet_id).into_bytes(),
+            subnet_record(cost_schedule).encode_to_vec(),
+        );
+    }
 
     fn insert_routing_table_to_snapshot(
         routing_table: RoutingTable,
@@ -110,6 +248,141 @@ mod tests {
         snapshot.insert(
             make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
             routing_table.encode_to_vec(),
+        );
+    }
+
+    /// The cycles cost schedule a canister is charged under must not change, be it by
+    /// moving the canister to a subnet on a different cost schedule or by changing the
+    /// cost schedule of the subnet hosting it.
+    #[test]
+    fn canister_cost_schedule_is_immutable() {
+        // Two subnets on the normal cost schedule and one on the free one, as a rental
+        // subnet is.
+        let normal_subnet_id = subnet_test_id(1);
+        let other_normal_subnet_id = subnet_test_id(2);
+        let free_subnet_id = subnet_test_id(3);
+
+        // A subnet record that predates the field leaves it `Unspecified`, which means
+        // the same as `Normal`.
+        let cost_schedules = btreemap! {
+            normal_subnet_id => CanisterCyclesCostSchedule::Normal,
+            other_normal_subnet_id => CanisterCyclesCostSchedule::Unspecified,
+            free_subnet_id => CanisterCyclesCostSchedule::Free,
+        };
+        let previous_cost_schedules = cost_schedules
+            .iter()
+            .map(|(subnet_id, cost_schedule)| {
+                (
+                    make_subnet_record_key(*subnet_id).into_bytes(),
+                    normalized_cost_schedule(&subnet_record(*cost_schedule)),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let mut snapshot = RegistrySnapshot::new();
+        for (subnet_id, cost_schedule) in &cost_schedules {
+            insert_subnet_record_to_snapshot(*subnet_id, *cost_schedule, &mut snapshot);
+        }
+
+        let range = |start: u64, end: u64| CanisterIdRange {
+            start: CanisterId::from(start),
+            end: CanisterId::from(end),
+        };
+        let routing_table = |entries: Vec<(CanisterIdRange, SubnetId)>| {
+            RoutingTable::try_from(entries.into_iter().collect::<BTreeMap<_, _>>()).unwrap()
+        };
+        let previous_routing_table = routing_table(vec![
+            (range(0x0, 0xff), normal_subnet_id),
+            (range(0x100, 0x1ff), free_subnet_id),
+        ]);
+
+        let check = |entries: Vec<(CanisterIdRange, SubnetId)>, snapshot: &mut RegistrySnapshot| {
+            insert_routing_table_to_snapshot(routing_table(entries), snapshot);
+            check_canister_cost_schedule_invariants(
+                &previous_routing_table,
+                &previous_cost_schedules,
+                snapshot,
+            )
+        };
+
+        // Leaving the routing table alone is fine, ...
+        check(
+            vec![
+                (range(0x0, 0xff), normal_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+            ],
+            &mut snapshot,
+        )
+        .unwrap();
+        // ... as is moving a range to a subnet on the same cost schedule, splitting it
+        // in the process, ...
+        check(
+            vec![
+                (range(0x0, 0x7f), normal_subnet_id),
+                (range(0x80, 0xff), other_normal_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+            ],
+            &mut snapshot,
+        )
+        .unwrap();
+        // ... dropping a range, ...
+        check(vec![(range(0x100, 0x1ff), free_subnet_id)], &mut snapshot).unwrap();
+        // ... or assigning a range that was not hosted by any subnet before.
+        check(
+            vec![
+                (range(0x0, 0xff), normal_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+                (range(0x200, 0x2ff), free_subnet_id),
+            ],
+            &mut snapshot,
+        )
+        .unwrap();
+
+        // Moving a range to a subnet on a different cost schedule is not, in either
+        // direction, and neither is moving only a part of it.
+        for entries in [
+            vec![
+                (range(0x0, 0xff), free_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+            ],
+            vec![
+                (range(0x0, 0x7f), normal_subnet_id),
+                (range(0x80, 0xff), free_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+            ],
+            vec![
+                (range(0x0, 0xff), normal_subnet_id),
+                (range(0x100, 0x1ff), normal_subnet_id),
+            ],
+        ] {
+            let err = check(entries, &mut snapshot)
+                .expect_err("Expected the move across cost schedules to be rejected");
+            assert!(
+                err.msg.contains("changes its cycles cost schedule"),
+                "unexpected error message: {}",
+                err.msg
+            );
+        }
+
+        // Neither is changing the cost schedule of the subnet hosting a range, even
+        // with the routing table left alone.
+        insert_subnet_record_to_snapshot(
+            normal_subnet_id,
+            CanisterCyclesCostSchedule::Free,
+            &mut snapshot,
+        );
+        let err = check(
+            vec![
+                (range(0x0, 0xff), normal_subnet_id),
+                (range(0x100, 0x1ff), free_subnet_id),
+            ],
+            &mut snapshot,
+        )
+        .expect_err("Expected the change of the cost schedule to be rejected");
+        assert!(
+            err.msg.contains("changes its cycles cost schedule"),
+            "unexpected error message: {}",
+            err.msg
         );
     }
 

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -107,10 +107,17 @@ pub(crate) fn check_canister_cost_schedule_invariants(
             && let Some(cost_schedule) = cost_schedule(&cost_schedules, subnet_id)
             && previous_cost_schedule != cost_schedule
         {
+            // Only the intersection of the two ranges changes its cost schedule: the
+            // rest of either range is hosted by the same subnet in both states, is
+            // newly assigned, or is not hosted anymore.
+            let affected_range = CanisterIdRange {
+                start: previous_range.start.max(range.start),
+                end: previous_range.end.min(range.end),
+            };
             return Err(InvariantCheckError {
                 msg: format!(
-                    "canister ID range {range:?} changes its cycles cost schedule from \
-                    {previous_cost_schedule:?} on subnet {previous_subnet_id} to \
+                    "canister ID range {affected_range:?} changes its cycles cost schedule \
+                    from {previous_cost_schedule:?} on subnet {previous_subnet_id} to \
                     {cost_schedule:?} on subnet {subnet_id}"
                 ),
                 source: None,
@@ -339,27 +346,47 @@ mod tests {
         .unwrap();
 
         // Moving a range to a subnet on a different cost schedule is not, in either
-        // direction, and neither is moving only a part of it.
-        for entries in [
-            vec![
-                (range(0x0, 0xff), free_subnet_id),
-                (range(0x100, 0x1ff), free_subnet_id),
-            ],
-            vec![
-                (range(0x0, 0x7f), normal_subnet_id),
-                (range(0x80, 0xff), free_subnet_id),
-                (range(0x100, 0x1ff), free_subnet_id),
-            ],
-            vec![
-                (range(0x0, 0xff), normal_subnet_id),
-                (range(0x100, 0x1ff), normal_subnet_id),
-            ],
+        // direction, and neither is moving only a part of it. The reported range is the
+        // part that actually changed its cost schedule, i.e. the intersection of the
+        // range hosting the canisters before and the one hosting them now.
+        for (entries, affected_range) in [
+            (
+                vec![
+                    (range(0x0, 0xff), free_subnet_id),
+                    (range(0x100, 0x1ff), free_subnet_id),
+                ],
+                range(0x0, 0xff),
+            ),
+            // Only the second half of the first range moves.
+            (
+                vec![
+                    (range(0x0, 0x7f), normal_subnet_id),
+                    (range(0x80, 0xff), free_subnet_id),
+                    (range(0x100, 0x1ff), free_subnet_id),
+                ],
+                range(0x80, 0xff),
+            ),
+            (
+                vec![
+                    (range(0x0, 0xff), normal_subnet_id),
+                    (range(0x100, 0x1ff), normal_subnet_id),
+                ],
+                range(0x100, 0x1ff),
+            ),
+            // The two ranges are merged into one hosted by the subnet that hosted the
+            // second one all along, so only the first one changes its cost schedule.
+            (vec![(range(0x0, 0x1ff), free_subnet_id)], range(0x0, 0xff)),
         ] {
             let err = check(entries, &mut snapshot)
                 .expect_err("Expected the move across cost schedules to be rejected");
             assert!(
                 err.msg.contains("changes its cycles cost schedule"),
                 "unexpected error message: {}",
+                err.msg
+            );
+            assert!(
+                err.msg.contains(&format!("{affected_range:?}")),
+                "expected {affected_range:?} to be reported: {}",
                 err.msg
             );
         }

--- a/rs/registry/canister/src/invariants/subnet.rs
+++ b/rs/registry/canister/src/invariants/subnet.rs
@@ -3,12 +3,15 @@ use std::{
     convert::TryFrom,
 };
 
-use crate::invariants::{
-    common::{
-        InvariantCheckError, RegistrySnapshot, get_node_record_from_snapshot,
-        get_subnet_ids_from_snapshot, get_value_from_snapshot,
+use crate::{
+    invariants::{
+        common::{
+            InvariantCheckError, RegistrySnapshot, get_node_record_from_snapshot,
+            get_subnet_ids_from_snapshot, get_value_from_snapshot,
+        },
+        replica_version::has_launch_measurements,
     },
-    replica_version::has_launch_measurements,
+    mutations::common::normalized_canister_cycles_cost_schedule,
 };
 
 use ic_base_types::{NodeId, PrincipalId, SubnetId, subnet_id_try_from_protobuf};
@@ -277,6 +280,48 @@ pub(crate) fn get_subnet_records_map(
         }
     }
     subnets
+}
+
+/// Checks that no subnet changes its cycles cost schedule.
+///
+/// The cost schedule a canister is charged under has to stay put for as long as the
+/// canister has calls in flight: the cycles prepaid for a response execution are
+/// settled against the cycles that execution requires, derived when the response is
+/// executed (`CyclesAccountManager::adjust_prepayment_for_response_execution`), and
+/// the two amounts are only comparable if both were derived under the same cost
+/// schedule. An amount that is free under the free cost schedule has a zero real part
+/// but a non-zero nominal one, so settling across a switch either forfeits the real
+/// part of the prepayment or credits real cycles that were never withdrawn.
+///
+/// A subnet is assigned its cost schedule when it is created and no payload exposes a
+/// field to change it afterwards, so this invariant is a backstop: it holds whichever
+/// path a mutation of a subnet record takes.
+///
+/// `previous_cost_schedules` maps the registry key of a subnet record to the cost
+/// schedule that subnet had before the mutations under check were applied; subnets
+/// missing from it are newly created and are free to pick any cost schedule.
+pub(crate) fn check_subnet_cost_schedule_immutability(
+    previous_cost_schedules: &BTreeMap<Vec<u8>, CanisterCyclesCostSchedule>,
+    snapshot: &RegistrySnapshot,
+) -> Result<(), InvariantCheckError> {
+    for (key, subnet_record) in get_subnet_records_map(snapshot) {
+        let Some(previous_cost_schedule) = previous_cost_schedules.get(&key) else {
+            continue;
+        };
+        let cost_schedule = normalized_canister_cycles_cost_schedule(&subnet_record);
+        if cost_schedule != *previous_cost_schedule {
+            return Err(InvariantCheckError {
+                msg: format!(
+                    "Subnet record {} changes its cycles cost schedule from \
+                    {previous_cost_schedule:?} to {cost_schedule:?}",
+                    String::from_utf8_lossy(&key),
+                ),
+                source: None,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 /// SEV-enabled subnets must consist of SEV-supporting nodes only, and must run a

--- a/rs/registry/canister/src/invariants/subnet/tests.rs
+++ b/rs/registry/canister/src/invariants/subnet/tests.rs
@@ -580,6 +580,80 @@ fn only_cloud_engine_subnets_can_have_type4_nodes() {
     );
 }
 
+#[test]
+fn subnet_cycles_cost_schedule_is_immutable() {
+    let key = make_subnet_record_key(subnet_test_id(1)).into_bytes();
+    let snapshot_with = |cost_schedule: CanisterCyclesCostSchedule| {
+        let subnet_record = SubnetRecord {
+            canister_cycles_cost_schedule: i32::from(cost_schedule),
+            ..Default::default()
+        };
+        let mut snapshot = RegistrySnapshot::new();
+        snapshot.insert(key.clone(), subnet_record.encode_to_vec());
+        snapshot
+    };
+
+    // A newly created subnet may pick any cost schedule.
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Unspecified,
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        check_subnet_cost_schedule_immutability(&BTreeMap::new(), &snapshot_with(cost_schedule))
+            .unwrap();
+    }
+
+    // Keeping the cost schedule is fine, ...
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let previous_cost_schedules = BTreeMap::from([(key.clone(), cost_schedule)]);
+        check_subnet_cost_schedule_immutability(
+            &previous_cost_schedules,
+            &snapshot_with(cost_schedule),
+        )
+        .unwrap();
+    }
+
+    // ... as is leaving it `Unspecified`, which means `Normal`.
+    let previous_cost_schedules =
+        BTreeMap::from([(key.clone(), CanisterCyclesCostSchedule::Normal)]);
+    check_subnet_cost_schedule_immutability(
+        &previous_cost_schedules,
+        &snapshot_with(CanisterCyclesCostSchedule::Unspecified),
+    )
+    .unwrap();
+
+    // Changing the cost schedule is not, in either direction.
+    for (previous_cost_schedule, cost_schedule) in [
+        (
+            CanisterCyclesCostSchedule::Normal,
+            CanisterCyclesCostSchedule::Free,
+        ),
+        (
+            CanisterCyclesCostSchedule::Free,
+            CanisterCyclesCostSchedule::Normal,
+        ),
+        (
+            CanisterCyclesCostSchedule::Free,
+            CanisterCyclesCostSchedule::Unspecified,
+        ),
+    ] {
+        let previous_cost_schedules = BTreeMap::from([(key.clone(), previous_cost_schedule)]);
+        let err = check_subnet_cost_schedule_immutability(
+            &previous_cost_schedules,
+            &snapshot_with(cost_schedule),
+        )
+        .expect_err("Expected the change of the cycles cost schedule to be rejected");
+        assert!(
+            err.msg.contains("changes its cycles cost schedule"),
+            "unexpected error message: {}",
+            err.msg
+        );
+    }
+}
+
 fn setup_minimal_registry_snapshot_for_check_subnet_invariants(
     system_subnet_id: SubnetId,
     test_subnet_id: SubnetId,

--- a/rs/registry/canister/src/mutations/common.rs
+++ b/rs/registry/canister/src/mutations/common.rs
@@ -1,7 +1,8 @@
 use crate::{common::key_family::get_key_family_iter, registry::Registry};
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_protobuf::registry::{
-    replica_version::v1::ReplicaVersionRecord, subnet::v1::SubnetListRecord,
+    replica_version::v1::ReplicaVersionRecord,
+    subnet::v1::{CanisterCyclesCostSchedule, SubnetListRecord, SubnetRecord},
     unassigned_nodes_config::v1::UnassignedNodesConfigRecord,
 };
 use ic_registry_keys::{
@@ -10,6 +11,22 @@ use ic_registry_keys::{
 };
 use prost::Message;
 use std::{cmp::Eq, collections::HashSet, convert::TryFrom, hash::Hash};
+
+/// Returns the cycles cost schedule of `subnet_record`, with `Unspecified` normalized
+/// to `Normal`.
+///
+/// A subnet record that predates the field leaves it `Unspecified`, which the replica
+/// reads as `Normal` (cf. `Registry::get_subnet`), so the two must compare equal.
+pub(crate) fn normalized_canister_cycles_cost_schedule(
+    subnet_record: &SubnetRecord,
+) -> CanisterCyclesCostSchedule {
+    match subnet_record.canister_cycles_cost_schedule() {
+        CanisterCyclesCostSchedule::Unspecified | CanisterCyclesCostSchedule::Normal => {
+            CanisterCyclesCostSchedule::Normal
+        }
+        CanisterCyclesCostSchedule::Free => CanisterCyclesCostSchedule::Free,
+    }
+}
 
 pub fn get_subnet_ids_from_subnet_list(subnet_list: SubnetListRecord) -> Vec<SubnetId> {
     subnet_list

--- a/rs/registry/canister/src/mutations/do_migrate_canisters.rs
+++ b/rs/registry/canister/src/mutations/do_migrate_canisters.rs
@@ -1,4 +1,7 @@
-use crate::registry::{Registry, Version};
+use crate::{
+    mutations::common::normalized_canister_cycles_cost_schedule,
+    registry::{Registry, Version},
+};
 use candid::{CandidType, Deserialize};
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use serde::Serialize;
@@ -51,7 +54,65 @@ impl Registry {
         // Hence, we intentionally do not validate that the target subnet exists here.
         let target_subnet_id = SubnetId::new(target_subnet_id);
 
+        self.validate_cost_schedules(&canister_ids, target_subnet_id)?;
+
         Ok((canister_ids, target_subnet_id))
+    }
+
+    /// Validates that migrating `canister_ids` to `target_subnet_id` does not change
+    /// the cycles cost schedule any of them is charged under.
+    ///
+    /// That schedule has to stay put for as long as a canister has calls in flight:
+    /// the cycles prepaid for a response execution are settled against the cycles that
+    /// execution requires, derived when the response is executed
+    /// (`CyclesAccountManager::adjust_prepayment_for_response_execution`), and the two
+    /// amounts are only comparable if both were derived under the same cost schedule.
+    /// An amount that is free under the free cost schedule has a zero real part but a
+    /// non-zero nominal one, so settling across a switch either forfeits the real part
+    /// of the prepayment or credits real cycles that were never withdrawn.
+    ///
+    /// The `check_canister_cost_schedule_invariants` registry invariant enforces this
+    /// too, whichever mutation would change a canister's cost schedule; validating it
+    /// here as well reports which canister and which subnets are at fault.
+    fn validate_cost_schedules(
+        &self,
+        canister_ids: &[CanisterId],
+        target_subnet_id: SubnetId,
+    ) -> Result<(), String> {
+        let version = self.latest_version();
+        let routing_table = self.get_routing_table_or_panic(version);
+
+        // Only a target subnet that already appears in the routing table hosts the
+        // canisters after the migration; otherwise they are unassigned rather than
+        // moved (see above), which leaves no cost schedule to preserve. This mirrors
+        // the condition in `migrate_canisters_to_subnet`.
+        if !routing_table
+            .iter()
+            .any(|(_range, subnet_id)| *subnet_id == target_subnet_id)
+        {
+            return Ok(());
+        }
+        let target_cost_schedule =
+            normalized_canister_cycles_cost_schedule(&self.get_subnet(target_subnet_id, version)?);
+
+        for canister_id in canister_ids {
+            // A canister that no subnet hosts has no cost schedule to preserve either.
+            let Some((_range, source_subnet_id)) = routing_table.lookup_entry(*canister_id) else {
+                continue;
+            };
+            let source_cost_schedule = normalized_canister_cycles_cost_schedule(
+                &self.get_subnet(source_subnet_id, version)?,
+            );
+            if source_cost_schedule != target_cost_schedule {
+                return Err(format!(
+                    "canister {canister_id} is hosted by subnet {source_subnet_id} on the \
+                     {source_cost_schedule:?} cycles cost schedule and hence cannot be migrated \
+                     to subnet {target_subnet_id} on the {target_cost_schedule:?} one"
+                ));
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -76,8 +137,12 @@ mod test {
     use crate::mutations::routing_table::routing_table_into_registry_mutation;
     use ic_base_types::CanisterId;
     use ic_base_types::PrincipalId;
+    use ic_protobuf::registry::subnet::v1::CanisterCyclesCostSchedule;
+    use ic_registry_keys::make_subnet_record_key;
     use ic_registry_routing_table::CanisterIdRange;
     use ic_registry_routing_table::RoutingTable;
+    use ic_registry_transport::update;
+    use prost::Message;
 
     // We only need a basic test, because the rest of the logic for this is tested in the tests
     // for migrating canister ranges, which is already supported.
@@ -322,5 +387,64 @@ mod test {
             )
             .unwrap();
         assert_eq!(updated_routing_table, expected_routing_table);
+    }
+    /// A canister must not be migrated to a subnet that uses a different cycles cost
+    /// schedule; see `Registry::validate_cost_schedules`.
+    #[test]
+    #[should_panic(expected = "cannot be migrated to subnet")]
+    fn test_migrate_canisters_to_subnet_with_different_cost_schedule() {
+        let mut registry = invariant_compliant_registry(0);
+        let system_subnet =
+            PrincipalId::try_from(registry.get_subnet_list_record().subnets.first().unwrap())
+                .unwrap();
+
+        let (mutate_request, node_ids_and_dkg_pks) = prepare_registry_with_nodes(1, 6);
+        registry.maybe_apply_mutation_internal(mutate_request.mutations);
+        let target_subnet_id =
+            registry_create_subnet_with_nodes(&mut registry, &node_ids_and_dkg_pks, &[0, 1, 2, 3]);
+
+        // Put the target subnet on the free cycles cost schedule, as a rental subnet
+        // is, while the system subnet hosting the canister stays on the normal one. The
+        // mutation has to bypass the invariant checks, which reject a change of the cost
+        // schedule of an existing subnet (see `check_subnet_cost_schedule_immutability`).
+        let mut subnet_record = registry
+            .get_subnet(target_subnet_id, registry.latest_version())
+            .unwrap();
+        subnet_record.canister_cycles_cost_schedule = i32::from(CanisterCyclesCostSchedule::Free);
+        registry.apply_mutations_for_test(vec![update(
+            make_subnet_record_key(target_subnet_id).as_bytes(),
+            subnet_record.encode_to_vec(),
+        )]);
+
+        // As above, the target subnet must already appear in the routing table for the
+        // migration to keep the canister assigned to it.
+        let mut initial_routing_table = RoutingTable::new();
+        initial_routing_table
+            .insert(
+                CanisterIdRange {
+                    start: CanisterId::from(0),
+                    end: CanisterId::from(255),
+                },
+                system_subnet.into(),
+            )
+            .unwrap();
+        initial_routing_table
+            .insert(
+                CanisterIdRange {
+                    start: CanisterId::from_u64(256),
+                    end: CanisterId::from_u64(256),
+                },
+                target_subnet_id,
+            )
+            .unwrap();
+        registry.apply_mutations_for_test(routing_table_into_registry_mutation(
+            &registry,
+            initial_routing_table,
+        ));
+
+        registry.do_migrate_canisters(MigrateCanistersPayload {
+            canister_ids: vec![PrincipalId::from(CanisterId::from(100))],
+            target_subnet_id: target_subnet_id.get(),
+        });
     }
 }

--- a/rs/registry/canister/src/mutations/do_migrate_canisters.rs
+++ b/rs/registry/canister/src/mutations/do_migrate_canisters.rs
@@ -96,7 +96,11 @@ impl Registry {
             normalized_canister_cycles_cost_schedule(&self.get_subnet(target_subnet_id, version)?);
 
         for canister_id in canister_ids {
-            // A canister that no subnet hosts has no cost schedule to preserve either.
+            // An unrouted canister ID has no cost schedule to compare the target's
+            // with. Note that this is what leaves the gap documented on
+            // `check_canister_cost_schedule_invariants`: unrouting a canister ID and
+            // routing it to a subnet on a different cost schedule afterwards is not
+            // caught, here or there.
             let Some((_range, source_subnet_id)) = routing_table.lookup_entry(*canister_id) else {
                 continue;
             };

--- a/rs/registry/canister/src/mutations/merge_subnets.rs
+++ b/rs/registry/canister/src/mutations/merge_subnets.rs
@@ -1,10 +1,15 @@
-use crate::{common::LOG_PREFIX, registry::Registry};
+use crate::{
+    common::LOG_PREFIX, mutations::common::normalized_canister_cycles_cost_schedule,
+    registry::Registry,
+};
 use candid::CandidType;
 #[cfg(target_arch = "wasm32")]
 use dfn_core::println;
 use ic_base_types::SubnetId;
+use ic_protobuf::registry::subnet::v1::SubnetRecord;
 use ic_registry_keys::make_subnet_record_key;
 use ic_registry_routing_table::are_disjoint;
+use prost::Message;
 use serde::{Deserialize, Serialize};
 
 impl Registry {
@@ -22,6 +27,8 @@ impl Registry {
     ///
     /// Note that only the routing table is updated: neither subnet record is
     /// modified and, in particular, the source subnet is not deleted.
+    ///
+    /// Both subnets must use the same cycles cost schedule; see the check below.
     pub fn merge_subnets(&mut self, payload: MergeSubnetsPayload) -> Result<(), String> {
         println!("{LOG_PREFIX}merge_subnets: {payload:?}");
 
@@ -40,13 +47,46 @@ impl Registry {
         let version = self.latest_version();
 
         // The subnets must exist.
-        self.get(&make_subnet_record_key(source_subnet).into_bytes(), version)
+        let source_subnet_record = self
+            .get(&make_subnet_record_key(source_subnet).into_bytes(), version)
             .ok_or_else(|| format!("source {source_subnet} is not a known subnet"))?;
-        self.get(
-            &make_subnet_record_key(destination_subnet).into_bytes(),
-            version,
-        )
-        .ok_or_else(|| format!("destination {destination_subnet} is not a known subnet"))?;
+        let destination_subnet_record = self
+            .get(
+                &make_subnet_record_key(destination_subnet).into_bytes(),
+                version,
+            )
+            .ok_or_else(|| format!("destination {destination_subnet} is not a known subnet"))?;
+
+        // The subnets must use the same cycles cost schedule. The merged canisters carry
+        // their callbacks along, and each callback records the cycles prepaid for its
+        // response execution under the cost schedule of the subnet on which the call was
+        // performed. When the response is executed, that prepayment is settled against
+        // the cycles the execution requires, derived under the cost schedule of the
+        // subnet hosting the canister by then
+        // (`CyclesAccountManager::adjust_prepayment_for_response_execution`). The two
+        // amounts are only comparable if both were derived under the same cost schedule:
+        // an amount that is free under the free cost schedule has a zero real part but a
+        // non-zero nominal one, so settling across a switch either forfeits the real part
+        // of the prepayment or credits real cycles that were never withdrawn.
+        let source_cost_schedule = normalized_canister_cycles_cost_schedule(
+            &SubnetRecord::decode(source_subnet_record.value.as_slice()).map_err(|err| {
+                format!("failed to decode the record of source subnet {source_subnet}: {err}")
+            })?,
+        );
+        let destination_cost_schedule = normalized_canister_cycles_cost_schedule(
+            &SubnetRecord::decode(destination_subnet_record.value.as_slice()).map_err(|err| {
+                format!(
+                    "failed to decode the record of destination subnet {destination_subnet}: {err}"
+                )
+            })?,
+        );
+        if source_cost_schedule != destination_cost_schedule {
+            return Err(format!(
+                "cycles cost schedules do not match: source subnet {source_subnet} uses the \
+                 {source_cost_schedule:?} cycles cost schedule, destination subnet \
+                 {destination_subnet} uses the {destination_cost_schedule:?} one"
+            ));
+        }
 
         // The source subnet must be nonempty.
         let routing_table = self.get_routing_table_or_panic(version);
@@ -103,7 +143,9 @@ mod tests {
             routing_table::routing_table_into_registry_mutation,
         },
     };
+    use ic_protobuf::registry::subnet::v1::CanisterCyclesCostSchedule;
     use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
+    use ic_registry_transport::update;
     use ic_types::CanisterId;
     use ic_types_test_utils::ids::{SUBNET_1, SUBNET_2, SUBNET_3};
     use lazy_static::lazy_static;
@@ -286,6 +328,40 @@ mod tests {
         let error_message = result.unwrap_err();
         assert!(
             error_message.contains(&format!("destination {SUBNET_3} is not a known subnet")),
+            "{error_message}"
+        );
+        assert_eq!(
+            get_routing_table_entries(&registry),
+            FIXTURE_ROUTING_TABLE_ENTRIES.to_vec(),
+        );
+    }
+
+    #[test]
+    fn test_merge_subnets_fails_when_cost_schedules_differ() {
+        // Step 1: Prepare the world: put the destination subnet on the free cycles cost
+        // schedule, as a rental subnet is. The mutation has to bypass the invariant
+        // checks, which reject a change of the cost schedule of an existing subnet (see
+        // `check_subnet_cost_schedule_immutability`).
+        let mut registry = TWO_SUBNETS_REGISTRY.clone();
+        let mut subnet_record = registry
+            .get_subnet(SUBNET_2, registry.latest_version())
+            .unwrap();
+        subnet_record.canister_cycles_cost_schedule = i32::from(CanisterCyclesCostSchedule::Free);
+        registry.apply_mutations_for_test(vec![update(
+            make_subnet_record_key(SUBNET_2).as_bytes(),
+            subnet_record.encode_to_vec(),
+        )]);
+
+        // Step 2: Run the code under test.
+        let result = registry.merge_subnets(MergeSubnetsPayload {
+            source_subnet: SUBNET_1,
+            destination_subnet: SUBNET_2,
+        });
+
+        // Step 3: Verify results.
+        let error_message = result.unwrap_err();
+        assert!(
+            error_message.contains("cycles cost schedules do not match"),
             "{error_message}"
         );
         assert_eq!(

--- a/rs/registry/canister/src/mutations/prepare_canister_migration.rs
+++ b/rs/registry/canister/src/mutations/prepare_canister_migration.rs
@@ -1,7 +1,10 @@
-use crate::registry::{Registry, Version};
+use crate::{
+    mutations::common::normalized_canister_cycles_cost_schedule,
+    registry::{Registry, Version},
+};
 use candid::CandidType;
 use ic_base_types::SubnetId;
-use ic_protobuf::registry::subnet::v1::{SubnetRecord, SubnetType};
+use ic_protobuf::registry::subnet::v1::{CanisterCyclesCostSchedule, SubnetRecord, SubnetType};
 use ic_registry_routing_table::{
     CanisterIdRange, CanisterIdRanges, WellFormedError, are_disjoint, is_subset_of,
 };
@@ -32,6 +35,10 @@ pub enum PrepareCanisterMigrationError {
         /*destination size=*/ usize,
     ),
     SubnetTypesMismatch(Option<SubnetType>, Option<SubnetType>),
+    CostSchedulesMismatch(
+        /*source schedule=*/ CanisterCyclesCostSchedule,
+        /*destination schedule=*/ CanisterCyclesCostSchedule,
+    ),
     CanisterIdsNotWellFormed(WellFormedError),
     UnhostedCanisterIds,
     CanisterIdsAlreadyBeingMigrated(CanisterIdRanges),
@@ -119,8 +126,9 @@ impl Registry {
 /// Validates that the subnets satisfy the following conditions:
 /// 1. Both subnets have the same size,
 /// 2. Both subnets have the same type,
-/// 3. Neither of the subnets is a signing subnet, and
-/// 4. Both subnets are Application subnets.
+/// 3. Both subnets have the same cycles cost schedule,
+/// 4. Neither of the subnets is a signing subnet, and
+/// 5. Both subnets are Application subnets.
 fn validate_subnets(
     source_subnet_id: SubnetId,
     source_subnet_record: &SubnetRecord,
@@ -179,6 +187,25 @@ fn validate_subnets_consistency(
         ));
     }
 
+    // A migrated canister carries its callbacks along, and each callback records the
+    // cycles prepaid for its response execution under the cost schedule of the subnet
+    // on which the call was performed. When the response is executed, that prepayment
+    // is settled against the cycles the execution requires, derived under the cost
+    // schedule of the subnet hosting the canister by then
+    // (`CyclesAccountManager::adjust_prepayment_for_response_execution`). The two
+    // amounts are only comparable if both were derived under the same cost schedule:
+    // an amount that is free under the free cost schedule has a zero real part but a
+    // non-zero nominal one, so settling across a switch either forfeits the real part
+    // of the prepayment or credits real cycles that were never withdrawn.
+    let source_cost_schedule = normalized_canister_cycles_cost_schedule(source_subnet);
+    let destination_cost_schedule = normalized_canister_cycles_cost_schedule(destination_subnet);
+    if source_cost_schedule != destination_cost_schedule {
+        return Err(PrepareCanisterMigrationError::CostSchedulesMismatch(
+            source_cost_schedule,
+            destination_cost_schedule,
+        ));
+    }
+
     Ok(())
 }
 
@@ -210,6 +237,17 @@ impl fmt::Display for PrepareCanisterMigrationError {
                     f,
                     "Subnet types do not match. \
                     Source subnet's type: {source_type:?}, destination subnet's type: {destination_type:?}"
+                )
+            }
+            PrepareCanisterMigrationError::CostSchedulesMismatch(
+                source_cost_schedule,
+                destination_cost_schedule,
+            ) => {
+                write!(
+                    f,
+                    "Subnet cycles cost schedules do not match. \
+                    Source subnet's cost schedule: {source_cost_schedule:?}, \
+                    destination subnet's cost schedule: {destination_cost_schedule:?}"
                 )
             }
             PrepareCanisterMigrationError::UnhostedCanisterIds => {
@@ -254,6 +292,7 @@ mod tests {
     struct SubnetInfo {
         subnet_id: SubnetId,
         subnet_type: SubnetType,
+        cost_schedule: CanisterCyclesCostSchedule,
         nodes_count: u64,
         canister_id_ranges: Vec<CanisterIdRange>,
     }
@@ -281,10 +320,13 @@ mod tests {
             source_node_ids_and_dkg_pks.keys().copied().collect(),
         );
         source_subnet_record.subnet_type = source_subnet.subnet_type as i32;
+        source_subnet_record.canister_cycles_cost_schedule = source_subnet.cost_schedule as i32;
         let mut destination_subnet_record = get_invariant_compliant_subnet_record(
             destination_node_ids_and_dkg_pks.keys().copied().collect(),
         );
         destination_subnet_record.subnet_type = destination_subnet.subnet_type as i32;
+        destination_subnet_record.canister_cycles_cost_schedule =
+            destination_subnet.cost_schedule as i32;
 
         let subnet_mutation = add_fake_subnet(
             source_subnet.subnet_id,
@@ -329,6 +371,7 @@ mod tests {
             SubnetInfo {
                 subnet_id: source_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![CanisterIdRange {
                     start: CanisterId::from(0),
@@ -338,6 +381,7 @@ mod tests {
             SubnetInfo {
                 subnet_id: destination_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![],
             },
@@ -363,12 +407,14 @@ mod tests {
             SubnetInfo {
                 subnet_id: source_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 2,
                 canister_id_ranges: vec![],
             },
             SubnetInfo {
                 subnet_id: destination_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![],
             },
@@ -398,12 +444,14 @@ mod tests {
             SubnetInfo {
                 subnet_id: source_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![],
             },
             SubnetInfo {
                 subnet_id: destination_subnet_id,
                 subnet_type: SubnetType::VerifiedApplication,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![],
             },
@@ -433,6 +481,7 @@ mod tests {
             SubnetInfo {
                 subnet_id: source_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![CanisterIdRange {
                     start: CanisterId::from(0),
@@ -442,6 +491,7 @@ mod tests {
             SubnetInfo {
                 subnet_id: destination_subnet_id,
                 subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
                 nodes_count: 1,
                 canister_id_ranges: vec![],
             },
@@ -461,5 +511,85 @@ mod tests {
             .expect_err("Canister migration preparation should fail");
 
         assert_matches!(err, PrepareCanisterMigrationError::UnhostedCanisterIds);
+    }
+
+    #[test]
+    fn prepare_canister_migration_should_fail_when_cost_schedules_dont_match_test() {
+        let (source_subnet_id, destination_subnet_id) = dummy_subnet_ids();
+
+        // A rental subnet is an application subnet on the free cost schedule, i.e. it
+        // has the same type and may have the same size as a regular application subnet.
+        let mut registry = set_up(
+            SubnetInfo {
+                subnet_id: source_subnet_id,
+                subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
+                nodes_count: 1,
+                canister_id_ranges: vec![],
+            },
+            SubnetInfo {
+                subnet_id: destination_subnet_id,
+                subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Free,
+                nodes_count: 1,
+                canister_id_ranges: vec![],
+            },
+        );
+
+        let payload = PrepareCanisterMigrationPayload {
+            canister_id_ranges: vec![],
+            source_subnet: source_subnet_id,
+            destination_subnet: destination_subnet_id,
+        };
+
+        let err = registry
+            .prepare_canister_migration(payload)
+            .expect_err("Canister migration preparation should fail");
+
+        assert_matches!(
+            err,
+            PrepareCanisterMigrationError::CostSchedulesMismatch(
+                CanisterCyclesCostSchedule::Normal,
+                CanisterCyclesCostSchedule::Free,
+            )
+        );
+    }
+
+    /// A subnet record that predates the cycles cost schedule field leaves it
+    /// `Unspecified`, which means the same as `Normal`.
+    #[test]
+    fn prepare_canister_migration_should_succeed_when_cost_schedule_is_unspecified_test() {
+        let (source_subnet_id, destination_subnet_id) = dummy_subnet_ids();
+
+        let mut registry = set_up(
+            SubnetInfo {
+                subnet_id: source_subnet_id,
+                subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Unspecified,
+                nodes_count: 1,
+                canister_id_ranges: vec![CanisterIdRange {
+                    start: CanisterId::from(0),
+                    end: CanisterId::from(10),
+                }],
+            },
+            SubnetInfo {
+                subnet_id: destination_subnet_id,
+                subnet_type: SubnetType::Application,
+                cost_schedule: CanisterCyclesCostSchedule::Normal,
+                nodes_count: 1,
+                canister_id_ranges: vec![],
+            },
+        );
+
+        let payload = PrepareCanisterMigrationPayload {
+            canister_id_ranges: vec![CanisterIdRange {
+                start: CanisterId::from(3),
+                end: CanisterId::from(7),
+            }],
+            source_subnet: source_subnet_id,
+            destination_subnet: destination_subnet_id,
+        };
+
+        assert!(registry.prepare_canister_migration(payload).is_ok());
     }
 }


### PR DESCRIPTION
The cycles prepaid for a response execution are recorded in the callback under the cost schedule in effect when the call was performed, and settled when the response is executed against the cycles that execution requires, derived under the cost schedule in effect by then. The two amounts are only comparable if both were derived under the same cost schedule: an amount that is free under the free cost schedule has a zero real part but a non-zero nominal one, so settling across a switch either forfeits the real part of the prepayment or credits the canister with real cycles that were never withdrawn from its balance.

Nothing enforced that today. This PR enforces it for every canister that a subnet hosts, with one gap that it cannot close and documents instead: see [Known gap](#known-gap-canister-ids-that-pass-through-an-unrouted-state).

### The property, not its mutations

A canister is charged under the cost schedule of the subnet that the routing table assigns its canister ID to, so `check_canister_cost_schedule_invariants` compares, for every canister ID routed both before and after the mutations under check, the cost schedule of the subnet that hosted it with the one of the subnet that hosts it now. That covers both ways of changing it — moving the canister and changing the cost schedule of its subnet — in any combination, and hence every mutation of the routing table or of a subnet record, present and future.

Enforcing this at the individual mutations instead would have kept missing paths: `merge_subnets` moves every canister ID range of the source subnet to the destination subnet without touching either subnet record, and `do_migrate_canisters` reassigns individual canisters without validating anything at all, not even that the target subnet exists.

`check_subnet_cost_schedule_immutability` is kept alongside it as the stronger and simpler statement — no existing subnet ever changes its cost schedule, whichever mutation would change it; a newly created subnet is free to pick either. It also catches a change on a subnet that hosts no canister ID range yet.

### Validation at the mutations

An invariant failure traps, so the paths that a proposal or the canister migration orchestrator can reach validate the cost schedules themselves and report which subnets, or which canister, are at fault:

- `prepare_canister_migration` rejects preparing a migration between subnets on different cost schedules. This one is not covered by the invariant at all: it only writes `canister_migrations`, and the move happens later in `reroute_canister_ranges`;
- `merge_subnets` rejects merging a source subnet into a destination on a different cost schedule;
- `do_migrate_canisters` rejects migrating a canister to a subnet on a cost schedule other than that of the subnet hosting it.

`reroute_canister_ranges` compares nothing of its own: it only reroutes ranges covered by a canister migration, which `prepare_canister_migration` has already validated. `do_split_subnet` needs no check either, as the new subnet inherits the cost schedule of the source subnet.

All comparisons normalize `Unspecified` to `Normal`, as a subnet record that predates the field leaves it unset and the replica reads that as `Normal`.

### What the checks cost

Reading the subnet records and the routing table is not free, and a first version of this PR had every mutation pay for reading the routing table twice over — once from the registry for its pre-mutation state and once from the snapshot, each read decoding every canister ranges shard. The canbench benchmarks caught it: `migrate_canisters_*` regressed by 71% to 74% and `upgrade_with_routing_table_*` by 5% to 11%.

Each check is now charged to the mutations that can actually break it:

- a subnet record mutation pays for `check_subnet_cost_schedule_immutability`;
- a canister ranges shard mutation pays for `check_canister_cost_schedule_invariants`, which compares only the shards that mutation touches. A canister ID whose covering entry did not change is still assigned to the same subnet, and the cost schedule of that subnet cannot have changed either, which the invariant above enforces. An entry can move between shards, e.g. when two adjacent ranges are merged into one, which mutates the shard it leaves as well as the shard it lands in, so both are compared. The shards are collected into a set, as a single batch can mutate one of them more than once and decoding a shard twice would produce duplicate entries, which `RoutingTable` rejects;
- every other mutation, `post_upgrade` with its empty mutation list included, pays for neither.

Thirteen of the fourteen benchmarks are within the noise threshold with that in place. `migrate_canisters_10_times_100` remains 4.81% more expensive, which is the cost of the check itself on a routing table small enough for it to show — the 1k and the 10k variants of the same benchmark are within noise — and the recorded results are updated accordingly.

### Known gap: canister IDs that pass through an unrouted state

An unrouted canister ID has no cost schedule, so a canister ID that passes through an unrouted state is **not** covered by any of the above. `do_migrate_canisters` unroutes a canister ID when the target subnet is absent from the routing table, `remove_subnet_from_routing_table` does when its subnet is deleted, and `do_migrate_canisters` then supports routing it to a subnet again — that is how a canister whose subnet was deleted is migrated (`test_migrate_canisters_succeeds_if_source_subnet_deleted`). Two such calls in a row move a canister ID between cost schedules unchecked, and unrouting does not destroy the canister state, callbacks included.

This was raised in review and is documented rather than fixed, as none of the available remedies fits in this PR:

- **preserve the cost schedule each unrouted canister ID last had** and compare against it. Sound, but it takes a new persistent registry record and a lifecycle for it, i.e. a change to the canister migration protocol that is the governance team's call;
- **make unrouting terminal**, i.e. refuse to route an unrouted canister ID to any subnet. This breaks the migration of a canister off a deleted subnet, which the test named above covers;
- **prove the source cost schedule compatible** at the second call. There is nothing to prove it against: the canister ID is unrouted, so the registry state carries no schedule for it, and finding the last version at which it was routed means scanning the changelog backwards without a bound, which a canister cannot do.

Reaching the gap takes a canister migration orchestrator that unroutes a canister and then routes it to a subnet on a different cost schedule, which is not part of any current flow. The gap is documented on `check_canister_cost_schedule_invariants` and pointed at from the skip in `Registry::validate_cost_schedules`, so it is not left implicit in the code either.

Shipping with it is a call for a reviewer to make rather than mine: if it should be closed, the persistent record of the cost schedule each unrouted canister ID last had is the way to do it, and it belongs in its own change to the canister migration protocol.

### Relation to #11431

Independent of #11431 (no shared files), but that PR relies on this assumption: it settles the prepayment on the nominal parts, which ignores a cost schedule switch entirely, whereas comparing the real parts happened to detect one. Merging this first means the assumption is enforced before anything depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
