### PR TITLE
fix(ic-heap-bytes): account for the ArcInner allocation in Arc<T>

### DIFF
--- a/packages/ic-heap-bytes/src/lib.rs
+++ b/packages/ic-heap-bytes/src/lib.rs
@@ -109,8 +109,13 @@ impl<K: DeterministicHeapBytes, V: DeterministicHeapBytes> DeterministicHeapByte
 }
 
 impl<T: DeterministicHeapBytes> DeterministicHeapBytes for std::sync::Arc<T> {
+    /// `Arc<T>` stores only a pointer inline; the heap holds an `ArcInner<T>`
+    /// with the strong and weak reference counters (`usize`-sized each) plus the
+    /// `T` value. That pointee is counted here — as the `Vec<T>` impl counts its
+    /// heap-resident elements — ignoring any alignment padding between the
+    /// counters and `T`.
     fn deterministic_heap_bytes(&self) -> usize {
-        self.as_ref().deterministic_heap_bytes()
+        2 * size_of::<usize>() + size_of::<T>() + self.as_ref().deterministic_heap_bytes()
     }
 }
 

--- a/packages/ic-heap-bytes/src/tests.rs
+++ b/packages/ic-heap-bytes/src/tests.rs
@@ -568,6 +568,24 @@ fn result_basic_total_bytes() {
 }
 
 #[test]
+fn arc_total_bytes() {
+    use std::sync::Arc;
+
+    // Only the pointer is inline; the `ArcInner` allocation adds two `usize`
+    // counters plus the pointee (here a `u64` with no further heap).
+    assert_eq!(
+        deterministic_total_bytes(&Arc::new(42_u64)),
+        size_of::<Arc<u64>>() + 2 * size_of::<usize>() + size_of::<u64>()
+    );
+
+    // A pointee that itself owns heap: its own heap is added on top.
+    assert_eq!(
+        deterministic_total_bytes(&Arc::new(vec![0_u8; 10])),
+        size_of::<Arc<Vec<u8>>>() + 2 * size_of::<usize>() + size_of::<Vec<u8>>() + 10
+    );
+}
+
+#[test]
 fn mixed_struct() {
     #[derive(DeterministicHeapBytes, Default)]
     struct S {


### PR DESCRIPTION
## What

`<Arc<T> as DeterministicHeapBytes>::deterministic_heap_bytes` was a pass-through
into `T`'s own heap. It ignored the `ArcInner<T>` that `Arc` allocates on the
heap — the strong and weak reference counters plus the `T` value itself. Since
only the pointer is stored inline, `size_of_val` in `deterministic_total_bytes`
does not see any of it, so `deterministic_total_bytes(&Arc::new(x))` was
under-counted by `2 * size_of::<usize>() + size_of::<T>()`.

The fix adds those bytes, mirroring the existing `Vec<T>` impl which already
counts its heap-resident elements (`len * size_of::<T>()`). Alignment padding
between the counters and `T` is still ignored, consistent with the crate's other
estimates (`String` uses `len` not `capacity`, `BTreeMap` uses an edge
approximation).

## Tests

Adds `arc_total_bytes` covering a plain payload (`Arc<u64>`) and a heap-carrying
one (`Arc<Vec<u8>>`). `cargo test -p ic-heap-bytes` passes (33 tests); `clippy`
and `rustfmt` are clean.

## Notes for reviewers

- `Mutex<T>` deliberately stays a pass-through (its `T` is stored inline, not in a
  separate allocation), so only `Arc<T>` changes here.
- No public API or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)