### PR TITLE
chore(rosetta): fix typos in rs/rosetta-api comments and messages

### DIFF
--- a/rs/rosetta-api/icp/client/src/lib.rs
+++ b/rs/rosetta-api/icp/client/src/lib.rs
@@ -1635,8 +1635,8 @@ impl RosettaTransferArgsBuilder {
 pub struct RosettaCreateNeuronArgs {
     // The index of the neuron relative to the signer_keypair
     // If set the user specifies which index the neuron should have
-    // This is especially usuful if the user wants to create multiple neurons on the same signer keypair
-    // If the user for example already has a neuron at index 0, they may want to specify the the new nueral should be at index 1
+    // This is especially useful if the user wants to create multiple neurons on the same signer keypair
+    // If the user for example already has a neuron at index 0, they may want to specify that the new neuron should be at index 1
     // The default value will be set to 0
     pub neuron_index: Option<u64>,
     // The amount the user wants to stake

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/blocks.rs
@@ -297,7 +297,7 @@ mod database_access {
             .map(|block| block.unwrap())?;
         Ok(block_idx)
     }
-    // The option is left None if both verified and unverified blocks should be querried. It is set to False for only unverified blocks and True for only verified blocks
+    // The option is left None if both verified and unverified blocks should be queried. It is set to False for only unverified blocks and True for only verified blocks
     pub fn get_first_hashed_block(
         con: &mut Connection,
         verified: Option<bool>,
@@ -321,7 +321,7 @@ mod database_access {
             None => Err(BlockStoreError::Other("Blockchain is empty".to_string())),
         }
     }
-    // The option is left None if both verified and unverified blocks should be querried. It is set to False for only unverified blocks and True for only verified blocks
+    // The option is left None if both verified and unverified blocks should be queried. It is set to False for only unverified blocks and True for only verified blocks
 
     pub fn get_latest_hashed_block(
         con: &mut Connection,
@@ -1505,7 +1505,7 @@ impl Blocks {
         let mut connection = self
             .connection
             .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
+            .map_err(|e| format!("Unable to acquire the connection mutex: {e:?}"))?;
 
         let sql_tx = connection
             .transaction()
@@ -1691,7 +1691,7 @@ impl Blocks {
         let connection = self
             .connection
             .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
+            .map_err(|e| format!("Unable to acquire the connection mutex: {e:?}"))?;
         let block_idx = match connection
             .prepare_cached("SELECT MAX(rosetta_block_idx) FROM rosetta_blocks")
             .map_err(|e| format!("Unable to prepare query: {e:?}"))?
@@ -1715,7 +1715,7 @@ impl Blocks {
         let connection = self
             .connection
             .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
+            .map_err(|e| format!("Unable to acquire the connection mutex: {e:?}"))?;
         let mut statement = connection
             .prepare_cached(
                 "SELECT parent_hash, timestamp FROM rosetta_blocks WHERE rosetta_block_idx=:idx",
@@ -1743,7 +1743,7 @@ impl Blocks {
         let connection = self
             .connection
             .lock()
-            .map_err(|e| format!("Unable to aquire the connection mutex: {e:?}"))?;
+            .map_err(|e| format!("Unable to acquire the connection mutex: {e:?}"))?;
         let mut statement = connection
             .prepare_cached(
                 r#"SELECT blocks.block_idx, encoded_block

--- a/rs/rosetta-api/icp/runner/src/lib.rs
+++ b/rs/rosetta-api/icp/runner/src/lib.rs
@@ -32,7 +32,7 @@ impl Drop for KillOnDrop {
     fn drop(&mut self) {
         match self.0.kill() {
             Ok(_) => println!("Rosetta has been successfully stopped"),
-            Err(err) => println!("Rosetta was NOT sucessfully stopped: {err:?}"),
+            Err(err) => println!("Rosetta was NOT successfully stopped: {err:?}"),
         }
     }
 }

--- a/rs/rosetta-api/icp/src/request_handler/construction_parse.rs
+++ b/rs/rosetta-api/icp/src/request_handler/construction_parse.rs
@@ -776,7 +776,7 @@ mod tests {
             prop_assert_eq!(operations.clone(), parsed.operations);
 
             // metadata must always be present
-            prop_assert!(parsed.metadata.is_some(), "Metatada should always be returned");
+            prop_assert!(parsed.metadata.is_some(), "Metadata should always be returned");
 
             check_metadata(metadata, parsed.metadata.unwrap()).unwrap()
         });
@@ -826,7 +826,7 @@ mod tests {
             prop_assert_eq!(operations.clone(), parsed.operations);
 
             // metadata must always be present
-            prop_assert!(parsed.metadata.is_some(), "Metatada should always be returned");
+            prop_assert!(parsed.metadata.is_some(), "Metadata should always be returned");
 
             check_metadata(metadata, parsed.metadata.unwrap()).unwrap()
         });

--- a/rs/rosetta-api/icp/tests/integration_tests/src/lib.rs
+++ b/rs/rosetta-api/icp/tests/integration_tests/src/lib.rs
@@ -34,7 +34,7 @@ impl Drop for KillOnDrop {
     fn drop(&mut self) {
         match self.0.kill() {
             Ok(_) => println!("Rosetta has been successfully stopped"),
-            Err(err) => println!("Rosetta was NOT sucessfully stopped: {err:?}"),
+            Err(err) => println!("Rosetta was NOT successfully stopped: {err:?}"),
         }
     }
 }

--- a/rs/rosetta-api/icp/tests/integration_tests/tests/tests.rs
+++ b/rs/rosetta-api/icp/tests/integration_tests/tests/tests.rs
@@ -251,7 +251,7 @@ impl TestEnv {
         while retries > 0 {
             match rosetta_client.network_status(network.clone()).await {
                 Ok(_) => {
-                    println!("call to /network/status was successfull");
+                    println!("call to /network/status was successful");
                     break;
                 }
                 Err(Error(err)) if matches_blockchain_is_empty_or_still_syncing_error(&err) => {

--- a/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/utils.rs
@@ -221,7 +221,7 @@ pub async fn update_neuron(agent: &Agent, neuron: ic_nns_governance_api::Neuron)
 }
 
 // Get the balance by directly calling the PocketIC, without agent. Useful
-// if the agent time is behind the PocketIC time due to advanving the PocketIC time.
+// if the agent time is behind the PocketIC time due to advancing the PocketIC time.
 pub async fn account_balance(pocket_ic: &PocketIc, account: &AccountIdentifier) -> Tokens {
     let arg = Encode!(&BinaryAccountBalanceArgs {
         account: account.to_address(),

--- a/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
@@ -580,7 +580,7 @@ fn test_disburse_neuron() {
             Err(e) => panic!("Unexpected error: {e}"),
             Ok(_) => panic!("Expected an error but got success"),
         }
-        // Let rosetta catch up with the transfer that happended when creating the neuron
+        // Let rosetta catch up with the transfer that happened when creating the neuron
         wait_for_rosetta_to_catch_up_with_icp_ledger(
             &env.rosetta_client,
             env.network_identifier.clone(),
@@ -1535,7 +1535,7 @@ fn test_disburse_maturity() {
         let mut neuron = list_neurons(&agent).await.full_neurons[0].to_owned();
         assert_eq!(neuron.maturity_e8s_equivalent, 0);
 
-        // Assing maturity to the neuron
+        // Assign maturity to the neuron
         let new_maturity = 300_000_000;
         neuron.maturity_e8s_equivalent = new_maturity;
         update_neuron(&agent, neuron).await;

--- a/rs/rosetta-api/icrc1/src/common/storage/storage_client.rs
+++ b/rs/rosetta-api/icrc1/src/common/storage/storage_client.rs
@@ -473,7 +473,7 @@ impl StorageClient {
             .await?)
     }
 
-    // Retrieves the account balance at the heighest block height in the database
+    // Retrieves the account balance at the highest block height in the database
     // Returns None if the account does not exist in the database
     pub async fn get_account_balance(&self, account: &Account) -> anyhow::Result<Option<Nat>> {
         let account = *account;

--- a/rs/rosetta-api/icrc1/src/common/storage/types.rs
+++ b/rs/rosetta-api/icrc1/src/common/storage/types.rs
@@ -85,7 +85,7 @@ pub struct RosettaBlock {
 
 impl RosettaBlock {
     // Converts a generic block to a RosettaBlock
-    // Use this method for blocks that come directly from an ICRC-1 Ledger, because only then can be guarenteed that the block hash is correct
+    // Use this method for blocks that come directly from an ICRC-1 Ledger, because only then can be guaranteed that the block hash is correct
     pub fn from_generic_block(generic_block: GenericBlock, block_idx: u64) -> anyhow::Result<Self> {
         Ok(Self {
             block: IcrcBlock::try_from(generic_block)?,

--- a/rs/rosetta-api/icrc1/src/common/utils/utils.rs
+++ b/rs/rosetta-api/icrc1/src/common/utils/utils.rs
@@ -537,7 +537,7 @@ pub fn icrc1_operation_to_rosetta_core_operations(
                 operations.push(rosetta_core::objects::Operation::new(
                     1,
                     OperationType::Fee.to_string(),
-                    Some(to.into()), // Mint fees are payed by the receiving account.
+                    Some(to.into()), // Mint fees are paid by the receiving account.
                     Some(Amount::new(
                         BigInt::from_biguint(num_bigint::Sign::Minus, fee_paid.0),
                         currency,

--- a/rs/rosetta-api/icrc1/src/data_api/services.rs
+++ b/rs/rosetta-api/icrc1/src/data_api/services.rs
@@ -59,7 +59,7 @@ pub fn network_options(ledger_id: &Principal) -> NetworkOptionsResponse {
                 Error::unable_to_find_block(&"Unable to find block".to_owned()).into(),
                 Error::invalid_block_identifier(&"Unable to find block".to_owned()).into(),
                 Error::failed_to_build_block_response(
-                    &"Faild to create a response for fetching blocks.".to_owned(),
+                    &"Failed to create a response for fetching blocks.".to_owned(),
                 )
                 .into(),
                 Error::invalid_transaction_identifier().into(),
@@ -69,7 +69,7 @@ pub fn network_options(ledger_id: &Principal) -> NetworkOptionsResponse {
                 Error::ledger_communication_unsuccessful(&"Rosetta could not communicate with the ICRC-1 Ledger successfully.".to_owned()).into(),
                 Error::unable_to_find_account_balance(&"The balance for the given account could not be fetched.".to_owned()).into(),
                 Error::request_processing_error(&"The input of the user resulted in an error while trying to process the request.".to_owned()).into(),
-                Error::processing_construction_failed(&"An error while processing an construction api endpoint occured.".to_owned()).into(),
+                Error::processing_construction_failed(&"An error while processing a construction api endpoint occurred.".to_owned()).into(),
                 Error::invalid_metadata(&"The metadata provided by the user is invalid.".to_owned()).into(),
             ],
             historical_balance_lookup: true,

--- a/rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs
+++ b/rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs
@@ -724,7 +724,7 @@ pub mod blocks_verifier {
         Ok(())
     }
 
-    /// Checks whether the blocks in the blockchain are a continous subset of the requested indices
+    /// Checks whether the blocks in the blockchain are a continuous subset of the requested indices
     pub fn indices_are_valid(
         blockchain: &[RosettaBlock],
         requested_indices: RangeInclusive<u64>,
@@ -735,7 +735,7 @@ pub mod blocks_verifier {
 
         let mut current_index = *requested_indices.start();
         for block in blockchain {
-            // The fetched blockchain should be continous with respect to the requested indices.
+            // The fetched blockchain should be continuous with respect to the requested indices.
             if block.index != current_index {
                 return false;
             }

--- a/rs/rosetta-api/icrc1/tests/integration_test_components/blocks_synchronizer/fetching_blocks_interval_test.rs
+++ b/rs/rosetta-api/icrc1/tests/integration_test_components/blocks_synchronizer/fetching_blocks_interval_test.rs
@@ -111,7 +111,7 @@ proptest! {
             // Create the storage client where blocks will be stored
             let storage_client = Arc::new(StorageClient::new_in_memory().await.unwrap());
 
-            // Start the synching process
+            // Start the syncing process
             // Conduct a full sync from the tip of the blockchain to genesis block
             blocks_synchronizer::start_synching_blocks(agent.clone(), storage_client.clone(),2,Arc::new(AsyncMutex::new(vec![])), RecurrencyMode::OneShot, Box::new(|| {})).await.unwrap();
 
@@ -181,7 +181,7 @@ proptest! {
             // Create the storage client where blocks will be stored
             let storage_client = Arc::new(StorageClient::new_in_memory().await.unwrap());
 
-            // Start the synching process
+            // Start the syncing process
             // Conduct a full sync from the tip of the blockchain to genesis block
             // Fetched blocks from the ledger and the archive
             blocks_synchronizer::start_synching_blocks(agent.clone(), storage_client.clone(),10,Arc::new(AsyncMutex::new(vec![])), RecurrencyMode::OneShot, Box::new(|| {})).await.unwrap();
@@ -330,7 +330,7 @@ fn test_gaps_handling() {
         // Create the storage client where blocks will be stored (using on-disk database)
         let storage_client = Arc::new(StorageClient::new_persistent(&db_path_clone).await.unwrap());
 
-        // Start the synching process
+        // Start the syncing process
         // Conduct a full sync from the tip of the blockchain to genesis block
         blocks_synchronizer::start_synching_blocks(
             agent.clone(),


### PR DESCRIPTION
## What

Spelling fixes across `rs/rosetta-api` (ICP and ICRC-1 Rosetta
implementations): doc comments, code comments, `prop_assert!` messages,
and user-facing log / error strings.

**Text only — no code, API, or behaviour changes.** Identifiers are left
alone on purpose: the `start_synching_blocks` function and the
`fee_payed` parameter keep their spelling.

| Fix | Where |
| --- | --- |
| `aquire` → `acquire` | `blocks.rs` mutex error message (×4) |
| `querried` → `queried` | `blocks.rs` comment (×2) |
| `Metatada` → `Metadata` | `construction_parse.rs` test message (×2) |
| `continous` → `continuous` | `blocks_synchronizer.rs` (×2) |
| `synching` → `syncing` | `fetching_blocks_interval_test.rs` comment (×3) |
| `sucessfully` → `successfully` | `runner`, `integration_tests` |
| `successfull` → `successful` | `integration_tests` |
| `Faild` → `Failed`, `occured` → `occurred` | `services.rs` error strings (also `an construction` → `a construction` on the same line) |
| `guarenteed` → `guaranteed` | `storage/types.rs` |
| `heighest` → `highest` | `storage_client.rs` |
| `payed` → `paid` | `utils.rs` comment |
| `happended`/`Assing`/`advanving` | system-test comments |
| `usuful` → `useful`, `the the new nueral` → `the new neuron` | `client` doc comment |

Found with `codespell`; each hit reviewed individually. No `CHANGELOG.md`
files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)