### PR TITLE
refactor: compare a CompoundCycles on a part it names

### DIFF
--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -560,7 +560,7 @@ impl CyclesAccountManager {
                 self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
                 subnet_cycles_config,
             )
-            .min(prepaid_execution_cycles);
+            .min_nominal(prepaid_execution_cycles);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);
     }
 
@@ -954,7 +954,7 @@ impl CyclesAccountManager {
         );
         // The prepayment covers the fixed per-message execution fee, but clamp the
         // charge to it so that no more than the prepayment is ever charged.
-        let charge = base_fee.min(prepayment_for_response_execution);
+        let charge = base_fee.min_nominal(prepayment_for_response_execution);
         system_state.refund_cycles(
             prepayment_for_response_execution,
             prepayment_for_response_execution - charge,
@@ -1001,7 +1001,7 @@ impl CyclesAccountManager {
             subnet_cycles_config,
         );
         prepayment_for_response_transmission
-            - transmission_cost.min(prepayment_for_response_transmission)
+            - transmission_cost.min_nominal(prepayment_for_response_transmission)
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2408,7 +2408,7 @@ impl CanisterManager {
                     subnet_cycles_config,
                     wasm_execution_mode,
                 )
-                .min(prepaid_execution_cycles);
+                .min_nominal(prepaid_execution_cycles);
             consumed_cycles.add(
                 prepaid_execution_cycles - cycles_to_refund,
                 instructions_for_execution,

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -457,7 +457,10 @@ fn cycles_correct_if_response_fails() {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(a_id).system_state.balance(),
         initial_cycles
@@ -507,7 +510,10 @@ fn cycles_correct_if_cleanup_fails() {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(a_id).system_state.balance(),
         initial_cycles
@@ -1188,7 +1194,10 @@ fn response_fail_scenario(test: &mut ExecutionTest) -> (CanisterId, MessageId) {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     let ingress_status = test.ingress_status(&ingress_id);
     let result = check_ingress_status(ingress_status).unwrap_err();
@@ -1237,7 +1246,10 @@ fn cleanup_fail_scenario(test: &mut ExecutionTest) -> (CanisterId, MessageId) {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     let ingress_status = test.ingress_status(&ingress_id);
     let result = check_ingress_status(ingress_status).unwrap_err();
@@ -2025,7 +2037,10 @@ fn reserve_instructions_for_cleanup_callback_scenario(
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     // Assert that the response failed with exceeding instructions limit.
     let ingress_status = test.ingress_status(&ingress_id);

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -7228,7 +7228,10 @@ fn cycles_correct_if_update_fails() {
     let execution_cost_before = test.canister_execution_cost(b_id);
     test.execute_message(b_id);
     let execution_cost_after = test.canister_execution_cost(b_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(b_id).system_state.balance(),
         initial_cycles - test.canister_execution_cost(b_id).real()

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -74,7 +74,12 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 /// let total = cc_instructions + cc_memory;
 /// assert_eq!(total.real(), Cycles::new(30));
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+///
+/// `CompoundCycles` deliberately implements neither `Ord` nor `PartialOrd`: a
+/// comparison has to say which of the two parts it is made on, and the two parts do
+/// not order an amount the same way. Use `min_nominal` and the `real()`/`nominal()`
+/// accessors to compare explicitly.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CompoundCycles<T: CyclesUseCaseKind> {
     real: Cycles,
     nominal: NominalCycles,
@@ -128,6 +133,21 @@ impl<T: CyclesUseCaseKind> CompoundCycles<T> {
     // are zero.
     pub fn is_zero(&self) -> bool {
         self.real.is_zero() && self.nominal.is_zero()
+    }
+
+    /// Returns the smaller of `self` and `other`, compared on their nominal parts.
+    ///
+    /// The nominal part is the one that is independent of the cost schedule: the real
+    /// part of an amount whose use case is free under the free cost schedule is zero
+    /// (cf. `CompoundCycles::new`), so a comparison of real parts cannot tell two such
+    /// amounts apart. The two parts coincide under the normal cost schedule, hence
+    /// this is equivalent to comparing the real parts there.
+    pub fn min_nominal(self, other: Self) -> Self {
+        if self.nominal <= other.nominal {
+            self
+        } else {
+            other
+        }
     }
 
     /// Returns this amount reduced by the part of `real()` that could not be


### PR DESCRIPTION
`CompoundCycles` derived `Ord` and `PartialOrd` over its fields, so a comparison of two amounts was made on their **real** parts first and only fell back to the nominal ones for amounts whose real parts are equal.

Which part a comparison is made on matters. The real part of an amount whose use case is free under the free cost schedule is zero (cf. `CompoundCycles::new`), so a comparison of real parts cannot tell two such amounts apart; the nominal part is independent of the cost schedule. Under the normal cost schedule the two parts coincide, so the distinction is invisible there.

Nothing derived that ordering on purpose, and all four call sites that used it clamp a cost to a prepayment, for which the nominal part is the right one:

- `CyclesAccountManager::refund_unused_execution_cycles`
- `CyclesAccountManager::settle_prepayment_for_unexecuted_response`
- `CyclesAccountManager::refund_for_response_transmission`
- `CanisterManager`, which recomputes the same clamp to record the net cycle charge

They were correct only because the real and the nominal parts coincide under the normal cost schedule and the real parts are both zero under the free one, i.e. because the fallback to the nominal part happened to kick in. Reordering the two fields of the struct would have changed what they mean.

This PR drops the two derives and adds `CompoundCycles::min_nominal`, which says which part it compares, and uses it at those four call sites. It is behavior-preserving: for two amounts derived under the same cost schedule, and for the use cases those call sites deal with, `min_nominal` picks the same amount as the derived ordering did. The tests that compared two execution costs with `assert_gt!` now compare their nominal parts.

### Why now

Cleanup split out of #11431, which fixes a bug of exactly this shape: the cycles prepaid for a response execution were settled against the requirement by comparing their real parts, which made the adjustment a no-op under the free cost schedule and misreported the consumed cycles metrics. Removing the derived ordering means no call site can compare on a part it did not name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
