### PR TITLE
fix(nss_icos): recover from a failed IPv6 lookup instead of caching it forever

### DIFF
--- a/ic-os/components/monitoring/metrics-proxy/metrics-proxy.service
+++ b/ic-os/components/monitoring/metrics-proxy/metrics-proxy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Prometheus metrics proxy
-After=node_exporter.service
+After=node_exporter.service network-online.target
+Wants=network-online.target
 
 [Service]
 User=metrics-proxy

--- a/rs/ic_os/networking/nss_icos/BUILD.bazel
+++ b/rs/ic_os/networking/nss_icos/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_shared_library")
+load("@rules_rust//rust:defs.bzl", "rust_shared_library", "rust_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -17,4 +17,10 @@ rust_shared_library(
         "@crate_index//:libnss",
         "@crate_index//:local-ip-address",
     ],
+)
+
+rust_test(
+    name = "test",
+    size = "small",
+    crate = ":nss_icos",
 )

--- a/rs/ic_os/networking/nss_icos/src/lib.rs
+++ b/rs/ic_os/networking/nss_icos/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate libc;
+// Required by the libnss_host_hooks! macro, which expands to a lazy_static!.
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -6,33 +7,38 @@ extern crate libnss;
 
 use libnss::host::{AddressFamily, Addresses, Host, HostHooks};
 use libnss::interop::Response;
-use local_ip_address::{Error, local_ipv6};
+use local_ip_address::local_ipv6;
 
 use std::net::{IpAddr, Ipv6Addr};
-use std::sync::Arc;
+use std::sync::OnceLock;
 
 struct ICOSHosts;
 libnss_host_hooks!(icos, ICOSHosts);
 
-// This function is invoked strictly once under lazy_static
-// below.  This avoids having to re-query network interfaces
-// on every host name resolution.  The disadvantage is that
-// long-running programs will not be able to detect runtime
-// changes of IPv6 addresses on the host.
-//
-// Why do we use an Arc<Error> for the error leg of the return?
-// Because the Error we are returning does not implement the
-// Copy trait, so we can't unpack it as-is — we must wrap it
-// into an atomic reference-counted value so that we may then
-// clone it for use.
-fn get_local_ipv6() -> Result<Ipv6Addr, Arc<Error>> {
-    match local_ipv6() {
-        Ok(addr) => match addr {
-            IpAddr::V6(v6addr) => Ok(v6addr),
-            _ => Err(Arc::new(Error::LocalIpAddressNotFound)),
-        },
-        Err(e) => Err(Arc::new(e)),
+static PUBLIC_IPV6: OnceLock<Ipv6Addr> = OnceLock::new();
+
+// Only successful lookups are memoized. This avoids having to re-query
+// network interfaces on every host name resolution, while never poisoning the
+// process for the rest of its lifetime. A program that resolves a name before
+// the machine has a global IPv6 address, for instance a service that starts
+// before the first router advertisement arrives, would otherwise fail to
+// resolve it for the rest of its lifetime.
+fn memoize(
+    cache: &OnceLock<Ipv6Addr>,
+    query: impl FnOnce() -> Option<Ipv6Addr>,
+) -> Option<Ipv6Addr> {
+    if let Some(addr) = cache.get() {
+        return Some(*addr);
     }
+    let addr = query()?;
+    Some(*cache.get_or_init(|| addr))
+}
+
+fn get_local_ipv6() -> Option<Ipv6Addr> {
+    memoize(&PUBLIC_IPV6, || match local_ipv6() {
+        Ok(IpAddr::V6(v6addr)) => Some(v6addr),
+        _ => None,
+    })
 }
 
 fn ipv6_to_hostos_ipv6(addr: Ipv6Addr) -> Ipv6Addr {
@@ -49,14 +55,10 @@ fn ipv6_to_guestos_ipv6(addr: Ipv6Addr) -> Ipv6Addr {
     Ipv6Addr::new(s[0], s[1], s[2], s[3], 0x6801, s[5], s[6], s[7])
 }
 
-lazy_static! {
-    static ref PUBLIC_IPV6: Result<Ipv6Addr, Arc<Error>> = get_local_ipv6();
-}
-
 impl HostHooks for ICOSHosts {
     fn get_all_entries() -> Response<Vec<Host>> {
-        match PUBLIC_IPV6.clone() {
-            Ok(local_ipv6) => Response::Success(vec![
+        match get_local_ipv6() {
+            Some(local_ipv6) => Response::Success(vec![
                 Host {
                     name: "hostos".to_string(),
                     addresses: Addresses::V6(vec![ipv6_to_hostos_ipv6(local_ipv6)]),
@@ -68,14 +70,14 @@ impl HostHooks for ICOSHosts {
                     aliases: vec![],
                 },
             ]),
-            Err(_) => Response::Success(vec![]),
+            None => Response::Success(vec![]),
         }
     }
 
     fn get_host_by_addr(addr: IpAddr) -> Response<Host> {
         match addr {
-            IpAddr::V6(addr) => match PUBLIC_IPV6.clone() {
-                Ok(local_ipv6) => {
+            IpAddr::V6(addr) => match get_local_ipv6() {
+                Some(local_ipv6) => {
                     if addr == ipv6_to_guestos_ipv6(local_ipv6) {
                         Response::Success(Host {
                             name: "guestos".to_string(),
@@ -101,25 +103,54 @@ impl HostHooks for ICOSHosts {
     fn get_host_by_name(name: &str, family: AddressFamily) -> Response<Host> {
         match family {
             AddressFamily::IPv6 => match name {
-                "guestos" => match PUBLIC_IPV6.clone() {
-                    Ok(local_ipv6) => Response::Success(Host {
+                "guestos" => match get_local_ipv6() {
+                    Some(local_ipv6) => Response::Success(Host {
                         name: name.to_string(),
                         addresses: Addresses::V6(vec![ipv6_to_guestos_ipv6(local_ipv6)]),
                         aliases: vec![],
                     }),
-                    Err(_) => Response::NotFound,
+                    None => Response::NotFound,
                 },
-                "hostos" => match PUBLIC_IPV6.clone() {
-                    Ok(local_ipv6) => Response::Success(Host {
+                "hostos" => match get_local_ipv6() {
+                    Some(local_ipv6) => Response::Success(Host {
                         name: name.to_string(),
                         addresses: Addresses::V6(vec![ipv6_to_hostos_ipv6(local_ipv6)]),
                         aliases: vec![],
                     }),
-                    Err(_) => Response::NotFound,
+                    None => Response::NotFound,
                 },
                 _ => Response::NotFound,
             },
             _ => Response::NotFound,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOCAL: Ipv6Addr = Ipv6Addr::new(0x2001, 0x0db8, 1, 2, 0x6802, 3, 4, 5);
+    const HOSTOS: Ipv6Addr = Ipv6Addr::new(0x2001, 0x0db8, 1, 2, 0x6800, 3, 4, 5);
+    const GUESTOS: Ipv6Addr = Ipv6Addr::new(0x2001, 0x0db8, 1, 2, 0x6801, 3, 4, 5);
+
+    #[test]
+    fn derives_the_peer_addresses() {
+        assert_eq!(ipv6_to_hostos_ipv6(LOCAL), HOSTOS);
+        assert_eq!(ipv6_to_guestos_ipv6(LOCAL), GUESTOS);
+        // The derivation overwrites the word it keys on, so it also works
+        // starting from either peer's address.
+        assert_eq!(ipv6_to_hostos_ipv6(GUESTOS), HOSTOS);
+        assert_eq!(ipv6_to_guestos_ipv6(HOSTOS), GUESTOS);
+    }
+
+    // A lookup that fails because the machine has no global IPv6 address yet
+    // must not poison the lookups that follow it.
+    #[test]
+    fn only_successful_lookups_are_memoized() {
+        let cache = OnceLock::new();
+        assert_eq!(memoize(&cache, || None), None);
+        assert_eq!(memoize(&cache, || Some(LOCAL)), Some(LOCAL));
+        assert_eq!(memoize(&cache, || None), Some(LOCAL));
     }
 }


### PR DESCRIPTION
On HostOS, metrics-proxy resolves `guestos` through the `nss_icos` NSS module. The module memoized the whole result of the local IPv6 lookup, failures included, so a process that resolved a name before the interface had a global IPv6 address kept the failure for its entire lifetime. glibc reads the resulting NotFound as "no answer from this source" and falls through to DNS, which refuses the single-label name.

metrics-proxy then serves 502s for the two guestos targets without crashing, so `Restart=on-failure` never fires and the node stays like that until something else restarts the process. The replica is unaffected and keeps finalizing blocks, but its metrics are invisible to dashboards and alerting.