### PR TITLE
feat: Add flexible HTTPS outcalls and pay-as-you-go pricing to public management canister types

### DIFF
--- a/packages/ic-management-canister-types/CHANGELOG.md
+++ b/packages/ic-management-canister-types/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Types for `subnet_metrics`:
   - Added the types `SubnetMetricsArgs` and `SubnetMetricsResult`.
+- Added the `pricing_version` field to `HttpRequestArgs`, selecting the pricing mechanism for a canister HTTPS outcall: `1` ("legacy", the default, deprecated) or `2` ("pay-as-you-go").
+- Types for `flexible_http_request`, a variant of `http_request` in which a committee of nodes return their individual HTTP responses instead of the subnet reaching consensus on one:
+  - Added the types `FlexibleHttpRequestArgs`, `ReplicationCounts`, `FlexibleHttpRequestResult`, `FlexibleHttpRequestErr`, `FlexibleHttpGlobalError`, `FlexibleHttpNodeDetail`, `HttpRequestResourceReport`, `ResourceUsage` and `FlexibleHttpNodeError`.
 
 ## [0.9.0] - 2026-08-13
 

--- a/packages/ic-management-canister-types/src/lib.rs
+++ b/packages/ic-management-canister-types/src/lib.rs
@@ -892,6 +892,15 @@ pub struct HttpRequestArgs {
     pub transform: Option<TransformContext>,
     /// If `Some(false)`, the HTTP request will be made by single replica instead of all nodes in the subnet.
     pub is_replicated: Option<bool>,
+    /// The pricing mechanism to apply to this request: `1` ("legacy") or `2` ("pay-as-you-go").
+    ///
+    /// If None, `1` is used. Version `1` is deprecated: version `2` is to become the default,
+    /// after which version `1` will be removed. Version `2` prices the resources the call
+    /// actually consumes rather than `max_response_bytes`.
+    ///
+    /// The field is not validated. Any value other than `1` or `2` is priced with version `1`
+    /// and no error is returned.
+    pub pricing_version: Option<u32>,
 }
 
 /// # HTTP Request Result
@@ -1019,6 +1028,190 @@ pub struct TransformArgs {
     /// Context for response transformation
     #[serde(with = "serde_bytes")]
     pub context: Vec<u8>,
+}
+
+/// # Flexible HTTP Request Args
+///
+/// Argument type of [`flexible_http_request`](https://docs.internetcomputer.org/references/management-canister/#flexible_http_request).
+///
+/// As for [`HttpRequestArgs`], except that there is no `is_replicated` and no
+/// `pricing_version` (a flexible outcall is always priced with pricing version `2`),
+/// and the committee can be sized with [`Self::replication`].
+#[derive(CandidType, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct FlexibleHttpRequestArgs {
+    /// The requested URL.
+    pub url: String,
+    /// The maximal size of any single node's response in bytes.
+    ///
+    /// If None, 2MB will be the limit. This bounds the response but does not set the
+    /// price, since a flexible outcall is charged for the resources it consumes.
+    pub max_response_bytes: Option<u64>,
+    /// The method of HTTP request.
+    ///
+    /// `PUT`, `DELETE` and `PATCH` are accepted only when the replication counts are
+    /// deterministic, that is when `min_responses`, `max_responses` and `total_requests`
+    /// are all equal.
+    pub method: HttpMethod,
+    /// List of HTTP request headers and their corresponding values.
+    pub headers: Vec<HttpHeader>,
+    /// Optionally provide request body.
+    pub body: Option<Vec<u8>>,
+    /// Name of the transform function which is `func (transform_args) -> (http_response) query`.
+    ///
+    /// Each node runs it on its own response.
+    pub transform: Option<TransformContext>,
+    /// How many nodes issue the request, and how many responses the caller requires
+    /// and will accept.
+    ///
+    /// If None, the defaults of `floor(2 / 3 * N) + 1`, `N` and `N` are used for
+    /// `min_responses`, `max_responses` and `total_requests`, where `N` is the number
+    /// of nodes on the subnet.
+    pub replication: Option<ReplicationCounts>,
+}
+
+/// # Replication Counts.
+///
+/// How many nodes perform a flexible HTTP outcall and how many responses the caller
+/// requires and will accept.
+///
+/// The caller must ensure that `0 <= min_responses <= max_responses <= total_requests`
+/// and `1 <= total_requests <= N`, where `N` is the number of nodes on the subnet, as
+/// returned by [`ic_cdk::api::subnet_self_node_count`](https://docs.rs/ic-cdk/latest/ic_cdk/api/fn.subnet_self_node_count.html).
+///
+/// See [`FlexibleHttpRequestArgs::replication`].
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub struct ReplicationCounts {
+    /// The fewest responses a successful outcall may carry.
+    ///
+    /// This determines when the outcall returns.
+    pub min_responses: u32,
+    /// The most responses the caller is willing to receive.
+    pub max_responses: u32,
+    /// How many nodes issue the HTTP request.
+    pub total_requests: u32,
+}
+
+/// # Flexible HTTP Request Result
+///
+/// Result type of [`flexible_http_request`](https://docs.internetcomputer.org/references/management-canister/#flexible_http_request).
+///
+/// Both arms are delivered as a reply rather than as a reject. Only failures detected
+/// before the requests are issued, such as invalid arguments or too few attached
+/// cycles, are delivered as a reject.
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum FlexibleHttpRequestResult {
+    /// Between `min_responses` and `max_responses` individual responses.
+    ///
+    /// The responses do not identify the node that produced them and their order is
+    /// not specified.
+    #[serde(rename = "ok")]
+    Ok(Vec<HttpRequestResult>),
+    /// The outcall could not meet the requested replication.
+    #[serde(rename = "err")]
+    Err(FlexibleHttpRequestErr),
+}
+
+/// # Flexible HTTP Request Err
+///
+/// The error arm of [`FlexibleHttpRequestResult`].
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct FlexibleHttpRequestErr {
+    /// Why the outcall as a whole failed to meet the requested replication.
+    pub global_error: Option<FlexibleHttpGlobalError>,
+    /// What the individual nodes did.
+    ///
+    /// Which nodes appear depends on the error, and the vector is not guaranteed to
+    /// list every node the outcall was issued to.
+    pub node_details: Vec<FlexibleHttpNodeDetail>,
+    /// A textual error message.
+    pub message: String,
+}
+
+/// # Flexible HTTP Global Error.
+///
+/// See [`FlexibleHttpRequestErr::global_error`].
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum FlexibleHttpGlobalError {
+    /// Fewer than `min_responses` responses were collected before a system-defined timeout.
+    #[serde(rename = "timeout")]
+    Timeout(Reserved),
+    /// What the nodes left unspent of the attached cycles no longer covers delivering
+    /// any result the outcall could still produce.
+    #[serde(rename = "out_of_cycles")]
+    OutOfCycles(Reserved),
+    /// No combination of at least `min_responses` available responses could fit into
+    /// the total result limit.
+    #[serde(rename = "responses_too_large")]
+    ResponsesTooLarge(Reserved),
+    /// More than `total_requests - min_responses` nodes returned reject responses, so
+    /// at least `min_responses` successful responses can never be collected.
+    #[serde(rename = "too_many_rejects")]
+    TooManyRejects(Reserved),
+}
+
+/// # Flexible HTTP Node Detail.
+///
+/// What one node did. See [`FlexibleHttpRequestErr::node_details`].
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct FlexibleHttpNodeDetail {
+    /// The node this entry is about.
+    pub node_id: Principal,
+    /// The resources the node used.
+    pub report: HttpRequestResourceReport,
+    /// Diagnostic detail about what the node did.
+    pub error: Option<FlexibleHttpNodeError>,
+}
+
+/// # HTTP Request Resource Report.
+///
+/// An accounting of the resources one node used. See [`FlexibleHttpNodeDetail::report`].
+///
+/// Every field is optional: a field is absent when the corresponding resource is not
+/// reported. An implementation may leave the whole report empty, so do not rely on it
+/// to diagnose a failure.
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct HttpRequestResourceReport {
+    /// Bytes of the HTTP response, before transformation.
+    pub raw_response_bytes: Option<ResourceUsage<u64>>,
+    /// Time between sending the request and fully receiving the response.
+    pub http_roundtrip_time_ms: Option<ResourceUsage<u64>>,
+    /// Instructions the transform function used.
+    pub transform_instructions: Option<ResourceUsage<u64>>,
+    /// Bytes of the response after transformation.
+    pub transformed_response_bytes: Option<ResourceUsage<u64>>,
+    /// Cycles the node spent.
+    pub cycles: Option<ResourceUsage<Nat>>,
+}
+
+/// # Resource Usage.
+///
+/// Whether a resource was consumed, and how much, or whether it ran over its budget.
+///
+/// See [`HttpRequestResourceReport`].
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum ResourceUsage<T> {
+    /// The amount consumed.
+    #[serde(rename = "used")]
+    Used(T),
+    /// The node failed because this resource ran over its budget.
+    #[serde(rename = "exceeded")]
+    Exceeded(Reserved),
+}
+
+/// # Flexible HTTP Node Error.
+///
+/// See [`FlexibleHttpNodeDetail::error`].
+///
+/// The `code` values are diagnostic strings and are not a fixed enumeration, so do not
+/// branch on them.
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct FlexibleHttpNodeError {
+    /// A short diagnostic code.
+    pub code: String,
+    /// A textual message.
+    pub message: String,
 }
 
 /// # ECDSA Key ID.

--- a/packages/ic-management-canister-types/tests/candid_equality.rs
+++ b/packages/ic-management-canister-types/tests/candid_equality.rs
@@ -98,6 +98,11 @@ fn http_request(_: HttpRequestArgs) -> HttpRequestResult {
 }
 
 #[candid_method(update)]
+fn flexible_http_request(_: FlexibleHttpRequestArgs) -> FlexibleHttpRequestResult {
+    unimplemented!()
+}
+
+#[candid_method(update)]
 fn ecdsa_public_key(_: EcdsaPublicKeyArgs) -> EcdsaPublicKeyResult {
     unimplemented!()
 }

--- a/packages/ic-management-canister-types/tests/ic.did
+++ b/packages/ic-management-canister-types/tests/ic.did
@@ -124,6 +124,34 @@ type http_request_result = record {
     body : blob;
 };
 
+type http_request_resource_report = record {
+    raw_response_bytes : opt variant { used : nat64; exceeded : reserved };
+    http_roundtrip_time_ms : opt variant { used : nat64; exceeded : reserved };
+    transform_instructions : opt variant { used : nat64; exceeded : reserved };
+    transformed_response_bytes : opt variant { used : nat64; exceeded : reserved };
+    cycles : opt variant { used : nat; exceeded : reserved };
+};
+
+type flexible_http_request_err = record {
+    global_error : opt variant {
+        timeout : reserved;
+        out_of_cycles : reserved;
+        responses_too_large : reserved;
+        too_many_rejects : reserved;
+    };
+    node_details : vec record {
+        node_id : principal;
+        report : http_request_resource_report;
+        error : opt record { code : text; message : text };
+    };
+    message : text;
+};
+
+type flexible_http_request_result = variant {
+    ok : vec http_request_result;
+    err : flexible_http_request_err;
+};
+
 type ecdsa_curve = variant {
     secp256k1;
 };
@@ -365,6 +393,24 @@ type http_request_args = record {
         context : blob;
     };
     is_replicated : opt bool;
+    pricing_version : opt nat32;
+};
+
+type flexible_http_request_args = record {
+    url : text;
+    max_response_bytes : opt nat64;
+    method : variant { get; head; post; put; delete; patch };
+    headers : vec http_header;
+    body : opt blob;
+    transform : opt record {
+        function : func(record { response : http_request_result; context : blob }) -> (http_request_result) query;
+        context : blob;
+    };
+    replication : opt record {
+        min_responses : nat32;
+        max_responses : nat32;
+        total_requests : nat32;
+    };
 };
 
 type ecdsa_public_key_args = record {
@@ -715,6 +761,7 @@ service ic : {
     deposit_cycles : (deposit_cycles_args) -> ();
     raw_rand : () -> (raw_rand_result);
     http_request : (http_request_args) -> (http_request_result);
+    flexible_http_request : (flexible_http_request_args) -> (flexible_http_request_result);
 
     // Public canister data
     canister_info : (canister_info_args) -> (canister_info_result) query;


### PR DESCRIPTION
This is needed in order to implement CDK support