### PR TITLE
fix: deflake //rs/tests/cross_chain:doge_adapter_basics_test_local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15551,6 +15551,7 @@ dependencies = [
  "ic-btc-adapter-test-utils",
  "ic-btc-checker",
  "ic-btc-interface",
+ "ic-cdk",
  "ic-ckbtc-agent",
  "ic-ckbtc-minter",
  "ic-ckdoge-agent",

--- a/rs/tests/ckbtc/BUILD.bazel
+++ b/rs/tests/ckbtc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//rs/tests:common.bzl", "DEFAULT_VCPUS_PER_VM", "MESSAGE_CANISTER_RUNTIME_DEPS", "MIN_LOCAL_CPUS")
 load("//rs/tests:system_tests.bzl", "system_test_nns")
 
@@ -54,6 +54,11 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_tests_ckbtc",
     deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "unit_tests",
+    crate = ":ckbtc",
 )
 
 system_test_nns(

--- a/rs/tests/ckbtc/BUILD.bazel
+++ b/rs/tests/ckbtc/BUILD.bazel
@@ -59,6 +59,9 @@ rust_library(
 rust_test(
     name = "unit_tests",
     crate = ":ckbtc",
+    deps = [
+        "@crate_index//:ic-cdk",
+    ],
 )
 
 system_test_nns(

--- a/rs/tests/ckbtc/Cargo.toml
+++ b/rs/tests/ckbtc/Cargo.toml
@@ -48,6 +48,9 @@ serde_bytes = { workspace = true }
 slog = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+ic-cdk = { workspace = true }
+
 [[bin]]
 name = "ic-systest-ckbtc-minter-basics-test"
 path = "ckbtc_minter_basics_test.rs"

--- a/rs/tests/ckbtc/src/adapter.rs
+++ b/rs/tests/ckbtc/src/adapter.rs
@@ -146,6 +146,13 @@ impl<'a, T: IcRpcClientType> AdapterProxy<'a, T> {
         Ok(())
     }
 
+    /// Repeatedly calls `bitcoin_get_successors` starting from `anchor` until at least
+    /// `max_num_blocks` blocks have been collected or `max_tries` requests have been made.
+    ///
+    /// Every request counts towards `max_tries`, whether it returned blocks or failed with a
+    /// transient adapter error (see [`is_transient_adapter_reject_message`]). Transient errors
+    /// are retried after a one second pause; once `max_tries` is exhausted the last transient
+    /// error is returned. Any other error is returned immediately.
     pub async fn sync_blocks(
         &self,
         headers: &mut Vec<Vec<u8>>,
@@ -158,36 +165,24 @@ impl<'a, T: IcRpcClientType> AdapterProxy<'a, T> {
 
         while blocks.len() < max_num_blocks && tries < max_tries {
             let (new_blocks, _) = loop {
+                tries += 1;
                 match self.get_successors(anchor.clone(), headers.clone()).await {
                     // Break inner loop, if adapter returned data
                     Ok(successor) => break successor,
-                    // Retry on transient adapter errors. The request fails with
-                    // `Unavailable` while the adapter is not yet reachable (e.g. still
-                    // starting up or syncing the header chain), and with
-                    // `Cancelled(Timeout expired)` when the adapter does not respond within
-                    // the replica's (short, 50ms) adapter timeout, which can happen e.g. for
-                    // the very first request right after the adapter started. Both are
-                    // transient, so the request should simply be retried.
-                    //
-                    // Note: the call is proxied through the `message` canister, which
-                    // re-rejects any error via `msg_reject`. The reject code observed here is
-                    // therefore always `CanisterReject`, regardless of the adapter's original
-                    // reject code, so we match on the reject message instead.
-                    Err(AgentError::CertifiedReject { reject, .. })
-                    | Err(AgentError::UncertifiedReject { reject, .. })
-                        if reject.reject_message.starts_with("Unavailable")
-                            || reject.reject_message.starts_with("Cancelled") => {}
+                    Err(err) if is_transient_adapter_reject(&err) => {
+                        // Don't retry forever: once `max_tries` is exhausted, surface the last
+                        // transient error instead of silently returning the blocks collected
+                        // so far.
+                        if tries >= max_tries {
+                            return Err(err);
+                        }
+                        info!(
+                            self.log,
+                            "Transient adapter error on get_successors try {tries}/{max_tries}, retrying in 1s: {err}"
+                        );
+                    }
                     // Other errors are fatal
                     Err(err) => return Err(err),
-                }
-
-                tries += 1;
-                // Don't retry forever: once `max_tries` is exhausted, give up and
-                // return the blocks collected so far (matching the outer loop's
-                // behaviour) instead of looping indefinitely on a persistently failing
-                // adapter.
-                if tries >= max_tries {
-                    break (vec![], vec![]);
                 }
                 tokio::time::sleep(Duration::from_secs(1)).await;
             };
@@ -200,7 +195,6 @@ impl<'a, T: IcRpcClientType> AdapterProxy<'a, T> {
             headers.extend(new_headers);
             blocks.extend(new_blocks);
 
-            tries += 1;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
 
@@ -239,6 +233,44 @@ impl<'a, T: IcRpcClientType> AdapterProxy<'a, T> {
 
         Ok((vec![reconstructed_block], next))
     }
+}
+
+/// Returns whether `err` is a transient adapter error that is worth retrying.
+///
+/// Requests to the adapter are proxied through the `message` canister, which re-rejects any
+/// error from the management canister via `msg_reject`, so the reject code observed by the
+/// caller is always `CanisterReject` regardless of the original one. The classification
+/// therefore has to be based on the reject message, see
+/// [`is_transient_adapter_reject_message`].
+fn is_transient_adapter_reject(err: &AgentError) -> bool {
+    match err {
+        AgentError::CertifiedReject { reject, .. }
+        | AgentError::UncertifiedReject { reject, .. } => {
+            is_transient_adapter_reject_message(&reject.reject_message)
+        }
+        _ => false,
+    }
+}
+
+/// Returns whether a reject message received through the `message` proxy canister describes a
+/// transient adapter error.
+///
+/// The bitcoin payload builder turns every adapter `RpcError` into a `SysTransient` reject whose
+/// message is the error's `Display`: `Unavailable(...)` while the replica cannot connect to the
+/// adapter's socket yet (tonic maps a refused/reset connection to `Code::Unavailable`, with the
+/// transport error as the message), or `Cancelled(Timeout expired)` when the adapter did not
+/// respond within the replica's (short, 50ms by default) adapter timeout, which regularly
+/// happens for the very first request after the adapter started. Only these two are transient;
+/// `ConnectionBroken` and `Unknown(...)` are fatal, so the reject code alone cannot be used to
+/// decide whether to retry.
+///
+/// The `message` canister rejects with ic-cdk's `CallRejected` `Display`, so the message
+/// arrives as `"call rejected: <code> - <original message>"` (before the canister migrated to
+/// the new ic-cdk call API it was the original message verbatim). Match the original message
+/// wherever it appears rather than as a prefix, so that a change of the wrapper text cannot
+/// silently disable the retry again.
+fn is_transient_adapter_reject_message(reject_message: &str) -> bool {
+    reject_message.contains("Unavailable(") || reject_message.contains("Cancelled(")
 }
 
 pub fn fund_with_tokens<T: RpcClientType>(
@@ -293,4 +325,49 @@ fn calculate_regtest_reward<T: RpcClientType>(height: u64) -> Amount {
     let halvings = (height / 150) as u32;
     let base_reward = T::REGTEST_INITIAL_BLOCK_REWARDS;
     base_reward / 2_u64.pow(halvings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_adapter_reject_message;
+
+    #[test]
+    fn raw_transient_adapter_errors_are_retried() {
+        // Reject messages in the form produced by the bitcoin payload builder (the adapter
+        // `RpcError` `Display`), i.e. how the `message` canister used to pass them on verbatim.
+        // `Cancelled(Timeout expired)` is verbatim; the inner text of `Unavailable(..)` is tonic's
+        // transport error.
+        assert!(is_transient_adapter_reject_message(
+            "Cancelled(Timeout expired)"
+        ));
+        assert!(is_transient_adapter_reject_message(
+            "Unavailable(Connection refused (os error 111))"
+        ));
+    }
+
+    #[test]
+    fn proxied_transient_adapter_errors_are_retried() {
+        // Reject messages as re-rejected by the `message` canister using ic-cdk's `CallRejected`
+        // `Display` (`call rejected: <code> - <message>`); `2` is `SysTransient`.
+        assert!(is_transient_adapter_reject_message(
+            "call rejected: 2 - Cancelled(Timeout expired)"
+        ));
+        assert!(is_transient_adapter_reject_message(
+            "call rejected: 2 - Unavailable(Connection refused (os error 111))"
+        ));
+    }
+
+    #[test]
+    fn other_errors_are_fatal() {
+        assert!(!is_transient_adapter_reject_message(
+            "call rejected: 2 - Unknown(unexpected error)"
+        ));
+        assert!(!is_transient_adapter_reject_message(
+            "call rejected: 2 - ConnectionBroken"
+        ));
+        assert!(!is_transient_adapter_reject_message(
+            "call rejected: 5 - Canister trapped explicitly: Unavailable"
+        ));
+        assert!(!is_transient_adapter_reject_message(""));
+    }
 }

--- a/rs/tests/ckbtc/src/adapter.rs
+++ b/rs/tests/ckbtc/src/adapter.rs
@@ -265,12 +265,20 @@ fn is_transient_adapter_reject(err: &AgentError) -> bool {
 /// decide whether to retry.
 ///
 /// The `message` canister rejects with ic-cdk's `CallRejected` `Display`, so the message
-/// arrives as `"call rejected: <code> - <original message>"` (before the canister migrated to
-/// the new ic-cdk call API it was the original message verbatim). Match the original message
-/// wherever it appears rather than as a prefix, so that a change of the wrapper text cannot
-/// silently disable the retry again.
+/// arrives wrapped as `"call rejected: <code> - <adapter error>"` (before the canister migrated
+/// to the new ic-cdk call API it was the adapter error verbatim). Unwrap that envelope, if
+/// present, and classify by the top-level `RpcError` variant only, so that a fatal
+/// `Unknown(...)` whose inner text happens to mention a transient variant is not retried. The
+/// unit tests derive the envelope from ic-cdk itself, so a change of the wrapper text fails
+/// loudly instead of silently disabling the retry again.
 fn is_transient_adapter_reject_message(reject_message: &str) -> bool {
-    reject_message.contains("Unavailable(") || reject_message.contains("Cancelled(")
+    let adapter_error = reject_message
+        .strip_prefix("call rejected: ")
+        .and_then(|rest| rest.split_once(" - "))
+        .map_or(reject_message, |(_reject_code, adapter_error)| {
+            adapter_error
+        });
+    adapter_error.starts_with("Unavailable(") || adapter_error.starts_with("Cancelled(")
 }
 
 pub fn fund_with_tokens<T: RpcClientType>(
@@ -330,6 +338,29 @@ fn calculate_regtest_reward<T: RpcClientType>(height: u64) -> Amount {
 #[cfg(test)]
 mod tests {
     use super::is_transient_adapter_reject_message;
+    use ic_agent::agent::RejectCode;
+    use ic_cdk::call::{CallFailed, CallRejected};
+
+    /// Wraps an adapter error the way the `message` canister does: it rejects with
+    /// `CallFailed::to_string()` of the reject it received from the management canister, whose
+    /// reject code is `SysTransient` for every adapter error (see the bitcoin payload builder).
+    fn proxied(adapter_error: &str) -> String {
+        CallFailed::CallRejected(CallRejected::with_rejection(
+            RejectCode::SysTransient as u32,
+            adapter_error.to_string(),
+        ))
+        .to_string()
+    }
+
+    #[test]
+    fn proxied_envelope_matches_ic_cdk() {
+        // The envelope unwrapped by `is_transient_adapter_reject_message` must be the one ic-cdk
+        // actually produces.
+        assert_eq!(
+            proxied("Cancelled(Timeout expired)"),
+            "call rejected: 2 - Cancelled(Timeout expired)"
+        );
+    }
 
     #[test]
     fn raw_transient_adapter_errors_are_retried() {
@@ -347,27 +378,41 @@ mod tests {
 
     #[test]
     fn proxied_transient_adapter_errors_are_retried() {
-        // Reject messages as re-rejected by the `message` canister using ic-cdk's `CallRejected`
-        // `Display` (`call rejected: <code> - <message>`); `2` is `SysTransient`.
-        assert!(is_transient_adapter_reject_message(
-            "call rejected: 2 - Cancelled(Timeout expired)"
-        ));
-        assert!(is_transient_adapter_reject_message(
-            "call rejected: 2 - Unavailable(Connection refused (os error 111))"
-        ));
+        // Reject messages as re-rejected by the `message` canister.
+        assert!(is_transient_adapter_reject_message(&proxied(
+            "Cancelled(Timeout expired)"
+        )));
+        assert!(is_transient_adapter_reject_message(&proxied(
+            "Unavailable(Connection refused (os error 111))"
+        )));
     }
 
     #[test]
     fn other_errors_are_fatal() {
-        assert!(!is_transient_adapter_reject_message(
-            "call rejected: 2 - Unknown(unexpected error)"
-        ));
-        assert!(!is_transient_adapter_reject_message(
-            "call rejected: 2 - ConnectionBroken"
-        ));
+        assert!(!is_transient_adapter_reject_message(&proxied(
+            "Unknown(unexpected error)"
+        )));
+        assert!(!is_transient_adapter_reject_message(&proxied(
+            "ConnectionBroken"
+        )));
         assert!(!is_transient_adapter_reject_message(
             "call rejected: 5 - Canister trapped explicitly: Unavailable"
         ));
         assert!(!is_transient_adapter_reject_message(""));
+    }
+
+    #[test]
+    fn fatal_errors_mentioning_transient_variants_are_not_retried() {
+        // Only the top-level `RpcError` variant decides; a fatal `Unknown(..)` whose inner text
+        // happens to contain a transient variant must not be retried, whether wrapped or not.
+        assert!(!is_transient_adapter_reject_message(&proxied(
+            "Unknown(Cancelled(upstream))"
+        )));
+        assert!(!is_transient_adapter_reject_message(
+            "Unknown(Unavailable(Connection refused (os error 111)))"
+        ));
+        assert!(!is_transient_adapter_reject_message(
+            "call rejected: 2 - something else - Cancelled(Timeout expired)"
+        ));
     }
 }

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -736,6 +736,14 @@ impl<'a> MessageCanister<'a> {
     /// Forwards a message to the `receiver` that calls
     /// `receiver.method(payload)` along with the specified amount of cycles
     /// and returns the result.
+    ///
+    /// If the receiver rejects the call, the message canister re-rejects it via
+    /// `msg_reject(err.to_string())`. The caller therefore always observes the
+    /// reject code `CanisterReject` and a reject message of the form
+    /// `"call rejected: <code> - <message>"` (ic-cdk's `CallRejected` `Display`),
+    /// where `<code>` and `<message>` are the receiver's original reject code and
+    /// message. Don't rely on the observed reject code or on a prefix of the
+    /// message when classifying such errors.
     pub async fn forward_with_cycles_to(
         &self,
         receiver: &Principal,
@@ -760,6 +768,9 @@ impl<'a> MessageCanister<'a> {
 
     /// Forwards a message to the `receiver` that calls
     /// `receiver.method(payload)` and returns the result.
+    ///
+    /// See [`Self::forward_with_cycles_to`] for how rejects of the receiver are
+    /// reported.
     pub async fn forward_to(
         &self,
         receiver: &Principal,


### PR DESCRIPTION
## Problem

`//rs/tests/cross_chain:doge_adapter_basics_test_local` flaked in 2 of its 5 (40%) nightly runs last week (3 failed attempts on 2026-09-05 and 2026-09-06), always in `test_received_blocks` with:

```
Failed to syncronize blocks: CertifiedReject { reject: RejectResponse {
  reject_code: CanisterReject,
  reject_message: "call rejected: 2 - Cancelled(Timeout expired)",
  error_code: Some("IC0406") }, operation: Some(Call { ..., method: "forward" }) }
```

The very first `bitcoin_get_successors` request after the dogecoin adapter started misses the replica's 50ms `adapter_timeout` (`rs/config/src/bitcoin_payload_builder_config.rs`): the replica's tonic channel to the adapter is connected lazily and the adapter is idle until its first request. The payload builder turns that into a `SysTransient` reject with message `Cancelled(Timeout expired)`. That is expected, transient behaviour, and each failed attempt shows exactly one such replica warning (for callback id 0) while passing runs show none.

#10530 made `AdapterProxy::sync_blocks` retry such rejects by matching `reject_message.starts_with("Unavailable") || starts_with("Cancelled")`, which worked because the `message` proxy canister passed the reject message through verbatim.

Since #10995 (2026-08-04) the `message` canister's `forward` re-rejects with `msg_reject(err.to_string())`, where `err` is ic-cdk's `CallFailed`, whose `CallRejected` variant displays as `call rejected: <code> - <message>`. The test therefore now sees `call rejected: 2 - Cancelled(Timeout expired)`, the prefix match never succeeds, and the retry arm has been dead code since then: the transient first-request timeout falls through to the fatal `Err(err) => return Err(err)` arm. The same format change broke the tecdsa system tests and was fixed there the same day (#11020), but `sync_blocks` was missed because a prefix match fails silently and the retry arm logged nothing.

`btc_adapter_basics_test{,_local}` and the Farm `doge_adapter_basics_test` share this code path and have the same latent bug; the `_local` variant is hit most because its tests start 10ms after setup (on Farm the tests only start once `metrics_setup` has finished allocating the Prometheus/Vector VMs, which in the observed passing runs was 17s to ~2 minutes after `setup` and gave the adapter time to warm up).

## Fix

In `rs/tests/ckbtc/src/adapter.rs`:

- Classify rejects with a new helper `is_transient_adapter_reject_message` that unwraps the proxy's `call rejected: <code> - ` envelope (when present) and checks the top-level adapter `RpcError` variant (`Unavailable(`, `Cancelled(`). Retrying on the embedded reject code instead was rejected on purpose: the payload builder maps *every* adapter error, including the fatal `ConnectionBroken`/`Unknown(..)`, to `SysTransient`.
- Log every retried transient reject (the retry arm used to be silent, which is why this regression went unnoticed for five weeks).
- When `max_tries` is exhausted, return the last transient error instead of `break (vec![], vec![])`, which surfaced as a confusing block-count `assert_eq!` mismatch in the caller.
- Unit tests for the helper covering the raw and the proxied message formats plus fatal errors (including fatal `Unknown(..)` errors whose inner text mentions a transient variant). The proxied fixtures are built with ic-cdk's own `CallFailed`/`CallRejected` `Display` (new `ic-cdk` dev-dependency), so a future change of the envelope text fails the unit test instead of silently disabling the retry again. `rs/tests/ckbtc` had no test target, so this adds `//rs/tests/ckbtc:unit_tests`.

In `rs/tests/driver/src/util.rs`: document on `MessageCanister::forward_to`/`forward_with_cycles_to` how rejects of the receiver are reported, so future callers don't repeat the mistake.

Changing the `message` canister back to rejecting with the raw message was considered and rejected: the tecdsa tests already assert the `call rejected: <code> - ...` format (#11020).

## Testing

Following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`, all in the dev container:

- `cargo check --all-targets --all-features -p ic-tests-ckbtc -p ic-system-test-driver`, `cargo fmt` and `./ci/scripts/rust-lint.sh` are clean.
- `bazel build //rs/tests/ckbtc:ckbtc //rs/tests/driver:ic-system-test-driver` and `bazel test //rs/tests/ckbtc:unit_tests //rs/tests/driver:unit_tests //rs/tests/idx:test_e2e_scenarios` pass.
- `bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/tests/cross_chain:doge_adapter_basics_test_local //rs/tests/cross_chain:btc_adapter_basics_test_local`: all 6 runs passed.

Run 3 of the doge test reproduced the flake condition (exactly one replica-side `Sending the request with callback id 0 to the adapter failed with Cancelled("Timeout expired")` warning, as in every failed CI attempt) and the new retry path handled it, after which `test_received_blocks` passed in 30.6s:

```
INFO[test_received_blocks::<T>:rs/tests/ckbtc/src/adapter.rs:179:0] Transient adapter error on get_successors try 1/15, retrying in 1s: The replica returned a rejection error: reject code CanisterReject, reject message call rejected: 2 - Cancelled(Timeout expired), error code Some("IC0406")
```

Follow-up commit (addresses the Copilot review, envelope unwrapping + ic-cdk-derived fixtures): `cargo check`, `cargo fmt`, `./ci/scripts/rust-lint.sh`, `bazel build //... --nobuild` and `bazel run //:buildifier` are clean; `bazel test //rs/tests/ckbtc:unit_tests //rs/tests/driver:unit_tests //rs/tests/idx:test_e2e_scenarios` pass; one more run of `//rs/tests/cross_chain:doge_adapter_basics_test_local` passed.

## Root cause analysis

Full analysis (both this and the unrelated Farm setup-timeout flake of `doge_adapter_basics_test`, fixed separately) was done following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`; the write-up lives outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
