### PR TITLE
feat(registry): Let the engine controller make a cloud engine cool down

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -184,11 +184,12 @@ async fn delete_engine(args: DeleteEngineArgs) -> Result<(), String> {
 }
 
 /// Validates that the only fields set on the proxied `UpdateSubnetPayload`
-/// are the ones the engine controller is allowed to manage: `subnet_admins`
-/// and `is_halted` (subnet halting / unhalting). Every other `Option<_>`
-/// field must be `None`, and the single non-optional knob
-/// (`set_gossip_config_to_default`) must hold its default value (`false`).
-/// The required `subnet_id` is exempt because it merely identifies the target.
+/// are the ones the engine controller is allowed to manage: `subnet_admins`,
+/// `is_halted` (subnet halting / unhalting) and `cooling_down` (letting the
+/// subnet quiesce before it is halted). Every other `Option<_>` field must be
+/// `None`, and the single non-optional knob (`set_gossip_config_to_default`)
+/// must hold its default value (`false`). The required `subnet_id` is exempt
+/// because it merely identifies the target.
 ///
 /// This keeps the surface of `update_subnet` deliberately tiny: only the
 /// fields the engine controller is intended to manage flow through. Adding a
@@ -199,6 +200,7 @@ fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), S
         // The fields we allow.
         subnet_admins: _,
         is_halted: _,
+        cooling_down: _,
 
         max_ingress_bytes_per_message,
         max_ingress_bytes_per_block,
@@ -211,7 +213,6 @@ fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), S
         start_as_nns,
         subnet_type,
         halt_at_cup_height,
-        cooling_down,
         features,
         resource_limits,
         chain_key_config,
@@ -259,7 +260,6 @@ fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), S
     check_none!(start_as_nns, "start_as_nns");
     check_none!(subnet_type, "subnet_type");
     check_none!(halt_at_cup_height, "halt_at_cup_height");
-    check_none!(cooling_down, "cooling_down");
     check_none!(features, "features");
     check_none!(resource_limits, "resource_limits");
     check_none!(chain_key_config, "chain_key_config");
@@ -288,15 +288,16 @@ fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), S
     } else {
         Err(format!(
             "Updating these fields via the engine controller is not allowed: {}. \
-             Only `subnet_admins` and `is_halted` may be updated.",
+             Only `subnet_admins`, `is_halted` and `cooling_down` may be updated.",
             disallowed.join(", ")
         ))
     }
 }
 
-/// Proxies to the registry's `update_subnet` endpoint. Only `subnet_admins`
-/// and `is_halted` may be updated through this path; every other field must be
-/// left at its default value (`None` / `false`) or the call is rejected.
+/// Proxies to the registry's `update_subnet` endpoint. Only `subnet_admins`,
+/// `is_halted` and `cooling_down` may be updated through this path; every
+/// other field must be left at its default value (`None` / `false`) or the
+/// call is rejected.
 #[update]
 async fn update_subnet(payload: UpdateSubnetPayload) -> Result<(), String> {
     ensure_authorized()?;

--- a/rs/engine_controller/canister/tests.rs
+++ b/rs/engine_controller/canister/tests.rs
@@ -103,12 +103,23 @@ fn ensure_only_allowed_fields_set_accepts_is_halted() {
 }
 
 #[test]
-fn ensure_only_allowed_fields_set_accepts_subnet_admins_and_is_halted() {
+fn ensure_only_allowed_fields_set_accepts_cooling_down() {
+    for cooling_down in [true, false] {
+        let mut payload = empty_update_payload();
+        payload.cooling_down = Some(cooling_down);
+        ensure_only_allowed_fields_set(&payload)
+            .unwrap_or_else(|e| panic!("cooling_down={cooling_down} payload must be allowed: {e}"));
+    }
+}
+
+#[test]
+fn ensure_only_allowed_fields_set_accepts_all_allowed_fields() {
     let mut payload = empty_update_payload();
     payload.subnet_admins = Some(vec![PrincipalId::new_user_test_id(42)]);
     payload.is_halted = Some(true);
+    payload.cooling_down = Some(true);
     ensure_only_allowed_fields_set(&payload)
-        .expect("subnet_admins + is_halted payload must be allowed");
+        .expect("subnet_admins + is_halted + cooling_down payload must be allowed");
 }
 
 #[test]

--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -43,8 +43,8 @@ type ResourceLimits = record {
 
 // Mirror of the subset of registry types referenced by UpdateSubnetPayload.
 // The engine controller forwards the payload unchanged to the registry, but
-// only `subnet_id` and `subnet_admins` may be set; every other field must be
-// `null`/`false` or the call is rejected.
+// besides `subnet_id` only `subnet_admins`, `is_halted` and `cooling_down` may
+// be set; every other field must be `null`/`false` or the call is rejected.
 type EcdsaCurve = variant { secp256k1 };
 type EcdsaKeyId = record { curve : EcdsaCurve; name : text };
 type SchnorrAlgorithm = variant { bip340secp256k1; ed25519 };

--- a/rs/engine_controller/unreleased_changelog.md
+++ b/rs/engine_controller/unreleased_changelog.md
@@ -19,8 +19,10 @@ on the process that this file is part of, see
   (super admin) into the `subnet_admins` list. The supplied list is now
   forwarded to the registry as-is.
 
-* `update_subnet` rejects the new `UpdateSubnetPayload.cooling_down` field:
-  only `subnet_admins` and `is_halted` remain in the engine controller's scope.
+* `update_subnet` accepts the new `UpdateSubnetPayload.cooling_down` field, so
+  the engine controller can make a cloud engine subnet cool down (and stop
+  cooling down again). Its scope is now `subnet_admins`, `is_halted` and
+  `cooling_down`; every other field is still rejected.
 
 ## Deprecated
 

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -235,10 +235,10 @@ impl Registry {
 
 /// Defence-in-depth check that the engine controller canister never reaches
 /// `do_update_subnet` with anything other than the small set of fields it is
-/// allowed to manage (currently `subnet_admins` and `is_halted`). The engine
-/// controller proxy already enforces this, but mirroring the check here keeps
-/// the registry's invariants self-contained and prevents future drift if the
-/// proxy's surface ever changes.
+/// allowed to manage (currently `subnet_admins`, `is_halted` and
+/// `cooling_down`). The engine controller proxy already enforces this, but
+/// mirroring the check here keeps the registry's invariants self-contained and
+/// prevents future drift if the proxy's surface ever changes.
 ///
 /// Uses exhaustive destructuring so adding a new field to `UpdateSubnetPayload`
 /// will fail to compile here until it is explicitly classified as
@@ -249,6 +249,7 @@ fn ensure_engine_controller_payload_scope(payload: &UpdateSubnetPayload) {
         // The fields the engine controller is allowed to set.
         subnet_admins: _,
         is_halted: _,
+        cooling_down: _,
 
         max_ingress_bytes_per_message,
         max_ingress_bytes_per_block,
@@ -261,7 +262,6 @@ fn ensure_engine_controller_payload_scope(payload: &UpdateSubnetPayload) {
         start_as_nns,
         subnet_type,
         halt_at_cup_height,
-        cooling_down,
         features,
         resource_limits,
         chain_key_config,
@@ -306,7 +306,6 @@ fn ensure_engine_controller_payload_scope(payload: &UpdateSubnetPayload) {
     check_none!(start_as_nns, "start_as_nns");
     check_none!(subnet_type, "subnet_type");
     check_none!(halt_at_cup_height, "halt_at_cup_height");
-    check_none!(cooling_down, "cooling_down");
     check_none!(features, "features");
     check_none!(resource_limits, "resource_limits");
     check_none!(chain_key_config, "chain_key_config");
@@ -333,8 +332,8 @@ fn ensure_engine_controller_payload_scope(payload: &UpdateSubnetPayload) {
     assert!(
         disallowed.is_empty(),
         "{LOG_PREFIX}do_update_subnet: engine controller may only update \
-         `subnet_admins` and `is_halted`, but the following fields were also \
-         set: {disallowed:?}",
+         `subnet_admins`, `is_halted` and `cooling_down`, but the following \
+         fields were also set: {disallowed:?}",
     );
 }
 
@@ -1909,7 +1908,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "engine controller may only update `subnet_admins` and `is_halted`")]
+    #[should_panic(
+        expected = "engine controller may only update `subnet_admins`, `is_halted` and `cooling_down`"
+    )]
     fn engine_controller_cannot_update_disallowed_fields() {
         use ic_nns_constants::ENGINE_CONTROLLER_CANISTER_ID;
 
@@ -1937,18 +1938,25 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "engine controller may only update `subnet_admins` and `is_halted`")]
-    fn engine_controller_cannot_set_cooling_down() {
+    fn engine_controller_can_set_cooling_down() {
         use ic_nns_constants::ENGINE_CONTROLLER_CANISTER_ID;
 
         let (mut registry, subnet_id) = make_registry_with_cloud_engine_subnet();
 
-        let mut payload = make_empty_update_payload(subnet_id);
-        // `cooling_down` is outside the engine controller's scope, even though
-        // it is halting-adjacent: only `is_halted` is in scope.
-        payload.cooling_down = Some(true);
+        // Sanity check: subnets do not cool down by default.
+        assert!(!registry.get_subnet_or_panic(subnet_id).cooling_down);
 
-        registry.do_update_subnet(ENGINE_CONTROLLER_CANISTER_ID.get(), payload);
+        for cooling_down in [true, false] {
+            let mut payload = make_empty_update_payload(subnet_id);
+            payload.cooling_down = Some(cooling_down);
+
+            registry.do_update_subnet(ENGINE_CONTROLLER_CANISTER_ID.get(), payload);
+
+            assert_eq!(
+                registry.get_subnet_or_panic(subnet_id).cooling_down,
+                cooling_down
+            );
+        }
     }
 
     #[test]

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -28,6 +28,10 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `update_subnet` now also lets the engine controller canister set `cooling_down` on a cloud engine
+  subnet. The engine controller's scope is thus `subnet_admins`, `is_halted` and `cooling_down`;
+  every other field remains rejected for that caller.
+
 * `UpdateStandardEngineReplicaVersion` can now start a new deployment after the previous one has been
   fully rolled back (`deployment_progress == 0.0`), not just after it has been fully rolled forward
   (`deployment_progress == 1.0`).


### PR DESCRIPTION
Adds `cooling_down` to the small set of `UpdateSubnetPayload` fields the engine
controller canister may set, alongside `subnet_admins` and `is_halted`. The
engine controller can thus let a cloud engine subnet quiesce -- drain its subnet
queues and its streams while executing no canister messages and serving no
queries (see #11495) -- before halting it.

The scope check exists twice: once in the engine controller proxy
(`ensure_only_allowed_fields_set`) and once as a defence-in-depth check in the
registry (`ensure_engine_controller_payload_scope`). Both are widened, and their
exhaustive destructuring of `UpdateSubnetPayload` keeps them from drifting.
Every other field remains rejected for that caller, and the registry still
requires the target subnet to be of type `CloudEngine`.

The stale comment in `engine_controller.did`, which claimed only `subnet_id` and
`subnet_admins` could be set, now names the actual surface.

**Tests:** the registry's `engine_controller_cannot_set_cooling_down` becomes
`engine_controller_can_set_cooling_down`, asserting the flag round-trips both
ways on a `CloudEngine` subnet; the proxy gains
`ensure_only_allowed_fields_set_accepts_cooling_down`, and its combined-fields
test now sets all three allowed fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)