### PR TITLE
fix: deflake //rs/tests/cross_chain:doge_adapter_basics_test

### DIFF
--- a/rs/tests/ckbtc/src/lib.rs
+++ b/rs/tests/ckbtc/src/lib.rs
@@ -51,9 +51,27 @@ use std::{
 pub mod adapter;
 pub mod utils;
 
-/// For an, as of yet, unexplained reason the setup task of all the ckbtc system-tests often times out
-/// after the default 10 minutes because creating the btc-node takes a long time.
-/// So to reduce flakiness we bump the timeout to 15 minutes.
+/// The setup task of the ckbtc system-tests can need more than the driver's default 10 minutes
+/// on Farm: it performs two sequential Farm VM allocations (the bitcoind/dogecoind universal VM,
+/// then the IC node(s)), and on a slow Farm day a single VM allocation takes 3-5 minutes
+/// (observed on 2026-09-08, when the two allocations consumed 8.5 of the 10 minutes).
+/// So to reduce flakiness we bump the per-task timeout to 15 minutes.
+///
+/// When metrics are enabled the driver additionally runs a `metrics_setup` task in parallel with
+/// `setup`, under the same per-task timeout. It allocates a third Farm VM (Prometheus) only once
+/// ic-prep has run, i.e. after the IC node allocation, so it is effectively a third sequential
+/// allocation. If it does not finish within the per-task timeout it is killed and the tests run
+/// without metrics (it cannot fail `setup`), but the tests only start once it has finished or
+/// been killed, so the larger budget also lets the Prometheus VM come up.
+///
+/// Note that the driver can only enforce these timeouts itself (and report the timed-out task)
+/// if bazel's own test timeout is larger, i.e. the target has `test_timeout = "eternal"`. Under
+/// the default `"long"` (15 minutes) bazel's clock starts first (`run_systest.sh` `exec`s the
+/// driver), so the 15 minute per-task timeout never fires, the 20 minute overall timeout is
+/// unreachable, and a too-slow setup ends as a bazel `TIMEOUT` without a driver report. The bump
+/// still matters there, since it stops the driver from killing `setup` after 10 minutes. The
+/// adapter basics tests in `rs/tests/cross_chain` use `"eternal"`; the ckbtc minter tests in this
+/// directory currently still run under `"long"`.
 pub const TIMEOUT_PER_TEST: Duration = Duration::from_secs(15 * 60);
 pub const OVERALL_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 

--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -147,6 +147,10 @@ system_test_nns(
             "long_test",  # this test has a P90 duration of over 6 minutes for the week starting on 2025-08-21.
         ],
         test_name = adapter + "_adapter_basics_test",
+        # The driver's 15/20 minute per-task/overall timeouts (see adapter_basics_test.rs) only
+        # take effect if bazel's own timeout is larger; with the default "long" (15 minutes)
+        # bazel would kill the test first and no test report would be produced.
+        test_timeout = "eternal",
         runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS | {
             "CKBTC_UVM_CONFIG_PATH": "//rs/tests:ckbtc_uvm_config_image",
             "UNIVERSAL_CANISTER_WASM_PATH": "//rs/universal_canister/impl:universal_canister.wasm.gz",

--- a/rs/tests/cross_chain/adapter_basics_test.rs
+++ b/rs/tests/cross_chain/adapter_basics_test.rs
@@ -11,7 +11,7 @@ use ic_system_test_driver::{
     util::{assert_create_agent, block_on},
 };
 use ic_tests_ckbtc::{
-    IcRpcClientType,
+    IcRpcClientType, OVERALL_TIMEOUT, TIMEOUT_PER_TEST,
     adapter::{AdapterProxy, fund_with_tokens},
     adapter_test_setup, subnet_sys,
     utils::get_rpc_client,
@@ -178,6 +178,11 @@ fn test_send_tx<T: IcRpcClientType>(env: TestEnv) {
 
 fn test<T: 'static + IcRpcClientType>() -> Result<()> {
     SystemTestGroup::new()
+        // Setting up the bitcoind/dogecoind UVM and the IC node requires two sequential Farm VM
+        // allocations, which can exceed the driver's default 10 minute setup timeout on a slow
+        // Farm day (see the docs of `TIMEOUT_PER_TEST`).
+        .with_timeout_per_test(TIMEOUT_PER_TEST)
+        .with_overall_timeout(OVERALL_TIMEOUT)
         .with_setup(adapter_test_setup::<T>)
         .add_test(systest!(test_received_blocks::<T>))
         .add_test(systest!(test_receives_new_3rd_party_txs::<T>))


### PR DESCRIPTION
## Problem

`//rs/tests/cross_chain:doge_adapter_basics_test` flaked on 2026-09-08 (and `btc_adapter_basics_test` twice in the same half hour) with:

```
Task setup FAILED in 600.00s -- Timeout after 600s
Task test_received_blocks::<T> FAILED -- Failed to find SetupResult attribute after setup. Cancelling test function.
```

The driver's default per-task timeout of 10 minutes (`DEFAULT_TIMEOUT_PER_TEST` in `rs/tests/driver/src/driver/group.rs`) was exceeded by `setup` while waiting for Farm. Timeline of the failed doge attempt:

| Time (UTC) | Event | Elapsed |
|---|---|---|
| 15:03:00 | `setup` starts | 0:00 |
| 15:08:13 | Farm created the `btc-node` universal VM | 5:13 |
| 15:09:11 | universal VM booted, docker images loaded, `dogecoind` started | 6:11 |
| 15:12:33 | Farm created the IC node VM | 9:33 |
| 15:12:39 | `Checking readiness of all nodes ...` (takes ~20s in every passing run) | 9:39 |
| 15:13:00 | killed: `Timeout after 600s` | 10:00 |

The node's console log shows a normal boot that was powered off by the teardown 27s after creation, i.e. the readiness check was simply cut short. The two `btc_adapter_basics_test` failures in the ten minutes before it (setup 14:53-15:03 UTC) never even got their IC node VM within the 10 minutes, and their passing retries needed 570-583s for setup (the doge retry: 381s), so Farm VM allocation in `dm1` hovered right at the limit for about half an hour. Even the passing doge retry, started seconds after the failed attempt was killed, spent 2:55 + 2:21 of the 10 minutes on the two allocations; on a fast day (the 2026-09-09 runs in the Testing section) the whole setup takes under two minutes, so the budget is only tight when Farm allocation latency spikes to 3-5 minutes per VM. The `_local` variants are unaffected (setup took 75-96s in last week's `doge_adapter_basics_test_local` runs and 78-120s in the `btc_` ones).

The ckbtc minter system tests hit exactly this in 2025 and #6473 introduced `TIMEOUT_PER_TEST` (15 min) / `OVERALL_TIMEOUT` (20 min) in `rs/tests/ckbtc/src/lib.rs` for them, but `adapter_basics_test.rs` (which lived in `rs/tests/ckbtc/` at the time) was skipped and still uses the bare `SystemTestGroup::new()` defaults.

## Fix

- `rs/tests/cross_chain/adapter_basics_test.rs`: use `.with_timeout_per_test(TIMEOUT_PER_TEST).with_overall_timeout(OVERALL_TIMEOUT)` like the other ckbtc system tests.
- `rs/tests/cross_chain/BUILD.bazel`: set `test_timeout = "eternal"` for the adapter basics tests. `run_systest.sh` `exec`s the driver, so bazel's timeout starts first; with the default `"long"` (15 minutes) a 15 minute driver timeout can never fire, the 20 minute overall timeout is unreachable, and a slow setup would surface as a bazel `TIMEOUT` without a driver test report. With `"eternal"` the driver's own 20 minute overall timeout bounds the test. (76 other system tests already use `"eternal"` for this reason.)
- `rs/tests/ckbtc/src/lib.rs`: replace the "as of yet unexplained" comment on `TIMEOUT_PER_TEST` with the explanation from the logs, and note the bazel timeout requirement.

Notes for reviewers:

- `enable_metrics = True` (added deliberately in #8426) puts a third Farm allocation (the Prometheus VM) on the critical path after the IC node allocation, inside the same timed `setup + metrics_setup` group. In both btc passing retries on 2026-09-08 `metrics_setup` was still allocating when the 600s timeout fired and was killed, so the tests ran without metrics; in the one run where it completed it delayed the tests by 1m47s. With the 15 minute budget it will now complete on slow days too. If the metrics VM isn't actually used for these tests, dropping `enable_metrics` would take that allocation off the critical path; left as is here to keep this PR to the timeout.
- The ckbtc minter tests use the same 15/20 minute constants but still run under bazel's `"long"` timeout, so for them the constants effectively mean "defer to bazel". Not changed here.
- Possible follow-up: overlap the ~1 minute docker bootstrap of the universal VM with the IC setup (`setup_bitcoind_uvm` in `rs/tests/ckbtc/src/lib.rs`), or overlap the two Farm allocations themselves, which needs a driver-level split of `InternetComputer::setup_and_start`.

## Testing

Following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`, all in the dev container:

- `cargo check --all-targets --all-features -p ic-tests-cross-chain -p ic-tests-ckbtc`, `cargo fmt` and `./ci/scripts/rust-lint.sh` are clean; `bazel build //... --nobuild` and `bazel run //:buildifier` are clean.
- `bazel build //rs/tests/ckbtc:ckbtc //rs/tests/cross_chain:btc_adapter_basics_test_bin //rs/tests/cross_chain:doge_adapter_basics_test_bin` passes.
- `bazel test --test_output=errors --runs_per_test='doge_adapter_basics_test$@3' --jobs=6 //rs/tests/cross_chain:{btc,doge}_adapter_basics_test{,_local}`:
  - `doge_adapter_basics_test` (Farm): 3/3 runs passed; `btc_adapter_basics_test` (Farm) and `btc_adapter_basics_test_local` passed.
  - The driver's plan in the Farm runs shows the new limits in effect: `timed(children=[setup, metrics_setup], timeout=900s)`, `timeout=900s` per test function and `timeout(::group)` at `1200s`. Farm was fast today (setup took 111-115s), so the extra headroom itself was not exercised.
  - The single `doge_adapter_basics_test_local` run failed in `test_received_blocks` with `call rejected: 2 - Cancelled(Timeout expired)` after exactly one replica-side adapter timeout warning. That is the unrelated first-request retry regression fixed by #11518, which this branch does not contain; its setup passed in 194.62s.

## Root cause analysis

Done following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`. The other flake of this test family (`doge_adapter_basics_test_local`, a dead retry path in `sync_blocks`) is unrelated and fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
