### PR TITLE
feat(consensus): report the consensus status as a metric

### DIFF
--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -29,7 +29,7 @@ use crate::consensus::{
     catchup_package_maker::CatchUpPackageMaker, finalizer::Finalizer, metrics::ConsensusMetrics,
     notary::Notary, payload_builder::PayloadBuilderImpl, priority::new_bouncer, purger::Purger,
     random_beacon_maker::RandomBeaconMaker, random_tape_maker::RandomTapeMaker,
-    share_aggregator::ShareAggregator, validator::Validator,
+    share_aggregator::ShareAggregator, status::Status, validator::Validator,
 };
 use ic_consensus_dkg::DkgKeyManager;
 use ic_consensus_utils::{
@@ -404,6 +404,11 @@ impl<T: ConsensusPool> PoolMutationsProducer<T> for ConsensusImpl {
 
         // Consensus halts if instructed by the registry
         if self.should_halt_by_subnet_record() {
+            // Report the status from here, as this returns without reaching the
+            // finalizer, which is what observes it for a subnet that is not
+            // halted this way. No blocks are created and no batches delivered
+            // for as long as the subnet record says so, which is `Halted`.
+            self.finalizer.observe_status(Status::Halted);
             info!(
                 every_n_seconds => 5,
                 self.log,
@@ -630,7 +635,12 @@ mod tests {
     fn set_up_consensus_with_subnet_record(
         record: SubnetRecord,
         pool_config: ArtifactPoolConfig,
-    ) -> (ConsensusImpl, TestConsensusPool, Arc<FastForwardTimeSource>) {
+    ) -> (
+        ConsensusImpl,
+        TestConsensusPool,
+        Arc<FastForwardTimeSource>,
+        MetricsRegistry,
+    ) {
         let Dependencies {
             pool,
             registry,
@@ -685,10 +695,23 @@ mod tests {
             time_source.clone(),
             0,
             MaliciousFlags::default(),
-            metrics_registry,
+            metrics_registry.clone(),
             no_op_logger(),
         );
-        (consensus_impl, pool, time_source)
+        (consensus_impl, pool, time_source, metrics_registry)
+    }
+
+    /// The `consensus_status` gauge of `status`, or [None] if the metric does
+    /// not report that status at all.
+    fn consensus_status(metrics_registry: &MetricsRegistry, status: &str) -> Option<i64> {
+        metrics_registry
+            .prometheus_registry()
+            .gather()
+            .into_iter()
+            .filter(|family| family.name() == "consensus_status")
+            .flat_map(|family| family.get_metric().to_vec())
+            .find(|metric| metric.get_label()[0].value() == status)
+            .map(|metric| metric.get_gauge().value() as i64)
     }
 
     #[test]
@@ -699,7 +722,7 @@ mod tests {
 
             // ensure that a consensus implementation with a subnet record with is_halted =
             // false returns changes
-            let (consensus_impl, pool, _) = set_up_consensus_with_subnet_record(
+            let (consensus_impl, pool, _, metrics_registry) = set_up_consensus_with_subnet_record(
                 SubnetRecordBuilder::from(&committee)
                     .with_dkg_interval_length(interval_length)
                     .with_is_halted(false)
@@ -708,10 +731,11 @@ mod tests {
             );
 
             assert!(!consensus_impl.on_state_change(&pool).is_empty());
+            assert_eq!(consensus_status(&metrics_registry, "halted"), Some(0));
 
             // ensure that an consensus_impl with a subnet record with is_halted =
             // true returns no changes
-            let (consensus_impl, pool, _) = set_up_consensus_with_subnet_record(
+            let (consensus_impl, pool, _, metrics_registry) = set_up_consensus_with_subnet_record(
                 SubnetRecordBuilder::from(&committee)
                     .with_dkg_interval_length(interval_length)
                     .with_is_halted(true)
@@ -719,6 +743,10 @@ mod tests {
                 pool_config,
             );
             assert!(consensus_impl.on_state_change(&pool).is_empty());
+            // A subnet halted this way returns above the finalizer, so the
+            // status is reported from there rather than by the delivery path.
+            assert_eq!(consensus_status(&metrics_registry, "halted"), Some(1));
+            assert_eq!(consensus_status(&metrics_registry, "running"), Some(0));
         })
     }
 }

--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -29,7 +29,7 @@ use crate::consensus::{
     catchup_package_maker::CatchUpPackageMaker, finalizer::Finalizer, metrics::ConsensusMetrics,
     notary::Notary, payload_builder::PayloadBuilderImpl, priority::new_bouncer, purger::Purger,
     random_beacon_maker::RandomBeaconMaker, random_tape_maker::RandomTapeMaker,
-    share_aggregator::ShareAggregator, status::Status, validator::Validator,
+    share_aggregator::ShareAggregator, validator::Validator,
 };
 use ic_consensus_dkg::DkgKeyManager;
 use ic_consensus_utils::{
@@ -402,13 +402,17 @@ impl<T: ConsensusPool> PoolMutationsProducer<T> for ConsensusImpl {
             .unwrap()
             .on_state_change(&pool_reader);
 
-        // Consensus halts if instructed by the registry
-        if self.should_halt_by_subnet_record() {
-            // Report the status from here, as this returns without reaching the
-            // finalizer, which is what observes it for a subnet that is not
-            // halted this way. No blocks are created and no batches delivered
-            // for as long as the subnet record says so, which is `Halted`.
-            self.finalizer.observe_status(Status::Halted);
+        // Consensus halts if instructed by the registry. Reported on every
+        // invocation, whether it halts or not, so that the metric answers what
+        // the registry says right now. `consensus_status` cannot answer it: the
+        // subnet produces no blocks while halted this way, so once the flag is
+        // cleared the delivery path has nothing to look at and would go on
+        // reporting the status it last computed.
+        let halted_by_subnet_record = self.should_halt_by_subnet_record();
+        self.metrics
+            .halted_by_subnet_record
+            .set(halted_by_subnet_record as i64);
+        if halted_by_subnet_record {
             info!(
                 every_n_seconds => 5,
                 self.log,
@@ -619,6 +623,8 @@ mod tests {
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
     use ic_protobuf::registry::subnet::v1::SubnetRecord;
+    use ic_registry_client_fake::FakeRegistryClient;
+    use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
     use ic_test_artifact_pool::consensus_pool::TestConsensusPool;
     use ic_test_utilities::{
         ingress_selector::FakeIngressSelector, message_routing::FakeMessageRouting,
@@ -626,24 +632,30 @@ mod tests {
         xnet_payload_builder::FakeXNetPayloadBuilder,
     };
     use ic_test_utilities_consensus::batch::MockBatchPayloadBuilder;
-    use ic_test_utilities_registry::SubnetRecordBuilder;
+    use ic_test_utilities_registry::{SubnetRecordBuilder, add_single_subnet_record};
     use ic_test_utilities_time::FastForwardTimeSource;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::{CryptoHashOfState, Height, crypto::CryptoHash};
     use std::sync::Arc;
 
+    struct ConsensusSetUp {
+        consensus_impl: ConsensusImpl,
+        pool: TestConsensusPool,
+        #[allow(dead_code)]
+        time_source: Arc<FastForwardTimeSource>,
+        metrics_registry: MetricsRegistry,
+        registry: Arc<FakeRegistryClient>,
+        registry_data_provider: Arc<ProtoRegistryDataProvider>,
+    }
+
     fn set_up_consensus_with_subnet_record(
         record: SubnetRecord,
         pool_config: ArtifactPoolConfig,
-    ) -> (
-        ConsensusImpl,
-        TestConsensusPool,
-        Arc<FastForwardTimeSource>,
-        MetricsRegistry,
-    ) {
+    ) -> ConsensusSetUp {
         let Dependencies {
             pool,
             registry,
+            registry_data_provider,
             crypto,
             time_source,
             replica_config,
@@ -686,7 +698,7 @@ mod tests {
                 crypto,
                 no_op_logger(),
                 &PoolReader::new(&pool),
-                registry,
+                registry.clone(),
                 replica_config,
             ))),
             Arc::new(FakeMessageRouting::new()),
@@ -698,19 +710,25 @@ mod tests {
             metrics_registry.clone(),
             no_op_logger(),
         );
-        (consensus_impl, pool, time_source, metrics_registry)
+        ConsensusSetUp {
+            consensus_impl,
+            pool,
+            time_source,
+            metrics_registry,
+            registry,
+            registry_data_provider,
+        }
     }
 
-    /// The `consensus_status` gauge of `status`, or [None] if the metric does
-    /// not report that status at all.
-    fn consensus_status(metrics_registry: &MetricsRegistry, status: &str) -> Option<i64> {
+    /// The `consensus_halted_by_subnet_record` gauge, or [None] if the metrics
+    /// registry does not report it.
+    fn halted_by_subnet_record(metrics_registry: &MetricsRegistry) -> Option<i64> {
         metrics_registry
             .prometheus_registry()
             .gather()
             .into_iter()
-            .filter(|family| family.name() == "consensus_status")
-            .flat_map(|family| family.get_metric().to_vec())
-            .find(|metric| metric.get_label()[0].value() == status)
+            .find(|family| family.name() == "consensus_halted_by_subnet_record")
+            .and_then(|family| family.get_metric().first().cloned())
             .map(|metric| metric.get_gauge().value() as i64)
     }
 
@@ -720,33 +738,52 @@ mod tests {
             let committee: Vec<_> = (0..4).map(node_test_id).collect();
             let interval_length = 99;
 
-            // ensure that a consensus implementation with a subnet record with is_halted =
-            // false returns changes
-            let (consensus_impl, pool, _, metrics_registry) = set_up_consensus_with_subnet_record(
+            let record = |is_halted| {
                 SubnetRecordBuilder::from(&committee)
                     .with_dkg_interval_length(interval_length)
-                    .with_is_halted(false)
-                    .build(),
-                pool_config.clone(),
-            );
+                    .with_is_halted(is_halted)
+                    .build()
+            };
 
-            assert!(!consensus_impl.on_state_change(&pool).is_empty());
-            assert_eq!(consensus_status(&metrics_registry, "halted"), Some(0));
+            // ensure that a consensus implementation with a subnet record with is_halted =
+            // false returns changes
+            let running = set_up_consensus_with_subnet_record(record(false), pool_config.clone());
+
+            assert!(
+                !running
+                    .consensus_impl
+                    .on_state_change(&running.pool)
+                    .is_empty()
+            );
+            assert_eq!(halted_by_subnet_record(&running.metrics_registry), Some(0));
 
             // ensure that an consensus_impl with a subnet record with is_halted =
             // true returns no changes
-            let (consensus_impl, pool, _, metrics_registry) = set_up_consensus_with_subnet_record(
-                SubnetRecordBuilder::from(&committee)
-                    .with_dkg_interval_length(interval_length)
-                    .with_is_halted(true)
-                    .build(),
-                pool_config,
+            let halted = set_up_consensus_with_subnet_record(record(true), pool_config);
+            assert!(
+                halted
+                    .consensus_impl
+                    .on_state_change(&halted.pool)
+                    .is_empty()
             );
-            assert!(consensus_impl.on_state_change(&pool).is_empty());
-            // A subnet halted this way returns above the finalizer, so the
-            // status is reported from there rather than by the delivery path.
-            assert_eq!(consensus_status(&metrics_registry, "halted"), Some(1));
-            assert_eq!(consensus_status(&metrics_registry, "running"), Some(0));
+            // A subnet halted this way returns above the finalizer, which is what
+            // reports `consensus_status`, so it has a gauge of its own.
+            assert_eq!(halted_by_subnet_record(&halted.metrics_registry), Some(1));
+
+            // Clearing the flag clears the gauge, on the very next invocation
+            // rather than once consensus has a block to show for it. Reported
+            // above the branch that returns, so that it is reported whether the
+            // subnet halts or not.
+            add_single_subnet_record(
+                &halted.registry_data_provider,
+                /*version=*/ 2,
+                subnet_test_id(0),
+                record(false),
+            );
+            halted.registry.update_to_latest_version();
+
+            halted.consensus_impl.on_state_change(&halted.pool);
+            assert_eq!(halted_by_subnet_record(&halted.metrics_registry), Some(0));
         })
     }
 }

--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -402,17 +402,8 @@ impl<T: ConsensusPool> PoolMutationsProducer<T> for ConsensusImpl {
             .unwrap()
             .on_state_change(&pool_reader);
 
-        // Consensus halts if instructed by the registry. Reported on every
-        // invocation, whether it halts or not, so that the metric answers what
-        // the registry says right now. `consensus_status` cannot answer it: the
-        // subnet produces no blocks while halted this way, so once the flag is
-        // cleared the delivery path has nothing to look at and would go on
-        // reporting the status it last computed.
-        let halted_by_subnet_record = self.should_halt_by_subnet_record();
-        self.metrics
-            .halted_by_subnet_record
-            .set(halted_by_subnet_record as i64);
-        if halted_by_subnet_record {
+        // Consensus halts if instructed by the registry
+        if self.should_halt_by_subnet_record() {
             info!(
                 every_n_seconds => 5,
                 self.log,
@@ -623,8 +614,6 @@ mod tests {
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
     use ic_protobuf::registry::subnet::v1::SubnetRecord;
-    use ic_registry_client_fake::FakeRegistryClient;
-    use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
     use ic_test_artifact_pool::consensus_pool::TestConsensusPool;
     use ic_test_utilities::{
         ingress_selector::FakeIngressSelector, message_routing::FakeMessageRouting,
@@ -632,30 +621,19 @@ mod tests {
         xnet_payload_builder::FakeXNetPayloadBuilder,
     };
     use ic_test_utilities_consensus::batch::MockBatchPayloadBuilder;
-    use ic_test_utilities_registry::{SubnetRecordBuilder, add_single_subnet_record};
+    use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_time::FastForwardTimeSource;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::{CryptoHashOfState, Height, crypto::CryptoHash};
     use std::sync::Arc;
 
-    struct ConsensusSetUp {
-        consensus_impl: ConsensusImpl,
-        pool: TestConsensusPool,
-        #[allow(dead_code)]
-        time_source: Arc<FastForwardTimeSource>,
-        metrics_registry: MetricsRegistry,
-        registry: Arc<FakeRegistryClient>,
-        registry_data_provider: Arc<ProtoRegistryDataProvider>,
-    }
-
     fn set_up_consensus_with_subnet_record(
         record: SubnetRecord,
         pool_config: ArtifactPoolConfig,
-    ) -> ConsensusSetUp {
+    ) -> (ConsensusImpl, TestConsensusPool, Arc<FastForwardTimeSource>) {
         let Dependencies {
             pool,
             registry,
-            registry_data_provider,
             crypto,
             time_source,
             replica_config,
@@ -698,7 +676,7 @@ mod tests {
                 crypto,
                 no_op_logger(),
                 &PoolReader::new(&pool),
-                registry.clone(),
+                registry,
                 replica_config,
             ))),
             Arc::new(FakeMessageRouting::new()),
@@ -707,29 +685,10 @@ mod tests {
             time_source.clone(),
             0,
             MaliciousFlags::default(),
-            metrics_registry.clone(),
+            metrics_registry,
             no_op_logger(),
         );
-        ConsensusSetUp {
-            consensus_impl,
-            pool,
-            time_source,
-            metrics_registry,
-            registry,
-            registry_data_provider,
-        }
-    }
-
-    /// The `consensus_halted_by_subnet_record` gauge, or [None] if the metrics
-    /// registry does not report it.
-    fn halted_by_subnet_record(metrics_registry: &MetricsRegistry) -> Option<i64> {
-        metrics_registry
-            .prometheus_registry()
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == "consensus_halted_by_subnet_record")
-            .and_then(|family| family.get_metric().first().cloned())
-            .map(|metric| metric.get_gauge().value() as i64)
+        (consensus_impl, pool, time_source)
     }
 
     #[test]
@@ -738,52 +697,28 @@ mod tests {
             let committee: Vec<_> = (0..4).map(node_test_id).collect();
             let interval_length = 99;
 
-            let record = |is_halted| {
-                SubnetRecordBuilder::from(&committee)
-                    .with_dkg_interval_length(interval_length)
-                    .with_is_halted(is_halted)
-                    .build()
-            };
-
             // ensure that a consensus implementation with a subnet record with is_halted =
             // false returns changes
-            let running = set_up_consensus_with_subnet_record(record(false), pool_config.clone());
-
-            assert!(
-                !running
-                    .consensus_impl
-                    .on_state_change(&running.pool)
-                    .is_empty()
+            let (consensus_impl, pool, _) = set_up_consensus_with_subnet_record(
+                SubnetRecordBuilder::from(&committee)
+                    .with_dkg_interval_length(interval_length)
+                    .with_is_halted(false)
+                    .build(),
+                pool_config.clone(),
             );
-            assert_eq!(halted_by_subnet_record(&running.metrics_registry), Some(0));
+
+            assert!(!consensus_impl.on_state_change(&pool).is_empty());
 
             // ensure that an consensus_impl with a subnet record with is_halted =
             // true returns no changes
-            let halted = set_up_consensus_with_subnet_record(record(true), pool_config);
-            assert!(
-                halted
-                    .consensus_impl
-                    .on_state_change(&halted.pool)
-                    .is_empty()
+            let (consensus_impl, pool, _) = set_up_consensus_with_subnet_record(
+                SubnetRecordBuilder::from(&committee)
+                    .with_dkg_interval_length(interval_length)
+                    .with_is_halted(true)
+                    .build(),
+                pool_config,
             );
-            // A subnet halted this way returns above the finalizer, which is what
-            // reports `consensus_status`, so it has a gauge of its own.
-            assert_eq!(halted_by_subnet_record(&halted.metrics_registry), Some(1));
-
-            // Clearing the flag clears the gauge, on the very next invocation
-            // rather than once consensus has a block to show for it. Reported
-            // above the branch that returns, so that it is reported whether the
-            // subnet halts or not.
-            add_single_subnet_record(
-                &halted.registry_data_provider,
-                /*version=*/ 2,
-                subnet_test_id(0),
-                record(false),
-            );
-            halted.registry.update_to_latest_version();
-
-            halted.consensus_impl.on_state_change(&halted.pool);
-            assert_eq!(halted_by_subnet_record(&halted.metrics_registry), Some(0));
+            assert!(consensus_impl.on_state_change(&pool).is_empty());
         })
     }
 }

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -67,7 +67,6 @@ pub fn deliver_batches_for_ic_replay(
         subnet_id,
         max_batch_height_to_deliver,
         /*result_processor=*/ |_, _, _| {},
-        /*status_observer=*/ |_| {},
     )
 }
 
@@ -85,7 +84,6 @@ pub(crate) fn deliver_batches_for_finalizer(
     node_id: NodeId,
     subnet_id: SubnetId,
     result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    status_observer: impl FnMut(Option<Status>),
 ) -> Result<Height, MessageRoutingError> {
     deliver_batches(
         message_routing,
@@ -97,7 +95,6 @@ pub(crate) fn deliver_batches_for_finalizer(
         subnet_id,
         /*max_batch_height_to_deliver=*/ None,
         result_processor,
-        status_observer,
     )
 }
 
@@ -114,7 +111,6 @@ fn deliver_batches(
     subnet_id: SubnetId,
     max_batch_height_to_deliver: Option<Height>,
     mut result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    mut status_observer: impl FnMut(Option<Status>),
 ) -> Result<Height, MessageRoutingError> {
     let finalized_height = pool.get_finalized_height();
     // If `max_batch_height_to_deliver` is specified and smaller than
@@ -130,10 +126,6 @@ fn deliver_batches(
     let mut last_delivered_batch_height = height.decrement();
     while height <= target_height {
         let Some(block) = pool.get_finalized_block(height) else {
-            // There is no block to compute a status from, so report that the
-            // status is not known rather than leave the metric reporting the
-            // status of an earlier height as though it still held.
-            status_observer(None);
             warn!(
                 every_n_seconds => 30,
                 log,
@@ -146,9 +138,7 @@ fn deliver_batches(
             break;
         };
         let Some(tape) = pool.get_random_tape(height) else {
-            // Do not deliver batch if we don't have random tape, and report the
-            // status as not known, as this height did not reach one.
-            status_observer(None);
+            // Do not deliver batch if we don't have random tape
             warn!(
                 every_n_seconds => 30,
                 log,
@@ -172,7 +162,6 @@ fn deliver_batches(
 
         // Retrieve the dkg summary block
         let Some(summary_block) = pool.dkg_summary_block_for_finalized_height(height) else {
-            status_observer(None);
             warn!(
                 every_n_seconds => 30,
                 log,
@@ -185,23 +174,6 @@ fn deliver_batches(
         };
         let dkg_summary = &summary_block.payload.as_ref().as_summary().dkg;
 
-        // The status is computed for every block, the CUP block included, and
-        // handed to the observer before it is acted upon. A subnet halting at
-        // its CUP height stops running at exactly that height, and the CUP
-        // block is delivered whatever the status says, which makes it the one
-        // block whose status is observed without being acted upon -- and the
-        // block on which the answer changes.
-        let status = status::get_status(
-            height,
-            &summary_block,
-            registry_client,
-            subnet_id,
-            pool,
-            replica_version,
-            log,
-        );
-        status_observer(status);
-
         if block.payload.is_summary() {
             info!(
                 log,
@@ -211,7 +183,15 @@ fn deliver_batches(
         // When we are not delivering CUP block, we must check if the subnet is
         // halting towards, or halted at, a CUP height.
         else {
-            match status {
+            match status::get_status(
+                height,
+                &summary_block,
+                registry_client,
+                subnet_id,
+                pool,
+                replica_version,
+                log,
+            ) {
                 Some(status @ (Status::Halting | Status::Halted)) => {
                     info!(
                         every_n_seconds => 5,
@@ -665,7 +645,6 @@ mod tests {
     use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests;
     use ic_logger::replica_logger::no_op_logger;
     use ic_management_canister_types_private::{SetupInitialDKGResponse, VetKdCurve, VetKdKeyId};
-    use ic_test_artifact_pool::consensus_pool::Round;
     use ic_test_utilities::message_routing::FakeMessageRouting;
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{
@@ -879,121 +858,6 @@ mod tests {
         );
     }
 
-    /// Every status the delivery path computes is handed to the observer, which
-    /// is what keeps the finalizer's `consensus_status` metric current. The
-    /// status of a subnet halting towards, or halted at, a CUP height is observed
-    /// on the early return that leaves its batch undelivered.
-    ///
-    /// `at_cup_height` delivers the CUP block itself, the round on which a
-    /// subnet halting at its CUP height halts. That batch is delivered whatever
-    /// the status is, so the status is observed but not acted upon.
-    #[rstest]
-    #[case::running(
-        /* halt_at_cup_height= */ false,
-        /* at_cup_height= */ false,
-        Status::Running
-    )]
-    #[case::halted(
-        /* halt_at_cup_height= */ true,
-        /* at_cup_height= */ false,
-        Status::Halted
-    )]
-    #[case::running_at_cup_height(
-        /* halt_at_cup_height= */ false,
-        /* at_cup_height= */ true,
-        Status::Running
-    )]
-    #[case::halting_at_cup_height(
-        /* halt_at_cup_height= */ true,
-        /* at_cup_height= */ true,
-        // `Halted` needs the subnet to have been halting as of the certified
-        // height of the finalized tip as well. That height is still below the
-        // CUP height, as delivering this batch is what produces the state of
-        // the CUP height, and the subnet halts only from the CUP height on.
-        Status::Halting
-    )]
-    fn test_deliver_batches_observes_status(
-        #[case] halt_at_cup_height: bool,
-        #[case] at_cup_height: bool,
-        #[case] expected_status: Status,
-    ) {
-        const INTERVAL_LENGTH: u64 = 3;
-        const HALT_REGISTRY_VERSION: u64 = 10;
-        // A summary, and hence a CUP, every `INTERVAL_LENGTH + 1` heights.
-        const CUP_HEIGHT: Height = Height::new(2 * (INTERVAL_LENGTH + 1));
-
-        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
-            let record = || {
-                SubnetRecordBuilder::from(&[NODE_1])
-                    .with_dkg_interval_length(INTERVAL_LENGTH)
-                    .with_replica_version(test_replica_version().as_ref())
-            };
-            let Dependencies {
-                mut pool,
-                membership,
-                registry,
-                replica_config,
-                ..
-            } = DependenciesBuilder::single_subnet(
-                pool_config,
-                SUBNET_1,
-                vec![
-                    (1, record().build()),
-                    (
-                        HALT_REGISTRY_VERSION,
-                        record().with_halt_at_cup_height(halt_at_cup_height).build(),
-                    ),
-                ],
-            )
-            .build();
-
-            // Advance to the CUP height, whose block is a summary one.
-            pool.advance_round_normal_operation_n(CUP_HEIGHT.get());
-            let batch_height = if at_cup_height {
-                // That summary block is the one to deliver.
-                CUP_HEIGHT
-            } else {
-                // One round more, to a data block. Its certified height has
-                // reached the CUP height, which is what tells a subnet that is
-                // halted from one that is only halting.
-                Round::new(&mut pool)
-                    .with_certified_height(CUP_HEIGHT)
-                    .advance();
-                CUP_HEIGHT.increment()
-            };
-
-            let message_routing = FakeMessageRouting::new();
-            *message_routing.next_batch_height.write().unwrap() = batch_height;
-
-            // A plain mutable closure, as the observer is `FnMut`.
-            let mut observed = Vec::new();
-            let result = deliver_batches_for_finalizer(
-                &message_routing,
-                &membership,
-                &PoolReader::new(&pool),
-                registry.as_ref(),
-                &no_op_logger(),
-                replica_config.node_id,
-                replica_config.subnet_id,
-                |_, _, _| {},
-                |status| observed.push(status),
-            );
-
-            assert!(result.is_ok(), "delivery failed: {result:?}");
-            assert_eq!(
-                observed,
-                vec![Some(expected_status)],
-                "the observed statuses of a subnet that is {}halted, at height {batch_height}",
-                if halt_at_cup_height { "" } else { "not " },
-            );
-            // The CUP batch is delivered even by a subnet that is halting.
-            assert_eq!(
-                message_routing.batches.read().unwrap().len(),
-                usize::from(at_cup_height || !halt_at_cup_height),
-            );
-        });
-    }
-
     #[rstest]
     #[case::node_on_source_subnet(NODE_1, SOURCE_SUBNET_ID, DESTINATION_SUBNET_ID)]
     #[case::node_on_destination_subnet(NODE_4, DESTINATION_SUBNET_ID, SOURCE_SUBNET_ID)]
@@ -1078,7 +942,6 @@ mod tests {
                 replica_config.node_id,
                 replica_config.subnet_id,
                 |_, _, _| {},
-                |_| {},
             );
 
             assert_eq!(result, Ok(summary_height));

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -180,10 +180,8 @@ fn deliver_batches(
 
         // The status is computed for every block, the CUP block included, and
         // handed to the observer before it is acted upon. The CUP block is
-        // delivered whatever the status is, but a subnet halting at its CUP
-        // height is halting while that batch is delivered, and an observer that
-        // only heard about the blocks the status is acted upon would report it
-        // as running until the first block above the CUP is finalized.
+        // delivered whatever the status is, and a subnet halting at its CUP
+        // height is already halting as that batch is delivered.
         let status = status::get_status(
             height,
             &summary_block,
@@ -896,9 +894,10 @@ mod tests {
     #[case::halting_at_cup_height(
         /* halt_at_cup_height= */ true,
         /* at_cup_height= */ true,
-        // The certified height of the finalized tip is below the CUP height, as
-        // the batch delivering the state of the CUP height is the one about to
-        // be delivered, so the subnet is halting rather than halted.
+        // `Halted` needs the subnet to have been halting as of the certified
+        // height of the finalized tip as well. That height is still below the
+        // CUP height, as delivering this batch is what produces the state of
+        // the CUP height, and the subnet halts only from the CUP height on.
         Status::Halting
     )]
     fn test_deliver_batches_observes_status(
@@ -936,13 +935,15 @@ mod tests {
             )
             .build();
 
-            // Up to the CUP, and, unless the CUP block is the one to deliver, one
-            // round more, whose block is not a summary one and whose certified
-            // height has reached the CUP height.
+            // Advance to the CUP height, whose block is a summary one.
             pool.advance_round_normal_operation_n(CUP_HEIGHT.get());
             let batch_height = if at_cup_height {
+                // That summary block is the one to deliver.
                 CUP_HEIGHT
             } else {
+                // One round more, to a data block. Its certified height has
+                // reached the CUP height, which is what tells a subnet that is
+                // halted from one that is only halting.
                 Round::new(&mut pool)
                     .with_certified_height(CUP_HEIGHT)
                     .advance();

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -994,66 +994,6 @@ mod tests {
         });
     }
 
-    /// A height the delivery path cannot get past has its status reported as not
-    /// known, rather than leaving the metric reporting the status of an earlier
-    /// height as though it still held. The missing random tape stands here for
-    /// all three of the guards that leave the loop.
-    #[test]
-    fn test_deliver_batches_observes_unknown_without_random_tape() {
-        const INTERVAL_LENGTH: u64 = 3;
-
-        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
-            let Dependencies {
-                mut pool,
-                membership,
-                registry,
-                replica_config,
-                ..
-            } = DependenciesBuilder::single_subnet(
-                pool_config,
-                SUBNET_1,
-                vec![(
-                    1,
-                    SubnetRecordBuilder::from(&[NODE_1])
-                        .with_dkg_interval_length(INTERVAL_LENGTH)
-                        .with_replica_version(test_replica_version().as_ref())
-                        .build(),
-                )],
-            )
-            .build();
-
-            pool.advance_round_normal_operation_n(1);
-
-            // Finalize a block, leaving out the random tape of its height.
-            let proposal = pool.make_next_block();
-            pool.insert_validated(proposal.clone());
-            pool.notarize(&proposal);
-            pool.finalize(&proposal);
-            let height = proposal.content.as_ref().height;
-
-            let message_routing = FakeMessageRouting::new();
-            *message_routing.next_batch_height.write().unwrap() = height;
-
-            let mut observed = Vec::new();
-            let result = deliver_batches_for_finalizer(
-                &message_routing,
-                &membership,
-                &PoolReader::new(&pool),
-                registry.as_ref(),
-                &no_op_logger(),
-                replica_config.node_id,
-                replica_config.subnet_id,
-                |_, _, _| {},
-                |status| observed.push(status),
-            );
-
-            // The batch is not delivered, and the status is reported as not known.
-            assert_eq!(result, Ok(height.decrement()));
-            assert!(message_routing.batches.read().unwrap().is_empty());
-            assert_eq!(observed, vec![None]);
-        })
-    }
-
     #[rstest]
     #[case::node_on_source_subnet(NODE_1, SOURCE_SUBNET_ID, DESTINATION_SUBNET_ID)]
     #[case::node_on_destination_subnet(NODE_4, DESTINATION_SUBNET_ID, SOURCE_SUBNET_ID)]

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -870,16 +870,13 @@ mod tests {
     }
 
     /// Every status the delivery path computes is handed to the observer, which
-    /// is what keeps the finalizer's `consensus_status` metric current: a halted
-    /// subnet returns early, and a metric only set on the way to a delivered
-    /// batch would be stuck at whatever it said before the subnet halted.
+    /// is what keeps the finalizer's `consensus_status` metric current. The
+    /// status of a halting or halted subnet is observed on the early return that
+    /// leaves its batch undelivered.
     ///
     /// `at_cup_height` delivers the CUP block itself, the round on which a
     /// subnet halting at its CUP height halts. That batch is delivered whatever
-    /// the status is, so the status is observed but not acted upon; were it only
-    /// observed where it is acted upon, the metric would report the subnet as
-    /// running for as long as it took the first block above the CUP to be
-    /// finalized -- or forever, on a node that never gets that block.
+    /// the status is, so the status is observed but not acted upon.
     #[rstest]
     #[case::running(
         /* halt_at_cup_height= */ false,

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -67,6 +67,7 @@ pub fn deliver_batches_for_ic_replay(
         subnet_id,
         max_batch_height_to_deliver,
         /*result_processor=*/ |_, _, _| {},
+        /*status_observer=*/ |_| {},
     )
 }
 
@@ -84,6 +85,7 @@ pub(crate) fn deliver_batches_for_finalizer(
     node_id: NodeId,
     subnet_id: SubnetId,
     result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
+    status_observer: impl Fn(Status),
 ) -> Result<Height, MessageRoutingError> {
     deliver_batches(
         message_routing,
@@ -95,6 +97,7 @@ pub(crate) fn deliver_batches_for_finalizer(
         subnet_id,
         /*max_batch_height_to_deliver=*/ None,
         result_processor,
+        status_observer,
     )
 }
 
@@ -111,6 +114,7 @@ fn deliver_batches(
     subnet_id: SubnetId,
     max_batch_height_to_deliver: Option<Height>,
     mut result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
+    status_observer: impl Fn(Status),
 ) -> Result<Height, MessageRoutingError> {
     let finalized_height = pool.get_finalized_height();
     // If `max_batch_height_to_deliver` is specified and smaller than
@@ -191,7 +195,8 @@ fn deliver_batches(
                 replica_version,
                 log,
             ) {
-                Some(Status::Halting | Status::Halted) => {
+                Some(status @ (Status::Halting | Status::Halted)) => {
+                    status_observer(status);
                     info!(
                         every_n_seconds => 5,
                         log,
@@ -200,7 +205,7 @@ fn deliver_batches(
                     );
                     return Ok(last_delivered_batch_height);
                 }
-                Some(Status::Running) => {}
+                Some(Status::Running) => status_observer(Status::Running),
                 None => {
                     warn!(
                         log,
@@ -939,6 +944,7 @@ mod tests {
                 replica_config.node_id,
                 replica_config.subnet_id,
                 |_, _, _| {},
+                |_| {},
             );
 
             assert_eq!(result, Ok(summary_height));

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -130,6 +130,10 @@ fn deliver_batches(
     let mut last_delivered_batch_height = height.decrement();
     while height <= target_height {
         let Some(block) = pool.get_finalized_block(height) else {
+            // There is no block to compute a status from, so report that the
+            // status is not known rather than leave the metric reporting the
+            // status of an earlier height as though it still held.
+            status_observer(None);
             warn!(
                 every_n_seconds => 30,
                 log,
@@ -138,16 +142,6 @@ fn deliver_batches(
                 Finalized height: {}",
                 height,
                 finalized_height
-            );
-            break;
-        };
-        let Some(tape) = pool.get_random_tape(height) else {
-            // Do not deliver batch if we don't have random tape
-            warn!(
-                every_n_seconds => 30,
-                log,
-                "Do not deliver height {} because RandomTape is not ready. Will re-try later",
-                height
             );
             break;
         };
@@ -166,6 +160,7 @@ fn deliver_batches(
 
         // Retrieve the dkg summary block
         let Some(summary_block) = pool.dkg_summary_block_for_finalized_height(height) else {
+            status_observer(None);
             warn!(
                 every_n_seconds => 30,
                 log,
@@ -222,6 +217,19 @@ fn deliver_batches(
             }
         }
 
+        // Looked up here rather than above the status, which does not need it,
+        // so that a height whose tape is not ready yet still has its status
+        // reported instead of the loop leaving with nothing to say.
+        let Some(tape) = pool.get_random_tape(height) else {
+            // Do not deliver batch if we don't have random tape
+            warn!(
+                every_n_seconds => 30,
+                log,
+                "Do not deliver height {} because RandomTape is not ready. Will re-try later",
+                height
+            );
+            break;
+        };
         let randomness = randomness_from_crypto_hashable(&tape);
 
         let mut chain_key_subnet_public_keys = BTreeMap::new();
@@ -980,6 +988,66 @@ mod tests {
                 usize::from(at_cup_height || !halt_at_cup_height),
             );
         });
+    }
+
+    /// The random tape is needed to deliver a batch but not to compute a status,
+    /// and a height whose tape is not ready yet is one the delivery path has a
+    /// status for. The status is reported before the tape is looked up, so that
+    /// waiting on the tape does not leave the metric with nothing to say.
+    #[test]
+    fn test_deliver_batches_observes_status_without_random_tape() {
+        const INTERVAL_LENGTH: u64 = 3;
+
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            let Dependencies {
+                mut pool,
+                membership,
+                registry,
+                replica_config,
+                ..
+            } = DependenciesBuilder::single_subnet(
+                pool_config,
+                SUBNET_1,
+                vec![(
+                    1,
+                    SubnetRecordBuilder::from(&[NODE_1])
+                        .with_dkg_interval_length(INTERVAL_LENGTH)
+                        .with_replica_version(test_replica_version().as_ref())
+                        .build(),
+                )],
+            )
+            .build();
+
+            pool.advance_round_normal_operation_n(1);
+
+            // Finalize a block, leaving out the random tape of its height.
+            let proposal = pool.make_next_block();
+            pool.insert_validated(proposal.clone());
+            pool.notarize(&proposal);
+            pool.finalize(&proposal);
+            let height = proposal.content.as_ref().height;
+
+            let message_routing = FakeMessageRouting::new();
+            *message_routing.next_batch_height.write().unwrap() = height;
+
+            let mut observed = Vec::new();
+            let result = deliver_batches_for_finalizer(
+                &message_routing,
+                &membership,
+                &PoolReader::new(&pool),
+                registry.as_ref(),
+                &no_op_logger(),
+                replica_config.node_id,
+                replica_config.subnet_id,
+                |_, _, _| {},
+                |status| observed.push(status),
+            );
+
+            // The batch is not delivered, and the status is reported all the same.
+            assert_eq!(result, Ok(height.decrement()));
+            assert!(message_routing.batches.read().unwrap().is_empty());
+            assert_eq!(observed, vec![Some(Status::Running)]);
+        })
     }
 
     #[rstest]

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -85,7 +85,7 @@ pub(crate) fn deliver_batches_for_finalizer(
     node_id: NodeId,
     subnet_id: SubnetId,
     result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    status_observer: impl Fn(Status),
+    status_observer: impl FnMut(Status),
 ) -> Result<Height, MessageRoutingError> {
     deliver_batches(
         message_routing,
@@ -114,7 +114,7 @@ fn deliver_batches(
     subnet_id: SubnetId,
     max_batch_height_to_deliver: Option<Height>,
     mut result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    status_observer: impl Fn(Status),
+    mut status_observer: impl FnMut(Status),
 ) -> Result<Height, MessageRoutingError> {
     let finalized_height = pool.get_finalized_height();
     // If `max_batch_height_to_deliver` is specified and smaller than
@@ -647,6 +647,7 @@ mod tests {
     use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests;
     use ic_logger::replica_logger::no_op_logger;
     use ic_management_canister_types_private::{SetupInitialDKGResponse, VetKdCurve, VetKdKeyId};
+    use ic_test_artifact_pool::consensus_pool::Round;
     use ic_test_utilities::message_routing::FakeMessageRouting;
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{
@@ -858,6 +859,82 @@ mod tests {
             initial_response.fresh_subnet_id,
             SubnetId::from(PrincipalId::from_str(EXPECTED_FRESH_SUBNET_ID_STR).unwrap())
         );
+    }
+
+    /// Every status the delivery path computes is handed to the observer, which
+    /// is what keeps the finalizer's `consensus_status` metric current: a halted
+    /// subnet returns early, and a metric only set on the way to a delivered
+    /// batch would be stuck at whatever it said before the subnet halted.
+    #[rstest]
+    #[case::running(/* halt_at_cup_height= */ false, Status::Running)]
+    #[case::halted(/* halt_at_cup_height= */ true, Status::Halted)]
+    fn test_deliver_batches_observes_status(
+        #[case] halt_at_cup_height: bool,
+        #[case] expected_status: Status,
+    ) {
+        const INTERVAL_LENGTH: u64 = 3;
+        const HALT_REGISTRY_VERSION: u64 = 10;
+        // A summary, and hence a CUP, every `INTERVAL_LENGTH + 1` heights.
+        const CUP_HEIGHT: Height = Height::new(2 * (INTERVAL_LENGTH + 1));
+
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            let record = || {
+                SubnetRecordBuilder::from(&[NODE_1])
+                    .with_dkg_interval_length(INTERVAL_LENGTH)
+                    .with_replica_version(test_replica_version().as_ref())
+            };
+            let Dependencies {
+                mut pool,
+                membership,
+                registry,
+                replica_config,
+                ..
+            } = DependenciesBuilder::single_subnet(
+                pool_config,
+                SUBNET_1,
+                vec![
+                    (1, record().build()),
+                    (
+                        HALT_REGISTRY_VERSION,
+                        record().with_halt_at_cup_height(halt_at_cup_height).build(),
+                    ),
+                ],
+            )
+            .build();
+
+            // Up to the CUP, and then one round more whose block is not a summary
+            // one: the delivery path only asks for the status of a subnet when the
+            // block it is about to deliver is not the CUP block.
+            pool.advance_round_normal_operation_n(CUP_HEIGHT.get());
+            Round::new(&mut pool)
+                .with_certified_height(CUP_HEIGHT)
+                .advance();
+
+            let message_routing = FakeMessageRouting::new();
+            *message_routing.next_batch_height.write().unwrap() = CUP_HEIGHT.increment();
+
+            // A plain mutable closure, as the observer is `FnMut`.
+            let mut observed = Vec::new();
+            let result = deliver_batches_for_finalizer(
+                &message_routing,
+                &membership,
+                &PoolReader::new(&pool),
+                registry.as_ref(),
+                &no_op_logger(),
+                replica_config.node_id,
+                replica_config.subnet_id,
+                |_, _, _| {},
+                |status| observed.push(status),
+            );
+
+            assert!(result.is_ok(), "delivery failed: {result:?}");
+            assert_eq!(
+                observed,
+                vec![expected_status],
+                "the observed statuses of a subnet that is {}halted",
+                if halt_at_cup_height { "" } else { "not " },
+            );
+        });
     }
 
     #[rstest]

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -194,7 +194,8 @@ fn deliver_batches(
                 "Delivering finalized batch at CUP height of {}", height
             );
         }
-        // When we are not delivering CUP block, we must check if the subnet is halted.
+        // When we are not delivering CUP block, we must check if the subnet is
+        // halting towards, or halted at, a CUP height.
         else {
             match status {
                 Some(Status::Halting | Status::Halted) => {
@@ -877,8 +878,8 @@ mod tests {
 
     /// Every status the delivery path computes is handed to the observer, which
     /// is what keeps the finalizer's `consensus_status` metric current. The
-    /// status of a halting or halted subnet is observed on the early return that
-    /// leaves its batch undelivered.
+    /// status of a subnet halting towards, or halted at, a CUP height is observed
+    /// on the early return that leaves its batch undelivered.
     ///
     /// `at_cup_height` delivers the CUP block itself, the round on which a
     /// subnet halting at its CUP height halts. That batch is delivered whatever

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -85,7 +85,7 @@ pub(crate) fn deliver_batches_for_finalizer(
     node_id: NodeId,
     subnet_id: SubnetId,
     result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    status_observer: impl FnMut(Status),
+    status_observer: impl FnMut(Option<Status>),
 ) -> Result<Height, MessageRoutingError> {
     deliver_batches(
         message_routing,
@@ -114,7 +114,7 @@ fn deliver_batches(
     subnet_id: SubnetId,
     max_batch_height_to_deliver: Option<Height>,
     mut result_processor: impl FnMut(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
-    mut status_observer: impl FnMut(Status),
+    mut status_observer: impl FnMut(Option<Status>),
 ) -> Result<Height, MessageRoutingError> {
     let finalized_height = pool.get_finalized_height();
     // If `max_batch_height_to_deliver` is specified and smaller than
@@ -178,6 +178,23 @@ fn deliver_batches(
         };
         let dkg_summary = &summary_block.payload.as_ref().as_summary().dkg;
 
+        // The status is computed for every block, the CUP block included, and
+        // handed to the observer before it is acted upon. The CUP block is
+        // delivered whatever the status is, but a subnet halting at its CUP
+        // height is halting while that batch is delivered, and an observer that
+        // only heard about the blocks the status is acted upon would report it
+        // as running until the first block above the CUP is finalized.
+        let status = status::get_status(
+            height,
+            &summary_block,
+            registry_client,
+            subnet_id,
+            pool,
+            replica_version,
+            log,
+        );
+        status_observer(status);
+
         if block.payload.is_summary() {
             info!(
                 log,
@@ -186,17 +203,8 @@ fn deliver_batches(
         }
         // When we are not delivering CUP block, we must check if the subnet is halted.
         else {
-            match status::get_status(
-                height,
-                &summary_block,
-                registry_client,
-                subnet_id,
-                pool,
-                replica_version,
-                log,
-            ) {
-                Some(status @ (Status::Halting | Status::Halted)) => {
-                    status_observer(status);
+            match status {
+                Some(Status::Halting | Status::Halted) => {
                     info!(
                         every_n_seconds => 5,
                         log,
@@ -205,7 +213,7 @@ fn deliver_batches(
                     );
                     return Ok(last_delivered_batch_height);
                 }
-                Some(Status::Running) => status_observer(Status::Running),
+                Some(Status::Running) => {}
                 None => {
                     warn!(
                         log,
@@ -865,11 +873,40 @@ mod tests {
     /// is what keeps the finalizer's `consensus_status` metric current: a halted
     /// subnet returns early, and a metric only set on the way to a delivered
     /// batch would be stuck at whatever it said before the subnet halted.
+    ///
+    /// `at_cup_height` delivers the CUP block itself, the round on which a
+    /// subnet halting at its CUP height halts. That batch is delivered whatever
+    /// the status is, so the status is observed but not acted upon; were it only
+    /// observed where it is acted upon, the metric would report the subnet as
+    /// running for as long as it took the first block above the CUP to be
+    /// finalized -- or forever, on a node that never gets that block.
     #[rstest]
-    #[case::running(/* halt_at_cup_height= */ false, Status::Running)]
-    #[case::halted(/* halt_at_cup_height= */ true, Status::Halted)]
+    #[case::running(
+        /* halt_at_cup_height= */ false,
+        /* at_cup_height= */ false,
+        Status::Running
+    )]
+    #[case::halted(
+        /* halt_at_cup_height= */ true,
+        /* at_cup_height= */ false,
+        Status::Halted
+    )]
+    #[case::running_at_cup_height(
+        /* halt_at_cup_height= */ false,
+        /* at_cup_height= */ true,
+        Status::Running
+    )]
+    #[case::halting_at_cup_height(
+        /* halt_at_cup_height= */ true,
+        /* at_cup_height= */ true,
+        // The certified height of the finalized tip is below the CUP height, as
+        // the batch delivering the state of the CUP height is the one about to
+        // be delivered, so the subnet is halting rather than halted.
+        Status::Halting
+    )]
     fn test_deliver_batches_observes_status(
         #[case] halt_at_cup_height: bool,
+        #[case] at_cup_height: bool,
         #[case] expected_status: Status,
     ) {
         const INTERVAL_LENGTH: u64 = 3;
@@ -902,16 +939,21 @@ mod tests {
             )
             .build();
 
-            // Up to the CUP, and then one round more whose block is not a summary
-            // one: the delivery path only asks for the status of a subnet when the
-            // block it is about to deliver is not the CUP block.
+            // Up to the CUP, and, unless the CUP block is the one to deliver, one
+            // round more, whose block is not a summary one and whose certified
+            // height has reached the CUP height.
             pool.advance_round_normal_operation_n(CUP_HEIGHT.get());
-            Round::new(&mut pool)
-                .with_certified_height(CUP_HEIGHT)
-                .advance();
+            let batch_height = if at_cup_height {
+                CUP_HEIGHT
+            } else {
+                Round::new(&mut pool)
+                    .with_certified_height(CUP_HEIGHT)
+                    .advance();
+                CUP_HEIGHT.increment()
+            };
 
             let message_routing = FakeMessageRouting::new();
-            *message_routing.next_batch_height.write().unwrap() = CUP_HEIGHT.increment();
+            *message_routing.next_batch_height.write().unwrap() = batch_height;
 
             // A plain mutable closure, as the observer is `FnMut`.
             let mut observed = Vec::new();
@@ -930,9 +972,14 @@ mod tests {
             assert!(result.is_ok(), "delivery failed: {result:?}");
             assert_eq!(
                 observed,
-                vec![expected_status],
-                "the observed statuses of a subnet that is {}halted",
+                vec![Some(expected_status)],
+                "the observed statuses of a subnet that is {}halted, at height {batch_height}",
                 if halt_at_cup_height { "" } else { "not " },
+            );
+            // The CUP batch is delivered even by a subnet that is halting.
+            assert_eq!(
+                message_routing.batches.read().unwrap().len(),
+                usize::from(at_cup_height || !halt_at_cup_height),
             );
         });
     }

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -145,6 +145,18 @@ fn deliver_batches(
             );
             break;
         };
+        let Some(tape) = pool.get_random_tape(height) else {
+            // Do not deliver batch if we don't have random tape, and report the
+            // status as not known, as this height did not reach one.
+            status_observer(None);
+            warn!(
+                every_n_seconds => 30,
+                log,
+                "Do not deliver height {} because RandomTape is not ready. Will re-try later",
+                height
+            );
+            break;
+        };
         let replica_version = block.version();
         let mut block_stats = BlockStats::from(&block);
         debug!(
@@ -174,9 +186,11 @@ fn deliver_batches(
         let dkg_summary = &summary_block.payload.as_ref().as_summary().dkg;
 
         // The status is computed for every block, the CUP block included, and
-        // handed to the observer before it is acted upon. The CUP block is
-        // delivered whatever the status is, and a subnet halting at its CUP
-        // height is already halting as that batch is delivered.
+        // handed to the observer before it is acted upon. A subnet halting at
+        // its CUP height stops running at exactly that height, and the CUP
+        // block is delivered whatever the status says, which makes it the one
+        // block whose status is observed without being acted upon -- and the
+        // block on which the answer changes.
         let status = status::get_status(
             height,
             &summary_block,
@@ -220,19 +234,6 @@ fn deliver_batches(
             }
         }
 
-        // Looked up here rather than above the status, which does not need it,
-        // so that a height whose tape is not ready yet still has its status
-        // reported instead of the loop leaving with nothing to say.
-        let Some(tape) = pool.get_random_tape(height) else {
-            // Do not deliver batch if we don't have random tape
-            warn!(
-                every_n_seconds => 30,
-                log,
-                "Do not deliver height {} because RandomTape is not ready. Will re-try later",
-                height
-            );
-            break;
-        };
         let randomness = randomness_from_crypto_hashable(&tape);
 
         let mut chain_key_subnet_public_keys = BTreeMap::new();
@@ -993,12 +994,12 @@ mod tests {
         });
     }
 
-    /// The random tape is needed to deliver a batch but not to compute a status,
-    /// and a height whose tape is not ready yet is one the delivery path has a
-    /// status for. The status is reported before the tape is looked up, so that
-    /// waiting on the tape does not leave the metric with nothing to say.
+    /// A height the delivery path cannot get past has its status reported as not
+    /// known, rather than leaving the metric reporting the status of an earlier
+    /// height as though it still held. The missing random tape stands here for
+    /// all three of the guards that leave the loop.
     #[test]
-    fn test_deliver_batches_observes_status_without_random_tape() {
+    fn test_deliver_batches_observes_unknown_without_random_tape() {
         const INTERVAL_LENGTH: u64 = 3;
 
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
@@ -1046,10 +1047,10 @@ mod tests {
                 |status| observed.push(status),
             );
 
-            // The batch is not delivered, and the status is reported all the same.
+            // The batch is not delivered, and the status is reported as not known.
             assert_eq!(result, Ok(height.decrement()));
             assert!(message_routing.batches.read().unwrap().is_empty());
-            assert_eq!(observed, vec![Some(Status::Running)]);
+            assert_eq!(observed, vec![None]);
         })
     }
 

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -198,12 +198,13 @@ fn deliver_batches(
         // halting towards, or halted at, a CUP height.
         else {
             match status {
-                Some(Status::Halting | Status::Halted) => {
+                Some(status @ (Status::Halting | Status::Halted)) => {
                     info!(
                         every_n_seconds => 5,
                         log,
-                        "Batch of height {} is not delivered because replica is halted",
+                        "Batch of height {} is not delivered because the subnet is {}",
                         height,
+                        status,
                     );
                     return Ok(last_delivered_batch_height);
                 }
@@ -211,7 +212,8 @@ fn deliver_batches(
                 None => {
                     warn!(
                         log,
-                        "Skipping batch delivery because checking if replica is halted failed",
+                        "Skipping batch delivery because the consensus status could not be \
+                         computed",
                     );
                     return Ok(last_delivered_batch_height);
                 }

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -19,6 +19,7 @@
 use crate::consensus::{
     batch_delivery::deliver_batches_for_finalizer,
     metrics::{BatchStats, BlockStats, FinalizerMetrics},
+    status::{self, Status},
 };
 use ic_consensus_utils::{
     crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
@@ -95,7 +96,7 @@ impl Finalizer {
         }
 
         // Try to deliver finalized batches to messaging
-        let _ = deliver_batches_for_finalizer(
+        let last_delivered_batch_height = deliver_batches_for_finalizer(
             &*self.message_routing,
             &self.membership,
             pool,
@@ -106,14 +107,47 @@ impl Finalizer {
             |result, block_stats, batch_stats| {
                 self.process_batch_delivery_result(result, block_stats, batch_stats)
             },
-            |status| self.metrics.observe_status(status),
         );
+        self.metrics
+            .observe_status(self.get_status(pool, last_delivered_batch_height));
 
         // Try to finalize rounds from finalized_height + 1 up to (and including)
         // notarized_height
         (finalized_height.increment().get()..=notarized_height.get())
             .filter_map(|h| self.finalize_height(pool, Height::from(h)))
             .collect()
+    }
+
+    /// The consensus status as of the last batch delivery, or [`None`] if it
+    /// could not be computed.
+    ///
+    /// It is the status of the last height whose batch was delivered, which is
+    /// the height to ask about: the halts this status covers take effect from a
+    /// summary height on, and the batch at that height is delivered whatever
+    /// the status is. The first height at which a subnet is halting is
+    /// therefore also the last one whose batch it delivers, so asking about
+    /// that height reports the halt from the round it begins.
+    ///
+    /// A delivery that failed leaves no height to ask about and no way to tell
+    /// whether the subnet is halting, so it is reported as unknown rather than
+    /// as though everything had gone well.
+    fn get_status(
+        &self,
+        pool: &PoolReader<'_>,
+        last_delivered_batch_height: Result<Height, MessageRoutingError>,
+    ) -> Option<Status> {
+        let height = last_delivered_batch_height.ok()?;
+        let summary_block = pool.dkg_summary_block_for_finalized_height(height)?;
+
+        status::get_status(
+            height,
+            &summary_block,
+            self.registry_client.as_ref(),
+            self.replica_config.subnet_id,
+            pool,
+            self.replica_config.replica_version(),
+            &self.log,
+        )
     }
 
     /// Write logs, report metrics depending on the batch deliver result.
@@ -257,16 +291,123 @@ mod tests {
     use ic_consensus_mocks::{Dependencies, DependenciesBuilder};
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
+    use ic_test_artifact_pool::consensus_pool::Round;
     use ic_test_utilities::{
         ingress_selector::FakeIngressSelector, message_routing::FakeMessageRouting,
     };
     use ic_test_utilities_registry::SubnetRecordBuilder;
-    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id, test_replica_version};
     use ic_types::{
         RegistryVersion,
         consensus::{HasHeight, HashedBlock},
     };
+    use rstest::rstest;
     use std::sync::Arc;
+
+    /// The `consensus_status` labels whose gauge reads 1. Exactly one of them
+    /// does once the finalizer has computed a status.
+    fn observed_statuses(metrics_registry: &MetricsRegistry) -> Vec<String> {
+        metrics_registry
+            .prometheus_registry()
+            .gather()
+            .into_iter()
+            .filter(|family| family.name() == "consensus_status")
+            .flat_map(|family| family.get_metric().to_vec())
+            .filter(|metric| metric.get_gauge().value() == 1.0)
+            .map(|metric| metric.get_label()[0].value().to_string())
+            .collect()
+    }
+
+    /// The finalizer reports the consensus status of the height whose batch was
+    /// delivered last. For a subnet halting at a CUP height that is the CUP
+    /// height itself: its batch is delivered whatever the status is, so the
+    /// first height at which the subnet halts is also the last one it delivers.
+    #[rstest]
+    #[case::running(
+        /* halt_at_cup_height= */ false,
+        /* certified_up_to_cup_height= */ false,
+        "running"
+    )]
+    #[case::halting(
+        /* halt_at_cup_height= */ true,
+        /* certified_up_to_cup_height= */ false,
+        "halting"
+    )]
+    #[case::halted(
+        /* halt_at_cup_height= */ true,
+        /* certified_up_to_cup_height= */ true,
+        "halted_at_cup_height"
+    )]
+    fn test_finalizer_observes_status(
+        #[case] halt_at_cup_height: bool,
+        #[case] certified_up_to_cup_height: bool,
+        #[case] expected_status: &str,
+    ) {
+        const INTERVAL_LENGTH: u64 = 3;
+        const HALT_REGISTRY_VERSION: u64 = 10;
+        // A summary block, and hence a CUP, every `INTERVAL_LENGTH + 1` heights.
+        const CUP_HEIGHT: Height = Height::new(2 * (INTERVAL_LENGTH + 1));
+
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            // The same replica version throughout, so that the subnet record is
+            // the only thing that can halt the subnet.
+            let record = || {
+                SubnetRecordBuilder::from(&[node_test_id(0)])
+                    .with_dkg_interval_length(INTERVAL_LENGTH)
+                    .with_replica_version(test_replica_version().as_ref())
+            };
+            let Dependencies {
+                mut pool,
+                replica_config,
+                membership,
+                registry,
+                crypto,
+                ..
+            } = DependenciesBuilder::single_subnet(
+                pool_config,
+                subnet_test_id(0),
+                vec![
+                    (1, record().build()),
+                    (
+                        HALT_REGISTRY_VERSION,
+                        record().with_halt_at_cup_height(halt_at_cup_height).build(),
+                    ),
+                ],
+            )
+            .build();
+
+            pool.advance_round_normal_operation_n(CUP_HEIGHT.get());
+            let batch_height = if certified_up_to_cup_height {
+                // One round more, so that the certified height of the finalized
+                // tip reaches the CUP height. That is what tells a subnet that
+                // is halted from one that is only halting towards that height.
+                Round::new(&mut pool)
+                    .with_certified_height(CUP_HEIGHT)
+                    .advance();
+                CUP_HEIGHT.increment()
+            } else {
+                CUP_HEIGHT
+            };
+
+            let metrics_registry = MetricsRegistry::new();
+            let message_routing = Arc::new(FakeMessageRouting::new());
+            *message_routing.next_batch_height.write().unwrap() = batch_height;
+            let finalizer = Finalizer::new(
+                replica_config,
+                registry,
+                membership,
+                crypto,
+                message_routing,
+                Arc::new(FakeIngressSelector::new()),
+                no_op_logger(),
+                metrics_registry.clone(),
+            );
+
+            let _ = finalizer.on_state_change(&PoolReader::new(&pool));
+
+            assert_eq!(observed_statuses(&metrics_registry), vec![expected_status]);
+        })
+    }
 
     /// Given a single block, just finalize it
     #[test]

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -106,6 +106,7 @@ impl Finalizer {
             |result, block_stats, batch_stats| {
                 self.process_batch_delivery_result(result, block_stats, batch_stats)
             },
+            |status| self.metrics.observe_status(status),
         );
 
         // Try to finalize rounds from finalized_height + 1 up to (and including)

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -128,9 +128,11 @@ impl Finalizer {
     /// therefore also the last one whose batch it delivers, so asking about
     /// that height reports the halt from the round it begins.
     ///
-    /// A delivery that failed leaves no height to ask about and no way to tell
-    /// whether the subnet is halting, so it is reported as unknown rather than
-    /// as though everything had gone well.
+    /// A delivery that failed returns an error rather than the height it got
+    /// to, leaving nothing to ask about, so the status is reported as unknown
+    /// rather than as though everything had gone well. So is a height with no
+    /// summary block, and one whose status [`status::get_status`] could not
+    /// compute.
     fn get_status(
         &self,
         pool: &PoolReader<'_>,

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -19,7 +19,6 @@
 use crate::consensus::{
     batch_delivery::deliver_batches_for_finalizer,
     metrics::{BatchStats, BlockStats, FinalizerMetrics},
-    status::Status,
 };
 use ic_consensus_utils::{
     crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
@@ -115,15 +114,6 @@ impl Finalizer {
         (finalized_height.increment().get()..=notarized_height.get())
             .filter_map(|h| self.finalize_height(pool, Height::from(h)))
             .collect()
-    }
-
-    /// Records the status consensus is in, for the `consensus_status` metric.
-    ///
-    /// The delivery path observes the status of every block it considers on its
-    /// own. This is for the callers that halt consensus before the finalizer is
-    /// reached at all, and so before that path has anything to say.
-    pub(crate) fn observe_status(&self, status: Status) {
-        self.metrics.observe_status(Some(status));
     }
 
     /// Write logs, report metrics depending on the batch deliver result.

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -19,6 +19,7 @@
 use crate::consensus::{
     batch_delivery::deliver_batches_for_finalizer,
     metrics::{BatchStats, BlockStats, FinalizerMetrics},
+    status::Status,
 };
 use ic_consensus_utils::{
     crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
@@ -114,6 +115,15 @@ impl Finalizer {
         (finalized_height.increment().get()..=notarized_height.get())
             .filter_map(|h| self.finalize_height(pool, Height::from(h)))
             .collect()
+    }
+
+    /// Records the status consensus is in, for the `consensus_status` metric.
+    ///
+    /// The delivery path observes the status of every block it considers on its
+    /// own. This is for the callers that halt consensus before the finalizer is
+    /// reached at all, and so before that path has anything to say.
+    pub(crate) fn observe_status(&self, status: Status) {
+        self.metrics.observe_status(Some(status));
     }
 
     /// Write logs, report metrics depending on the batch deliver result.

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -228,11 +228,12 @@ impl FinalizerMetrics {
              that has not looked yet rather than a status of its own.",
             &[STATUS_LABEL],
         );
-        // Create every child up front. A gauge vector with no children is
-        // dropped by the Prometheus registry, so until the delivery path first
-        // computes a status the scrape would carry no `consensus_status` at all,
-        // which a dashboard cannot tell apart from a subnet that is not halted.
-        // All four reading 0 is that state instead, as the help text says.
+        // Report every status from the start. A gauge vector reports only the
+        // label values it has been given, so until the delivery path computes a
+        // status for the first time the scrape would carry no `consensus_status`
+        // at all, and a query for the halted status would find nothing -- the
+        // answer it also gives for a subnet that is not halted. All four reading
+        // 0 is that state instead, as the help text says.
         for (label, _) in CONSENSUS_STATUSES {
             consensus_status.with_label_values(&[label]).set(0);
         }
@@ -766,19 +767,22 @@ mod tests {
             .collect()
     }
 
-    /// A gauge vector with no children is dropped by the Prometheus registry, so
-    /// the statuses are reported as zero from the moment the metrics are built:
-    /// a replica that has not delivered a batch since it started -- one whose
-    /// subnet is halted, for instance -- would otherwise report no
-    /// `consensus_status` at all, which reads the same as a subnet that is fine.
-    /// Observing a status then reports that one alone.
+    /// The statuses are reported, as zero, from the moment the metrics are
+    /// built, rather than from the first time one of them is observed. A gauge
+    /// vector reports only the label values it has been given, and one that has
+    /// been given none is left out of the scrape altogether, so on a replica
+    /// that has not delivered a batch since it started -- one whose subnet is
+    /// halted, say -- a query for the halted status would find nothing, which is
+    /// the answer that query also gives for a subnet that is not halted.
+    ///
+    /// Observing a status sets that one to one and the other three back to zero.
     #[test]
     fn test_consensus_status_is_reported_before_it_is_observed() {
         let metrics_registry = MetricsRegistry::new();
         let metrics = FinalizerMetrics::new(metrics_registry.clone());
 
         // Zero across the statuses: batch delivery has not computed one yet.
-        assert_eq!(consensus_status(&metrics_registry).values().sum::<i64>(), 0,);
+        assert_eq!(consensus_status(&metrics_registry).values().sum::<i64>(), 0);
 
         metrics.observe_status(Some(Status::Halted));
 

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -386,10 +386,10 @@ impl FinalizerMetrics {
     ///
     /// Reported as a gauge per status rather than a single number, so that a
     /// dashboard can select the status it asks about by name. Only the batch
-    /// delivery path computes the status, and only when it has a block to
-    /// consider, so this says what that path saw the last time it looked: a
-    /// subnet that stopped producing blocks altogether keeps reporting the
-    /// status that made it stop.
+    /// delivery path computes the status, so this says what that path saw the
+    /// last time it looked: a subnet that stopped producing blocks altogether
+    /// keeps reporting the status that made it stop, and a replica with no
+    /// block to compute a status from reports `unknown`.
     pub fn observe_status(&self, status: Option<Status>) {
         for (label, value) in CONSENSUS_STATUSES {
             self.consensus_status

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -26,13 +26,18 @@ use std::sync::RwLock;
 // the range of ranks that are permitted to show up in metrics.
 const RANKS_TO_RECORD: [&str; 6] = ["0", "1", "2", "3", "4", "5"];
 
-/// The label of `consensus_status`, whose values are the statuses of
-/// [`Status`], lowercased, plus `unknown` for a status that could not be
-/// computed at all.
+/// The label of `consensus_status`, whose values name the statuses of
+/// [`Status`], plus `unknown` for a status that could not be computed at all.
+///
+/// [`Status::Halted`] is reported as `halted_at_cup_height` rather than
+/// `halted`: it is the halt that ends a subnet on a CUP, which is the only halt
+/// the delivery path can see. The subnet record's `is_halted` stops a subnet
+/// wherever it happens to be, above the finalizer, and reads as
+/// `halted_at_cup_height=0` here like a subnet that is not halting at all.
 const STATUS_LABEL: &str = "status";
 const STATUS_RUNNING: &str = "running";
 const STATUS_HALTING: &str = "halting";
-const STATUS_HALTED: &str = "halted";
+const STATUS_HALTED_AT_CUP_HEIGHT: &str = "halted_at_cup_height";
 const STATUS_UNKNOWN: &str = "unknown";
 
 /// The label value `consensus_status` reports each status under. [`None`] is
@@ -42,7 +47,7 @@ const STATUS_UNKNOWN: &str = "unknown";
 const CONSENSUS_STATUSES: [(&str, Option<Status>); 4] = [
     (STATUS_RUNNING, Some(Status::Running)),
     (STATUS_HALTING, Some(Status::Halting)),
-    (STATUS_HALTED, Some(Status::Halted)),
+    (STATUS_HALTED_AT_CUP_HEIGHT, Some(Status::Halted)),
     (STATUS_UNKNOWN, None),
 ];
 
@@ -220,20 +225,24 @@ impl FinalizerMetrics {
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
         let consensus_status = metrics_registry.int_gauge_vec(
             "consensus_status",
-            "Whether consensus is running, halting (producing empty blocks but delivering \
-             no batches), halted (producing no blocks either) or unknown (the status could \
-             not be computed), as of the last time batch delivery looked. 1 for the status \
-             that held then, 0 for the other three. All four are 0 until batch delivery \
-             computes a status for the first time, so a sum of 0 over the four is a replica \
-             that has not looked yet rather than a status of its own.",
+            "Whether consensus is running, halting towards a CUP height (producing empty \
+             blocks but delivering no batches), halted at a CUP height (producing no blocks \
+             either) or unknown (the status could not be computed), as of the last time \
+             batch delivery looked. 1 for the status that held then, 0 for the other three. \
+             All four are 0 until batch delivery computes a status for the first time, so a \
+             sum of 0 over the four is a replica that has not looked yet rather than a \
+             status of its own. A subnet halted by the `is_halted` flag of its subnet record \
+             rather than at a CUP height is not reported here at all: consensus acts on that \
+             flag before batch delivery runs, so this metric reads as it did before, or not \
+             at all on a replica that started while the subnet was already halted.",
             &[STATUS_LABEL],
         );
         // Report every status from the start. A gauge vector reports only the
         // label values it has been given, so until the delivery path computes a
         // status for the first time the scrape would carry no `consensus_status`
-        // at all, and a query for the halted status would find nothing -- the
-        // answer it also gives for a subnet that is not halted. All four reading
-        // 0 is that state instead, as the help text says.
+        // at all, and a query for one of the statuses would find nothing -- the
+        // answer it also gives for a subnet that is not in that status. All four
+        // reading 0 is that state instead, as the help text says.
         for (label, _) in CONSENSUS_STATUSES {
             consensus_status.with_label_values(&[label]).set(0);
         }
@@ -373,7 +382,8 @@ impl FinalizerMetrics {
 
     /// Records `status` as the status consensus is in, and the other three as
     /// ones it is not. [`None`] is recorded as `unknown`, the status the
-    /// delivery path failed to compute.
+    /// delivery path failed to compute, and [`Status::Halted`] as
+    /// `halted_at_cup_height`, the only halt this path sees.
     ///
     /// Reported as a gauge per status rather than a single number, so that a
     /// dashboard can select the status it asks about by name. Only the batch
@@ -771,9 +781,9 @@ mod tests {
     /// built, rather than from the first time one of them is observed. A gauge
     /// vector reports only the label values it has been given, and one that has
     /// been given none is left out of the scrape altogether, so on a replica
-    /// that has not delivered a batch since it started -- one whose subnet is
-    /// halted, say -- a query for the halted status would find nothing, which is
-    /// the answer that query also gives for a subnet that is not halted.
+    /// that has not reached the status computation a query for one of the
+    /// statuses would find nothing, which is the answer that query also gives
+    /// for a subnet that is not in that status.
     ///
     /// Observing a status sets that one to one and the other three back to zero.
     #[test]
@@ -789,7 +799,7 @@ mod tests {
             BTreeMap::from([
                 (STATUS_RUNNING.into(), 0),
                 (STATUS_HALTING.into(), 0),
-                (STATUS_HALTED.into(), 0),
+                (STATUS_HALTED_AT_CUP_HEIGHT.into(), 0),
                 (STATUS_UNKNOWN.into(), 0),
             ]),
         );
@@ -801,7 +811,7 @@ mod tests {
             BTreeMap::from([
                 (STATUS_RUNNING.into(), 0),
                 (STATUS_HALTING.into(), 0),
-                (STATUS_HALTED.into(), 1),
+                (STATUS_HALTED_AT_CUP_HEIGHT.into(), 1),
                 (STATUS_UNKNOWN.into(), 0),
             ]),
         );

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -92,7 +92,6 @@ pub(crate) struct ConsensusMetrics {
     pub on_state_change_change_set_size: HistogramVec,
     pub time_since_last_invoked: GaugeVec,
     pub starvation_counter: IntCounterVec,
-    pub halted_by_subnet_record: IntGauge,
 }
 
 impl ConsensusMetrics {
@@ -105,16 +104,6 @@ impl ConsensusMetrics {
                 // 1s, 2s, 5s, 10s, 20s, 50s, 100s, 200s, 500s
                 decimal_buckets(-4, 2),
                 &["sub_component"],
-            ),
-            halted_by_subnet_record: metrics_registry.int_gauge(
-                "consensus_halted_by_subnet_record",
-                "Whether the `is_halted` flag of the subnet record instructs the subnet to halt, \
-                 as of the latest registry version: 1 while it does, 0 while it does not. A \
-                 subnet halting this way creates no blocks and delivers no batches, and does so \
-                 from whatever height it is at rather than from a CUP height, which is what \
-                 `consensus_status` reports instead. A registry that cannot be read reads as 0 \
-                 here, as consensus carries on in that case rather than halting; the read \
-                 failure itself is logged as an error.",
             ),
             on_state_change_invocations: metrics_registry.int_counter_vec(
                 "consensus_on_state_change_invocations",

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -223,12 +223,12 @@ impl FinalizerMetrics {
         let consensus_status = metrics_registry.int_gauge_vec(
             "consensus_status",
             "Whether consensus is running, halting towards a CUP height (producing empty \
-             blocks but delivering no batches), halted at a CUP height (producing no blocks \
-             either) or unknown (the status could not be computed), as of the last time \
-             batch delivery looked. 1 for the status that held then, 0 for the other three. \
-             All four are 0 until batch delivery computes a status for the first time, so a \
-             sum of 0 over the four is a replica that has not looked yet rather than a \
-             status of its own. A subnet halted by the `is_halted` flag of its subnet record \
+             blocks and delivering no batch but the one at that height), halted at a CUP \
+             height (producing no blocks either) or unknown (the status could not be \
+             computed), as of the last time batch delivery looked. 1 for the status that \
+             held then, 0 for the other three. All four are 0 until batch delivery computes \
+             a status for the first time, so a sum of 0 over the four is a replica that has \
+             not looked yet rather than a status of its own. A subnet halted by the `is_halted` flag of its subnet record \
              rather than at a CUP height has no status of its own here: consensus acts on \
              that flag before batch delivery runs, so this metric goes on reporting whatever \
              it last did, or all four zeros on a replica that started while the subnet was \

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -781,8 +781,18 @@ mod tests {
         let metrics_registry = MetricsRegistry::new();
         let metrics = FinalizerMetrics::new(metrics_registry.clone());
 
-        // Zero across the statuses: batch delivery has not computed one yet.
-        assert_eq!(consensus_status(&metrics_registry).values().sum::<i64>(), 0);
+        // Every status reported, and zero: batch delivery has not computed one
+        // yet. Asserted over the whole map, as a sum of zero would also be what
+        // an empty one adds up to -- the very state this is here to catch.
+        assert_eq!(
+            consensus_status(&metrics_registry),
+            BTreeMap::from([
+                (STATUS_RUNNING.into(), 0),
+                (STATUS_HALTING.into(), 0),
+                (STATUS_HALTED.into(), 0),
+                (STATUS_UNKNOWN.into(), 0),
+            ]),
+        );
 
         metrics.observe_status(Some(Status::Halted));
 

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -771,41 +771,25 @@ mod tests {
     /// a replica that has not delivered a batch since it started -- one whose
     /// subnet is halted, for instance -- would otherwise report no
     /// `consensus_status` at all, which reads the same as a subnet that is fine.
+    /// Observing a status then reports that one alone.
     #[test]
     fn test_consensus_status_is_reported_before_it_is_observed() {
         let metrics_registry = MetricsRegistry::new();
-        let _metrics = FinalizerMetrics::new(metrics_registry.clone());
+        let metrics = FinalizerMetrics::new(metrics_registry.clone());
+
+        // Zero across the statuses: batch delivery has not computed one yet.
+        assert_eq!(consensus_status(&metrics_registry).values().sum::<i64>(), 0,);
+
+        metrics.observe_status(Some(Status::Halted));
 
         assert_eq!(
             consensus_status(&metrics_registry),
             BTreeMap::from([
                 (STATUS_RUNNING.into(), 0),
                 (STATUS_HALTING.into(), 0),
-                (STATUS_HALTED.into(), 0),
+                (STATUS_HALTED.into(), 1),
                 (STATUS_UNKNOWN.into(), 0),
             ]),
         );
-    }
-
-    /// Every status, the one that could not be computed included, is reported as
-    /// itself and as not any of the others.
-    #[test]
-    fn test_observe_status() {
-        let metrics_registry = MetricsRegistry::new();
-        let metrics = FinalizerMetrics::new(metrics_registry.clone());
-
-        for (observed_label, observed) in CONSENSUS_STATUSES {
-            metrics.observe_status(observed);
-
-            let expected = CONSENSUS_STATUSES
-                .iter()
-                .map(|(label, _)| ((*label).into(), i64::from(*label == observed_label)))
-                .collect();
-            assert_eq!(
-                consensus_status(&metrics_registry),
-                expected,
-                "after observing {observed:?}",
-            );
-        }
     }
 }

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -232,9 +232,10 @@ impl FinalizerMetrics {
              All four are 0 until batch delivery computes a status for the first time, so a \
              sum of 0 over the four is a replica that has not looked yet rather than a \
              status of its own. A subnet halted by the `is_halted` flag of its subnet record \
-             rather than at a CUP height is not reported here at all: consensus acts on that \
-             flag before batch delivery runs, so this metric reads as it did before, or not \
-             at all on a replica that started while the subnet was already halted.",
+             rather than at a CUP height has no status of its own here: consensus acts on \
+             that flag before batch delivery runs, so this metric goes on reporting whatever \
+             it last did, or all four zeros on a replica that started while the subnet was \
+             already halted.",
             &[STATUS_LABEL],
         );
         // Report every status from the start. A gauge vector reports only the

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -30,10 +30,7 @@ const RANKS_TO_RECORD: [&str; 6] = ["0", "1", "2", "3", "4", "5"];
 /// [`Status`], plus `unknown` for a status that could not be computed at all.
 ///
 /// [`Status::Halted`] is reported as `halted_at_cup_height` rather than
-/// `halted`: it is the halt that ends a subnet on a CUP, which is the only halt
-/// the delivery path can see. The subnet record's `is_halted` stops a subnet
-/// wherever it happens to be, above the finalizer, and reads as
-/// `halted_at_cup_height=0` here like a subnet that is not halting at all.
+/// `halted`, after the halt it stands for: the one that ends a subnet on a CUP.
 const STATUS_LABEL: &str = "status";
 const STATUS_RUNNING: &str = "running";
 const STATUS_HALTING: &str = "halting";

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -38,7 +38,7 @@ const STATUS_HALTED_AT_CUP_HEIGHT: &str = "halted_at_cup_height";
 const STATUS_UNKNOWN: &str = "unknown";
 
 /// The label value `consensus_status` reports each status under. [`None`] is
-/// the status the delivery path failed to compute, rather than a status of its
+/// the status the finalizer failed to compute, rather than a status of its
 /// own, so that a subnet whose registry cannot be read is not mistaken for one
 /// that is running.
 const CONSENSUS_STATUSES: [(&str, Option<Status>); 4] = [
@@ -220,30 +220,6 @@ pub(crate) struct FinalizerMetrics {
 
 impl FinalizerMetrics {
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
-        let consensus_status = metrics_registry.int_gauge_vec(
-            "consensus_status",
-            "Whether consensus is running, halting towards a CUP height (producing empty \
-             blocks and delivering no batch but the one at that height), halted at a CUP \
-             height (producing no blocks either) or unknown (the status could not be \
-             computed), as of the last time batch delivery looked. 1 for the status that \
-             held then, 0 for the other three. All four are 0 until batch delivery computes \
-             a status for the first time, so a sum of 0 over the four is a replica that has \
-             not looked yet rather than a status of its own. A subnet halted by the `is_halted` flag of its subnet record \
-             rather than at a CUP height has no status of its own here: consensus acts on \
-             that flag before batch delivery runs, so this metric goes on reporting whatever \
-             it last did, or all four zeros on a replica that started while the subnet was \
-             already halted.",
-            &[STATUS_LABEL],
-        );
-        // Report every status from the start. A gauge vector reports only the
-        // label values it has been given, so until the delivery path computes a
-        // status for the first time the scrape would carry no `consensus_status`
-        // at all. Created here, all four read 0 until it does, as the help text
-        // says.
-        for (label, _) in CONSENSUS_STATUSES {
-            consensus_status.with_label_values(&[label]).set(0);
-        }
-
         Self {
             batches_delivered: metrics_registry.int_counter_vec(
                 "consensus_batches_delivered",
@@ -254,7 +230,19 @@ impl FinalizerMetrics {
                 "consensus_batch_height",
                 "The height of batches sent to Message Routing",
             ),
-            consensus_status,
+            consensus_status: metrics_registry.int_gauge_vec(
+                "consensus_status",
+                "Whether consensus is running, halting towards a CUP height (producing \
+                 empty blocks and delivering no batch but the one at that height), halted \
+                 at a CUP height (producing no blocks either) or unknown (the status could \
+                 not be computed), as of the height whose batch was delivered last. 1 for \
+                 the status that held then, 0 for the other three. Reported from the first \
+                 time the finalizer computes a status, and absent before that -- including \
+                 on a replica that started while its subnet record's `is_halted` flag was \
+                 set, as consensus acts on that flag before the finalizer runs. That halt \
+                 has no status of its own here.",
+                &[STATUS_LABEL],
+            ),
             batch_delivery_interval: metrics_registry.histogram(
                 "consensus_batch_delivery_interval_seconds",
                 "Time elapsed since the delivery of the previous batch, in seconds",
@@ -379,13 +367,11 @@ impl FinalizerMetrics {
 
     /// Records `status` as the status consensus is in, and the other three as
     /// ones it is not. [`None`] is recorded as `unknown`, the status the
-    /// delivery path failed to compute, and [`Status::Halted`] as
-    /// `halted_at_cup_height`, the only halt this path sees.
+    /// finalizer failed to compute, and [`Status::Halted`] as
+    /// `halted_at_cup_height`, the only halt the finalizer sees.
     ///
     /// Reported as a gauge per status rather than a single number, so that a
-    /// dashboard can select the status it asks about by name. Only the batch
-    /// delivery path computes the status, so this says what that path saw the
-    /// last time it looked.
+    /// dashboard can select the status it asks about by name.
     pub fn observe_status(&self, status: Option<Status>) {
         for (label, value) in CONSENSUS_STATUSES {
             self.consensus_status
@@ -772,30 +758,15 @@ mod tests {
             .collect()
     }
 
-    /// The statuses are reported, as zero, from the moment the metrics are
-    /// built, rather than from the first time one of them is observed. A gauge
-    /// vector reports only the label values it has been given, and one that has
-    /// been given none is left out of the scrape altogether.
-    ///
-    /// Observing a status sets that one to one and the other three back to zero.
+    /// Observing a status reports that one as one and the other three as zero,
+    /// so that a status the subnet has left does not go on being reported
+    /// alongside the one it is in.
     #[test]
-    fn test_consensus_status_is_reported_before_it_is_observed() {
+    fn test_observe_status_reports_one_status() {
         let metrics_registry = MetricsRegistry::new();
         let metrics = FinalizerMetrics::new(metrics_registry.clone());
 
-        // Every status reported, and zero: batch delivery has not computed one
-        // yet. Asserted over the whole map, as a sum of zero would also be what
-        // an empty one adds up to, which is what this is here to catch.
-        assert_eq!(
-            consensus_status(&metrics_registry),
-            BTreeMap::from([
-                (STATUS_RUNNING.into(), 0),
-                (STATUS_HALTING.into(), 0),
-                (STATUS_HALTED_AT_CUP_HEIGHT.into(), 0),
-                (STATUS_UNKNOWN.into(), 0),
-            ]),
-        );
-
+        metrics.observe_status(Some(Status::Halting));
         metrics.observe_status(Some(Status::Halted));
 
         assert_eq!(

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -27,11 +27,24 @@ use std::sync::RwLock;
 const RANKS_TO_RECORD: [&str; 6] = ["0", "1", "2", "3", "4", "5"];
 
 /// The label of `consensus_status`, whose values are the statuses of
-/// [`Status`], lowercased.
+/// [`Status`], lowercased, plus `unknown` for a status that could not be
+/// computed at all.
 const STATUS_LABEL: &str = "status";
 const STATUS_RUNNING: &str = "running";
 const STATUS_HALTING: &str = "halting";
 const STATUS_HALTED: &str = "halted";
+const STATUS_UNKNOWN: &str = "unknown";
+
+/// The label value `consensus_status` reports each status under. [`None`] is
+/// the status the delivery path failed to compute, rather than a status of its
+/// own, so that a subnet whose registry cannot be read is not mistaken for one
+/// that is running.
+const CONSENSUS_STATUSES: [(&str, Option<Status>); 4] = [
+    (STATUS_RUNNING, Some(Status::Running)),
+    (STATUS_HALTING, Some(Status::Halting)),
+    (STATUS_HALTED, Some(Status::Halted)),
+    (STATUS_UNKNOWN, None),
+];
 
 pub(crate) const CRITICAL_ERROR_PAYLOAD_TOO_LARGE: &str = "consensus_payload_too_large";
 pub(crate) const CRITICAL_ERROR_VALIDATION_NOT_PASSED: &str = "consensus_validation_not_passed";
@@ -205,6 +218,22 @@ pub(crate) struct FinalizerMetrics {
 
 impl FinalizerMetrics {
     pub fn new(metrics_registry: MetricsRegistry) -> Self {
+        let consensus_status = metrics_registry.int_gauge_vec(
+            "consensus_status",
+            "Whether consensus is running, halting (producing empty blocks but delivering \
+             no batches), halted (producing no blocks either) or unknown (the status could \
+             not be computed), as of the last time batch delivery looked. 1 for the status \
+             that held then, 0 for the other three.",
+            &[STATUS_LABEL],
+        );
+        // Create every child up front. A gauge vector with no children is
+        // dropped by the Prometheus registry, so until the delivery path first
+        // computes a status the scrape would carry no `consensus_status` at all,
+        // which a dashboard cannot tell apart from a subnet that is not halted.
+        for (label, _) in CONSENSUS_STATUSES {
+            consensus_status.with_label_values(&[label]).set(0);
+        }
+
         Self {
             batches_delivered: metrics_registry.int_counter_vec(
                 "consensus_batches_delivered",
@@ -215,13 +244,7 @@ impl FinalizerMetrics {
                 "consensus_batch_height",
                 "The height of batches sent to Message Routing",
             ),
-            consensus_status: metrics_registry.int_gauge_vec(
-                "consensus_status",
-                "Whether consensus is running, halting (producing empty blocks but delivering \
-                 no batches) or halted (producing no blocks either), as of the last time batch \
-                 delivery looked. 1 for the status that held then, 0 for the other two.",
-                &[STATUS_LABEL],
-            ),
+            consensus_status,
             batch_delivery_interval: metrics_registry.histogram(
                 "consensus_batch_delivery_interval_seconds",
                 "Time elapsed since the delivery of the previous batch, in seconds",
@@ -344,8 +367,9 @@ impl FinalizerMetrics {
         }
     }
 
-    /// Records `status` as the status consensus is in, and the other two as ones
-    /// it is not.
+    /// Records `status` as the status consensus is in, and the other three as
+    /// ones it is not. [`None`] is recorded as `unknown`, the status the
+    /// delivery path failed to compute.
     ///
     /// Reported as a gauge per status rather than a single number, so that a
     /// dashboard can select the status it asks about by name. Only the batch
@@ -353,12 +377,8 @@ impl FinalizerMetrics {
     /// consider, so this says what that path saw the last time it looked: a
     /// subnet that stopped producing blocks altogether keeps reporting the
     /// status that made it stop.
-    pub fn observe_status(&self, status: Status) {
-        for (label, value) in [
-            (STATUS_RUNNING, Status::Running),
-            (STATUS_HALTING, Status::Halting),
-            (STATUS_HALTED, Status::Halted),
-        ] {
+    pub fn observe_status(&self, status: Option<Status>) {
+        for (label, value) in CONSENSUS_STATUSES {
             self.consensus_status
                 .with_label_values(&[label])
                 .set((value == status) as i64);
@@ -713,6 +733,76 @@ impl PurgerMetrics {
                 "validated_pool_bounds_exceeded",
                 "The validated pool exceeded its size bounds",
             ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// The `consensus_status` gauges the registry reports, by label.
+    fn consensus_status(metrics_registry: &MetricsRegistry) -> BTreeMap<String, i64> {
+        metrics_registry
+            .prometheus_registry()
+            .gather()
+            .into_iter()
+            .filter(|family| family.name() == "consensus_status")
+            .flat_map(|family| family.get_metric().to_vec())
+            .map(|metric| {
+                let labels = metric.get_label();
+                assert_eq!(labels.len(), 1);
+                assert_eq!(labels[0].name(), STATUS_LABEL);
+
+                (
+                    labels[0].value().to_string(),
+                    metric.get_gauge().value() as i64,
+                )
+            })
+            .collect()
+    }
+
+    /// A gauge vector with no children is dropped by the Prometheus registry, so
+    /// the statuses are reported as zero from the moment the metrics are built:
+    /// a replica that has not delivered a batch since it started -- one whose
+    /// subnet is halted, for instance -- would otherwise report no
+    /// `consensus_status` at all, which reads the same as a subnet that is fine.
+    #[test]
+    fn test_consensus_status_is_reported_before_it_is_observed() {
+        let metrics_registry = MetricsRegistry::new();
+        let _metrics = FinalizerMetrics::new(metrics_registry.clone());
+
+        assert_eq!(
+            consensus_status(&metrics_registry),
+            BTreeMap::from([
+                (STATUS_RUNNING.into(), 0),
+                (STATUS_HALTING.into(), 0),
+                (STATUS_HALTED.into(), 0),
+                (STATUS_UNKNOWN.into(), 0),
+            ]),
+        );
+    }
+
+    /// Every status, the one that could not be computed included, is reported as
+    /// itself and as not any of the others.
+    #[test]
+    fn test_observe_status() {
+        let metrics_registry = MetricsRegistry::new();
+        let metrics = FinalizerMetrics::new(metrics_registry.clone());
+
+        for (observed_label, observed) in CONSENSUS_STATUSES {
+            metrics.observe_status(observed);
+
+            let expected = CONSENSUS_STATUSES
+                .iter()
+                .map(|(label, _)| ((*label).into(), i64::from(*label == observed_label)))
+                .collect();
+            assert_eq!(
+                consensus_status(&metrics_registry),
+                expected,
+                "after observing {observed:?}",
+            );
         }
     }
 }

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -238,9 +238,8 @@ impl FinalizerMetrics {
         // Report every status from the start. A gauge vector reports only the
         // label values it has been given, so until the delivery path computes a
         // status for the first time the scrape would carry no `consensus_status`
-        // at all, and a query for one of the statuses would find nothing -- the
-        // answer it also gives for a subnet that is not in that status. All four
-        // reading 0 is that state instead, as the help text says.
+        // at all. Created here, all four read 0 until it does, as the help text
+        // says.
         for (label, _) in CONSENSUS_STATUSES {
             consensus_status.with_label_values(&[label]).set(0);
         }
@@ -386,9 +385,7 @@ impl FinalizerMetrics {
     /// Reported as a gauge per status rather than a single number, so that a
     /// dashboard can select the status it asks about by name. Only the batch
     /// delivery path computes the status, so this says what that path saw the
-    /// last time it looked: a subnet that stopped producing blocks altogether
-    /// keeps reporting the status that made it stop, and a replica with no
-    /// block to compute a status from reports `unknown`.
+    /// last time it looked.
     pub fn observe_status(&self, status: Option<Status>) {
         for (label, value) in CONSENSUS_STATUSES {
             self.consensus_status
@@ -778,10 +775,7 @@ mod tests {
     /// The statuses are reported, as zero, from the moment the metrics are
     /// built, rather than from the first time one of them is observed. A gauge
     /// vector reports only the label values it has been given, and one that has
-    /// been given none is left out of the scrape altogether, so on a replica
-    /// that has not reached the status computation a query for one of the
-    /// statuses would find nothing, which is the answer that query also gives
-    /// for a subnet that is not in that status.
+    /// been given none is left out of the scrape altogether.
     ///
     /// Observing a status sets that one to one and the other three back to zero.
     #[test]
@@ -791,7 +785,7 @@ mod tests {
 
         // Every status reported, and zero: batch delivery has not computed one
         // yet. Asserted over the whole map, as a sum of zero would also be what
-        // an empty one adds up to -- the very state this is here to catch.
+        // an empty one adds up to, which is what this is here to catch.
         assert_eq!(
             consensus_status(&metrics_registry),
             BTreeMap::from([

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -92,6 +92,7 @@ pub(crate) struct ConsensusMetrics {
     pub on_state_change_change_set_size: HistogramVec,
     pub time_since_last_invoked: GaugeVec,
     pub starvation_counter: IntCounterVec,
+    pub halted_by_subnet_record: IntGauge,
 }
 
 impl ConsensusMetrics {
@@ -104,6 +105,14 @@ impl ConsensusMetrics {
                 // 1s, 2s, 5s, 10s, 20s, 50s, 100s, 200s, 500s
                 decimal_buckets(-4, 2),
                 &["sub_component"],
+            ),
+            halted_by_subnet_record: metrics_registry.int_gauge(
+                "consensus_halted_by_subnet_record",
+                "Whether the `is_halted` flag of the subnet record instructs the subnet to halt, \
+                 as of the latest registry version: 1 while it does, 0 while it does not. A \
+                 subnet halting this way creates no blocks and delivers no batches, and does so \
+                 from whatever height it is at rather than from a CUP height, which is what \
+                 `consensus_status` reports instead.",
             ),
             on_state_change_invocations: metrics_registry.int_counter_vec(
                 "consensus_on_state_change_invocations",

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -112,7 +112,9 @@ impl ConsensusMetrics {
                  as of the latest registry version: 1 while it does, 0 while it does not. A \
                  subnet halting this way creates no blocks and delivers no batches, and does so \
                  from whatever height it is at rather than from a CUP height, which is what \
-                 `consensus_status` reports instead.",
+                 `consensus_status` reports instead. A registry that cannot be read reads as 0 \
+                 here, as consensus carries on in that case rather than halting; the read \
+                 failure itself is logged as an error.",
             ),
             on_state_change_invocations: metrics_registry.int_counter_vec(
                 "consensus_on_state_change_invocations",

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -223,13 +223,16 @@ impl FinalizerMetrics {
             "Whether consensus is running, halting (producing empty blocks but delivering \
              no batches), halted (producing no blocks either) or unknown (the status could \
              not be computed), as of the last time batch delivery looked. 1 for the status \
-             that held then, 0 for the other three.",
+             that held then, 0 for the other three. All four are 0 until batch delivery \
+             computes a status for the first time, so a sum of 0 over the four is a replica \
+             that has not looked yet rather than a status of its own.",
             &[STATUS_LABEL],
         );
         // Create every child up front. A gauge vector with no children is
         // dropped by the Prometheus registry, so until the delivery path first
         // computes a status the scrape would carry no `consensus_status` at all,
         // which a dashboard cannot tell apart from a subnet that is not halted.
+        // All four reading 0 is that state instead, as the help text says.
         for (label, _) in CONSENSUS_STATUSES {
             consensus_status.with_label_values(&[label]).set(0);
         }

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -1,3 +1,4 @@
+use crate::consensus::status::Status;
 use ic_consensus_dkg::metrics::DkgPayloadStats;
 use ic_consensus_idkg::{
     metrics::{CounterPerMasterPublicKeyId, IDkgPayloadStats, KEY_ID_LABEL, key_id_label},
@@ -24,6 +25,13 @@ use std::sync::RwLock;
 // Since we can only record limited number of them, the follow is
 // the range of ranks that are permitted to show up in metrics.
 const RANKS_TO_RECORD: [&str; 6] = ["0", "1", "2", "3", "4", "5"];
+
+/// The label of `consensus_status`, whose values are the statuses of
+/// [`Status`], lowercased.
+const STATUS_LABEL: &str = "status";
+const STATUS_RUNNING: &str = "running";
+const STATUS_HALTING: &str = "halting";
+const STATUS_HALTED: &str = "halted";
 
 pub(crate) const CRITICAL_ERROR_PAYLOAD_TOO_LARGE: &str = "consensus_payload_too_large";
 pub(crate) const CRITICAL_ERROR_VALIDATION_NOT_PASSED: &str = "consensus_validation_not_passed";
@@ -166,6 +174,7 @@ impl BatchStats {
 pub(crate) struct FinalizerMetrics {
     pub batches_delivered: IntCounterVec,
     pub batch_height: IntGauge,
+    pub consensus_status: IntGaugeVec,
     pub batch_delivery_interval: Histogram,
     pub batch_delivery_latency: Histogram,
     pub ingress_messages_delivered: Histogram,
@@ -205,6 +214,13 @@ impl FinalizerMetrics {
             batch_height: metrics_registry.int_gauge(
                 "consensus_batch_height",
                 "The height of batches sent to Message Routing",
+            ),
+            consensus_status: metrics_registry.int_gauge_vec(
+                "consensus_status",
+                "Whether consensus is running, halting (producing empty blocks but delivering \
+                 no batches) or halted (producing no blocks either), as of the last time batch \
+                 delivery looked. 1 for the status that held then, 0 for the other two.",
+                &[STATUS_LABEL],
             ),
             batch_delivery_interval: metrics_registry.histogram(
                 "consensus_batch_delivery_interval_seconds",
@@ -325,6 +341,27 @@ impl FinalizerMetrics {
                 // up to 5 * 10^6 ~= 5MB
                 decimal_buckets_with_zero(2, 6),
             ),
+        }
+    }
+
+    /// Records `status` as the status consensus is in, and the other two as ones
+    /// it is not.
+    ///
+    /// Reported as a gauge per status rather than a single number, so that a
+    /// dashboard can select the status it asks about by name. Only the batch
+    /// delivery path computes the status, and only when it has a block to
+    /// consider, so this says what that path saw the last time it looked: a
+    /// subnet that stopped producing blocks altogether keeps reporting the
+    /// status that made it stop.
+    pub fn observe_status(&self, status: Status) {
+        for (label, value) in [
+            (STATUS_RUNNING, Status::Running),
+            (STATUS_HALTING, Status::Halting),
+            (STATUS_HALTED, Status::Halted),
+        ] {
+            self.consensus_status
+                .with_label_values(&[label])
+                .set((value == status) as i64);
         }
     }
 

--- a/rs/consensus/src/consensus/status.rs
+++ b/rs/consensus/src/consensus/status.rs
@@ -16,11 +16,6 @@ use ic_types::{
 /// upgrade, a scheduled subnet split, and the subnet record's `halt_at_cup_height`. Each of them
 /// takes effect from a summary height on, so a subnet halted this way stops with a final
 /// checkpoint at a CUP height.
-///
-/// The subnet record's other halt, `is_halted`, is not one of these and never produces a
-/// [`Status::Halted`]: it stops a subnet wherever it happens to be, and
-/// `ConsensusImpl::on_state_change` acts on it before reaching any of the callers of
-/// [`get_status`].
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum Status {
     /// The Consensus is running normally.

--- a/rs/consensus/src/consensus/status.rs
+++ b/rs/consensus/src/consensus/status.rs
@@ -12,10 +12,9 @@ use ic_types::{
     },
 };
 
-/// The status of the consensus with respect to the halts that end a subnet on a CUP: a pending
-/// upgrade, a scheduled subnet split, and the subnet record's `halt_at_cup_height`. Each of them
-/// takes effect from a summary height on, so a subnet halted this way stops with a final
-/// checkpoint at a CUP height.
+/// The status of the consensus with respect to the halts that end a subnet on a CUP. They take
+/// effect from a summary height on, so a subnet halted this way stops with a final checkpoint at
+/// a CUP height.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum Status {
     /// The Consensus is running normally.

--- a/rs/consensus/src/consensus/status.rs
+++ b/rs/consensus/src/consensus/status.rs
@@ -12,14 +12,24 @@ use ic_types::{
     },
 };
 
+/// The status of the consensus with respect to the halts that end a subnet on a CUP: a pending
+/// upgrade, a scheduled subnet split, and the subnet record's `halt_at_cup_height`. Each of them
+/// takes effect from a summary height on, so a subnet halted this way stops with a final
+/// checkpoint at a CUP height.
+///
+/// The subnet record's other halt, `is_halted`, is not one of these and never produces a
+/// [`Status::Halted`]: it stops a subnet wherever it happens to be, and
+/// `ConsensusImpl::on_state_change` acts on it before reaching any of the callers of
+/// [`get_status`].
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum Status {
     /// The Consensus is running normally.
     Running,
-    /// The Consensus is halting, meaning we will produce *empty* blocks but no batches will be
-    /// delivered.
+    /// The Consensus is halting towards a CUP height, meaning we will produce *empty* blocks but
+    /// no batches will be delivered.
     Halting,
-    /// The Consensus is halted, meaning that no blocks are created and no batches are delivered.
+    /// The Consensus is halted at a CUP height, meaning that no blocks are created and no batches
+    /// are delivered.
     Halted,
 }
 

--- a/rs/consensus/src/consensus/status.rs
+++ b/rs/consensus/src/consensus/status.rs
@@ -33,6 +33,16 @@ pub(crate) enum Status {
     Halted,
 }
 
+impl Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Status::Running => write!(f, "running"),
+            Status::Halting => write!(f, "halting towards a CUP height"),
+            Status::Halted => write!(f, "halted at a CUP height"),
+        }
+    }
+}
+
 /// Get the status of the consensus.
 ///
 /// Note: If 'height' is smaller than the height of the last CUP, this will return [None].

--- a/rs/consensus/src/consensus/status.rs
+++ b/rs/consensus/src/consensus/status.rs
@@ -19,11 +19,12 @@ use ic_types::{
 pub(crate) enum Status {
     /// The Consensus is running normally.
     Running,
-    /// The Consensus is halting towards a CUP height, meaning we will produce *empty* blocks but
-    /// no batches will be delivered.
+    /// The Consensus is halting towards a CUP height, meaning we will produce *empty* blocks and
+    /// deliver no batch but the one at that CUP height.
     Halting,
-    /// The Consensus is halted at a CUP height, meaning that no blocks are created and no batches
-    /// are delivered.
+    /// The Consensus is halted at a CUP height, meaning that no blocks are created and no
+    /// batches are delivered. The batch at that CUP height has been delivered by then: the
+    /// status holds only once certification has passed the height.
     Halted,
 }
 


### PR DESCRIPTION
Whether a subnet has halted at a CUP height is only observable in the replica's
journal today. This PR reports it as a metric, too:

```
consensus_status{status="running"|"halting"|"halted_at_cup_height"|"unknown"}
```

an `IntGaugeVec` holding 1 for the status the finalizer last computed and 0 for
the other three.

The status is the one `status::get_status` computes: the halts that end a subnet
on a CUP -- a pending upgrade, a scheduled subnet split, and the subnet record's
`halt_at_cup_height`. The record's other halt, `is_halted`, is acted upon above
the finalizer, so the finalizer never sees it and this metric does not report it.

The finalizer computes the status for the height whose batch was delivered last.
That is the height to ask about: the halts above take effect from a summary
height on, and the batch at that height is delivered whatever the status is, so
the first height at which a subnet halts is also the last one whose batch it
delivers.

`unknown` is the status the finalizer did not compute -- an unreadable registry,
no summary block for the height, or a batch delivery that failed, which returns
an error rather than the height it got to -- rather than leaving the metric
asserting the status of an earlier height as though it still held.

The delivery path's log lines now name the status that held; one of them said
"replica is halted" for a halting subnet as well as a halted one.

This is operator-facing observability: the metric says why a subnet stopped
producing blocks where previously only the journal did. It is not a signal to
gate an operation on. It carries no height, and it does not say which of the
three halts fired, so a programmatic check that a subnet has halted at a given
checkpoint still has to look at the CUP itself -- as
`wait_until_halting_cup_reached` in `rs/tests/consensus/subnet_splitting_test.rs`
does, matching a CUP's summary registry version against the subnet record at
that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)