### PR TITLE
fix(node): read GuestOS serial logs from the journal

### DIFF
--- a/ic-os/components/hostos/misc/limited-console
+++ b/ic-os/components/hostos/misc/limited-console
@@ -168,7 +168,7 @@ execute_command() {
         "guestos-alternative")
             case "${2:-}" in
                 "show")
-                    /opt/ic/bin/hostos_tool guestos-alternative show
+                    sudo /opt/ic/bin/hostos_tool guestos-alternative show
                     ;;
                 "swap")
                     sudo /opt/ic/bin/hostos_tool guestos-alternative swap ${3:+"$3"}

--- a/ic-os/components/hostos/misc/limited-console
+++ b/ic-os/components/hostos/misc/limited-console
@@ -113,11 +113,19 @@ execute_command() {
             ;;
         "guestos-console-logs")
             echo "=== GuestOS Serial Console Logs ==="
-            env -i \
-                TERM="$TERM" \
-                LESSSECURE=1 \
-                PATH="$RESTRICTED_PATH" \
-                /usr/bin/less -f /var/log/libvirt/qemu/guestos-serial.log
+            # qemu writes the serial log as root, so read the copy
+            # export-guestos-serial-logs.sh forwards into the journal instead.
+            if journalctl -t guestos-serial -n 1 -q --no-pager | grep -q .; then
+                journalctl -t guestos-serial --no-pager \
+                    | env -i \
+                        TERM="$TERM" \
+                        LESSSECURE=1 \
+                        PATH="$RESTRICTED_PATH" \
+                        /usr/bin/less -f
+            else
+                echo "No serial console output in the journal."
+                echo "Check: service-status export-guestos-serial-logs"
+            fi
             ;;
         "network-config-settings")
             echo "=== Network Settings from Config ==="

--- a/ic-os/components/hostos/misc/sudoers
+++ b/ic-os/components/hostos/misc/sudoers
@@ -32,6 +32,9 @@ root	ALL=(ALL:ALL) NOPASSWD:ALL
 # Allow limited-console to run recovery via the secure launcher script
 limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/guestos-recovery-launcher.sh
 
+# Allow limited-console to show the GuestOS boot alternative
+limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/hostos_tool guestos-alternative show
+
 # Allow limited-console to swap the GuestOS boot alternative
 limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/hostos_tool guestos-alternative swap *
 


### PR DESCRIPTION
`guestos-console-logs` opened `/var/log/libvirt/qemu/guestos-serial.log` directly, but qemu writes it as root and the console runs as the unprivileged limited-console account, so the command always failed with "Permission denied".

`export-guestos-serial-logs.service` already forwards that output to the journal under the guestos-serial identifier, and limited-console is in the systemd-journal group, so read it from there instead.