### PR TITLE
chore: remove rust-toolchain.toml as container-autobuild trigger

### DIFF
--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -4,14 +4,12 @@ on:
   pull_request:
     paths:
       - '.github/workflows/container-autobuild.yml'
-      - 'rust-toolchain.toml'
       - 'ci/container/**'
   push:
     branches:
       - 'dev-gh-*'
     paths:
       - '.github/workflows/container-autobuild.yml'
-      - 'rust-toolchain.toml'
       - 'ci/container/**'
   workflow_dispatch:
 


### PR DESCRIPTION
The ic-build container doesn't use `rust-toolchain.toml` as an input anymore so we can remove it as a trigger for running the  container-autobuild workflow.