### PR TITLE
chore: release ic-management-canister-types v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11338,7 +11338,7 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "candid",
  "candid_parser",

--- a/packages/ic-management-canister-types/BUILD.bazel
+++ b/packages/ic-management-canister-types/BUILD.bazel
@@ -9,7 +9,7 @@ rust_library(
     proc_macro_deps = [
         "@crate_index//:strum_macros",
     ],
-    version = "0.9.0",
+    version = "0.10.0",
     deps = [
         # Keep sorted.
         "@crate_index//:candid",

--- a/packages/ic-management-canister-types/CHANGELOG.md
+++ b/packages/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-10
+
 ### Added
 
 - Types for `subnet_metrics`:

--- a/packages/ic-management-canister-types/Cargo.toml
+++ b/packages/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 description = "Types for calling the IC management canister"


### PR DESCRIPTION
Bump the crate version to 0.10.0 and close out the CHANGELOG's [Unreleased] section, which collects since v0.9.0:

- `SubnetMetricsArgs` and `SubnetMetricsResult` for `subnet_metrics`
- the `pricing_version` field on `HttpRequestArgs`, selecting legacy or pay-as-you-go pricing for a canister HTTPS outcall
- the `flexible_http_request` types: `FlexibleHttpRequestArgs`, `ReplicationCounts`, `FlexibleHttpRequestResult`,
`FlexibleHttpRequestErr`, `FlexibleHttpGlobalError`, `FlexibleHttpNodeDetail`, `HttpRequestResourceReport`, `ResourceUsage` and `FlexibleHttpNodeError`

New public struct fields are a breaking change, hence the minor bump.