### PR TITLE
fix: remove the ordering on CompoundCycles

### DIFF
--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -562,11 +562,12 @@ impl CyclesAccountManager {
         // Never refund more than was prepaid, part by part: `x - (x - y)` is the
         // part-wise minimum of `x` and `y` because both subtractions saturate.
         //
-        // The refund is derived from the instruction count, the Wasm execution mode,
-        // the cost schedule and the subnet size passed to this function, all of which
-        // the prepayment was made with as well. Should any of them have changed since
-        // then, e.g. should the subnet have grown between the prepayment and this
-        // refund, the refund can exceed the prepayment and is capped at it.
+        // The refund covers at most the instructions the prepayment was made for, but
+        // it is priced with the Wasm execution mode, the cost schedule and the subnet
+        // size passed to this function, i.e. with the ones in effect now rather than
+        // the ones the prepayment was priced with. `scale_cost` scales both parts of
+        // an amount by the subnet size, so a subnet that grew in between makes the
+        // refund exceed the prepayment, and the cap bounds it.
         let cycles_to_refund =
             prepaid_execution_cycles - (prepaid_execution_cycles - cycles_to_refund);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -560,11 +560,13 @@ impl CyclesAccountManager {
             subnet_cycles_config,
         );
         // Never refund more than was prepaid, part by part: `x - (x - y)` is the
-        // part-wise minimum of `x` and `y` because both subtractions saturate. The
-        // prepayment covers the instructions it was made for, and hence any refund
-        // derived from them, so this is defense in depth against a caller whose
-        // prepayment and refund disagree on the instruction count, the Wasm
-        // execution mode or the cost schedule.
+        // part-wise minimum of `x` and `y` because both subtractions saturate.
+        //
+        // The refund is derived from the instruction count, the Wasm execution mode,
+        // the cost schedule and the subnet size passed to this function, all of which
+        // the prepayment was made with as well. Should any of them have changed since
+        // then, e.g. should the subnet have grown between the prepayment and this
+        // refund, the refund can exceed the prepayment and is capped at it.
         let cycles_to_refund =
             prepaid_execution_cycles - (prepaid_execution_cycles - cycles_to_refund);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -564,10 +564,13 @@ impl CyclesAccountManager {
         //
         // The refund covers at most the instructions the prepayment was made for, but
         // it is priced with the Wasm execution mode, the cost schedule and the subnet
-        // size passed to this function, i.e. with the ones in effect now rather than
-        // the ones the prepayment was priced with. `scale_cost` scales both parts of
-        // an amount by the subnet size, so a subnet that grew in between makes the
-        // refund exceed the prepayment, and the cap bounds it.
+        // size passed to this function, which need not be the ones the prepayment was
+        // priced with. For an update call or an install these coincide, as the caller
+        // passes the same `subnet_cycles_config` it prepaid with. They can differ for
+        // a response execution, whose prepayment was made in an earlier round, when
+        // the corresponding call was performed: `scale_cost` scales both parts of an
+        // amount by the subnet size, so a subnet that grew in between can price the
+        // refund above the prepayment, and the cap bounds it.
         let cycles_to_refund =
             prepaid_execution_cycles - (prepaid_execution_cycles - cycles_to_refund);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -555,9 +555,7 @@ impl CyclesAccountManager {
         }
         let num_instructions_to_refund =
             std::cmp::min(num_instructions, num_instructions_initially_charged);
-        // Never refund more than was prepaid, in either the real or the nominal part:
-        // a prepayment made in an earlier round can have been priced with a smaller
-        // subnet size than the refund is.
+        // Never refund more than was prepaid, in either the real or the nominal part.
         let cycles_to_refund = self
             .scale_cost(
                 self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -555,12 +555,18 @@ impl CyclesAccountManager {
         }
         let num_instructions_to_refund =
             std::cmp::min(num_instructions, num_instructions_initially_charged);
-        let cycles_to_refund = self
-            .scale_cost(
-                self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
-                subnet_cycles_config,
-            )
-            .min(prepaid_execution_cycles);
+        let cycles_to_refund = self.scale_cost(
+            self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
+            subnet_cycles_config,
+        );
+        // Never refund more than was prepaid, part by part: `x - (x - y)` is the
+        // part-wise minimum of `x` and `y` because both subtractions saturate. The
+        // prepayment covers the instructions it was made for, and hence any refund
+        // derived from them, so this is defense in depth against a caller whose
+        // prepayment and refund disagree on the instruction count, the Wasm
+        // execution mode or the cost schedule.
+        let cycles_to_refund =
+            prepaid_execution_cycles - (prepaid_execution_cycles - cycles_to_refund);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);
     }
 
@@ -938,7 +944,8 @@ impl CyclesAccountManager {
     ///
     /// Note that the prepayment is never topped up for such a response: the additional
     /// cycles would be refunded right away and, unlike this refund, the withdrawal
-    /// could fail.
+    /// could fail. The subtraction below saturates part by part, so the canister is
+    /// charged at most what it prepaid in each part.
     pub fn settle_prepayment_for_unexecuted_response(
         &self,
         system_state: &mut SystemState,
@@ -952,12 +959,11 @@ impl CyclesAccountManager {
             subnet_cycles_config,
             execution_mode,
         );
-        // The prepayment covers the fixed per-message execution fee, but clamp the
-        // charge to it so that no more than the prepayment is ever charged.
-        let charge = base_fee.min(prepayment_for_response_execution);
+        // The prepayment covers the fixed per-message execution fee. The subtraction
+        // saturates part by part, so no more than the prepayment is ever charged.
         system_state.refund_cycles(
             prepayment_for_response_execution,
-            prepayment_for_response_execution - charge,
+            prepayment_for_response_execution - base_fee,
         );
     }
 
@@ -1000,8 +1006,9 @@ impl CyclesAccountManager {
             self.config.xnet_byte_transmission_fee * transmitted_bytes,
             subnet_cycles_config,
         );
-        prepayment_for_response_transmission
-            - transmission_cost.min(prepayment_for_response_transmission)
+        // The subtraction saturates part by part, so a transmission cost exceeding
+        // the prepayment simply leaves nothing to refund.
+        prepayment_for_response_transmission - transmission_cost
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -555,17 +555,9 @@ impl CyclesAccountManager {
         }
         let num_instructions_to_refund =
             std::cmp::min(num_instructions, num_instructions_initially_charged);
-        // Never refund more than was prepaid, in either component.
-        //
-        // The refund covers at most the instructions the prepayment was made for, but
-        // it is priced with the Wasm execution mode, the cost schedule and the subnet
-        // size passed to this function, which need not be the ones the prepayment was
-        // priced with. For an update call or an install these coincide, as the caller
-        // passes the same `subnet_cycles_config` it prepaid with. They can differ for
-        // a response execution, whose prepayment was made in an earlier round, when
-        // the corresponding call was performed: `scale_cost` scales both parts of an
-        // amount by the subnet size, so a subnet that grew in between can price the
-        // refund above the prepayment, and this cap bounds it.
+        // Never refund more than was prepaid, in either the real or the nominal part:
+        // a prepayment made in an earlier round can have been priced with a smaller
+        // subnet size than the refund is.
         let cycles_to_refund = self
             .scale_cost(
                 self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
@@ -949,8 +941,8 @@ impl CyclesAccountManager {
     ///
     /// Note that the prepayment is never topped up for such a response: the additional
     /// cycles would be refunded right away and, unlike this refund, the withdrawal
-    /// could fail. The subtraction below saturates part by part, so the canister is
-    /// charged at most what it prepaid in each part.
+    /// could fail. The subtraction below saturates in both the real and the nominal
+    /// part, so the canister is charged at most what it prepaid in each of them.
     pub fn settle_prepayment_for_unexecuted_response(
         &self,
         system_state: &mut SystemState,
@@ -965,7 +957,8 @@ impl CyclesAccountManager {
             execution_mode,
         );
         // The prepayment covers the fixed per-message execution fee. The subtraction
-        // saturates part by part, so no more than the prepayment is ever charged.
+        // saturates in both the real and the nominal part, so no more than the
+        // prepayment is ever charged.
         system_state.refund_cycles(
             prepayment_for_response_execution,
             prepayment_for_response_execution - base_fee,
@@ -1011,8 +1004,8 @@ impl CyclesAccountManager {
             self.config.xnet_byte_transmission_fee * transmitted_bytes,
             subnet_cycles_config,
         );
-        // The subtraction saturates part by part, so a transmission cost exceeding
-        // the prepayment simply leaves nothing to refund.
+        // The subtraction saturates in both the real and the nominal part, so a
+        // transmission cost exceeding the prepayment leaves nothing to refund.
         prepayment_for_response_transmission - transmission_cost
     }
 

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -555,12 +555,7 @@ impl CyclesAccountManager {
         }
         let num_instructions_to_refund =
             std::cmp::min(num_instructions, num_instructions_initially_charged);
-        let cycles_to_refund = self.scale_cost(
-            self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
-            subnet_cycles_config,
-        );
-        // Never refund more than was prepaid, part by part: `x - (x - y)` is the
-        // part-wise minimum of `x` and `y` because both subtractions saturate.
+        // Never refund more than was prepaid, in either component.
         //
         // The refund covers at most the instructions the prepayment was made for, but
         // it is priced with the Wasm execution mode, the cost schedule and the subnet
@@ -570,9 +565,13 @@ impl CyclesAccountManager {
         // a response execution, whose prepayment was made in an earlier round, when
         // the corresponding call was performed: `scale_cost` scales both parts of an
         // amount by the subnet size, so a subnet that grew in between can price the
-        // refund above the prepayment, and the cap bounds it.
-        let cycles_to_refund =
-            prepaid_execution_cycles - (prepaid_execution_cycles - cycles_to_refund);
+        // refund above the prepayment, and this cap bounds it.
+        let cycles_to_refund = self
+            .scale_cost(
+                self.convert_instructions_to_cycles(num_instructions_to_refund, execution_mode),
+                subnet_cycles_config,
+            )
+            .component_wise_min(prepaid_execution_cycles);
         system_state.refund_cycles(prepaid_execution_cycles, cycles_to_refund);
     }
 

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2400,17 +2400,17 @@ impl CanisterManager {
                 &self.log,
             );
             // Record the net cycle charge (prepay minus refund) so it survives
-            // the canister state rollback if a subsequent step fails.
-            // This recomputes the refund that `refund_unused_execution_cycles` above
-            // derived from the identical formula, before the `component_wise_min` cap
-            // to the prepayment that it applies. Applying that cap here as well would
-            // make no difference, as the subtraction below saturates part by part, so
-            // the net charge recorded here matches what that function refunded.
-            let cycles_to_refund = self.cycles_account_manager.variable_execution_cost(
-                instructions_to_refund,
-                subnet_cycles_config,
-                wasm_execution_mode,
-            );
+            // the canister state rollback if a subsequent step fails. This recomputes
+            // what `refund_unused_execution_cycles` above refunded, cap included, so
+            // that the two agree by construction.
+            let cycles_to_refund = self
+                .cycles_account_manager
+                .variable_execution_cost(
+                    instructions_to_refund,
+                    subnet_cycles_config,
+                    wasm_execution_mode,
+                )
+                .component_wise_min(prepaid_execution_cycles);
             consumed_cycles.add(
                 prepaid_execution_cycles - cycles_to_refund,
                 instructions_for_execution,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2402,10 +2402,9 @@ impl CanisterManager {
             // Record the net cycle charge (prepay minus refund) so it survives
             // the canister state rollback if a subsequent step fails.
             // This recomputes the refund that `refund_unused_execution_cycles` above
-            // derived from the identical formula, before the part-wise cap to the
-            // prepayment that it applies. Applying that cap here as well would make no
-            // difference: both subtractions saturate part by part, so in each part
-            // `prepaid - refund` equals `prepaid - min(prepaid, refund)`, and hence
+            // derived from the identical formula, before the `component_wise_min` cap
+            // to the prepayment that it applies. Applying that cap here as well would
+            // make no difference, as the subtraction below saturates part by part, so
             // the net charge recorded here matches what that function refunded.
             let cycles_to_refund = self.cycles_account_manager.variable_execution_cost(
                 instructions_to_refund,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2402,11 +2402,11 @@ impl CanisterManager {
             // Record the net cycle charge (prepay minus refund) so it survives
             // the canister state rollback if a subsequent step fails.
             // This recomputes the refund that `refund_unused_execution_cycles` above
-            // derived from the identical formula, before the cap it applies to the
-            // prepayment. Capping it here as well would make no difference: the
-            // subtraction below saturates part by part, so `prepaid - refund` already
-            // equals `prepaid - refund.min(prepaid)` and hence the net charge matches
-            // what that function actually refunded.
+            // derived from the identical formula, before the part-wise cap to the
+            // prepayment that it applies. Applying that cap here as well would make no
+            // difference: both subtractions saturate part by part, so in each part
+            // `prepaid - refund` equals `prepaid - min(prepaid, refund)`, and hence
+            // the net charge recorded here matches what that function refunded.
             let cycles_to_refund = self.cycles_account_manager.variable_execution_cost(
                 instructions_to_refund,
                 subnet_cycles_config,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2401,14 +2401,14 @@ impl CanisterManager {
             );
             // Record the net cycle charge (prepay minus refund) so it survives
             // the canister state rollback if a subsequent step fails.
-            let cycles_to_refund = self
-                .cycles_account_manager
-                .variable_execution_cost(
-                    instructions_to_refund,
-                    subnet_cycles_config,
-                    wasm_execution_mode,
-                )
-                .min(prepaid_execution_cycles);
+            // This is exactly the refund that `refund_unused_execution_cycles` above
+            // derived; the subtraction below saturates part by part, so its clamp to
+            // the prepayment needs no counterpart here.
+            let cycles_to_refund = self.cycles_account_manager.variable_execution_cost(
+                instructions_to_refund,
+                subnet_cycles_config,
+                wasm_execution_mode,
+            );
             consumed_cycles.add(
                 prepaid_execution_cycles - cycles_to_refund,
                 instructions_for_execution,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2401,9 +2401,12 @@ impl CanisterManager {
             );
             // Record the net cycle charge (prepay minus refund) so it survives
             // the canister state rollback if a subsequent step fails.
-            // This is exactly the refund that `refund_unused_execution_cycles` above
-            // derived; the subtraction below saturates part by part, so its clamp to
-            // the prepayment needs no counterpart here.
+            // This recomputes the refund that `refund_unused_execution_cycles` above
+            // derived from the identical formula, before the cap it applies to the
+            // prepayment. Capping it here as well would make no difference: the
+            // subtraction below saturates part by part, so `prepaid - refund` already
+            // equals `prepaid - refund.min(prepaid)` and hence the net charge matches
+            // what that function actually refunded.
             let cycles_to_refund = self.cycles_account_manager.variable_execution_cost(
                 instructions_to_refund,
                 subnet_cycles_config,

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -457,7 +457,10 @@ fn cycles_correct_if_response_fails() {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(a_id).system_state.balance(),
         initial_cycles
@@ -507,7 +510,10 @@ fn cycles_correct_if_cleanup_fails() {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(a_id).system_state.balance(),
         initial_cycles
@@ -1188,7 +1194,10 @@ fn response_fail_scenario(test: &mut ExecutionTest) -> (CanisterId, MessageId) {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     let ingress_status = test.ingress_status(&ingress_id);
     let result = check_ingress_status(ingress_status).unwrap_err();
@@ -1237,7 +1246,10 @@ fn cleanup_fail_scenario(test: &mut ExecutionTest) -> (CanisterId, MessageId) {
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     let ingress_status = test.ingress_status(&ingress_id);
     let result = check_ingress_status(ingress_status).unwrap_err();
@@ -2025,7 +2037,10 @@ fn reserve_instructions_for_cleanup_callback_scenario(
     let execution_cost_before = test.canister_execution_cost(a_id);
     test.execute_message(a_id);
     let execution_cost_after = test.canister_execution_cost(a_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
 
     // Assert that the response failed with exceeding instructions limit.
     let ingress_status = test.ingress_status(&ingress_id);

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -7228,7 +7228,10 @@ fn cycles_correct_if_update_fails() {
     let execution_cost_before = test.canister_execution_cost(b_id);
     test.execute_message(b_id);
     let execution_cost_after = test.canister_execution_cost(b_id);
-    assert_gt!(execution_cost_after, execution_cost_before);
+    assert_gt!(
+        execution_cost_after.nominal(),
+        execution_cost_before.nominal()
+    );
     assert_eq!(
         test.canister_state(b_id).system_state.balance(),
         initial_cycles - test.canister_execution_cost(b_id).real()

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -95,10 +95,10 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 /// executed: the one made free has a zero real part and compares as the smaller
 /// amount however large its nominal part is.
 ///
-/// Compare `real()` or `nominal()` explicitly instead. Note that subtraction
-/// saturates part by part, which covers the two idioms that would otherwise reach
-/// for an ordering: subtracting `y` from `x` without going below zero is `x - y`,
-/// and the part-wise minimum of `x` and `y` is `x - (x - y)`.
+/// Compare `real()` or `nominal()` explicitly instead, or use `component_wise_min`
+/// to bound both parts at once. Note also that subtraction saturates part by part,
+/// so capping an amount before subtracting it is redundant: `x - y` already equals
+/// `x - x.component_wise_min(y)`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CompoundCycles<T: CyclesUseCaseKind> {
     real: Cycles,
@@ -153,6 +153,22 @@ impl<T: CyclesUseCaseKind> CompoundCycles<T> {
     // are zero.
     pub fn is_zero(&self) -> bool {
         self.real.is_zero() && self.nominal.is_zero()
+    }
+
+    /// Returns the component-wise minimum of this amount and `other`, i.e. the
+    /// minimum of their real parts paired with the minimum of their nominal parts.
+    ///
+    /// The two components are minimized separately because there is no ordering on
+    /// the pair (see the note on this type). They coincide under the normal cost
+    /// schedule; under the free cost schedule the real part of a use case made free
+    /// is zero, so minimizing by the real parts alone would leave the nominal part
+    /// of the result unbounded.
+    pub fn component_wise_min(self, other: Self) -> Self {
+        Self {
+            real: self.real.min(other.real),
+            nominal: self.nominal.min(other.nominal),
+            _cycles_use_case_marker: self._cycles_use_case_marker,
+        }
     }
 
     /// Returns this amount reduced by the part of `real()` that could not be
@@ -279,10 +295,9 @@ mod tests {
     /// whereas its real part is zero under the free cost schedule. The two amounts
     /// below therefore order one way in their real parts and the other way in their
     /// nominal parts, which is exactly the case a lexicographic ordering of the pair
-    /// would decide on the real parts alone. Both identities documented on
-    /// `CompoundCycles` hold for it.
+    /// would decide on the real parts alone.
     #[test]
-    fn saturating_subtraction_is_part_wise() {
+    fn arithmetic_is_component_wise() {
         let x =
             CompoundCycles::<Instructions>::new(Cycles::new(5), CanisterCyclesCostSchedule::Normal);
         let y =
@@ -303,11 +318,15 @@ mod tests {
             (Cycles::new(5), NominalCycles::zero())
         );
 
-        // The part-wise minimum of `x` and `y`.
-        let minimum = x - (x - y);
+        // The component-wise minimum takes each part from a different amount.
+        let minimum = x.component_wise_min(y);
         assert_eq!(
             (minimum.real(), minimum.nominal()),
             (Cycles::zero(), NominalCycles::new(5))
         );
+        assert_eq!(y.component_wise_min(x), minimum);
+
+        // Capping before subtracting is redundant.
+        assert_eq!(x - x.component_wise_min(y), difference);
     }
 }

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -74,7 +74,22 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 /// let total = cc_instructions + cc_memory;
 /// assert_eq!(total.real(), Cycles::new(30));
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+///
+/// # No ordering
+///
+/// `CompoundCycles` deliberately implements neither `Ord` nor `PartialOrd`: its two
+/// parts are accounted for independently and there is no meaningful order on the
+/// pair. A derived impl would order lexicographically, i.e. by the real part first,
+/// and hence answer "which of the two amounts is larger?" from the real part alone
+/// whenever the real parts differ. That is exactly the wrong tie-break under the
+/// free cost schedule, where the real part of a use case made free is zero no matter
+/// how large the nominal part is.
+///
+/// Compare `real()` or `nominal()` explicitly instead. Note that subtraction
+/// saturates part by part, which covers the two idioms that would otherwise want an
+/// ordering: `x - x.min(y)` is simply `x - y`, and the part-wise minimum of `x` and
+/// `y` is `x - (x - y)`.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CompoundCycles<T: CyclesUseCaseKind> {
     real: Cycles,
     nominal: NominalCycles,

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -55,7 +55,10 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 ///
 /// Extra type-safety is added via use of generics and phantom data to enforce
 /// that arithmetic operations can only be performed on amounts that were
-/// created for the same `CyclesUseCase` and `CanisterCyclesCostSchedule`.
+/// created for the same `CyclesUseCase`. The `CanisterCyclesCostSchedule` is not
+/// part of the type: `new` folds it into the real part and does not retain it, so
+/// nothing stops two amounts created under different cost schedules from being
+/// combined (see the note on ordering below).
 ///
 /// E.g. the following code would not compile:
 ///
@@ -263,5 +266,48 @@ impl<T: CyclesUseCaseKind> TryFrom<PbCompoundCycles> for CompoundCycles<T> {
             nominal,
             _cycles_use_case_marker: PhantomData,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cycles_use_case::Instructions;
+    use crate::nominal_cycles::testing::NominalCyclesTesting;
+
+    /// An `Instructions` amount has coincident parts under the normal cost schedule,
+    /// whereas its real part is zero under the free cost schedule. The two amounts
+    /// below therefore order one way in their real parts and the other way in their
+    /// nominal parts, which is exactly the case a lexicographic ordering of the pair
+    /// would decide on the real parts alone. Both identities documented on
+    /// `CompoundCycles` hold for it.
+    #[test]
+    fn saturating_subtraction_is_part_wise() {
+        let x =
+            CompoundCycles::<Instructions>::new(Cycles::new(5), CanisterCyclesCostSchedule::Normal);
+        let y =
+            CompoundCycles::<Instructions>::new(Cycles::new(10), CanisterCyclesCostSchedule::Free);
+        assert_eq!(
+            (x.real(), x.nominal()),
+            (Cycles::new(5), NominalCycles::new(5))
+        );
+        assert_eq!(
+            (y.real(), y.nominal()),
+            (Cycles::zero(), NominalCycles::new(10))
+        );
+
+        // Subtracting `y` from `x` without going below zero, part by part.
+        let difference = x - y;
+        assert_eq!(
+            (difference.real(), difference.nominal()),
+            (Cycles::new(5), NominalCycles::zero())
+        );
+
+        // The part-wise minimum of `x` and `y`.
+        let minimum = x - (x - y);
+        assert_eq!(
+            (minimum.real(), minimum.nominal()),
+            (Cycles::zero(), NominalCycles::new(5))
+        );
     }
 }

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -80,15 +80,22 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 /// `CompoundCycles` deliberately implements neither `Ord` nor `PartialOrd`: its two
 /// parts are accounted for independently and there is no meaningful order on the
 /// pair. A derived impl would order lexicographically, i.e. by the real part first,
-/// and hence answer "which of the two amounts is larger?" from the real part alone
-/// whenever the real parts differ. That is exactly the wrong tie-break under the
-/// free cost schedule, where the real part of a use case made free is zero no matter
-/// how large the nominal part is.
+/// and hence decide a comparison on the real parts alone whenever those differ, no
+/// matter how the nominal parts compare.
+///
+/// Two amounts carrying the same cost schedule are safe to compare that way: under
+/// the normal cost schedule the two parts of an amount coincide, and under the free
+/// cost schedule the real part of a use case made free is zero on both sides, so the
+/// comparison falls through to the nominal parts. Such an order is misleading
+/// precisely when the two amounts carry *different* cost schedules, e.g. because one
+/// was recorded when a call was performed and the other derived when its response is
+/// executed: the one made free has a zero real part and compares as the smaller
+/// amount however large its nominal part is.
 ///
 /// Compare `real()` or `nominal()` explicitly instead. Note that subtraction
-/// saturates part by part, which covers the two idioms that would otherwise want an
-/// ordering: `x - x.min(y)` is simply `x - y`, and the part-wise minimum of `x` and
-/// `y` is `x - (x - y)`.
+/// saturates part by part, which covers the two idioms that would otherwise reach
+/// for an ordering: subtracting `y` from `x` without going below zero is `x - y`,
+/// and the part-wise minimum of `x` and `y` is `x - (x - y)`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CompoundCycles<T: CyclesUseCaseKind> {
     real: Cycles,

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -96,9 +96,9 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 /// amount however large its nominal part is.
 ///
 /// Compare `real()` or `nominal()` explicitly instead, or use `component_wise_min`
-/// to bound both parts at once. Note also that subtraction saturates part by part,
-/// so capping an amount before subtracting it is redundant: `x - y` already equals
-/// `x - x.component_wise_min(y)`.
+/// to bound both parts at once. Note also that subtraction saturates in both the
+/// real and the nominal part, so capping an amount before subtracting it is
+/// redundant: `x - y` already equals `x - x.component_wise_min(y)`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CompoundCycles<T: CyclesUseCaseKind> {
     real: Cycles,
@@ -311,7 +311,7 @@ mod tests {
             (Cycles::zero(), NominalCycles::new(10))
         );
 
-        // Subtracting `y` from `x` without going below zero, part by part.
+        // Subtracting `y` from `x` without going below zero in either part.
         let difference = x - y;
         assert_eq!(
             (difference.real(), difference.nominal()),


### PR DESCRIPTION
# Summary

`CompoundCycles` pairs a **real** amount, which moves the canister's cycles balance,
with a **nominal** one, which feeds the consumed cycles metrics. It derived `Ord`,
which orders lexicographically, i.e. by the real part first, so a comparison ignored
the nominal parts whenever the real parts differed.

There is no meaningful order on a pair of independently accounted amounts, and that one
is actively wrong for what the cycles accounting in `ic-cycles-account-manager` compares:
an amount recorded when a call is performed against one derived when its response is
executed. Under the free cost schedule the real part of an amount made free is zero
however large its nominal part, so the amount made free always compares as the smaller
one.

The derive is removed, so such a comparison is now a compile error, and the type
documents why it has no ordering. This also corrects a claim in the same doc comment:
the generics enforce the same `CyclesUseCase`, not the same cost schedule, which is
not part of the type at all.

# The four `min` calls

| site | before | after |
| --- | --- | --- |
| `settle_prepayment_for_unexecuted_response` | `p - base_fee.min(p)` | `p - base_fee` |
| `refund_for_response_transmission` | `p - cost.min(p)` | `p - cost` |
| `refund_unused_execution_cycles` | `refund.min(p)` | `refund.component_wise_min(p)` |
| `CanisterManager::load_canister_snapshot` | `p - cost.min(p)` | `p - cost.component_wise_min(p)` |

Subtraction saturates in both parts, so `x - y` already equals
`x - x.component_wise_min(y)`: capping a cost before subtracting it from that same
prepayment was redundant. Where a cap is wanted, `component_wise_min` replaces the
ordering with the minimum of the real parts paired with the minimum of the nominal
parts. `load_canister_snapshot` keeps its redundant cap so that it stays identical to
the `refund_unused_execution_cycles` refund it recomputes.

# Motivation

Hardening rather than a fix. Under a single cost schedule the two parts of an amount
agree on every ordering previously consulted, so the lexicographic tie-break was never
reached: no cycles balance and no consumed cycles metric changes. Removing the derive
keeps it out of reach as the accounting changes.

Concretely, were the two amounts ever to carry different cost schedules, the removed
ordering would produce:

- `settle_prepayment_for_unexecuted_response`: for a prepayment made under the free
  cost schedule and settled under the normal one, the ordering picks the whole
  prepayment as the charge. The consumed cycles counter then reports the nominal
  prepayment for the entire instruction limit — for a callback that never ran — instead
  of the fixed per-message execution fee.
- `refund_for_response_transmission`: same shape, same direction. Nothing is refunded
  and the whole nominal prepayment is reported as consumed.
- `refund_unused_execution_cycles`: the cap is decided by the real parts, so it need
  not bound the nominal one at all. For a prepayment made under the normal cost
  schedule and refunded under the free one, it selects the refund and leaves that
  refund's nominal part uncapped: exceeding the prepayment there trips the debug
  assertion in `refund_cycles`, and saturates both metrics in a release build. The
  other way round it selects the whole prepayment, refunding all of it and reporting
  the response as having consumed nothing.

None of the three moves a cycles balance: wherever the two orderings disagree, one of
the amounts carries the free cost schedule and hence a zero real part, so only the
nominal parts, i.e. the consumed cycles metrics, can differ.

One comparison of this kind is left after this PR, in
`adjust_prepayment_for_response_execution`, which weighs the prepayment for a response
against the requirement derived when that response is executed. It is likewise sound
only while both carry the same cost schedule. #11431 removes it.

# Note

#11431 builds on this and currently contains these hunks too. It will be rebased onto
this PR, so review this one on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
