### PR TITLE
feat: bump lru, axum-extra & mockito

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "045c2124b66060700903b339fc81a146c46b89aadce8fc576e1b43f16fc597fc",
+  "checksum": "e2869aadaa74bf57897300d2127b31b109918d9d426ad9f3be95d2796a6d22ad",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -8247,122 +8247,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "axum-extra 0.10.1": {
-      "name": "axum-extra",
-      "version": "0.10.1",
-      "package_url": "https://github.com/tokio-rs/axum",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/axum-extra/0.10.1/download",
-          "sha256": "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "axum_extra",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "axum_extra",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "tracing",
-            "typed-header"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "axum 0.8.9",
-              "target": "axum"
-            },
-            {
-              "id": "axum-core 0.5.6",
-              "target": "axum_core"
-            },
-            {
-              "id": "bytes 1.11.1",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-util 0.3.31",
-              "target": "futures_util"
-            },
-            {
-              "id": "headers 0.4.1",
-              "target": "headers"
-            },
-            {
-              "id": "http 1.3.1",
-              "target": "http"
-            },
-            {
-              "id": "http-body 1.0.1",
-              "target": "http_body"
-            },
-            {
-              "id": "http-body-util 0.1.3",
-              "target": "http_body_util"
-            },
-            {
-              "id": "mime 0.3.17",
-              "target": "mime"
-            },
-            {
-              "id": "pin-project-lite 0.2.17",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            },
-            {
-              "id": "tower 0.5.2",
-              "target": "tower"
-            },
-            {
-              "id": "tower-layer 0.3.3",
-              "target": "tower_layer"
-            },
-            {
-              "id": "tower-service 0.3.3",
-              "target": "tower_service"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "rustversion 1.0.14",
-              "target": "rustversion"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.10.1"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "axum-extra 0.12.6": {
       "name": "axum-extra",
       "version": "0.12.6",
@@ -8396,7 +8280,8 @@
           "common": [
             "default",
             "middleware",
-            "tracing"
+            "tracing",
+            "typed-header"
           ],
           "selects": {}
         },
@@ -8421,6 +8306,10 @@
             {
               "id": "futures-util 0.3.31",
               "target": "futures_util"
+            },
+            {
+              "id": "headers 0.4.1",
+              "target": "headers"
             },
             {
               "id": "http 1.3.1",
@@ -16082,55 +15971,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "colored 3.0.0": {
-      "name": "colored",
-      "version": "3.0.0",
-      "package_url": "https://github.com/mackwic/colored",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/colored/3.0.0/download",
-          "sha256": "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "colored",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "colored",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "3.0.0"
-      },
-      "license": "MPL-2.0",
-      "license_ids": [
-        "MPL-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "combine 4.6.7": {
       "name": "combine",
       "version": "4.6.7",
@@ -22935,7 +22775,7 @@
               "target": "axum"
             },
             {
-              "id": "axum-extra 0.10.1",
+              "id": "axum-extra 0.12.6",
               "target": "axum_extra"
             },
             {
@@ -23562,7 +23402,7 @@
               "alias": "loopdev_3"
             },
             {
-              "id": "lru 0.7.8",
+              "id": "lru 0.12.5",
               "target": "lru"
             },
             {
@@ -46466,44 +46306,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "lru 0.7.8": {
-      "name": "lru",
-      "version": "0.7.8",
-      "package_url": "https://github.com/jeromefroe/lru-rs.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/lru/0.7.8/download",
-          "sha256": "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lru",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "lru",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.7.8"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "lru 0.12.5": {
       "name": "lru",
       "version": "0.12.5",
@@ -48698,15 +48500,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "color",
-            "colored",
-            "default",
-            "parking_lot"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -48716,10 +48509,6 @@
             {
               "id": "bytes 1.11.1",
               "target": "bytes"
-            },
-            {
-              "id": "colored 3.0.0",
-              "target": "colored"
             },
             {
               "id": "futures-util 0.3.31",
@@ -94128,7 +93917,7 @@
     "async-stream 0.3.6",
     "async-trait 0.1.89",
     "axum 0.8.9",
-    "axum-extra 0.10.1",
+    "axum-extra 0.12.6",
     "axum-otel-metrics 0.14.1",
     "axum-server 0.7.3",
     "backon 1.6.0",
@@ -94287,7 +94076,7 @@
     "local-ip-address 0.6.13",
     "log 0.4.33",
     "loopdev-3 0.5.1",
-    "lru 0.7.8",
+    "lru 0.12.5",
     "lzma-sys 0.1.20",
     "macaddr 1.0.1",
     "maplit 1.0.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1520,29 +1520,6 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
-dependencies = [
- "axum",
- "axum-core",
- "bytes",
- "futures-util",
- "headers",
- "http 1.3.1",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "serde",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-extra"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
@@ -1552,6 +1529,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "headers",
  "http 1.3.1",
  "http-body",
  "http-body-util",
@@ -2774,15 +2752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,7 +3882,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "axum-extra 0.10.1",
+ "axum-extra",
  "axum-otel-metrics",
  "axum-server",
  "backon",
@@ -3945,7 +3914,7 @@ dependencies = [
  "ciborium",
  "cidr",
  "clap",
- "colored 2.0.4",
+ "colored",
  "comparable",
  "console 0.11.3",
  "convert_case 0.6.0",
@@ -4072,7 +4041,7 @@ dependencies = [
  "local-ip-address",
  "log",
  "loopdev-3",
- "lru 0.7.8",
+ "lru",
  "lzma-sys",
  "macaddr",
  "maplit",
@@ -4363,7 +4332,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e461c3f1e69d99372620640b3fd5f0309eeda2e26e4af69f6760c0e1df845"
 dependencies = [
- "colored 2.0.4",
+ "colored",
  "fnv",
 ]
 
@@ -6100,7 +6069,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-trait",
  "axum",
- "axum-extra 0.12.6",
+ "axum-extra",
  "base64 0.23.1",
  "bytes",
  "candid",
@@ -6428,7 +6397,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "axum-extra 0.12.6",
+ "axum-extra",
  "bytes",
  "candid",
  "clap",
@@ -8028,12 +7997,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-
-[[package]]
-name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
@@ -8370,7 +8333,6 @@ checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored 3.0.0",
  "futures-util",
  "http 1.3.1",
  "http-body",
@@ -10403,7 +10365,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru 0.12.5",
+ "lru",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",
@@ -12006,7 +11968,7 @@ version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
- "colored 2.0.4",
+ "colored",
  "log",
  "time",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,29 +1591,6 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
-dependencies = [
- "axum",
- "axum-core",
- "bytes",
- "futures-util",
- "headers",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "serde_core",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-extra"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
@@ -1623,6 +1600,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "headers",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -2937,15 +2915,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4540,7 +4509,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e461c3f1e69d99372620640b3fd5f0309eeda2e26e4af69f6760c0e1df845"
 dependencies = [
- "colored 2.2.0",
+ "colored",
  "fnv",
 ]
 
@@ -6897,7 +6866,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-trait",
  "axum",
- "axum-extra 0.12.6",
+ "axum-extra",
  "base64 0.23.1",
  "bytes",
  "candid",
@@ -6985,7 +6954,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "axum-extra 0.10.3",
+ "axum-extra",
  "bytes",
  "candid",
  "clap",
@@ -9917,7 +9886,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "axum-extra 0.12.6",
+ "axum-extra",
  "bytes",
  "candid",
  "clap",
@@ -12140,7 +12109,7 @@ name = "ic-neurons-fund-audit"
 version = "0.9.0"
 dependencies = [
  "candid",
- "colored 2.2.0",
+ "colored",
  "ic-agent",
  "ic-neurons-fund",
  "ic-sns-governance",
@@ -14104,7 +14073,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
- "colored 2.2.0",
+ "colored",
  "csv",
  "ic-agent",
  "ic-base-types",
@@ -15812,7 +15781,7 @@ version = "0.9.0"
 dependencies = [
  "ic-heap-bytes",
  "ic-types",
- "lru 0.7.8",
+ "lru",
  "proptest",
 ]
 
@@ -15820,7 +15789,7 @@ dependencies = [
 name = "ic-utils-mem-lru"
 version = "0.9.0"
 dependencies = [
- "lru 0.7.8",
+ "lru",
 ]
 
 [[package]]
@@ -17968,12 +17937,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-
-[[package]]
-name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
@@ -18444,7 +18407,6 @@ checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored 3.1.1",
  "futures-core",
  "http 1.4.0",
  "http-body",
@@ -20082,7 +20044,7 @@ dependencies = [
  "askama",
  "async-trait",
  "axum",
- "axum-extra 0.10.3",
+ "axum-extra",
  "axum-server",
  "backon",
  "base64 0.22.1",
@@ -20990,7 +20952,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru 0.12.5",
+ "lru",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",
@@ -21433,7 +21395,7 @@ dependencies = [
  "candid",
  "chrono",
  "clap",
- "colored 2.2.0",
+ "colored",
  "futures",
  "ic-agent",
  "ic-base-types",
@@ -23139,7 +23101,7 @@ version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
- "colored 2.2.0",
+ "colored",
  "log",
  "time",
  "windows-sys 0.48.0",
@@ -23762,7 +23724,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
- "colored 2.2.0",
+ "colored",
  "futures",
  "ic-agent",
  "ic-base-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,7 +618,7 @@ async-recursion = "1.0.5"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum = { version = "0.8.4", features = ["ws"] }
-axum-extra = { version = "0.10.1", features = ["typed-header"] }
+axum-extra = { version = "0.12", features = ["middleware", "typed-header"] }
 axum-otel-metrics = "0.14.1"
 axum-server = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 backon = { version = "1.6.0", default-features = false, features = ["std"] }
@@ -789,7 +789,7 @@ lmdb-rkv = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "a244a247789f
 lmdb-rkv-sys = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "a244a247789fd9ece0fe1a406180c32e5bbc0c3f" }
 local-ip-address = "0.6.13"
 loopdev-3 = "0.5"
-lru = { version = "0.7.8", default-features = false }
+lru = { version = "0.12", default-features = false }
 lzma-sys = { version = "0.1.20", features = ["static"] }
 macaddr = "1.0"
 maplit = "^1.0.2"
@@ -798,7 +798,7 @@ memmap2 = "0.9.5"
 minicbor = { version = "0.22.0", features = ["alloc", "derive"] }
 minicbor-derive = "0.14.0"
 mockall = "0.15.0"
-mockito = "1.6.1"
+mockito = { version = "1.6.1", default-features = false }
 more-asserts = "0.3.1"
 nftables = "0.4"
 nix = { version = "0.31.3", features = [

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -160,9 +160,12 @@ crate.spec(
     version = "^0.8.4",
 )
 crate.spec(
-    features = ["typed-header"],
+    features = [
+        "middleware",
+        "typed-header",
+    ],
     package = "axum-extra",
-    version = "^0.10.1",
+    version = "^0.12",
 )
 crate.spec(
     package = "axum-otel-metrics",
@@ -1024,7 +1027,7 @@ crate.spec(
 crate.spec(
     default_features = False,
     package = "lru",
-    version = "^0.7.8",
+    version = "^0.12",
 )
 crate.spec(
     features = [
@@ -1070,6 +1073,7 @@ crate.spec(
     version = "^0.15.0",
 )
 crate.spec(
+    default_features = False,
     package = "mockito",
     version = "^1.6.1",
 )

--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -12,7 +12,7 @@ use axum::{
     Router,
     extract::Request,
     middleware,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::method_routing::{any, get, post},
 };
 use axum_extra::middleware::option_layer;
@@ -822,6 +822,22 @@ fn setup_https(
 #[derive(Clone, Debug)]
 struct RequestTypeExtractor;
 
+/// Maps the generic response of a load shedder to an Axum response.
+///
+/// This is deliberately a named function rather than a closure. The layer
+/// stack built in `setup_router` is deeply nested (`Either`s of optional
+/// layers wrapping each other, each wrapped again in axum-extra's
+/// `ResponseAxumBodyLayer`), and with a closure here rustc spends tens of
+/// minutes in trait solving when type-checking that stack, even if the
+/// closure's signature is fully annotated. With a function item the crate
+/// type-checks in seconds.
+fn shed_map_response(resp: ShedResponse<Response>) -> Response {
+    match resp {
+        ShedResponse::Inner(inner) => inner,
+        ShedResponse::Overload(_) => ErrorCause::LoadShed.into_response(),
+    }
+}
+
 impl TypeExtractor for RequestTypeExtractor {
     type Type = RequestType;
     type Request = Request;
@@ -944,10 +960,7 @@ pub fn setup_router(
     // Load shedders
 
     // We need to map the generic response of a shedder to an Axum's Response
-    let shed_map_response = MapResponseLayer::new(|resp| match resp {
-        ShedResponse::Inner(inner) => inner,
-        ShedResponse::Overload(_) => ErrorCause::LoadShed.into_response(),
-    });
+    let shed_map_response = MapResponseLayer::new(shed_map_response);
 
     let load_shedder_system_mw = option_layer({
         let opts = &[

--- a/rs/utils/lru_cache/Cargo.toml
+++ b/rs/utils/lru_cache/Cargo.toml
@@ -11,7 +11,7 @@ documentation.workspace = true
 [dependencies]
 ic-heap-bytes = { path = "../../../packages/ic-heap-bytes" }
 ic-types = { path = "../../types/types" }
-lru = { version = "0.7.8", default-features = false }
+lru = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/rs/utils/mem-lru/src/lib.rs
+++ b/rs/utils/mem-lru/src/lib.rs
@@ -1,6 +1,7 @@
 //! A minimal, fixed-capacity, in-memory LRU cache that tracks hit/miss counts.
 
 use std::hash::Hash;
+use std::num::NonZeroUsize;
 
 /// A fixed-capacity LRU cache that additionally tracks hit/miss statistics.
 ///
@@ -32,9 +33,15 @@ pub struct LruCacheWithStats<K, V> {
 
 impl<K: Eq + Hash, V> LruCacheWithStats<K, V> {
     /// Create a new cache holding at most `max_size` entries.
+    ///
+    /// # Panics
+    /// Panics if `max_size` is zero: a zero-capacity LRU cache can never hold
+    /// anything, so that is a programming error rather than a valid configuration.
     pub fn with_size(max_size: usize) -> Self {
         Self {
-            cache: lru::LruCache::new(max_size),
+            cache: lru::LruCache::new(
+                NonZeroUsize::new(max_size).expect("LRU cache size must be non-zero"),
+            ),
             hits: 0,
             misses: 0,
         }


### PR DESCRIPTION
This bumps to more recent versions, in some cases also removing duplicated versions. For `mockito` we also disable default features which allow removing some more dependencies.