### PR TITLE
feat(cketh): sweep ETH deposits via sweepEthBatch

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -254,6 +254,10 @@ type MinterInfo = record {
     // balance scan to treat it as a deposit candidate. A smaller balance is never detected.
     minimum_deposit_amounts : opt vec record { erc20_contract_address: text; minimum_deposit_amount: nat};
 
+    // Minimum balance, in wei, that a deposit address must hold for the
+    // balance scan to treat it as an ETH deposit candidate. A smaller balance is never detected.
+    minimum_eth_deposit_amount : opt nat;
+
     // Last scraped block number for logs of the ETH helper contract.
     last_eth_scraped_block_number: opt nat;
 

--- a/rs/ethereum/cketh/minter/src/endpoints.rs
+++ b/rs/ethereum/cketh/minter/src/endpoints.rs
@@ -87,6 +87,7 @@ pub struct MinterInfo {
     pub last_gas_fee_estimate: Option<GasFeeEstimate>,
     pub erc20_balances: Option<Vec<Erc20Balance>>,
     pub minimum_deposit_amounts: Option<Vec<Erc20MinimumDeposit>>,
+    pub minimum_eth_deposit_amount: Option<Nat>,
     pub last_eth_scraped_block_number: Option<Nat>,
     pub last_erc20_scraped_block_number: Option<Nat>,
     pub last_deposit_with_subaccount_scraped_block_number: Option<Nat>,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1079,14 +1079,14 @@ fn get_events(arg: GetEventsArg) -> GetEventsResult {
                 EventType::AcceptedSweepRequest(SweepRequest {
                     id,
                     destination,
-                    token,
+                    asset,
                     items,
                     max_transaction_fee,
                     created_at,
                 }) => EP::AcceptedSweepRequest {
                     sweep_id: id.0.into(),
                     destination: destination.to_string(),
-                    asset: Asset::Erc20(token).into(),
+                    asset: asset.into(),
                     items: map_authorized_sweep_items(&items),
                     max_transaction_fee: max_transaction_fee.into(),
                     created_at,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -411,6 +411,7 @@ async fn get_minter_info() -> MinterInfo {
             ),
             erc20_balances,
             minimum_deposit_amounts,
+            minimum_eth_deposit_amount: Some(min_deposit(&Asset::Eth).into()),
             last_eth_scraped_block_number,
             last_erc20_scraped_block_number,
             last_deposit_with_subaccount_scraped_block_number,

--- a/rs/ethereum/cketh/minter/src/state/audit.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit.rs
@@ -123,7 +123,7 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType) {
             state.next_sweep_id = request.id.next();
             state.automatic_deposits.record_sweep_scheduled(
                 request.id,
-                request.token,
+                request.asset,
                 request.items.iter().map(|item| item.item.account),
             );
             state.update_sweeper_balance_upon_accepted_sweep(request);

--- a/rs/ethereum/cketh/minter/src/state/audit/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/audit/tests.rs
@@ -570,10 +570,7 @@ impl GetEventsFile {
                 } => ET::AcceptedSweepRequest(SweepRequest {
                     id: SweepId(sweep_id.0.to_u64().unwrap()),
                     destination: destination.parse().unwrap(),
-                    token: match crate::asset::Asset::try_from(asset).unwrap() {
-                        crate::asset::Asset::Erc20(address) => address,
-                        crate::asset::Asset::Eth => panic!("BUG: no recorded sweep moves ETH yet"),
-                    },
+                    asset: asset.try_into().unwrap(),
                     items: map_authorized_sweep_items(items),
                     max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                     created_at,

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/mod.rs
@@ -205,11 +205,11 @@ impl AutomaticDeposits {
             .sweeper_transactions
             .get_processed_request(&id)
             .expect("BUG: missing sweep request");
-        let token = request.token;
+        let asset = request.asset;
         let accounts: Vec<_> = request.items.iter().map(|item| item.item.account).collect();
 
         for account in accounts {
-            let request = DepositRequest::new(account, Asset::Erc20(token));
+            let request = DepositRequest::new(account, asset);
             let entry = self
                 .sweep
                 .remove(&request)
@@ -554,23 +554,14 @@ impl AutomaticDeposits {
         })
     }
 
-    /// The queued deposits a sweep could take next, batched by token, skipping those a sweep
+    /// The queued deposits a sweep could take next, batched by asset, skipping those a sweep
     /// already holds: taking them twice would move a balance the minter has already accounted for.
-    /// ETH entries stay queued but are never batched yet: they wait for the `sweepEthBatch` lane
-    /// (DEFI-2931).
-    pub fn requests_batch(
-        &self,
-        requested_batch_size: usize,
-    ) -> BTreeMap<Address, Vec<SweepTarget>> {
+    pub fn requests_batch(&self, requested_batch_size: usize) -> BTreeMap<Asset, Vec<SweepTarget>> {
         let mut batches = BTreeMap::new();
         for (deposit_request, sweep_entry) in
             self.sweep.iter().filter(|(_, entry)| entry.is_sweepable())
         {
-            let token = match deposit_request.asset {
-                Asset::Erc20(token) => token,
-                Asset::Eth => continue,
-            };
-            let batch: &mut Vec<_> = batches.entry(token).or_default();
+            let batch: &mut Vec<_> = batches.entry(deposit_request.asset).or_default();
             if batch.len() < requested_batch_size {
                 batch.push(SweepTarget {
                     account: deposit_request.account,
@@ -581,7 +572,7 @@ impl AutomaticDeposits {
         batches
     }
 
-    /// Record that `sweep_id` took these accounts' deposits of `token`: each leaves the pool of
+    /// Record that `sweep_id` took these accounts' deposits of `asset`: each leaves the pool of
     /// sweepable entries until the sweep is done with it.
     ///
     /// # Panics
@@ -591,11 +582,11 @@ impl AutomaticDeposits {
     pub fn record_sweep_scheduled(
         &mut self,
         sweep_id: SweepId,
-        token: Address,
+        asset: Asset,
         accounts: impl IntoIterator<Item = Account>,
     ) {
         for account in accounts {
-            let request = DepositRequest::new(account, Asset::Erc20(token));
+            let request = DepositRequest::new(account, asset);
             let entry = self
                 .sweep
                 .get_mut(&request)

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -879,6 +879,22 @@ fn should_batch_eth_entries_alongside_tokens() {
 }
 
 #[test]
+fn should_cap_each_asset_batch_at_the_requested_size() {
+    let mut entries: Vec<(Account, Asset)> =
+        (0..11).map(|index| (account(index), Asset::Eth)).collect();
+    entries.push((account(11), Asset::Erc20(usdc())));
+    let deposits = queued(&entries);
+
+    let batches = deposits.requests_batch(10);
+
+    assert_eq!(
+        accounts_in(&batches, Asset::Eth),
+        (0..10).map(account).collect::<Vec<_>>()
+    );
+    assert_eq!(accounts_in(&batches, usdc()), vec![account(11)]);
+}
+
+#[test]
 fn should_batch_queued_deposits_by_token() {
     let deposits = queued(&[
         (account(0), usdc()),
@@ -903,22 +919,24 @@ fn should_batch_queued_deposits_by_token() {
 
 #[test]
 fn should_stop_offering_a_deposit_a_sweep_has_taken() {
-    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
+    for asset in sweepable_assets() {
+        let mut deposits = queued(&[(account(0), asset), (account(1), asset)]);
 
-    deposits.record_sweep_scheduled(SweepId(7), Asset::Erc20(usdc()), [account(0)]);
+        deposits.record_sweep_scheduled(SweepId(7), asset, [account(0)]);
 
-    let batches = deposits.requests_batch(10);
-    assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
+        let batches = deposits.requests_batch(10);
+        assert_eq!(accounts_in(&batches, asset), vec![account(1)]);
 
-    // The taken deposit is still queued: only a settled sweep removes it.
-    assert_eq!(deposits.sweep_len(), 2);
+        // The taken deposit is still queued: only a settled sweep removes it.
+        assert_eq!(deposits.sweep_len(), 2);
+    }
 }
 
 #[test]
 fn should_offer_nothing_once_every_deposit_is_taken() {
-    let mut deposits = queued(&[(account(0), usdc()), (account(1), usdt())]);
+    let mut deposits = queued(&[(account(0), Asset::Eth), (account(1), Asset::Erc20(usdt()))]);
 
-    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Eth, [account(0)]);
     deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdt()), [account(1)]);
 
     assert!(deposits.requests_batch(10).is_empty());
@@ -927,11 +945,21 @@ fn should_offer_nothing_once_every_deposit_is_taken() {
 
 #[test]
 #[should_panic(expected = "was already taken by another sweep")]
-fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
-    let mut deposits = queued(&[(account(0), usdc())]);
+fn should_refuse_to_hand_the_same_erc20_deposit_to_two_sweeps() {
+    hand_a_deposit_to_two_sweeps(Asset::Erc20(usdc()));
+}
 
-    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
-    deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdc()), [account(0)]);
+#[test]
+#[should_panic(expected = "was already taken by another sweep")]
+fn should_refuse_to_hand_the_same_eth_deposit_to_two_sweeps() {
+    hand_a_deposit_to_two_sweeps(Asset::Eth);
+}
+
+fn hand_a_deposit_to_two_sweeps(asset: Asset) {
+    let mut deposits = queued(&[(account(0), asset)]);
+
+    deposits.record_sweep_scheduled(SweepId(1), asset, [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), asset, [account(0)]);
 }
 
 #[test]
@@ -944,40 +972,47 @@ fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
 
 #[tokio::test]
 async fn should_release_a_deposit_once_its_sweep_succeeds() {
-    let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
-    queue(&mut deposits, &[(account(1), usdc())]);
+    for asset in sweepable_assets() {
+        let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), asset)]).await;
+        queue(&mut deposits, &[(account(1), asset)]);
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+        finalize_sweep(&mut deposits, request, TransactionStatus::Success);
 
-    // The swept pair is gone from the queue; the pair queued after the sweep was decided is still
-    // offered.
-    assert_eq!(deposits.sweep_len(), 1);
-    assert_eq!(
-        accounts_in(&deposits.requests_batch(10), usdc()),
-        vec![account(1)]
-    );
+        // The swept pair is gone from the queue; the pair queued after the sweep was decided is
+        // still offered.
+        assert_eq!(deposits.sweep_len(), 1);
+        assert_eq!(
+            accounts_in(&deposits.requests_batch(10), asset),
+            vec![account(1)]
+        );
+    }
 }
 
 #[tokio::test]
-async fn should_drop_a_deposit_once_its_sweep_fails() {
-    let (mut deposits, request) = deposits_with_enqueued_sweep(&[(account(0), usdc())]).await;
+async fn should_drop_every_deposit_of_a_sweep_once_it_fails() {
+    for asset in sweepable_assets() {
+        let (mut deposits, request) =
+            deposits_with_enqueued_sweep(&[(account(0), asset), (account(1), asset)]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
+        finalize_sweep(&mut deposits, request, TransactionStatus::Failure);
 
-    // A reverted sweep moved nothing, but the minter does not retry: the pair leaves the queue and
-    // has to be armed afresh.
-    assert_eq!(deposits.sweep_len(), 0);
-    assert!(deposits.requests_batch(10).is_empty());
+        // A reverted sweep moved nothing, but the minter does not retry: every pair the sweep named
+        // leaves the queue, not only the one that made it revert, and each has to be armed afresh.
+        assert_eq!(deposits.sweep_len(), 0);
+        assert!(deposits.requests_batch(10).is_empty());
+    }
 }
 
 #[tokio::test]
 async fn should_release_every_account_a_sweep_held() {
-    let (mut deposits, request) =
-        deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
+    for asset in sweepable_assets() {
+        let (mut deposits, request) =
+            deposits_with_enqueued_sweep(&[(account(0), asset), (account(1), asset)]).await;
 
-    finalize_sweep(&mut deposits, request, TransactionStatus::Success);
+        finalize_sweep(&mut deposits, request, TransactionStatus::Success);
 
-    assert_eq!(deposits.sweep_len(), 0);
+        assert_eq!(deposits.sweep_len(), 0);
+    }
 }
 
 /// The mismatch this test finalizes cannot come out of `create_pending_sweeper_requests`, which
@@ -1032,31 +1067,32 @@ fn finalize_sweep(
 }
 
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs.
-fn queued(pairs: &[(Account, Address)]) -> AutomaticDeposits {
+fn queued<A: Into<Asset> + Copy>(pairs: &[(Account, A)]) -> AutomaticDeposits {
     let mut deposits = AutomaticDeposits::default();
     queue(&mut deposits, pairs);
     assert_eq!(deposits.sweep_len(), pairs.len());
     deposits
 }
 
-fn queue(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {
-    for (account, token) in pairs {
+fn queue<A: Into<Asset> + Copy>(deposits: &mut AutomaticDeposits, pairs: &[(Account, A)]) {
+    for (account, asset) in pairs {
+        let asset: Asset = (*asset).into();
         deposits
-            .watch_deposit(
-                ts(0),
-                *account,
-                Asset::Erc20(*token),
-                deposit_address(account),
-            )
+            .watch_deposit(ts(0), *account, asset, deposit_address(account))
             .unwrap();
         deposits.record_automatic_deposit_received(&automatic_deposit(
             *account,
-            *token,
+            asset,
             10,
             BlockNumber::new(900),
             3,
         ));
     }
+}
+
+/// One asset of each kind the sweep queue batches, so a lifecycle test covers both.
+fn sweepable_assets() -> [Asset; 2] {
+    [Asset::Eth, Asset::Erc20(usdc())]
 }
 
 fn accounts_in(

--- a/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/automatic_deposits/tests.rs
@@ -854,7 +854,7 @@ fn automatic_deposit(
 }
 
 #[test]
-fn should_keep_eth_entries_out_of_sweep_batches() {
+fn should_batch_eth_entries_alongside_tokens() {
     let mut deposits = AutomaticDeposits::default();
     deposits.record_automatic_deposit_received(&automatic_deposit(
         account(0),
@@ -873,13 +873,9 @@ fn should_keep_eth_entries_out_of_sweep_batches() {
 
     let batches = deposits.requests_batch(10);
 
-    assert_eq!(batches.len(), 1);
+    assert_eq!(batches.len(), 2);
+    assert_eq!(accounts_in(&batches, Asset::Eth), vec![account(0)]);
     assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
-    assert_eq!(
-        deposits.sweep_len(),
-        2,
-        "BUG: the ETH entry stays queued, awaiting the sweepEthBatch lane"
-    );
 }
 
 #[test]
@@ -894,7 +890,7 @@ fn should_batch_queued_deposits_by_token() {
 
     assert_eq!(
         batches.keys().copied().collect::<Vec<_>>(),
-        vec![usdc(), usdt()]
+        vec![Asset::Erc20(usdc()), Asset::Erc20(usdt())]
     );
     assert_eq!(accounts_in(&batches, usdc()), vec![account(0), account(1)]);
     assert_eq!(accounts_in(&batches, usdt()), vec![account(2)]);
@@ -909,7 +905,7 @@ fn should_batch_queued_deposits_by_token() {
 fn should_stop_offering_a_deposit_a_sweep_has_taken() {
     let mut deposits = queued(&[(account(0), usdc()), (account(1), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(7), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(7), Asset::Erc20(usdc()), [account(0)]);
 
     let batches = deposits.requests_batch(10);
     assert_eq!(accounts_in(&batches, usdc()), vec![account(1)]);
@@ -922,8 +918,8 @@ fn should_stop_offering_a_deposit_a_sweep_has_taken() {
 fn should_offer_nothing_once_every_deposit_is_taken() {
     let mut deposits = queued(&[(account(0), usdc()), (account(1), usdt())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
-    deposits.record_sweep_scheduled(SweepId(2), usdt(), [account(1)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdt()), [account(1)]);
 
     assert!(deposits.requests_batch(10).is_empty());
     assert_eq!(deposits.sweep_len(), 2);
@@ -934,8 +930,8 @@ fn should_offer_nothing_once_every_deposit_is_taken() {
 fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
     let mut deposits = queued(&[(account(0), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdc(), [account(0)]);
-    deposits.record_sweep_scheduled(SweepId(2), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdc()), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(2), Asset::Erc20(usdc()), [account(0)]);
 }
 
 #[test]
@@ -943,7 +939,7 @@ fn should_refuse_to_hand_the_same_deposit_to_two_sweeps() {
 fn should_refuse_to_schedule_a_deposit_that_is_not_queued() {
     let mut deposits = queued(&[(account(0), usdc())]);
 
-    deposits.record_sweep_scheduled(SweepId(1), usdt(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(1), Asset::Erc20(usdt()), [account(0)]);
 }
 
 #[tokio::test]
@@ -993,7 +989,7 @@ async fn should_refuse_to_finalize_a_sweep_whose_deposit_left_the_queue() {
     let (_, request) =
         deposits_with_enqueued_sweep(&[(account(0), usdc()), (account(1), usdc())]).await;
     let mut deposits = queued(&[(account(0), usdc())]);
-    deposits.record_sweep_scheduled(SweepId(0), usdc(), [account(0)]);
+    deposits.record_sweep_scheduled(SweepId(0), Asset::Erc20(usdc()), [account(0)]);
     deposits.record_sweep_request(request.clone());
 
     finalize_sweep(&mut deposits, request, TransactionStatus::Success);
@@ -1063,9 +1059,12 @@ fn queue(deposits: &mut AutomaticDeposits, pairs: &[(Account, Address)]) {
     }
 }
 
-fn accounts_in(batches: &BTreeMap<Address, Vec<SweepTarget>>, token: Address) -> Vec<Account> {
+fn accounts_in(
+    batches: &BTreeMap<Asset, Vec<SweepTarget>>,
+    asset: impl Into<Asset>,
+) -> Vec<Account> {
     batches
-        .get(&token)
+        .get(&asset.into())
         .map(|targets| targets.iter().map(|target| target.account()).collect())
         .unwrap_or_default()
 }

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -303,7 +303,14 @@ const SWEEP_GAS_PER_TRANSFER: GasAmount = GasAmount::new(110_000);
 /// had to declare, leaving 25'000 the figure to budget either way. Rounded up as its siblings are.
 const SWEEP_GAS_PER_AUTHORIZATION: GasAmount = GasAmount::new(40_000);
 
-pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
+/// Gas one address of an ETH sweep costs beyond its authorization: the per-address dispatch
+/// (calldata, `ecrecover`, the delegated call), one warm `address(this).balance` read and the
+/// helper's `depositEth`, a value transfer and one log. `sweepEth` walks no token array, so unlike
+/// an ERC-20 address there is no balance check or transfer to budget per pair. Measured at ~14'000
+/// on top of the tuple's 25'000 for a ten-deposit batch, rounded up as its siblings are.
+const SWEEP_GAS_PER_ETH_DEPOSIT: GasAmount = GasAmount::new(40_000);
+
+pub fn sweep_gas_limit(asset: Asset, items: &[AuthorizedSweepItem]) -> GasAmount {
     let addresses = u64::try_from(
         items
             .iter()
@@ -312,26 +319,30 @@ pub fn sweep_gas_limit(items: &[AuthorizedSweepItem]) -> GasAmount {
             .len(),
     )
     .unwrap_or(u64::MAX);
-    [
-        SWEEP_GAS_PER_BALANCE_CHECK,
-        SWEEP_GAS_PER_TRANSFER,
-        SWEEP_GAS_PER_AUTHORIZATION,
-    ]
-    .into_iter()
-    .fold(SWEEP_BASE_GAS, |total, gas_per_address| {
-        total
-            .checked_add(
-                gas_per_address
-                    .checked_mul(addresses)
-                    .unwrap_or(GasAmount::MAX),
-            )
-            .unwrap_or(GasAmount::MAX)
-    })
+    let gas_per_address: &[GasAmount] = match asset {
+        Asset::Eth => &[SWEEP_GAS_PER_ETH_DEPOSIT, SWEEP_GAS_PER_AUTHORIZATION],
+        Asset::Erc20(_) => &[
+            SWEEP_GAS_PER_BALANCE_CHECK,
+            SWEEP_GAS_PER_TRANSFER,
+            SWEEP_GAS_PER_AUTHORIZATION,
+        ],
+    };
+    gas_per_address
+        .iter()
+        .fold(SWEEP_BASE_GAS, |total, gas_per_address| {
+            total
+                .checked_add(
+                    gas_per_address
+                        .checked_mul(addresses)
+                        .unwrap_or(GasAmount::MAX),
+                )
+                .unwrap_or(GasAmount::MAX)
+        })
 }
 
 impl SweepRequest {
     pub fn gas_limit(&self) -> GasAmount {
-        sweep_gas_limit(&self.items)
+        sweep_gas_limit(self.asset, &self.items)
     }
 
     /// The delegate's batch call, naming every deposit address this sweep walks and the single

--- a/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/mod.rs
@@ -5,6 +5,7 @@ pub(in crate::state) mod tests;
 
 pub use request::PipelineRequest;
 
+use crate::asset::Asset;
 use crate::endpoints::{EthTransaction, RetrieveEthStatus, TxFinalizedStatus, WithdrawalStatus};
 use crate::eth_logs::LedgerSubaccount;
 use crate::eth_rpc::Hash;
@@ -16,7 +17,7 @@ use crate::numeric::{
     CkTokenAmount, Erc20Value, GasAmount, LedgerBurnIndex, LedgerMintIndex, TransactionCount,
     TransactionNonce, Wei,
 };
-use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
+use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::{
     Eip1559TransactionRequest, Finalized, FinalizedEip1559Transaction, GasFeeEstimate,
     Resubmittable, SignableTransaction, Signed, SignedAuthorization,
@@ -229,12 +230,13 @@ pub struct SweepRequest {
     /// sweeps every delegated deposit address the sweep names.
     #[n(1)]
     pub destination: Address,
-    /// The single ERC-20 this sweep moves. One token per sweep: the delegate applies the token
-    /// list to every item it walks, so a sweep mixing tokens would check balances that cannot be
-    /// there. Holding it as one address rather than a list is what makes that an invariant of the
-    /// request instead of a property of how the batch happened to be picked.
+    /// The single asset this sweep moves: one ERC-20 token, or ETH. One asset per sweep: the
+    /// delegate applies the token list to every item it walks, so a sweep mixing tokens would
+    /// check balances that cannot be there. Holding it as one asset rather than a list is what
+    /// makes that an invariant of the request instead of a property of how the batch happened to
+    /// be picked.
     #[n(2)]
-    pub token: Address,
+    pub asset: Asset,
     /// The deposits this sweep moves, one per account. A deposit address is derived per account,
     /// so an account has one address, one attestation and one authorization however many tokens
     /// it has queued.
@@ -333,10 +335,13 @@ impl SweepRequest {
     }
 
     /// The delegate's batch call, naming every deposit address this sweep walks and the single
-    /// token it moves.
+    /// asset it moves.
     pub fn call_data(&self) -> Vec<u8> {
         let items: Vec<_> = self.items.iter().map(|item| item.item.clone()).collect();
-        encode_sweep_erc20_batch(&items, &[self.token])
+        match self.asset {
+            Asset::Erc20(token) => encode_sweep_erc20_batch(&items, &[token]),
+            Asset::Eth => encode_sweep_eth_batch(&items),
+        }
     }
 
     /// The delegations the sweep installs on the way, one per deposit address it still has to

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2957,6 +2957,7 @@ mod sweep_lane {
     };
 
     const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
+    use crate::asset::Asset;
     use crate::sweeper_contract::SweepItem;
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
@@ -2977,7 +2978,7 @@ mod sweep_lane {
         SweepRequest {
             id: SweepId(id),
             destination: Address::new([id as u8; 20]),
-            token: Address::new([0xc0; 20]),
+            asset: Asset::Erc20(Address::new([0xc0; 20])),
             items: vec![sweep_item(1, None), sweep_item(2, None)],
             max_transaction_fee: Wei::from(1_000_000_000_000_000_u64),
             created_at: 1_620_328_630_000_000_000,

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -3056,20 +3056,47 @@ mod sweep_lane {
 
     #[test]
     fn should_scale_the_sweep_gas_limit_with_the_distinct_addresses_walked() {
-        const MEASURED_TEN_DEPOSIT_SWEEP_GAS: u128 = 609_431;
+        const MEASURED_TEN_DEPOSIT_ERC20_SWEEP_GAS: u128 = 609_431;
+        const MEASURED_TEN_DEPOSIT_ETH_SWEEP_GAS: u128 = 413_076;
+        let erc20 = Asset::Erc20(Address::new([0xc0; 20]));
 
         let items_for = |addresses: u8| -> Vec<AuthorizedSweepItem> {
             (1..=addresses).map(|seed| sweep_item(seed, None)).collect()
         };
 
-        assert_eq!(sweep_gas_limit(&items_for(1)), GasAmount::new(225_000));
-        assert_eq!(sweep_gas_limit(&items_for(10)), GasAmount::new(1_710_000));
-        assert!(sweep_gas_limit(&items_for(10)) > GasAmount::new(MEASURED_TEN_DEPOSIT_SWEEP_GAS));
+        assert_eq!(
+            sweep_gas_limit(erc20, &items_for(1)),
+            GasAmount::new(225_000)
+        );
+        assert_eq!(
+            sweep_gas_limit(erc20, &items_for(10)),
+            GasAmount::new(1_710_000)
+        );
+        assert!(
+            sweep_gas_limit(erc20, &items_for(10))
+                > GasAmount::new(MEASURED_TEN_DEPOSIT_ERC20_SWEEP_GAS)
+        );
+
+        assert_eq!(
+            sweep_gas_limit(Asset::Eth, &items_for(1)),
+            GasAmount::new(140_000)
+        );
+        assert_eq!(
+            sweep_gas_limit(Asset::Eth, &items_for(10)),
+            GasAmount::new(860_000)
+        );
+        assert!(
+            sweep_gas_limit(Asset::Eth, &items_for(10))
+                > GasAmount::new(MEASURED_TEN_DEPOSIT_ETH_SWEEP_GAS)
+        );
+        assert!(
+            sweep_gas_limit(Asset::Eth, &items_for(10)) < sweep_gas_limit(erc20, &items_for(10))
+        );
 
         let one_address_ten_times: Vec<_> = (0..10).map(|_| sweep_item(1, None)).collect();
         assert_eq!(
-            sweep_gas_limit(&one_address_ten_times),
-            sweep_gas_limit(&items_for(1))
+            sweep_gas_limit(erc20, &one_address_ten_times),
+            sweep_gas_limit(erc20, &items_for(1))
         );
     }
 
@@ -3085,8 +3112,14 @@ mod sweep_lane {
             )
             .expect("BUG: the fixture allowance covers the fixture fee");
 
-        assert_eq!(request.gas_limit(), sweep_gas_limit(&request.items));
-        assert_eq!(transaction.gas_limit(), sweep_gas_limit(&request.items));
+        assert_eq!(
+            request.gas_limit(),
+            sweep_gas_limit(request.asset, &request.items)
+        );
+        assert_eq!(
+            transaction.gas_limit(),
+            sweep_gas_limit(request.asset, &request.items)
+        );
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/transactions/tests.rs
@@ -2958,7 +2958,7 @@ mod sweep_lane {
 
     const SWEEP_TRANSACTION_GAS_LIMIT: GasAmount = GasAmount::new(100_000);
     use crate::asset::Asset;
-    use crate::sweeper_contract::SweepItem;
+    use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
     use crate::tx::{
         DelegatingSweep, Eip1559TransactionRequest, Eip7702TransactionRequest, GasFeeEstimate,
         SignableTransaction, SignedAuthorization, SweepTransaction, TransactionSignature,
@@ -3098,6 +3098,31 @@ mod sweep_lane {
             sweep_gas_limit(erc20, &one_address_ten_times),
             sweep_gas_limit(erc20, &items_for(1))
         );
+    }
+
+    #[test]
+    fn should_encode_the_batch_call_of_the_asset_the_sweep_moves() {
+        let token = Address::new([0xc0; 20]);
+        let items: Vec<SweepItem> = sweep_request(0)
+            .items
+            .iter()
+            .map(|authorized| authorized.item.clone())
+            .collect();
+        let erc20_sweep = SweepRequest {
+            asset: Asset::Erc20(token),
+            ..sweep_request(0)
+        };
+        let eth_sweep = SweepRequest {
+            asset: Asset::Eth,
+            ..sweep_request(0)
+        };
+
+        assert_eq!(
+            erc20_sweep.call_data(),
+            encode_sweep_erc20_batch(&items, &[token])
+        );
+        assert_eq!(eth_sweep.call_data(), encode_sweep_eth_batch(&items));
+        assert_ne!(eth_sweep.call_data(), erc20_sweep.call_data());
     }
 
     #[test]

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -12,6 +12,7 @@
 #[cfg(test)]
 mod tests;
 
+use crate::asset::Asset;
 use crate::attestation::{AttestationRequest, sign_attestation};
 use crate::sweeper_contract::SweepItem;
 use crate::{
@@ -69,9 +70,9 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     }
 
-    let batch_per_token =
+    let batch_per_asset =
         read_state(|s| s.automatic_deposits.requests_batch(MAX_DEPOSITS_PER_SWEEP));
-    if batch_per_token.is_empty() {
+    if batch_per_asset.is_empty() {
         return;
     }
 
@@ -83,7 +84,7 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         return;
     };
 
-    for (token, targets) in batch_per_token {
+    for (asset, targets) in batch_per_asset {
         let Some(attestation_requests) = read_state(|s| s.attestation_requests(&targets)) else {
             log!(
                 DEBUG,
@@ -101,18 +102,18 @@ pub async fn create_pending_sweeper_requests<R: CanisterRuntime>(runtime: &R) {
         };
         sign_attestations_batch(attestation_requests, runtime).await;
         sign_authorizations_batch(authorization_requests, runtime).await;
-        enqueue_sweep(token, &targets, &gas_fee_estimate, runtime);
+        enqueue_sweep(asset, &targets, &gas_fee_estimate, runtime);
     }
 }
 
-/// Enqueues one sweep of `token` from the targets both signing passes covered, so the pipeline can
+/// Enqueues one sweep of `asset` from the targets both signing passes covered, so the pipeline can
 /// price, sign and send it.
 ///
 /// A target whose attestation or authorization is missing is left out rather than swept: its
 /// signing failed, so the sweep has nothing to prove the address credits the account, or nothing to
 /// delegate it with. It stays queued, and the next tick tries it again.
 fn enqueue_sweep<R: CanisterRuntime>(
-    token: Address,
+    asset: Asset,
     targets: &[SweepTarget],
     gas_fee_estimate: &GasFeeEstimate,
     runtime: &R,
@@ -150,7 +151,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         if items.is_empty() {
             log!(
                 INFO,
-                "[create_pending_sweeper_requests]: SKIPPING {token}: none of its queued deposits could be signed for"
+                "[create_pending_sweeper_requests]: SKIPPING {asset}: none of its queued deposits could be signed for"
             );
             return;
         }
@@ -163,7 +164,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         if max_transaction_fee > sweeper_gas {
             log!(
                 INFO,
-                "[create_pending_sweeper_requests]: SKIPPING {token}: the sweep needs \
+                "[create_pending_sweeper_requests]: SKIPPING {asset}: the sweep needs \
                  {max_transaction_fee} of gas but the sweeper holds at least {sweeper_gas}"
             );
             return;
@@ -171,7 +172,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
         let request = SweepRequest {
             id: s.next_sweep_id,
             destination,
-            token,
+            asset,
             items,
             max_transaction_fee,
             created_at: runtime.time(),

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -46,7 +46,9 @@ use std::collections::BTreeSet;
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
-const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+/// Maximum number of deposits one sweep batches; a larger queue is drained over several
+/// sweeps.
+pub const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -46,9 +46,7 @@ use std::collections::BTreeSet;
 const SWEEP_REQUESTS_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SIGN_BATCH_SIZE: usize = 5;
 const SWEEP_TRANSACTIONS_TO_SEND_BATCH_SIZE: usize = 5;
-/// Maximum number of deposits one sweep batches; a larger queue is drained over several
-/// sweeps.
-pub const MAX_DEPOSITS_PER_SWEEP: usize = 10;
+const MAX_DEPOSITS_PER_SWEEP: usize = 10;
 
 /// Turns the deposits the balance scan queued into the sweep requests that
 /// [`process_sweeper_transactions`] prices, signs, sends and finalizes.

--- a/rs/ethereum/cketh/minter/src/sweep/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/mod.rs
@@ -158,7 +158,7 @@ fn enqueue_sweep<R: CanisterRuntime>(
 
         let max_transaction_fee = gas_fee_estimate
             .clone()
-            .to_price(sweep_gas_limit(&items))
+            .to_price(sweep_gas_limit(asset, &items))
             .max_transaction_fee();
         let sweeper_gas = s.sweeper_funding.sweeper_balance_lower_bound();
         if max_transaction_fee > sweeper_gas {

--- a/rs/ethereum/cketh/minter/src/sweep/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweep/tests.rs
@@ -179,8 +179,8 @@ async fn should_enqueue_one_sweep_per_token() {
 
     let enqueued = pending_sweeps();
     assert_eq!(
-        enqueued.iter().map(|r| r.token).collect::<Vec<_>>(),
-        vec![usdc(), usdt()]
+        enqueued.iter().map(|r| r.asset).collect::<Vec<_>>(),
+        vec![Asset::Erc20(usdc()), Asset::Erc20(usdt())]
     );
     assert_eq!(
         enqueued.iter().map(|r| r.id).collect::<Vec<_>>(),

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/mod.rs
@@ -18,6 +18,10 @@ use minicbor::{Decode, Encode};
 /// keccak256("sweepErc20Batch((address,bytes32,bytes32,bytes32,bytes32,uint8)[],address[])").
 const SWEEP_ERC20_BATCH_SELECTOR: [u8; 4] = hex_literal::hex!("3a7ce054");
 
+/// First 4 bytes of
+/// keccak256("sweepEthBatch((address,bytes32,bytes32,bytes32,bytes32,uint8)[])").
+const SWEEP_ETH_BATCH_SELECTOR: [u8; 4] = hex_literal::hex!("509181f7");
+
 /// A 6-word ABI head: `(address, bytes32, bytes32, bytes32, bytes32, uint8)`. Every component is
 /// static, so the elements of a `SweepItem[]` are encoded inline rather than behind offsets.
 const WORDS_PER_ITEM: usize = 6;
@@ -59,21 +63,46 @@ pub fn encode_sweep_erc20_batch(items: &[SweepItem], tokens: &[Address]) -> Vec<
 
     data.extend(word(items.len()));
     for item in items {
-        data.extend(<[u8; 32]>::from(item.deposit.as_address()));
-        data.extend(encode_principal(&item.account.owner));
-        data.extend(item.account.effective_subaccount());
-        data.extend(item.attestation.r.to_be_bytes());
-        data.extend(item.attestation.s.to_be_bytes());
-        // `ecrecover` wants v as 27 or 28, where the signature carries the parity bit.
-        data.extend(word(usize::from(
-            27 + u8::from(item.attestation.signature_y_parity),
-        )));
+        data.extend(encode_item(item));
     }
 
     data.extend(word(tokens.len()));
     for token in tokens {
         data.extend(<[u8; 32]>::from(token));
     }
+    data
+}
+
+/// Encode `sweepEthBatch(SweepItem[] items)` on the deployed delegate, which sweeps the whole
+/// ETH balance held by every `item`'s deposit address to the minter's main address through the
+/// deposit helper.
+///
+/// The single argument is dynamic, so the head holds one offset and the items block follows.
+pub fn encode_sweep_eth_batch(items: &[SweepItem]) -> Vec<u8> {
+    let head_len = WORD;
+    let items_block_len = WORD + items.len() * WORDS_PER_ITEM * WORD;
+
+    let mut data = Vec::with_capacity(SWEEP_ETH_BATCH_SELECTOR.len() + head_len + items_block_len);
+    data.extend(SWEEP_ETH_BATCH_SELECTOR);
+    data.extend(word(head_len));
+    data.extend(word(items.len()));
+    for item in items {
+        data.extend(encode_item(item));
+    }
+    data
+}
+
+fn encode_item(item: &SweepItem) -> Vec<u8> {
+    let mut data = Vec::with_capacity(WORDS_PER_ITEM * WORD);
+    data.extend(<[u8; 32]>::from(item.deposit.as_address()));
+    data.extend(encode_principal(&item.account.owner));
+    data.extend(item.account.effective_subaccount());
+    data.extend(item.attestation.r.to_be_bytes());
+    data.extend(item.attestation.s.to_be_bytes());
+    // `ecrecover` wants v as 27 or 28, where the signature carries the parity bit.
+    data.extend(word(usize::from(
+        27 + u8::from(item.attestation.signature_y_parity),
+    )));
     data
 }
 

--- a/rs/ethereum/cketh/minter/src/sweeper_contract/tests.rs
+++ b/rs/ethereum/cketh/minter/src/sweeper_contract/tests.rs
@@ -1,6 +1,6 @@
 use crate::deposit_address::DepositAddress;
 use crate::eth_logs::encode_principal;
-use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch};
+use crate::sweeper_contract::{SweepItem, encode_sweep_erc20_batch, encode_sweep_eth_batch};
 use crate::tx::TransactionSignature;
 use candid::Principal;
 use ethnum::u256;
@@ -93,6 +93,65 @@ fn should_encode_an_empty_batch() {
     assert_eq!(data.len(), 4 + 64 + 32 + 32);
     assert_eq!(&data[4 + 64..4 + 96], &word(0));
     assert_eq!(&data[4 + 96..], &word(0));
+}
+
+const ETH_SIGNATURE: &str = "sweepEthBatch((address,bytes32,bytes32,bytes32,bytes32,uint8)[])";
+
+#[test]
+fn should_call_the_eth_function_the_delegate_exposes() {
+    let (items, _tokens) = sweep();
+
+    let data = encode_sweep_eth_batch(&items);
+
+    assert_eq!(
+        &data[..4],
+        &ic_sha3::Keccak256::hash(ETH_SIGNATURE.as_bytes())[..4]
+    );
+}
+
+#[test]
+fn should_encode_an_eth_batch_sweep() {
+    use alloy_primitives::{Address, B256};
+    use alloy_sol_types::{SolValue, sol};
+
+    sol! {
+        struct EthSweepItem {
+            address deposit;
+            bytes32 principal;
+            bytes32 subaccount;
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+        }
+    }
+
+    let (items, _tokens) = sweep();
+
+    let data = encode_sweep_eth_batch(&items);
+
+    let expected_arguments = (items
+        .iter()
+        .map(|item| EthSweepItem {
+            deposit: Address::from(item.deposit.as_address().into_bytes()),
+            principal: B256::from(encode_principal(&item.account.owner)),
+            subaccount: B256::from(item.account.effective_subaccount()),
+            r: B256::from(item.attestation.r.to_be_bytes()),
+            s: B256::from(item.attestation.s.to_be_bytes()),
+            v: 27 + u8::from(item.attestation.signature_y_parity),
+        })
+        .collect::<Vec<_>>(),)
+        .abi_encode_params();
+
+    assert_eq!(&data[4..], expected_arguments.as_slice());
+}
+
+#[test]
+fn should_encode_an_empty_eth_batch() {
+    let data = encode_sweep_eth_batch(&[]);
+
+    assert_eq!(data.len(), 4 + 32 + 32);
+    assert_eq!(&data[4..4 + 32], &word(32));
+    assert_eq!(&data[4 + 32..], &word(0));
 }
 
 fn sweep() -> (Vec<SweepItem>, Vec<Address>) {

--- a/rs/ethereum/cketh/minter/src/test_fixtures.rs
+++ b/rs/ethereum/cketh/minter/src/test_fixtures.rs
@@ -147,8 +147,8 @@ pub fn automatic_deposit() -> AutomaticDeposit {
 /// An [`AutomaticDeposits`] whose sweep queue holds exactly these funded pairs, all taken by the
 /// one sweep [`create_pending_sweeper_requests`] enqueued for them, returned along with that
 /// request.
-pub async fn deposits_with_enqueued_sweep(
-    pairs: &[(Account, Address)],
+pub async fn deposits_with_enqueued_sweep<A: Into<Asset> + Copy>(
+    pairs: &[(Account, A)],
 ) -> (AutomaticDeposits, SweepRequest) {
     let (state, request) = state_with_enqueued_sweep(pairs).await;
     (state.automatic_deposits, request)
@@ -206,7 +206,9 @@ pub fn prepay_sweep_gas(state: &mut State) {
 /// [`create_pending_sweeper_requests`] enqueued for them, returned along with that request. The
 /// deposits, attestations and authorizations the enqueue pairs up arrive through the event log, so
 /// the sweep is assembled by the production path without the runtime signing anything.
-pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, SweepRequest) {
+pub async fn state_with_enqueued_sweep<A: Into<Asset> + Copy>(
+    pairs: &[(Account, A)],
+) -> (State, SweepRequest) {
     const SWEEP_DECIDED_AT: u64 = 1_620_328_630_000_000_000;
 
     let mut state = state_with_deposit_helper(deposit_helper());
@@ -214,21 +216,21 @@ pub async fn state_with_enqueued_sweep(pairs: &[(Account, Address)]) -> (State, 
     state.sweeper_contract_address = Some(sweeper_contract());
     state.last_transaction_price_estimate = Some((SWEEP_DECIDED_AT, gas_fee_estimate()));
     let chain_id = state.ethereum_network.chain_id();
-    for (account, token) in pairs {
+    for (account, asset) in pairs {
         apply_state_transition(
             &mut state,
             &EventType::AutomaticDepositReceived(AutomaticDeposit {
                 owner: account.owner,
                 subaccount: account.subaccount,
                 address: deposit_address(account),
-                asset: Asset::Erc20(*token),
+                asset: (*asset).into(),
                 ..automatic_deposit()
             }),
         );
     }
     for account in pairs
         .iter()
-        .map(|(account, _token)| *account)
+        .map(|(account, _asset)| *account)
         .collect::<BTreeSet<_>>()
     {
         apply_state_transition(

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -406,12 +406,9 @@ mod deposit_erc20 {
 
     /// Number of `AutomaticDepositReceived` events currently in the minter's audit log.
     fn count_automatic_deposits_received(ckerc20: &CkErc20Setup) -> usize {
-        ckerc20
-            .cketh
-            .get_all_events()
-            .into_iter()
-            .filter(|event| matches!(event.payload, EventPayload::AutomaticDepositReceived { .. }))
-            .count()
+        ckerc20.cketh.minter_count_events(|event| {
+            matches!(event.payload, EventPayload::AutomaticDepositReceived { .. })
+        })
     }
 
     /// EIP-55 address string of the first supported ckERC20 token.

--- a/rs/ethereum/cketh/minter/tests/ckerc20.rs
+++ b/rs/ethereum/cketh/minter/tests/ckerc20.rs
@@ -2365,6 +2365,7 @@ fn should_retrieve_minter_info() {
         .collect();
 
     const USD_STABLECOIN_MINIMUM_DEPOSIT: u64 = 10_000_000;
+    const MINIMUM_ETH_DEPOSIT_WEI: u64 = 5_000_000_000_000_000;
     let minimum_deposit_amounts = supported_ckerc20_tokens
         .iter()
         .map(|token| Erc20MinimumDeposit {
@@ -2398,6 +2399,7 @@ fn should_retrieve_minter_info() {
             last_gas_fee_estimate: None,
             erc20_balances: Some(erc20_balances),
             minimum_deposit_amounts: Some(minimum_deposit_amounts),
+            minimum_eth_deposit_amount: Some(Nat::from(MINIMUM_ETH_DEPOSIT_WEI)),
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_deposit_with_subaccount_scraped_block_number: Some(

--- a/rs/ethereum/cketh/minter/tests/cketh.rs
+++ b/rs/ethereum/cketh/minter/tests/cketh.rs
@@ -1192,6 +1192,8 @@ fn should_derive_minter_address() {
 #[allow(deprecated)]
 #[test]
 fn should_retrieve_minter_info() {
+    const MINIMUM_ETH_DEPOSIT_WEI: u64 = 5_000_000_000_000_000;
+
     let cketh = CkEthSetup::default();
     let max_eth_logs_block_range = cketh.max_logs_block_range();
     let caller: Principal = cketh.caller.into();
@@ -1223,6 +1225,7 @@ fn should_retrieve_minter_info() {
             last_gas_fee_estimate: None,
             erc20_balances: None,
             minimum_deposit_amounts: None,
+            minimum_eth_deposit_amount: Some(Nat::from(MINIMUM_ETH_DEPOSIT_WEI)),
             last_eth_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_erc20_scraped_block_number: Some(LAST_SCRAPED_BLOCK_NUMBER_AT_INSTALL.into()),
             last_deposit_with_subaccount_scraped_block_number: Some(

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -20,7 +20,7 @@ use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
-use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, LiveSetup};
+use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 use ic_ethereum_types::Address;
 
@@ -432,6 +432,43 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
         .assert_sweeper_spent_gas(&sweeper, funded_gas);
 
     setup.expect_mints(&deposits);
+}
+
+#[test]
+fn should_credit_an_eth_cex_deposit_through_a_sweep() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
+    const DEPOSIT_WEI: u128 = 20_000_000_000_000_000;
+
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+    let sweeper = setup.await_sweeper_address();
+    let owner = setup.depositor(1);
+
+    let (setup, deposits) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: DEPOSIT_WEI,
+        }])
+        .expect_deposit_responses();
+
+    let setup = setup
+        .credit_eth_deposits_from_cex(&deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+
+    let (setup, _sweeps) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_all_delegating_sweeps();
+
+    setup
+        .assert_eth_addresses_swept_empty(&deposits)
+        .expect_cketh_mints(&deposits);
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -549,7 +549,8 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let sweeper = setup.await_sweeper_address();
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
-    let mints_before = count_cketh_mints(&setup);
+    let mints_before = setup
+        .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }));
     let owner = setup.depositor(1);
 
     let (setup, first_deposits) = setup
@@ -623,18 +624,12 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
         .assert_minter_received_swept_eth_total(&all_deposits, minter_eth_before)
         .expect_cketh_mints(&all_deposits);
     assert_eq!(
-        count_cketh_mints(&setup) - mints_before,
+        setup
+            .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
+            - mints_before,
         2,
         "each deposit flow must be credited exactly once"
     );
-}
-
-fn count_cketh_mints(setup: &LiveSetup<CkErc20Setup>) -> usize {
-    setup
-        .minter_events()
-        .into_iter()
-        .filter(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
-        .count()
 }
 
 #[test]
@@ -730,10 +725,7 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         .assert_minter_holds_swept_totals(&all_deposits)
         .expect_mints(&all_deposits);
     let mints = setup
-        .minter_events()
-        .into_iter()
-        .filter(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }))
-        .count();
+        .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }));
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
 }
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -20,7 +20,9 @@ use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
-use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
+use ic_cketh_test_utils::live::{
+    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
+};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 
 const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
@@ -537,7 +539,112 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
 }
 
 #[test]
-fn should_sweep_a_second_deposit_despite_resending_a_stale_authorization() {
+fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
+
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+    // The fee-account funding above minted ckETH too, so the deposit mints are counted
+    // against this baseline.
+    let mints_before = count_cketh_mints(&setup);
+    let owner = setup.depositor(1);
+
+    let (setup, first_deposits) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: 3 * MINIMUM_ETH_DEPOSIT_WEI,
+        }])
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_eth_deposits_from_cex(&first_deposits)
+        .expect_deposit_balances_on_anvil()
+        .expect_each_awaiting_sweep();
+    let (setup, _first_sweeps) = setup
+        .await_sweeps(&sweeper, 1)
+        .expect_all_delegating_sweeps();
+    let setup = setup
+        .expect_sweeps_finalized(1)
+        .expect_cketh_mints(&first_deposits);
+    let address = first_deposits[0].address;
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        1,
+        "applying the first sweep's authorization must spend the deposit address' nonce 0"
+    );
+
+    let second_deposits = [EthCexDeposit {
+        amount: 2 * MINIMUM_ETH_DEPOSIT_WEI,
+        ..first_deposits[0].clone()
+    }];
+    let setup = setup
+        .credit_eth_deposits_from_cex(&second_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let (setup, second_registrations) = setup
+        .call_minter_deposit_eth([EthDepositPlan {
+            owner,
+            subaccount: DEPOSIT_SUBACCOUNT,
+            amount: second_deposits[0].amount,
+        }])
+        .expect_deposit_responses();
+    assert_eq!(
+        second_registrations[0].address, address,
+        "re-registering the pair must yield the same deposit address"
+    );
+    assert_matches!(
+        setup.await_eth_detection(owner, DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == second_deposits[0].amount
+    );
+
+    let (setup, sweeps) = setup
+        .await_sweeps(&sweeper, 2)
+        .expect_all_delegating_sweeps();
+    let second_sweep = &sweeps[1];
+    assert_eq!(
+        setup.anvil().authorization_nonces(&second_sweep.hash),
+        vec![0],
+        "the re-sent authorization still names nonce 0, stale now that the address is at nonce 1"
+    );
+    assert_eq!(
+        setup.anvil().transaction_count(&address),
+        1,
+        "a skipped stale authorization must not advance the deposit address' nonce"
+    );
+
+    let all_deposits = [first_deposits[0].clone(), second_deposits[0].clone()];
+    let setup = setup
+        .assert_eth_delegations_installed(&all_deposits, &delegate)
+        .assert_eth_addresses_swept_empty(&second_deposits)
+        .assert_minter_received_swept_eth_total(&all_deposits, minter_eth_before)
+        .expect_cketh_mints(&all_deposits);
+    assert_eq!(
+        count_cketh_mints(&setup) - mints_before,
+        2,
+        "each deposit flow must be credited exactly once"
+    );
+}
+
+fn count_cketh_mints(setup: &LiveSetup<CkErc20Setup>) -> usize {
+    setup
+        .minter_events()
+        .into_iter()
+        .filter(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }))
+        .count()
+}
+
+#[test]
+fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [7; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new()

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -353,6 +353,113 @@ fn should_flag_only_erc20_deposits_at_or_above_the_per_token_minimum() {
 }
 
 #[test]
+fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
+    let setup = LiveSetup::<CkErc20Setup>::new()
+        .fund_fee_account()
+        .expect_fee_account_credited()
+        .upgrade_minter()
+        .expect_sweeper_address_derived()
+        .expect_eth_received()
+        .expect_funding_finalized();
+
+    let sweeper = setup.await_sweeper_address();
+    let funded_gas = setup.anvil_eth_balance(&sweeper);
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+    let [usdc, usdt]: [Erc20Token; 2] = setup
+        .supported_erc20_tokens_owned()
+        .try_into()
+        .expect("expected exactly 2 supported tokens");
+
+    let erc20_only = (setup.depositor(1), [1_u8; 32]);
+    let both_assets = (setup.depositor(2), [2_u8; 32]);
+    let eth_only = (setup.depositor(3), [3_u8; 32]);
+    let usdc_amount = 3 * setup.minimum_deposit_amount(&usdc);
+    let usdt_amount = 5 * setup.minimum_deposit_amount(&usdt);
+    let both_eth_amount = 4 * MINIMUM_ETH_DEPOSIT_WEI;
+    let eth_only_amount = 7 * MINIMUM_ETH_DEPOSIT_WEI;
+
+    let (setup, erc20_deposits) = setup
+        .call_minter_deposit_erc20([
+            DepositPlan {
+                owner: erc20_only.0,
+                subaccount: erc20_only.1,
+                token: usdc.clone(),
+                amount: usdc_amount,
+            },
+            DepositPlan {
+                owner: both_assets.0,
+                subaccount: both_assets.1,
+                token: usdt.clone(),
+                amount: usdt_amount,
+            },
+        ])
+        .expect_deposit_responses();
+    let (setup, eth_deposits) = setup
+        .call_minter_deposit_eth([
+            EthDepositPlan {
+                owner: both_assets.0,
+                subaccount: both_assets.1,
+                amount: both_eth_amount,
+            },
+            EthDepositPlan {
+                owner: eth_only.0,
+                subaccount: eth_only.1,
+                amount: eth_only_amount,
+            },
+        ])
+        .expect_deposit_responses();
+    assert_eq!(
+        erc20_deposits[1].address, eth_deposits[0].address,
+        "one account deposits both assets at one address"
+    );
+
+    let setup = setup
+        .credit_deposits_from_cex(&erc20_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+    let setup = setup
+        .credit_eth_deposits_from_cex(&eth_deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+
+    assert_matches!(
+        setup.await_detection(erc20_only.0, erc20_only.1, &usdc).status,
+        DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == usdc_amount
+    );
+    assert_matches!(
+        setup.await_detection(both_assets.0, both_assets.1, &usdt).status,
+        DepositStatus::AwaitingSweep(detected) if detected.scanned_balance == usdt_amount
+    );
+    assert_matches!(
+        setup.await_eth_detection(both_assets.0, both_assets.1).status,
+        DepositEthStatus::AwaitingSweep(detected) if detected.scanned_balance == both_eth_amount
+    );
+    assert_matches!(
+        setup.await_eth_detection(eth_only.0, eth_only.1).status,
+        DepositEthStatus::AwaitingSweep(detected) if detected.scanned_balance == eth_only_amount
+    );
+
+    let (setup, _sweeps) = setup
+        .await_sweeps(&sweeper, 3)
+        .expect_all_delegating_sweeps();
+
+    let setup = setup
+        .assert_sweeps_batched_per_token(&erc20_deposits)
+        .assert_eth_sweeps_batched(&[2])
+        .assert_addresses_swept_empty(&erc20_deposits)
+        .assert_eth_addresses_swept_empty(&eth_deposits)
+        .assert_minter_holds_swept_totals(&erc20_deposits)
+        .assert_minter_received_swept_eth_total(&eth_deposits, minter_eth_before)
+        .assert_delegations_installed(&erc20_deposits, &delegate)
+        .assert_eth_delegations_installed(&eth_deposits, &delegate)
+        .assert_sweeper_spent_gas(&sweeper, funded_gas);
+
+    let setup = setup.expect_mints(&erc20_deposits);
+    setup.expect_cketh_mints(&eth_deposits);
+}
+
+#[test]
 fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -366,7 +366,7 @@ fn should_fund_the_sweeper_address_by_burning_cketh_from_the_fee_account() {
 }
 
 #[test]
-fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
+fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
     /// Ten depositors per token, so each sweep is a ten-deposit single-token batch — directly
     /// comparable with `deposit_from_cex_demo`'s measured scenarios.
     const DEPOSITORS_PER_TOKEN: u64 = 10;
@@ -435,9 +435,9 @@ fn should_credit_twenty_cex_deposits_through_one_sweep_per_token() {
 }
 
 #[test]
-fn should_credit_an_eth_cex_deposit_through_a_sweep() {
-    const DEPOSIT_SUBACCOUNT: [u8; 32] = [11; 32];
-    const DEPOSIT_WEI: u128 = 20_000_000_000_000_000;
+fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
+    const DEPOSITORS: u64 = 20;
+    const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 
     let setup = LiveSetup::<CkErc20Setup>::new()
         .fund_fee_account()
@@ -446,29 +446,47 @@ fn should_credit_an_eth_cex_deposit_through_a_sweep() {
         .expect_sweeper_address_derived()
         .expect_eth_received()
         .expect_funding_finalized();
+
     let sweeper = setup.await_sweeper_address();
-    let owner = setup.depositor(1);
+    let funded_gas = setup.anvil_eth_balance(&sweeper);
+    let delegate = setup.sweep_contracts().delegate;
+    let minter_eth_before = setup.minter_eth_balance();
+
+    // Every depositor gets a distinct principal and a distinct subaccount, so no two share a
+    // deposit address, and a distinct amount, so a positional mixup in the batch cannot cancel
+    // out in the totals.
+    let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
+        .map(|index| EthDepositPlan {
+            owner: setup.depositor(index),
+            subaccount: [u8::try_from(index).unwrap(); 32],
+            amount: (u128::from(index) + 2) * MINIMUM_ETH_DEPOSIT_WEI,
+        })
+        .collect();
 
     let (setup, deposits) = setup
-        .call_minter_deposit_eth([EthDepositPlan {
-            owner,
-            subaccount: DEPOSIT_SUBACCOUNT,
-            amount: DEPOSIT_WEI,
-        }])
+        .call_minter_deposit_eth(plans)
         .expect_deposit_responses();
+    let setup = setup.assert_eth_deposit_addresses_bare(&deposits);
 
+    // The CEX withdrawals: a plain ETH transfer to each address, carrying no calldata.
     let setup = setup
         .credit_eth_deposits_from_cex(&deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
+    // Two full ten-deposit sweeps, and nothing more.
     let (setup, _sweeps) = setup
-        .await_sweeps(&sweeper, 1)
+        .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
 
-    setup
+    let setup = setup
+        .assert_eth_sweeps_batched(&[10, 10])
         .assert_eth_addresses_swept_empty(&deposits)
-        .expect_cketh_mints(&deposits);
+        .assert_minter_received_swept_eth_total(&deposits, minter_eth_before)
+        .assert_eth_delegations_installed(&deposits, &delegate)
+        .assert_sweeper_spent_gas(&sweeper, funded_gas);
+
+    setup.expect_cketh_mints(&deposits);
 }
 
 #[test]

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -446,7 +446,7 @@ fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
 
     let setup = setup
         .assert_sweeps_batched_per_token(&erc20_deposits)
-        .assert_eth_sweeps_batched(&[2])
+        .assert_eth_sweeps_batched(&eth_deposits)
         .assert_addresses_swept_empty(&erc20_deposits)
         .assert_eth_addresses_swept_empty(&eth_deposits)
         .assert_minter_holds_swept_totals(&erc20_deposits)
@@ -632,7 +632,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     assert_eth_sweep_gas_near_demo(&sweeps, 10);
 
     let setup = setup
-        .assert_eth_sweeps_batched(&[10, 10])
+        .assert_eth_sweeps_batched(&deposits)
         .assert_eth_addresses_swept_empty(&deposits)
         .assert_minter_received_swept_eth_total(&deposits, minter_eth_before)
         .assert_eth_delegations_installed(&deposits, &delegate)

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -13,8 +13,8 @@ use ic_cketh_minter::balance_scan::batcher::{
     encode_eth_balance_batch,
 };
 use ic_cketh_minter::deposit_address::DepositAddress;
-use ic_cketh_minter::endpoints::DepositStatus;
 use ic_cketh_minter::endpoints::events::EventPayload;
+use ic_cketh_minter::endpoints::{DepositEthStatus, DepositStatus};
 use ic_cketh_minter::numeric::Erc20Value;
 use ic_cketh_test_utils::anvil::{
     Anvil, DEV_ACCOUNT, SentTransaction, address_from_hex, deploy_mock_erc20,
@@ -22,6 +22,8 @@ use ic_cketh_test_utils::anvil::{
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{CexDeposit, DepositPlan, EthDepositPlan, LiveSetup};
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
+
+const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 use ic_ethereum_types::Address;
 
 #[test]
@@ -294,7 +296,7 @@ fn should_revert_the_whole_call_when_a_token_is_not_a_contract() {
 /// tokens and must apply the per-token minimum to each. Only the two at-or-above-minimum deposits
 /// are flagged as candidates; the below-minimum deposit is scanned but not flagged.
 #[test]
-fn should_flag_only_deposits_at_or_above_the_per_token_minimum() {
+fn should_flag_only_erc20_deposits_at_or_above_the_per_token_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new();
@@ -344,6 +346,52 @@ fn should_flag_only_deposits_at_or_above_the_per_token_minimum() {
     assert_matches!(
         setup.await_scan(setup.depositor(3), DEPOSIT_SUBACCOUNT, &usdt).status,
         DepositStatus::Scanning { scan_count, last_scanned_block, .. }
+            if scan_count >= 1 && last_scanned_block.is_some()
+    );
+}
+
+#[test]
+fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
+    const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
+
+    let setup = LiveSetup::<CkErc20Setup>::new();
+    let above_minimum = 2 * MINIMUM_ETH_DEPOSIT_WEI;
+    let at_minimum = MINIMUM_ETH_DEPOSIT_WEI;
+    let below_minimum = MINIMUM_ETH_DEPOSIT_WEI / 10;
+    let plans = [
+        (setup.depositor(1), above_minimum),
+        (setup.depositor(2), at_minimum),
+        (setup.depositor(3), below_minimum),
+    ]
+    .map(|(owner, amount)| EthDepositPlan {
+        owner,
+        subaccount: DEPOSIT_SUBACCOUNT,
+        amount,
+    });
+
+    let (setup, deposits) = setup
+        .call_minter_deposit_eth(plans)
+        .expect_deposit_responses();
+    let setup = setup
+        .credit_eth_deposits_from_cex(&deposits)
+        .expect_deposit_balances_on_anvil()
+        .setup;
+
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(1), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == above_minimum
+                && detected.detected_at_block > 0_u8
+    );
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(2), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::AwaitingSweep(detected)
+            if detected.scanned_balance == at_minimum
+                && detected.detected_at_block > 0_u8
+    );
+    assert_matches!(
+        setup.await_eth_scan(setup.depositor(3), DEPOSIT_SUBACCOUNT).status,
+        DepositEthStatus::Scanning { scan_count, last_scanned_block, .. }
             if scan_count >= 1 && last_scanned_block.is_some()
     );
 }
@@ -437,7 +485,6 @@ fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
 #[test]
 fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     const DEPOSITORS: u64 = 20;
-    const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 
     let setup = LiveSetup::<CkErc20Setup>::new()
         .fund_fee_account()

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -579,7 +579,7 @@ fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
     let (setup, sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
-    assert_sweep_gas_near_demo(&sweeps, DEPOSITORS_PER_TOKEN);
+    assert_ten_deposit_sweep_gas_near_demo(&sweeps, DEMO_TEN_ERC20_DEPOSITS_GAS);
 
     let setup = setup
         .assert_sweeps_batched_per_token(&deposits)
@@ -630,7 +630,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     let (setup, sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
-    assert_eth_sweep_gas_near_demo(&sweeps, 10);
+    assert_ten_deposit_sweep_gas_near_demo(&sweeps, DEMO_TEN_ETH_DEPOSITS_GAS);
 
     let setup = setup
         .assert_eth_sweeps_batched(&deposits)
@@ -838,53 +838,26 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
 }
 
-fn assert_eth_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
-    const ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS: u64 = 413_076;
+/// The EIP-7702 (first sweep) column of the ten-deposit scenarios in deposit_from_cex_demo.rs.
+const DEMO_TEN_ERC20_DEPOSITS_GAS: u64 = 609_750;
+const DEMO_TEN_ETH_DEPOSITS_GAS: u64 = 413_076;
+
+fn assert_ten_deposit_sweep_gas_near_demo(sweeps: &[SentTransaction], demo_gas: u64) {
+    const DEPOSITS_PER_SWEEP: u64 = 10;
     const GAS_BAND_PERCENT: u64 = 10;
 
-    assert_eq!(
-        deposits_per_sweep, 10,
-        "the demo baseline is measured for ten-deposit sweeps"
-    );
     for sweep in sweeps {
-        assert!(
-            sweep
-                .gas_used
-                .abs_diff(ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS)
-                * 100
-                <= ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS * GAS_BAND_PERCENT,
-            "a ten-deposit ETH sweep used {} gas, more than {GAS_BAND_PERCENT}% away from the \
-             demo-measured {ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS}: {sweep:?}",
-            sweep.gas_used,
-        );
-    }
-}
-
-fn assert_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
-    // `ATTESTED_SCENARIOS` in deposit_from_cex_demo.rs, EIP-7702 (first sweep) column.
-    const DEMO_ONE_DEPOSIT: u64 = 98_075;
-    const DEMO_TEN_DEPOSITS: u64 = 609_750;
-    const GAS_BAND_PERCENT: u64 = 10;
-
-    assert_eq!(
-        deposits_per_sweep, 10,
-        "the demo baseline is measured for ten-deposit sweeps"
-    );
-    for sweep in sweeps {
-        let per_deposit = sweep.gas_used / deposits_per_sweep;
         println!(
-            "[gas] {} deposits: {} total, {} per deposit \
-             (demo: {DEMO_TEN_DEPOSITS} total, {} per deposit for ten; {DEMO_ONE_DEPOSIT} for one)",
-            deposits_per_sweep,
+            "[gas] {DEPOSITS_PER_SWEEP} deposits: {} total, {} per deposit \
+             (demo: {demo_gas} total, {} per deposit)",
             sweep.gas_used,
-            per_deposit,
-            DEMO_TEN_DEPOSITS / 10,
+            sweep.gas_used / DEPOSITS_PER_SWEEP,
+            demo_gas / DEPOSITS_PER_SWEEP,
         );
         assert!(
-            sweep.gas_used.abs_diff(DEMO_TEN_DEPOSITS) * 100
-                <= DEMO_TEN_DEPOSITS * GAS_BAND_PERCENT,
+            sweep.gas_used.abs_diff(demo_gas) * 100 <= demo_gas * GAS_BAND_PERCENT,
             "a ten-deposit sweep used {} gas, more than {GAS_BAND_PERCENT}% away from the \
-             demo-measured {DEMO_TEN_DEPOSITS}: {sweep:?}",
+             demo-measured {demo_gas}: {sweep:?}",
             sweep.gas_used,
         );
     }

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -519,9 +519,10 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
-    let (setup, _sweeps) = setup
+    let (setup, sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
+    assert_eth_sweep_gas_near_demo(&sweeps, 10);
 
     let setup = setup
         .assert_eth_sweeps_batched(&[10, 10])
@@ -734,6 +735,28 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         .filter(|event| matches!(event.payload, EventPayload::MintedCkErc20 { .. }))
         .count();
     assert_eq!(mints, 2, "each deposit flow must be credited exactly once");
+}
+
+fn assert_eth_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {
+    const ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS: u64 = 413_076;
+    const GAS_BAND_PERCENT: u64 = 10;
+
+    assert_eq!(
+        deposits_per_sweep, 10,
+        "the demo baseline is measured for ten-deposit sweeps"
+    );
+    for sweep in sweeps {
+        assert!(
+            sweep
+                .gas_used
+                .abs_diff(ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS)
+                * 100
+                <= ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS * GAS_BAND_PERCENT,
+            "a ten-deposit ETH sweep used {} gas, more than {GAS_BAND_PERCENT}% away from the \
+             demo-measured {ETH_SCENARIOS_DEMO_TEN_DEPOSITS_EIP7702_GAS}: {sweep:?}",
+            sweep.gas_used,
+        );
+    }
 }
 
 fn assert_sweep_gas_near_demo(sweeps: &[SentTransaction], deposits_per_sweep: u64) {

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -8,6 +8,7 @@
 //!    principal and subaccount.
 
 use assert_matches::assert_matches;
+use ic_cketh_minter::asset::Asset;
 use ic_cketh_minter::balance_scan::batcher::{
     BalanceOfCall, MAX_CALLS_PER_BATCH, decode_balance_batch, encode_balance_batch,
     encode_eth_balance_batch,
@@ -21,7 +22,7 @@ use ic_cketh_test_utils::anvil::{
 };
 use ic_cketh_test_utils::ckerc20::{CkErc20Setup, Erc20Token};
 use ic_cketh_test_utils::live::{
-    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
+    CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup, contract_address,
 };
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
 use ic_ethereum_types::Address;
@@ -305,9 +306,9 @@ fn should_flag_only_erc20_deposits_at_or_above_the_per_token_minimum() {
         .supported_erc20_tokens_owned()
         .try_into()
         .expect("expected exactly 2 supported tokens");
-    let usdt_minimum = setup.minimum_deposit_amount(&usdt);
+    let usdt_minimum = setup.minimum_deposit_amount(contract_address(&usdt));
     let usdt_above_minimum = 2 * usdt_minimum;
-    let usdc_at_minimum = setup.minimum_deposit_amount(&usdc);
+    let usdc_at_minimum = setup.minimum_deposit_amount(contract_address(&usdc));
     let usdt_below_minimum = usdt_minimum / 10;
     let plans = [
         (setup.depositor(1), usdt.clone(), usdt_above_minimum),
@@ -372,9 +373,9 @@ fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
     let erc20_only = (setup.depositor(1), [1_u8; 32]);
     let both_assets = (setup.depositor(2), [2_u8; 32]);
     let eth_only = (setup.depositor(3), [3_u8; 32]);
-    let usdc_amount = 3 * setup.minimum_deposit_amount(&usdc);
-    let usdt_amount = 5 * setup.minimum_deposit_amount(&usdt);
-    let eth_minimum = setup.minimum_eth_deposit_amount(both_assets.0, both_assets.1);
+    let usdc_amount = 3 * setup.minimum_deposit_amount(contract_address(&usdc));
+    let usdt_amount = 5 * setup.minimum_deposit_amount(contract_address(&usdt));
+    let eth_minimum = setup.minimum_deposit_amount(Asset::Eth);
     let both_eth_amount = 4 * eth_minimum;
     let eth_only_amount = 7 * eth_minimum;
 
@@ -463,7 +464,7 @@ fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new();
-    let minimum = setup.minimum_eth_deposit_amount(setup.depositor(1), DEPOSIT_SUBACCOUNT);
+    let minimum = setup.minimum_deposit_amount(Asset::Eth);
     let above_minimum = 2 * minimum;
     let at_minimum = minimum;
     let below_minimum = minimum / 10;
@@ -543,8 +544,8 @@ fn should_credit_twenty_erc20_deposits_through_one_sweep_per_token() {
         .supported_erc20_tokens_owned()
         .try_into()
         .expect("expected exactly 2 supported tokens");
-    let usdc_deposit = 10 * setup.minimum_deposit_amount(&usdc);
-    let usdt_deposit = 15 * setup.minimum_deposit_amount(&usdt);
+    let usdc_deposit = 10 * setup.minimum_deposit_amount(contract_address(&usdc));
+    let usdt_deposit = 15 * setup.minimum_deposit_amount(contract_address(&usdt));
 
     // Every depositor gets a distinct principal and a distinct subaccount, so no two share a
     // deposit address and each attestation binds a different account.
@@ -607,7 +608,7 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     let funded_gas = setup.anvil_eth_balance(&sweeper);
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
-    let eth_minimum = setup.minimum_eth_deposit_amount(setup.depositor(0), [0; 32]);
+    let eth_minimum = setup.minimum_deposit_amount(Asset::Eth);
 
     let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
         .map(|index| EthDepositPlan {
@@ -660,7 +661,7 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let mints_before = setup
         .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }));
     let owner = setup.depositor(1);
-    let eth_minimum = setup.minimum_eth_deposit_amount(owner, DEPOSIT_SUBACCOUNT);
+    let eth_minimum = setup.minimum_deposit_amount(Asset::Eth);
 
     let (setup, first_deposits) = setup
         .call_minter_deposit_eth([EthDepositPlan {
@@ -759,7 +760,7 @@ fn should_sweep_a_second_erc20_deposit_despite_resending_a_stale_authorization()
         .supported_erc20_tokens_owned()
         .try_into()
         .expect("expected exactly 2 supported tokens");
-    let usdc_minimum = setup.minimum_deposit_amount(&usdc);
+    let usdc_minimum = setup.minimum_deposit_amount(contract_address(&usdc));
     let owner = setup.depositor(1);
 
     let (setup, first_deposits) = setup

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -24,8 +24,6 @@ use ic_cketh_test_utils::live::{
     CexDeposit, DepositPlan, EthCexDeposit, EthDepositPlan, LiveSetup,
 };
 use ic_cketh_test_utils::{CkEthSetup, SWEEPER_ADDRESS};
-
-const MINIMUM_ETH_DEPOSIT_WEI: u128 = 5_000_000_000_000_000;
 use ic_ethereum_types::Address;
 
 #[test]
@@ -376,8 +374,9 @@ fn should_credit_mixed_erc20_and_eth_deposits_through_one_sweep_per_asset() {
     let eth_only = (setup.depositor(3), [3_u8; 32]);
     let usdc_amount = 3 * setup.minimum_deposit_amount(&usdc);
     let usdt_amount = 5 * setup.minimum_deposit_amount(&usdt);
-    let both_eth_amount = 4 * MINIMUM_ETH_DEPOSIT_WEI;
-    let eth_only_amount = 7 * MINIMUM_ETH_DEPOSIT_WEI;
+    let eth_minimum = setup.minimum_eth_deposit_amount(both_assets.0, both_assets.1);
+    let both_eth_amount = 4 * eth_minimum;
+    let eth_only_amount = 7 * eth_minimum;
 
     let (setup, erc20_deposits) = setup
         .call_minter_deposit_erc20([
@@ -464,9 +463,10 @@ fn should_flag_only_eth_deposits_at_or_above_the_minimum() {
     const DEPOSIT_SUBACCOUNT: [u8; 32] = [42; 32];
 
     let setup = LiveSetup::<CkErc20Setup>::new();
-    let above_minimum = 2 * MINIMUM_ETH_DEPOSIT_WEI;
-    let at_minimum = MINIMUM_ETH_DEPOSIT_WEI;
-    let below_minimum = MINIMUM_ETH_DEPOSIT_WEI / 10;
+    let minimum = setup.minimum_eth_deposit_amount(setup.depositor(1), DEPOSIT_SUBACCOUNT);
+    let above_minimum = 2 * minimum;
+    let at_minimum = minimum;
+    let below_minimum = minimum / 10;
     let plans = [
         (setup.depositor(1), above_minimum),
         (setup.depositor(2), at_minimum),
@@ -607,12 +607,13 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     let funded_gas = setup.anvil_eth_balance(&sweeper);
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
+    let eth_minimum = setup.minimum_eth_deposit_amount(setup.depositor(0), [0; 32]);
 
     let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
         .map(|index| EthDepositPlan {
             owner: setup.depositor(index),
             subaccount: [u8::try_from(index).unwrap(); 32],
-            amount: (u128::from(index) + 2) * MINIMUM_ETH_DEPOSIT_WEI,
+            amount: (u128::from(index) + 2) * eth_minimum,
         })
         .collect();
 
@@ -659,12 +660,13 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let mints_before = setup
         .minter_count_events(|event| matches!(event.payload, EventPayload::MintedCkEth { .. }));
     let owner = setup.depositor(1);
+    let eth_minimum = setup.minimum_eth_deposit_amount(owner, DEPOSIT_SUBACCOUNT);
 
     let (setup, first_deposits) = setup
         .call_minter_deposit_eth([EthDepositPlan {
             owner,
             subaccount: DEPOSIT_SUBACCOUNT,
-            amount: 3 * MINIMUM_ETH_DEPOSIT_WEI,
+            amount: 3 * eth_minimum,
         }])
         .expect_deposit_responses();
     let setup = setup
@@ -685,7 +687,7 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     );
 
     let second_deposits = [EthCexDeposit {
-        amount: 2 * MINIMUM_ETH_DEPOSIT_WEI,
+        amount: 2 * eth_minimum,
         ..first_deposits[0].clone()
     }];
     let setup = setup

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex.rs
@@ -501,9 +501,6 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
 
-    // Every depositor gets a distinct principal and a distinct subaccount, so no two share a
-    // deposit address, and a distinct amount, so a positional mixup in the batch cannot cancel
-    // out in the totals.
     let plans: Vec<EthDepositPlan> = (0..DEPOSITORS)
         .map(|index| EthDepositPlan {
             owner: setup.depositor(index),
@@ -517,13 +514,11 @@ fn should_credit_twenty_eth_deposits_through_ten_deposit_sweeps() {
         .expect_deposit_responses();
     let setup = setup.assert_eth_deposit_addresses_bare(&deposits);
 
-    // The CEX withdrawals: a plain ETH transfer to each address, carrying no calldata.
     let setup = setup
         .credit_eth_deposits_from_cex(&deposits)
         .expect_deposit_balances_on_anvil()
         .expect_each_awaiting_sweep();
 
-    // Two full ten-deposit sweeps, and nothing more.
     let (setup, _sweeps) = setup
         .await_sweeps(&sweeper, 2)
         .expect_all_delegating_sweeps();
@@ -553,8 +548,6 @@ fn should_sweep_a_second_eth_deposit_despite_resending_a_stale_authorization() {
     let sweeper = setup.await_sweeper_address();
     let delegate = setup.sweep_contracts().delegate;
     let minter_eth_before = setup.minter_eth_balance();
-    // The fee-account funding above minted ckETH too, so the deposit mints are counted
-    // against this baseline.
     let mints_before = count_cketh_mints(&setup);
     let owner = setup.depositor(1);
 

--- a/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
+++ b/rs/ethereum/cketh/minter/tests/deposit_from_cex_demo.rs
@@ -146,6 +146,97 @@ const ATTESTED_SCENARIOS: [BatchScenario; 3] = [
     },
 ];
 
+const ETH_ATTESTED_SCENARIOS: [BatchScenario; 3] = [
+    BatchScenario {
+        deposits: 1,
+        eip7702_total_gas_used: 63_283,
+        eip7702_average_gas_used: 63_283,
+        eip1559_total_gas_used: 53_283,
+        eip1559_average_gas_used: 53_283,
+    },
+    BatchScenario {
+        deposits: 10,
+        eip7702_total_gas_used: 413_076,
+        eip7702_average_gas_used: 41_307,
+        eip1559_total_gas_used: 291_345,
+        eip1559_average_gas_used: 29_134,
+    },
+    BatchScenario {
+        deposits: 20,
+        eip7702_total_gas_used: 804_603,
+        eip7702_average_gas_used: 40_230,
+        eip1559_total_gas_used: 555_753,
+        eip1559_average_gas_used: 27_787,
+    },
+];
+
+#[test]
+fn batched_eth_sweep_amortizes_gas_across_the_batch() {
+    let anvil = Anvil::start();
+    let chain_id = anvil.chain_id();
+
+    let minter = eth_address(&key_from_hex(MINTER_PRIVATE_KEY).public_key());
+    let cex = eth_address(&key_from_hex(CEX_PRIVATE_KEY).public_key());
+    let relayer_key = key_from_hex(RELAYER_PRIVATE_KEY);
+
+    let contracts = deploy_contracts(&anvil, &minter, &cex);
+
+    let mut previous_average = u64::MAX;
+    for scenario in ETH_ATTESTED_SCENARIOS {
+        let gas = sweep_eth_batch_attested(
+            &anvil,
+            chain_id,
+            &relayer_key,
+            &minter,
+            &cex,
+            &contracts,
+            scenario.deposits,
+        );
+        let deposits = scenario.deposits as u64;
+        let eip7702_average = gas.eip7702 / deposits;
+        let eip1559_average = gas.eip1559 / deposits;
+        println!(
+            "attested ETH batch of {}: EIP-7702 {} ({eip7702_average}/deposit), EIP-1559 {} ({eip1559_average}/deposit)",
+            scenario.deposits, gas.eip7702, gas.eip1559
+        );
+        assert_gas(
+            gas.eip7702,
+            scenario.eip7702_total_gas_used,
+            &format!("attested ETH batch of {} EIP-7702 total", scenario.deposits),
+        );
+        assert_gas(
+            eip7702_average,
+            scenario.eip7702_average_gas_used,
+            &format!(
+                "attested ETH batch of {} EIP-7702 average",
+                scenario.deposits
+            ),
+        );
+        assert_gas(
+            gas.eip1559,
+            scenario.eip1559_total_gas_used,
+            &format!("attested ETH batch of {} EIP-1559 total", scenario.deposits),
+        );
+        assert_gas(
+            eip1559_average,
+            scenario.eip1559_average_gas_used,
+            &format!(
+                "attested ETH batch of {} EIP-1559 average",
+                scenario.deposits
+            ),
+        );
+        assert!(
+            gas.eip1559 < gas.eip7702,
+            "an already-delegated (EIP-1559) sweep must cost less than one installing the delegation (EIP-7702)"
+        );
+        assert!(
+            eip7702_average < previous_average,
+            "per-deposit gas should shrink as the batch grows"
+        );
+        previous_average = eip7702_average;
+    }
+}
+
 #[test]
 fn batched_sweep_amortizes_gas_across_the_batch() {
     let anvil = Anvil::start();
@@ -986,6 +1077,122 @@ fn assert_batch_swept(
     assert_eq!(
         anvil.usdt_balance(usdt, minter),
         minter_before + DEPOSIT_AMOUNT * deposits.len() as u128,
+        "minter did not receive every deposit"
+    );
+    gas_used(receipt)
+}
+
+fn sweep_eth_batch_attested(
+    anvil: &Anvil,
+    chain_id: u64,
+    sender_key: &PrivateKey,
+    minter: &Address,
+    cex: &Address,
+    contracts: &Contracts,
+    n: usize,
+) -> BatchGas {
+    let Contracts {
+        helper, attested, ..
+    } = contracts;
+
+    let principals: Vec<Principal> = (0..n)
+        .map(|i| Principal::self_authenticating([0xE1, n as u8, i as u8]))
+        .collect();
+    let keys: Vec<PrivateKey> = principals.iter().map(derive_deposit_key).collect();
+    let deposits: Vec<Address> = keys.iter().map(|k| eth_address(&k.public_key())).collect();
+
+    let items: Vec<SweepItem> = keys
+        .iter()
+        .zip(&deposits)
+        .zip(&principals)
+        .map(|((key, deposit), principal)| {
+            let a = attest(key, chain_id, helper, principal, &[0_u8; 32]);
+            SweepItem {
+                deposit: alloy_address(deposit),
+                principal: B256::from(encode_principal(principal)),
+                subaccount: B256::ZERO,
+                r: B256::from(a.r),
+                s: B256::from(a.s),
+                v: a.v,
+            }
+        })
+        .collect();
+    let sweep_call = ICkSweeperAttested::sweepEthBatchCall { items }.abi_encode();
+
+    fund_eth(anvil, cex, &deposits);
+    let minter_before = anvil.balance(minter);
+    let authorizations: Vec<SignedAuthorization> = keys
+        .iter()
+        .map(|key| sign_authorization(key, chain_id, attested, 0))
+        .collect();
+    let receipt = anvil.send_eip7702(
+        sender_key,
+        chain_id,
+        attested,
+        sweep_call.clone(),
+        authorizations,
+    );
+    let eip7702 = assert_eth_batch_swept(
+        anvil,
+        &receipt,
+        contracts,
+        minter,
+        &deposits,
+        &principals,
+        minter_before,
+    );
+
+    fund_eth(anvil, cex, &deposits);
+    let minter_before = anvil.balance(minter);
+    let receipt = anvil.send_eip1559(sender_key, chain_id, attested, sweep_call);
+    let eip1559 = assert_eth_batch_swept(
+        anvil,
+        &receipt,
+        contracts,
+        minter,
+        &deposits,
+        &principals,
+        minter_before,
+    );
+
+    BatchGas { eip7702, eip1559 }
+}
+
+fn fund_eth(anvil: &Anvil, cex: &Address, deposits: &[Address]) {
+    for deposit in deposits {
+        let receipt = anvil.send_eth(cex, deposit, ETH_DEPOSIT_AMOUNT, None);
+        assert!(status_ok(&receipt), "CEX ETH transfer failed");
+    }
+}
+
+fn assert_eth_batch_swept(
+    anvil: &Anvil,
+    receipt: &Value,
+    contracts: &Contracts,
+    minter: &Address,
+    deposits: &[Address],
+    principals: &[Principal],
+    minter_before: u128,
+) -> u64 {
+    let Contracts { helper, .. } = contracts;
+    assert!(status_ok(receipt), "batch ETH sweep reverted");
+    let events = received_events(receipt, helper);
+    assert_eq!(
+        events.len(),
+        deposits.len(),
+        "one ReceivedEthOrErc20 event per deposit"
+    );
+    for (event, (deposit, principal)) in events.iter().zip(deposits.iter().zip(principals)) {
+        assert_eq!(event.owner, *deposit);
+        assert_eq!(event.principal, encode_principal(principal));
+        assert_eq!(event.amount, ETH_DEPOSIT_AMOUNT);
+    }
+    for deposit in deposits {
+        assert_eq!(anvil.balance(deposit), 0, "deposit not swept");
+    }
+    assert_eq!(
+        anvil.balance(minter),
+        minter_before + ETH_DEPOSIT_AMOUNT * deposits.len() as u128,
         "minter did not receive every deposit"
     );
     gas_used(receipt)

--- a/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
+++ b/rs/ethereum/cketh/minter/tests/dump_stable_memory.rs
@@ -505,12 +505,7 @@ fn map_event(CandidEvent { timestamp, payload }: CandidEvent) -> Event {
             } => ET::AcceptedSweepRequest(SweepRequest {
                 id: SweepId(sweep_id.0.to_u64().unwrap()),
                 destination: destination.parse().unwrap(),
-                token: match ic_cketh_minter::asset::Asset::try_from(asset).unwrap() {
-                    ic_cketh_minter::asset::Asset::Erc20(address) => address,
-                    ic_cketh_minter::asset::Asset::Eth => {
-                        panic!("BUG: no recorded sweep moves ETH yet")
-                    }
-                },
+                asset: asset.try_into().unwrap(),
                 items: map_authorized_sweep_items(items),
                 max_transaction_fee: max_transaction_fee.try_into().unwrap(),
                 created_at,

--- a/rs/ethereum/cketh/test_utils/src/lib.rs
+++ b/rs/ethereum/cketh/test_utils/src/lib.rs
@@ -464,6 +464,13 @@ impl CkEthSetup {
         .unwrap()
     }
 
+    pub fn minter_count_events(&self, filter: impl Fn(&Event) -> bool) -> usize {
+        self.get_all_events()
+            .into_iter()
+            .filter(|event| filter(event))
+            .count()
+    }
+
     pub fn get_all_events(&self) -> Vec<Event> {
         const FIRST_BATCH_SIZE: u64 = 100;
         let GetEventsResult {

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -50,6 +50,7 @@
 
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::PrincipalId;
+use ic_cketh_minter::asset::Asset;
 use ic_cketh_minter::endpoints::events::{
     Asset as EventAsset, Event, EventPayload, TransactionStatus,
 };
@@ -253,36 +254,38 @@ impl LiveSetup<CkErc20Setup> {
         self.fixture.supported_erc20_tokens.clone()
     }
 
-    pub fn minimum_deposit_amount(&self, token: &Erc20Token) -> u128 {
-        let minimum = self
-            .get_minter_info()
-            .minimum_deposit_amounts
-            .expect("BUG: the minter reports no minimum deposit amounts")
-            .into_iter()
-            .find(|minimum| {
-                Address::from_str(&minimum.erc20_contract_address)
-                    .expect("BUG: the minter reported an invalid token address")
-                    == contract_address(token)
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "BUG: the minter reports no minimum deposit amount for {}",
-                    token.contract.address
-                )
-            });
-        let no_minimum_sentinel: Nat = Erc20Value::MAX.into();
-        assert_ne!(
-            minimum.minimum_deposit_amount, no_minimum_sentinel,
-            "the minter reports no real minimum deposit amount for {}",
-            token.contract.address
-        );
-        nat_to_u128(minimum.minimum_deposit_amount)
-    }
-
-    /// The ETH minimum as `deposit_eth` reports it. Read through `caller`'s own registration,
-    /// which `deposit_eth` makes idempotently, so pass an account the test deposits for anyway.
-    pub fn minimum_eth_deposit_amount(&self, caller: Principal, subaccount: [u8; 32]) -> u128 {
-        nat_to_u128(self.deposit_eth(caller, subaccount).minimum_deposit_amount)
+    /// The minimum balance `asset`'s deposit address must hold for the balance scan to flag it,
+    /// as `get_minter_info` reports it.
+    pub fn minimum_deposit_amount(&self, asset: impl Into<Asset>) -> u128 {
+        let info = self.get_minter_info();
+        let minimum = match asset.into() {
+            Asset::Eth => info
+                .minimum_eth_deposit_amount
+                .expect("BUG: the minter reports no ETH minimum deposit amount"),
+            Asset::Erc20(token_address) => {
+                let minimum = info
+                    .minimum_deposit_amounts
+                    .expect("BUG: the minter reports no minimum deposit amounts")
+                    .into_iter()
+                    .find(|minimum| {
+                        Address::from_str(&minimum.erc20_contract_address)
+                            .expect("BUG: the minter reported an invalid token address")
+                            == token_address
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "BUG: the minter reports no minimum deposit amount for {token_address}"
+                        )
+                    });
+                let no_minimum_sentinel: Nat = Erc20Value::MAX.into();
+                assert_ne!(
+                    minimum.minimum_deposit_amount, no_minimum_sentinel,
+                    "the minter reports no real minimum deposit amount for {token_address}"
+                );
+                minimum.minimum_deposit_amount
+            }
+        };
+        nat_to_u128(minimum)
     }
 
     /// Calls `deposit_eth` as `caller`, which registers (idempotently) that user's

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -54,8 +54,8 @@ use ic_cketh_minter::endpoints::events::{
     Asset as EventAsset, Event, EventPayload, TransactionStatus,
 };
 use ic_cketh_minter::endpoints::{
-    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositMode,
-    DepositStatus, MinterInfo,
+    CkErc20Token, DepositErc20Arg, DepositErc20Error, DepositErc20Response, DepositEthArg,
+    DepositEthError, DepositEthResponse, DepositEthStatus, DepositMode, DepositStatus, MinterInfo,
 };
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
@@ -148,6 +148,20 @@ pub struct CexDeposit {
     pub owner: Principal,
     pub subaccount: [u8; 32],
     pub token: Erc20Token,
+    pub amount: u128,
+    pub address: Address,
+}
+
+pub struct EthDepositPlan {
+    pub owner: Principal,
+    pub subaccount: [u8; 32],
+    pub amount: u128,
+}
+
+#[derive(Clone)]
+pub struct EthCexDeposit {
+    pub owner: Principal,
+    pub subaccount: [u8; 32],
     pub amount: u128,
     pub address: Address,
 }
@@ -263,6 +277,28 @@ impl LiveSetup<CkErc20Setup> {
             token.contract.address
         );
         nat_to_u128(minimum.minimum_deposit_amount)
+    }
+
+    /// Calls `deposit_eth` as `caller`, which registers (idempotently) that user's
+    /// `(address, ETH)` pair for balance scanning and reports its scan progress.
+    fn deposit_eth(&self, caller: Principal, subaccount: [u8; 32]) -> DepositEthResponse {
+        let arg = DepositEthArg {
+            mode: DepositMode::Unsponsored {
+                subaccount: Some(subaccount),
+            },
+        };
+        let reply = self
+            .env()
+            .update_call(
+                self.minter_id(),
+                caller,
+                "deposit_eth",
+                Encode!(&arg).unwrap(),
+            )
+            .expect("BUG: deposit_eth was rejected");
+        Decode!(&reply, Result<DepositEthResponse, DepositEthError>)
+            .unwrap()
+            .expect("BUG: deposit_eth returned an error")
     }
 
     /// Calls `deposit_erc20` as `caller`, which registers (idempotently) that user's
@@ -397,6 +433,28 @@ impl LiveSetup<CkErc20Setup> {
         )
     }
 
+    pub fn await_eth_detection(
+        &self,
+        caller: Principal,
+        subaccount: [u8; 32],
+    ) -> DepositEthResponse {
+        let mut reached = None;
+        self.drive_until_with(
+            SCAN_TICK,
+            SCAN_TICKS,
+            |_| "the ETH deposit was not detected".to_string(),
+            |setup| {
+                let progress = setup.deposit_eth(caller, subaccount);
+                let done = matches!(progress.status, DepositEthStatus::AwaitingSweep(_));
+                if done {
+                    reached = Some(progress);
+                }
+                done
+            },
+        );
+        reached.expect("drive_until_with returns only once observe held")
+    }
+
     fn await_deposit_status(
         &self,
         caller: Principal,
@@ -467,6 +525,61 @@ impl LiveSetup<CkErc20Setup> {
             },
             |setup| setup.balance_of_ledger(ledger_id, account) == credited,
         );
+    }
+
+    pub fn call_minter_deposit_eth(
+        self,
+        plans: impl IntoIterator<Item = EthDepositPlan>,
+    ) -> DepositEthCalls {
+        let responses = plans
+            .into_iter()
+            .map(|plan| {
+                let response = self.deposit_eth(plan.owner, plan.subaccount);
+                (plan, response)
+            })
+            .collect();
+        DepositEthCalls {
+            setup: self,
+            responses,
+        }
+    }
+
+    /// Funds each ETH deposit with a plain transfer from the CEX-style dev account, the shape an
+    /// exchange withdrawal has: no calldata, no principal, just value.
+    pub fn credit_eth_deposits_from_cex(self, deposits: &[EthCexDeposit]) -> EthCexCredit<'_> {
+        let cex = address_from_hex(DEV_ACCOUNT);
+        for deposit in deposits {
+            self.anvil.send_eth(&cex, &deposit.address, deposit.amount);
+        }
+        EthCexCredit {
+            setup: self,
+            deposits,
+        }
+    }
+
+    pub fn expect_cketh_mints(self, deposits: &[EthCexDeposit]) -> Self {
+        let ledger_id = self.fixture.cketh_ledger_id();
+        let mut credits: BTreeMap<(Principal, Option<[u8; 32]>), u128> = BTreeMap::new();
+        for deposit in deposits {
+            *credits
+                .entry((deposit.owner, Some(deposit.subaccount)))
+                .or_default() += deposit.amount;
+        }
+        for ((owner, subaccount), amount) in credits {
+            self.await_credited(ledger_id, Account { owner, subaccount }, amount);
+        }
+        self
+    }
+
+    pub fn assert_eth_addresses_swept_empty(self, deposits: &[EthCexDeposit]) -> Self {
+        for deposit in deposits {
+            assert_eq!(
+                self.anvil.balance(&deposit.address),
+                0,
+                "the swept deposit address must hold no ETH"
+            );
+        }
+        self
     }
 
     pub fn call_minter_deposit_erc20(
@@ -1167,6 +1280,86 @@ impl DepositErc20Calls {
             "every account must get its own deposit address"
         );
         (self.setup, deposits)
+    }
+}
+
+#[must_use]
+pub struct DepositEthCalls {
+    setup: LiveSetup<CkErc20Setup>,
+    responses: Vec<(EthDepositPlan, DepositEthResponse)>,
+}
+
+impl DepositEthCalls {
+    pub fn expect_deposit_responses(self) -> (LiveSetup<CkErc20Setup>, Vec<EthCexDeposit>) {
+        let deposits: Vec<EthCexDeposit> = self
+            .responses
+            .into_iter()
+            .map(|(plan, response)| {
+                let minimum = nat_to_u128(response.minimum_deposit_amount);
+                assert!(
+                    plan.amount >= minimum,
+                    "the planned deposit of {} wei is below the reported minimum of {minimum} wei",
+                    plan.amount
+                );
+                EthCexDeposit {
+                    address: Address::from_str(&response.address)
+                        .expect("BUG: minter returned an invalid deposit address"),
+                    owner: plan.owner,
+                    subaccount: plan.subaccount,
+                    amount: plan.amount,
+                }
+            })
+            .collect();
+        (self.setup, deposits)
+    }
+}
+
+#[must_use]
+pub struct EthCexCredit<'a> {
+    setup: LiveSetup<CkErc20Setup>,
+    deposits: &'a [EthCexDeposit],
+}
+
+impl<'a> EthCexCredit<'a> {
+    pub fn expect_deposit_balances_on_anvil(self) -> EthDetectionWatch<'a> {
+        for deposit in self.deposits {
+            assert_eq!(
+                self.setup.anvil.balance(&deposit.address),
+                deposit.amount,
+                "the deposited ETH should be readable on anvil"
+            );
+        }
+        EthDetectionWatch {
+            setup: self.setup,
+            deposits: self.deposits,
+        }
+    }
+}
+
+#[must_use]
+pub struct EthDetectionWatch<'a> {
+    pub setup: LiveSetup<CkErc20Setup>,
+    deposits: &'a [EthCexDeposit],
+}
+
+impl EthDetectionWatch<'_> {
+    pub fn expect_each_awaiting_sweep(self) -> LiveSetup<CkErc20Setup> {
+        for deposit in self.deposits {
+            let detected = match self
+                .setup
+                .await_eth_detection(deposit.owner, deposit.subaccount)
+                .status
+            {
+                DepositEthStatus::AwaitingSweep(detected) => detected,
+                status => panic!("BUG: await_eth_detection returned {status:?}"),
+            };
+            assert_eq!(
+                detected.scanned_balance,
+                Nat::from(deposit.amount),
+                "the detected balance must match the deposited amount"
+            );
+        }
+        self.setup
     }
 }
 

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -60,6 +60,7 @@ use ic_cketh_minter::endpoints::{
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
 use ic_cketh_minter::numeric::Erc20Value;
+use ic_cketh_minter::sweep::MAX_DEPOSITS_PER_SWEEP;
 use ic_cketh_minter::{BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -607,8 +608,8 @@ impl LiveSetup<CkErc20Setup> {
         self
     }
 
-    pub fn assert_eth_sweeps_batched(self, expected_item_counts: &[usize]) -> Self {
-        let batched: Vec<usize> = self
+    pub fn assert_eth_sweeps_batched(self, deposits: &[EthCexDeposit]) -> Self {
+        let batches: Vec<Vec<Address>> = self
             .minter_events()
             .into_iter()
             .filter_map(|event| match event.payload {
@@ -616,13 +617,37 @@ impl LiveSetup<CkErc20Setup> {
                     asset: EventAsset::Eth,
                     items,
                     ..
-                } => Some(items.len()),
+                } => Some(
+                    items
+                        .iter()
+                        .map(|item| {
+                            Address::from_str(&item.deposit)
+                                .expect("BUG: the sweep names an invalid deposit address")
+                        })
+                        .collect(),
+                ),
                 _ => None,
             })
             .collect();
+
+        let mut expected_sizes = Vec::new();
+        let mut remaining = deposits.len();
+        while remaining > 0 {
+            let batch = remaining.min(MAX_DEPOSITS_PER_SWEEP);
+            expected_sizes.push(batch);
+            remaining -= batch;
+        }
         assert_eq!(
-            batched, expected_item_counts,
-            "the ETH deposits must be swept in full batches, oldest first"
+            batches.iter().map(Vec::len).collect::<Vec<_>>(),
+            expected_sizes,
+            "the ETH deposits must be swept in full batches"
+        );
+
+        let swept: BTreeSet<Address> = batches.into_iter().flatten().collect();
+        let expected: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
+        assert_eq!(
+            swept, expected,
+            "every ETH deposit address must appear in exactly one sweep"
         );
         self
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -946,6 +946,10 @@ impl<S: AsRef<CkEthSetup>> LiveSetup<S> {
         self.cketh().get_all_events()
     }
 
+    pub fn minter_count_events(&self, filter: impl Fn(&Event) -> bool) -> usize {
+        self.cketh().minter_count_events(filter)
+    }
+
     pub fn get_minter_info(&self) -> MinterInfo {
         self.cketh().get_minter_info()
     }

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -279,6 +279,12 @@ impl LiveSetup<CkErc20Setup> {
         nat_to_u128(minimum.minimum_deposit_amount)
     }
 
+    /// The ETH minimum as `deposit_eth` reports it. Read through `caller`'s own registration,
+    /// which `deposit_eth` makes idempotently, so pass an account the test deposits for anyway.
+    pub fn minimum_eth_deposit_amount(&self, caller: Principal, subaccount: [u8; 32]) -> u128 {
+        nat_to_u128(self.deposit_eth(caller, subaccount).minimum_deposit_amount)
+    }
+
     /// Calls `deposit_eth` as `caller`, which registers (idempotently) that user's
     /// `(address, ETH)` pair for balance scanning and reports its scan progress.
     fn deposit_eth(&self, caller: Principal, subaccount: [u8; 32]) -> DepositEthResponse {

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -438,14 +438,50 @@ impl LiveSetup<CkErc20Setup> {
         caller: Principal,
         subaccount: [u8; 32],
     ) -> DepositEthResponse {
+        self.await_eth_deposit_status(caller, subaccount, "the ETH deposit was not detected", {
+            |status| matches!(status, DepositEthStatus::AwaitingSweep(_))
+        })
+    }
+
+    /// The ETH pendant of [`Self::await_scan`]: waits until the pair was scanned at a block
+    /// where its funding is visible, observed through `deposit_eth`'s own status.
+    pub fn await_eth_scan(&self, caller: Principal, subaccount: [u8; 32]) -> DepositEthResponse {
+        let funded_by = Nat::from(self.anvil.block_number());
+        self.await_eth_deposit_status(
+            caller,
+            subaccount,
+            &format!("the ETH deposit address was not scanned at or past block {funded_by}"),
+            |status| match status {
+                DepositEthStatus::Scanning {
+                    scan_count,
+                    last_scanned_block,
+                    ..
+                } => {
+                    *scan_count >= 1
+                        && last_scanned_block
+                            .as_ref()
+                            .is_some_and(|block| *block >= funded_by)
+                }
+                DepositEthStatus::AwaitingSweep(_) => true,
+            },
+        )
+    }
+
+    fn await_eth_deposit_status(
+        &self,
+        caller: Principal,
+        subaccount: [u8; 32],
+        what: &str,
+        is_done: impl Fn(&DepositEthStatus) -> bool,
+    ) -> DepositEthResponse {
         let mut reached = None;
         self.drive_until_with(
             SCAN_TICK,
             SCAN_TICKS,
-            |_| "the ETH deposit was not detected".to_string(),
+            |_| what.to_string(),
             |setup| {
                 let progress = setup.deposit_eth(caller, subaccount);
-                let done = matches!(progress.status, DepositEthStatus::AwaitingSweep(_));
+                let done = is_done(&progress.status);
                 if done {
                     reached = Some(progress);
                 }
@@ -1359,20 +1395,12 @@ impl DepositEthCalls {
         let deposits: Vec<EthCexDeposit> = self
             .responses
             .into_iter()
-            .map(|(plan, response)| {
-                let minimum = nat_to_u128(response.minimum_deposit_amount);
-                assert!(
-                    plan.amount >= minimum,
-                    "the planned deposit of {} wei is below the reported minimum of {minimum} wei",
-                    plan.amount
-                );
-                EthCexDeposit {
-                    address: Address::from_str(&response.address)
-                        .expect("BUG: minter returned an invalid deposit address"),
-                    owner: plan.owner,
-                    subaccount: plan.subaccount,
-                    amount: plan.amount,
-                }
+            .map(|(plan, response)| EthCexDeposit {
+                address: Address::from_str(&response.address)
+                    .expect("BUG: minter returned an invalid deposit address"),
+                owner: plan.owner,
+                subaccount: plan.subaccount,
+                amount: plan.amount,
             })
             .collect();
         let accounts: BTreeSet<(Principal, [u8; 32])> = deposits

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -60,7 +60,6 @@ use ic_cketh_minter::endpoints::{
 use ic_cketh_minter::lifecycle::MinterArg;
 use ic_cketh_minter::lifecycle::upgrade::UpgradeArg;
 use ic_cketh_minter::numeric::Erc20Value;
-use ic_cketh_minter::sweep::MAX_DEPOSITS_PER_SWEEP;
 use ic_cketh_minter::{BALANCE_SCAN_INTERVAL, PROCESS_ETH_RETRIEVE_TRANSACTIONS_INTERVAL};
 use ic_ethereum_types::Address;
 use icrc_ledger_types::icrc1::account::Account;
@@ -609,7 +608,7 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_eth_sweeps_batched(self, deposits: &[EthCexDeposit]) -> Self {
-        let batches: Vec<Vec<Address>> = self
+        let swept: BTreeSet<Address> = self
             .minter_events()
             .into_iter()
             .filter_map(|event| match event.payload {
@@ -624,26 +623,13 @@ impl LiveSetup<CkErc20Setup> {
                             Address::from_str(&item.deposit)
                                 .expect("BUG: the sweep names an invalid deposit address")
                         })
-                        .collect(),
+                        .collect::<Vec<_>>(),
                 ),
                 _ => None,
             })
+            .flatten()
             .collect();
 
-        let mut expected_sizes = Vec::new();
-        let mut remaining = deposits.len();
-        while remaining > 0 {
-            let batch = remaining.min(MAX_DEPOSITS_PER_SWEEP);
-            expected_sizes.push(batch);
-            remaining -= batch;
-        }
-        assert_eq!(
-            batches.iter().map(Vec::len).collect::<Vec<_>>(),
-            expected_sizes,
-            "the ETH deposits must be swept in full batches"
-        );
-
-        let swept: BTreeSet<Address> = batches.into_iter().flatten().collect();
         let expected: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
         assert_eq!(
             swept, expected,

--- a/rs/ethereum/cketh/test_utils/src/live.rs
+++ b/rs/ethereum/cketh/test_utils/src/live.rs
@@ -571,6 +571,47 @@ impl LiveSetup<CkErc20Setup> {
         self
     }
 
+    pub fn assert_eth_sweeps_batched(self, expected_item_counts: &[usize]) -> Self {
+        let batched: Vec<usize> = self
+            .minter_events()
+            .into_iter()
+            .filter_map(|event| match event.payload {
+                EventPayload::AcceptedSweepRequest {
+                    asset: EventAsset::Eth,
+                    items,
+                    ..
+                } => Some(items.len()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            batched, expected_item_counts,
+            "the ETH deposits must be swept in full batches, oldest first"
+        );
+        self
+    }
+
+    /// The minter's main address ETH balance, as a baseline for
+    /// [`Self::assert_minter_received_swept_eth_total`]: the address also holds the residue of
+    /// the funding deposit, so only the delta attributes the swept ETH.
+    pub fn minter_eth_balance(&self) -> u128 {
+        self.anvil.balance(&self.minter_address)
+    }
+
+    pub fn assert_minter_received_swept_eth_total(
+        self,
+        deposits: &[EthCexDeposit],
+        balance_before: u128,
+    ) -> Self {
+        let total: u128 = deposits.iter().map(|deposit| deposit.amount).sum();
+        assert_eq!(
+            self.anvil.balance(&self.minter_address),
+            balance_before + total,
+            "the minter's main address should have received all swept ETH"
+        );
+        self
+    }
+
     pub fn assert_eth_addresses_swept_empty(self, deposits: &[EthCexDeposit]) -> Self {
         for deposit in deposits {
             assert_eq!(
@@ -600,13 +641,21 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_deposit_addresses_bare(self, deposits: &[CexDeposit]) -> Self {
-        for deposit in deposits {
+        self.assert_addresses_bare(deposits.iter().map(|deposit| deposit.address))
+    }
+
+    pub fn assert_eth_deposit_addresses_bare(self, deposits: &[EthCexDeposit]) -> Self {
+        self.assert_addresses_bare(deposits.iter().map(|deposit| deposit.address))
+    }
+
+    fn assert_addresses_bare(self, addresses: impl IntoIterator<Item = Address>) -> Self {
+        for address in addresses {
             assert!(
-                self.anvil.code(&deposit.address).is_empty(),
+                self.anvil.code(&address).is_empty(),
                 "a deposit address starts with no code"
             );
             assert_eq!(
-                self.anvil.balance(&deposit.address),
+                self.anvil.balance(&address),
                 0,
                 "a deposit address never needs ETH of its own"
             );
@@ -673,10 +722,26 @@ impl LiveSetup<CkErc20Setup> {
     }
 
     pub fn assert_delegations_installed(self, deposits: &[CexDeposit], delegate: &Address) -> Self {
+        self.assert_delegations_installed_at(deposits.iter().map(|d| d.address), delegate)
+    }
+
+    pub fn assert_eth_delegations_installed(
+        self,
+        deposits: &[EthCexDeposit],
+        delegate: &Address,
+    ) -> Self {
+        self.assert_delegations_installed_at(deposits.iter().map(|d| d.address), delegate)
+    }
+
+    fn assert_delegations_installed_at(
+        self,
+        addresses: impl IntoIterator<Item = Address>,
+        delegate: &Address,
+    ) -> Self {
         let designator = delegation_designator(delegate);
-        for deposit in deposits {
+        for address in addresses {
             assert_eq!(
-                self.anvil.code(&deposit.address),
+                self.anvil.code(&address),
                 designator,
                 "the sweep should have installed the delegation"
             );
@@ -1310,6 +1375,16 @@ impl DepositEthCalls {
                 }
             })
             .collect();
+        let accounts: BTreeSet<(Principal, [u8; 32])> = deposits
+            .iter()
+            .map(|deposit| (deposit.owner, deposit.subaccount))
+            .collect();
+        let addresses: BTreeSet<Address> = deposits.iter().map(|deposit| deposit.address).collect();
+        assert_eq!(
+            addresses.len(),
+            accounts.len(),
+            "every account must get its own deposit address"
+        );
         (self.setup, deposits)
     }
 }


### PR DESCRIPTION
Final step of the `deposit_eth` flow per the [spec](https://github.com/dfinity/ic/pull/11491), on top of the merged #11494, #11499 and #11508: queued ETH deposits are now swept and minted, so `deposit_eth` covers the whole pipeline from address derivation to the ckETH credit.

* A `SweepRequest` moves one asset, ETH or a single ERC-20 token. The `sweepEthBatch` entry point takes the same `SweepItem` array as the ERC-20 one without the token list, and attestations are reused unchanged because their digest binds only the account. The asset field keeps the CBOR encoding of the previous bare token address, so recorded sweep events replay unchanged. The sweep gas limit budgets an ETH address for the one balance read and `depositEth` call `sweepEth` makes rather than for the ERC-20 approve-and-transfer shape, so a ten-deposit ETH sweep declares about 860k gas against the 413k measured.
* The live anvil coverage mirrors the ERC-20 suite: twenty deposits credited through full ten-deposit `sweepEthBatch` sweeps, threshold gating around the 0.005 ETH minimum, a second sweep of an already-delegated address despite its re-sent stale authorization, and a mixed population where one account deposits both assets at its single address and each asset is swept by its own lane. Sweep gas is asserted within 10 percent of new demo-measured ETH scenarios (413,076 for a ten-deposit first sweep, about two thirds of the ERC-20 figure).
* Deferred, as decided: entry-point gating on the delegate an address actually runs (R18). Until the delegation-record and rotation work lands, a single Sepolia address still delegated to the pre-#11449 delegate reverts the whole `sweepEthBatch` it lands in, since `sweepEth` is a void call with no per-item fallback. A failed sweep drops every deposit it named from the queue, up to ten per batch, and each needs a fresh `deposit_eth` to be armed again. Mainnet is unaffected, since no production address was ever delegated with the old delegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Yv31YXb6YH1Gp71G54cL9
