### PR TITLE
chore: cargo clippy fixes to prepare for the rustc upgrade: 1.97.1 -> 1.98.1

### DIFF
--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -159,22 +159,22 @@ impl MetricsRunner {
         health: Arc<dyn Health>,
     ) -> Self {
         let mem_allocated = register_int_gauge_with_registry!(
-            format!("memory_allocated"),
-            format!("Allocated memory in bytes"),
+            "memory_allocated".to_string(),
+            "Allocated memory in bytes".to_string(),
             registry
         )
         .unwrap();
 
         let mem_resident = register_int_gauge_with_registry!(
-            format!("memory_resident"),
-            format!("Resident memory in bytes"),
+            "memory_resident".to_string(),
+            "Resident memory in bytes".to_string(),
             registry
         )
         .unwrap();
 
         let healthy = register_int_gauge_with_registry!(
-            format!("healthy"),
-            format!("Node health status"),
+            "healthy".to_string(),
+            "Node health status".to_string(),
             registry
         )
         .unwrap();
@@ -242,16 +242,16 @@ impl MetricParamsPersist {
         Self {
             // Number of ranges
             ranges: register_int_gauge_with_registry!(
-                format!("persist_ranges"),
-                format!("Number of canister ranges currently published"),
+                "persist_ranges".to_string(),
+                "Number of canister ranges currently published".to_string(),
                 registry
             )
             .unwrap(),
 
             // Number of nodes
             nodes: register_int_gauge_with_registry!(
-                format!("persist_nodes"),
-                format!("Number of nodes currently published"),
+                "persist_nodes".to_string(),
+                "Number of nodes currently published".to_string(),
                 registry
             )
             .unwrap(),
@@ -390,15 +390,15 @@ impl MetricParamsSnapshot {
     pub fn new(registry: &Registry) -> Self {
         Self {
             version: register_int_gauge_with_registry!(
-                format!("registry_version"),
-                format!("Currently published registry version"),
+                "registry_version".to_string(),
+                "Currently published registry version".to_string(),
                 registry
             )
             .unwrap(),
 
             timestamp: register_int_gauge_with_registry!(
-                format!("registry_timestamp"),
-                format!("Timestamp of the last registry update"),
+                "registry_timestamp".to_string(),
+                "Timestamp of the last registry update".to_string(),
                 registry
             )
             .unwrap(),
@@ -415,8 +415,8 @@ impl HttpMetricParamsStatus {
     pub fn new(registry: &Registry) -> Self {
         Self {
             counter: register_int_counter_vec_with_registry!(
-                format!("http_request_status_total"),
-                format!("Counts occurrences of status calls"),
+                "http_request_status_total".to_string(),
+                "Counts occurrences of status calls".to_string(),
                 &["health"],
                 registry
             )

--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -159,25 +159,21 @@ impl MetricsRunner {
         health: Arc<dyn Health>,
     ) -> Self {
         let mem_allocated = register_int_gauge_with_registry!(
-            "memory_allocated".to_string(),
-            "Allocated memory in bytes".to_string(),
+            "memory_allocated",
+            "Allocated memory in bytes",
             registry
         )
         .unwrap();
 
         let mem_resident = register_int_gauge_with_registry!(
-            "memory_resident".to_string(),
-            "Resident memory in bytes".to_string(),
+            "memory_resident",
+            "Resident memory in bytes",
             registry
         )
         .unwrap();
 
-        let healthy = register_int_gauge_with_registry!(
-            "healthy".to_string(),
-            "Node health status".to_string(),
-            registry
-        )
-        .unwrap();
+        let healthy =
+            register_int_gauge_with_registry!("healthy", "Node health status", registry).unwrap();
 
         Self {
             metrics_cache,
@@ -242,16 +238,16 @@ impl MetricParamsPersist {
         Self {
             // Number of ranges
             ranges: register_int_gauge_with_registry!(
-                "persist_ranges".to_string(),
-                "Number of canister ranges currently published".to_string(),
+                "persist_ranges",
+                "Number of canister ranges currently published",
                 registry
             )
             .unwrap(),
 
             // Number of nodes
             nodes: register_int_gauge_with_registry!(
-                "persist_nodes".to_string(),
-                "Number of nodes currently published".to_string(),
+                "persist_nodes",
+                "Number of nodes currently published",
                 registry
             )
             .unwrap(),
@@ -390,15 +386,15 @@ impl MetricParamsSnapshot {
     pub fn new(registry: &Registry) -> Self {
         Self {
             version: register_int_gauge_with_registry!(
-                "registry_version".to_string(),
-                "Currently published registry version".to_string(),
+                "registry_version",
+                "Currently published registry version",
                 registry
             )
             .unwrap(),
 
             timestamp: register_int_gauge_with_registry!(
-                "registry_timestamp".to_string(),
-                "Timestamp of the last registry update".to_string(),
+                "registry_timestamp",
+                "Timestamp of the last registry update",
                 registry
             )
             .unwrap(),
@@ -415,8 +411,8 @@ impl HttpMetricParamsStatus {
     pub fn new(registry: &Registry) -> Self {
         Self {
             counter: register_int_counter_vec_with_registry!(
-                "http_request_status_total".to_string(),
-                "Counts occurrences of status calls".to_string(),
+                "http_request_status_total",
+                "Counts occurrences of status calls",
                 &["health"],
                 registry
             )

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -196,45 +196,45 @@ impl Metrics {
     fn new(registry: &Registry) -> Self {
         Self {
             scale: register_int_gauge_with_registry!(
-                "generic_limiter_scale".to_string(),
-                "Current scale that's applied to the rules".to_string(),
+                "generic_limiter_scale",
+                "Current scale that's applied to the rules",
                 registry,
             )
             .unwrap(),
 
             last_successful_fetch: register_int_gauge_with_registry!(
-                "generic_limiter_last_successful_fetch".to_string(),
-                "How many seconds ago the last successful fetch happened".to_string(),
+                "generic_limiter_last_successful_fetch",
+                "How many seconds ago the last successful fetch happened",
                 registry
             )
             .unwrap(),
 
             active_rules: register_int_gauge_with_registry!(
-                "generic_limiter_rules".to_string(),
-                "Number of rules currently installed".to_string(),
+                "generic_limiter_rules",
+                "Number of rules currently installed",
                 registry
             )
             .unwrap(),
 
             fetches: register_int_counter_vec_with_registry!(
-                "generic_limiter_fetches".to_string(),
-                "Count of rule fetches and their outcome".to_string(),
+                "generic_limiter_fetches",
+                "Count of rule fetches and their outcome",
                 &["result"],
                 registry
             )
             .unwrap(),
 
             decisions: register_int_counter_vec_with_registry!(
-                "generic_limiter_decisions".to_string(),
-                "Count of decisions made by the ratelimiter".to_string(),
+                "generic_limiter_decisions",
+                "Count of decisions made by the ratelimiter",
                 &["decision"],
                 registry
             )
             .unwrap(),
 
             shards_count: register_int_gauge_with_registry!(
-                "generic_limiter_shards_count".to_string(),
-                "Number of dynamic shards if the corresponding rules are used".to_string(),
+                "generic_limiter_shards_count",
+                "Number of dynamic shards if the corresponding rules are used",
                 registry,
             )
             .unwrap(),

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -196,45 +196,45 @@ impl Metrics {
     fn new(registry: &Registry) -> Self {
         Self {
             scale: register_int_gauge_with_registry!(
-                format!("generic_limiter_scale"),
-                format!("Current scale that's applied to the rules"),
+                "generic_limiter_scale".to_string(),
+                "Current scale that's applied to the rules".to_string(),
                 registry,
             )
             .unwrap(),
 
             last_successful_fetch: register_int_gauge_with_registry!(
-                format!("generic_limiter_last_successful_fetch"),
-                format!("How many seconds ago the last successful fetch happened"),
+                "generic_limiter_last_successful_fetch".to_string(),
+                "How many seconds ago the last successful fetch happened".to_string(),
                 registry
             )
             .unwrap(),
 
             active_rules: register_int_gauge_with_registry!(
-                format!("generic_limiter_rules"),
-                format!("Number of rules currently installed"),
+                "generic_limiter_rules".to_string(),
+                "Number of rules currently installed".to_string(),
                 registry
             )
             .unwrap(),
 
             fetches: register_int_counter_vec_with_registry!(
-                format!("generic_limiter_fetches"),
-                format!("Count of rule fetches and their outcome"),
+                "generic_limiter_fetches".to_string(),
+                "Count of rule fetches and their outcome".to_string(),
                 &["result"],
                 registry
             )
             .unwrap(),
 
             decisions: register_int_counter_vec_with_registry!(
-                format!("generic_limiter_decisions"),
-                format!("Count of decisions made by the ratelimiter"),
+                "generic_limiter_decisions".to_string(),
+                "Count of decisions made by the ratelimiter".to_string(),
                 &["decision"],
                 registry
             )
             .unwrap(),
 
             shards_count: register_int_gauge_with_registry!(
-                format!("generic_limiter_shards_count"),
-                format!("Number of dynamic shards if the corresponding rules are used"),
+                "generic_limiter_shards_count".to_string(),
+                "Number of dynamic shards if the corresponding rules are used".to_string(),
                 registry,
             )
             .unwrap(),

--- a/rs/boundary_node/ic_boundary/src/salt_fetcher.rs
+++ b/rs/boundary_node/ic_boundary/src/salt_fetcher.rs
@@ -35,21 +35,21 @@ impl Metrics {
         Self {
             last_successful_fetch: register_int_gauge_with_registry!(
                 format!("{METRIC_PREFIX}_last_successful_fetch"),
-                "The Unix timestamp of the last successful salt fetch".to_string(),
+                "The Unix timestamp of the last successful salt fetch",
                 registry
             )
             .unwrap(),
 
             last_salt_id: register_int_gauge_with_registry!(
                 format!("{METRIC_PREFIX}_last_salt_id"),
-                "ID of the latest fetched salt".to_string(),
+                "ID of the latest fetched salt",
                 registry,
             )
             .unwrap(),
 
             fetches: register_int_counter_vec_with_registry!(
                 format!("{METRIC_PREFIX}_fetches"),
-                "Count of salt fetches and their outcome".to_string(),
+                "Count of salt fetches and their outcome",
                 &["status", "message"],
                 registry
             )

--- a/rs/boundary_node/ic_boundary/src/salt_fetcher.rs
+++ b/rs/boundary_node/ic_boundary/src/salt_fetcher.rs
@@ -35,21 +35,21 @@ impl Metrics {
         Self {
             last_successful_fetch: register_int_gauge_with_registry!(
                 format!("{METRIC_PREFIX}_last_successful_fetch"),
-                format!("The Unix timestamp of the last successful salt fetch"),
+                "The Unix timestamp of the last successful salt fetch".to_string(),
                 registry
             )
             .unwrap(),
 
             last_salt_id: register_int_gauge_with_registry!(
                 format!("{METRIC_PREFIX}_last_salt_id"),
-                format!("ID of the latest fetched salt"),
+                "ID of the latest fetched salt".to_string(),
                 registry,
             )
             .unwrap(),
 
             fetches: register_int_counter_vec_with_registry!(
                 format!("{METRIC_PREFIX}_fetches"),
-                format!("Count of salt fetches and their outcome"),
+                "Count of salt fetches and their outcome".to_string(),
                 &["status", "message"],
                 registry
             )

--- a/rs/canonical_state/tree_hash/src/hash_tree.rs
+++ b/rs/canonical_state/tree_hash/src/hash_tree.rs
@@ -1288,7 +1288,7 @@ pub fn hash_lazy_tree<'a>(
                 let mut next = Vec::with_capacity((nodes.len() as f64 / 2.0).ceil() as usize);
                 ht.reserve_forks(nodes.len() - 1);
                 loop {
-                    for pair in nodes.chunks_exact(2) {
+                    for pair in nodes.as_chunks::<2>().0 {
                         let mut h = Hasher::for_domain("ic-hashtree-fork");
                         h.update(ht.digest(pair[0]).as_bytes());
                         h.update(ht.digest(pair[1]).as_bytes());

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -398,7 +398,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             crypto.method_name => "combine_multi_sig_individuals",
         );
         debug!(logger;
-            crypto.description => format!("start"),
+            crypto.description => "start".to_string(),
             crypto.registry_version => registry_version.get(),
             crypto.signature_shares => format!("{:?}", signatures),
         );
@@ -417,7 +417,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             start_time,
         );
         debug!(logger;
-            crypto.description => format!("end"),
+            crypto.description => "end".to_string(),
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
             crypto.signature => log_ok_content(&result),
@@ -441,7 +441,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             crypto.method_name => "verify_multi_sig_combined",
         );
         debug!(logger;
-            crypto.description => format!("start"),
+            crypto.description => "start".to_string(),
             crypto.registry_version => registry_version.get(),
             crypto.signature => format!("{:?}", signature),
             crypto.signed_bytes => format!("0x{}", hex::encode(message.as_signed_bytes())),
@@ -464,7 +464,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             start_time,
         );
         debug!(logger;
-            crypto.description => format!("end"),
+            crypto.description => "end".to_string(),
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
         );
@@ -574,7 +574,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, T: Signable> ThresholdSigV
             crypto.method_name => "combine_threshold_sig_shares",
         );
         debug!(logger;
-            crypto.description => format!("start"),
+            crypto.description => "start".to_string(),
             crypto.dkg_id => format!("{}", dkg_id),
             crypto.signature_shares => format!("{:?}", shares),
         );
@@ -593,7 +593,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, T: Signable> ThresholdSigV
             start_time,
         );
         debug!(logger;
-            crypto.description => format!("end"),
+            crypto.description => "end".to_string(),
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
             crypto.signature => log_ok_content(&result),

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -398,7 +398,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             crypto.method_name => "combine_multi_sig_individuals",
         );
         debug!(logger;
-            crypto.description => "start".to_string(),
+            crypto.description => "start",
             crypto.registry_version => registry_version.get(),
             crypto.signature_shares => format!("{:?}", signatures),
         );
@@ -417,7 +417,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             start_time,
         );
         debug!(logger;
-            crypto.description => "end".to_string(),
+            crypto.description => "end",
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
             crypto.signature => log_ok_content(&result),
@@ -441,7 +441,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             crypto.method_name => "verify_multi_sig_combined",
         );
         debug!(logger;
-            crypto.description => "start".to_string(),
+            crypto.description => "start",
             crypto.registry_version => registry_version.get(),
             crypto.signature => format!("{:?}", signature),
             crypto.signed_bytes => format!("0x{}", hex::encode(message.as_signed_bytes())),
@@ -464,7 +464,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> MultiSigVerif
             start_time,
         );
         debug!(logger;
-            crypto.description => "end".to_string(),
+            crypto.description => "end",
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
         );
@@ -574,7 +574,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, T: Signable> ThresholdSigV
             crypto.method_name => "combine_threshold_sig_shares",
         );
         debug!(logger;
-            crypto.description => "start".to_string(),
+            crypto.description => "start",
             crypto.dkg_id => format!("{}", dkg_id),
             crypto.signature_shares => format!("{:?}", shares),
         );
@@ -593,7 +593,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, T: Signable> ThresholdSigV
             start_time,
         );
         debug!(logger;
-            crypto.description => "end".to_string(),
+            crypto.description => "end",
             crypto.is_ok => result.is_ok(),
             crypto.error => log_err(result.as_ref().err()),
             crypto.signature => log_ok_content(&result),

--- a/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
+++ b/rs/ethereum/cketh/minter/src/eth_logs/parser.rs
@@ -265,10 +265,8 @@ fn parse_hex_into_32_byte_words<const N: usize>(
         });
     }
     let mut result = Vec::with_capacity(N);
-    for chunk in data.chunks_exact(32) {
-        let mut word = [0; 32];
-        word.copy_from_slice(chunk);
-        result.push(word);
+    for chunk in data.as_chunks::<32>().0 {
+        result.push(*chunk);
     }
     Ok(result.try_into().unwrap())
 }

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -522,6 +522,8 @@ async fn withdrawal_status(parameter: WithdrawalSearchParameter) -> Vec<Withdraw
 }
 
 #[update]
+// Boxing the error would be a breaking change of the canister's Candid interface.
+#[allow(clippy::result_large_err)]
 async fn withdraw_erc20(
     WithdrawErc20Arg {
         amount,

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -522,7 +522,6 @@ async fn withdrawal_status(parameter: WithdrawalSearchParameter) -> Vec<Withdraw
 }
 
 #[update]
-// Boxing the error would be a breaking change of the canister's Candid interface.
 #[allow(clippy::result_large_err)]
 async fn withdraw_erc20(
     WithdrawErc20Arg {

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -1,3 +1,7 @@
+// `TaskError` is intentionally a plain (non-boxed) enum: boxing it would be a
+// breaking change for the many functions and tests returning `Result<_, TaskError>`.
+#![allow(clippy::result_large_err)]
+
 mod metrics;
 #[cfg(test)]
 pub mod test_fixtures;

--- a/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/scheduler/mod.rs
@@ -1,5 +1,3 @@
-// `TaskError` is intentionally a plain (non-boxed) enum: boxing it would be a
-// breaking change for the many functions and tests returning `Result<_, TaskError>`.
 #![allow(clippy::result_large_err)]
 
 mod metrics;

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -3109,8 +3109,10 @@ fn test_call_context_performance_counter_correctly_reported_on_reply() {
 
     let counters = result
         .bytes()
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|c| u64::from_le_bytes(*c))
         .collect::<Vec<_>>();
 
     assert_lt!(counters[0], counters[1]);
@@ -3159,8 +3161,10 @@ fn test_call_context_performance_counter_correctly_reported_on_reject() {
 
     let counters = result
         .bytes()
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|c| u64::from_le_bytes(*c))
         .collect::<Vec<_>>();
 
     assert_lt!(counters[0], counters[1]);
@@ -3207,8 +3211,10 @@ fn test_call_context_performance_counter_correctly_reported_on_cleanup() {
     let stable_memory = &state.execution_state.as_ref().unwrap().stable_memory;
     let page = stable_memory.page_map.get_page(0.into());
     let counters = page[0..(std::mem::size_of::<u64>() * 3)]
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|c| u64::from_le_bytes(*c))
         .collect::<Vec<_>>();
 
     assert_lt!(counters[0], counters[1]);

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1363,8 +1363,10 @@ fn test_call_context_performance_counter_correctly_reported_on_query() {
 
     let counters = result
         .bytes()
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|c| u64::from_le_bytes(*c))
         .collect::<Vec<_>>();
 
     assert_lt!(counters[0], counters[1]);
@@ -1415,8 +1417,10 @@ fn test_call_context_performance_counter_correctly_reported_on_composite_query()
 
     let counters = result
         .bytes()
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|c| u64::from_le_bytes(*c))
         .collect::<Vec<_>>();
 
     assert_lt!(counters[0], counters[1]);

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -284,8 +284,7 @@ impl SchedulerTest {
         let wasm_source = system_task
             .map(|x| x.to_string().as_bytes().to_vec())
             .unwrap_or(EMPTY_WASM.to_vec());
-        let time_of_last_allocation_charge =
-            time_of_last_allocation_charge.map_or(UNIX_EPOCH, |time| time);
+        let time_of_last_allocation_charge = time_of_last_allocation_charge.unwrap_or(UNIX_EPOCH);
         let controller = controller.unwrap_or(self.user_id.get());
         let mut builder = CanisterStateBuilder::new()
             .with_canister_id(canister_id)

--- a/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
+++ b/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
@@ -52,28 +52,19 @@ fn main() -> Result<()> {
 fn process_cmdline(input: &str) -> Result<String> {
     let boot_args_re = Regex::new(r"(^|\n)BOOT_ARGS=(.*)(\s+#|\n|$)").unwrap();
 
-    let left;
-    let indent;
-    let boot_args;
-    let tail;
-    let right;
-    match boot_args_re.captures(input) {
+    let (left, indent, boot_args, tail, right) = match boot_args_re.captures(input) {
         Some(captures) => {
             let whole_match = captures.get(0).unwrap();
 
-            left = whole_match.start();
-            indent = captures.get(1).unwrap().as_str();
-            boot_args = captures.get(2).unwrap().as_str().trim().trim_matches('"');
-            tail = captures.get(3).unwrap().as_str();
-            right = whole_match.end();
+            (
+                whole_match.start(),
+                captures.get(1).unwrap().as_str(),
+                captures.get(2).unwrap().as_str().trim().trim_matches('"'),
+                captures.get(3).unwrap().as_str(),
+                whole_match.end(),
+            )
         }
-        None => {
-            left = input.len();
-            indent = "";
-            boot_args = "";
-            tail = "\n";
-            right = input.len();
-        }
+        None => (input.len(), "", "", "\n", input.len()),
     };
 
     let mut cmdline = KernelCommandLine::from_str(boot_args)?;

--- a/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
+++ b/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
@@ -49,22 +49,34 @@ fn main() -> Result<()> {
 }
 
 /// Disable checks from the kernel command line
+// Naming each binding at its assignment is clearer here than destructuring a 5-tuple,
+// where it is easy to misread which value ends up in which variable.
+#[allow(clippy::needless_late_init)]
 fn process_cmdline(input: &str) -> Result<String> {
     let boot_args_re = Regex::new(r"(^|\n)BOOT_ARGS=(.*)(\s+#|\n|$)").unwrap();
 
-    let (left, indent, boot_args, tail, right) = match boot_args_re.captures(input) {
+    let left;
+    let indent;
+    let boot_args;
+    let tail;
+    let right;
+    match boot_args_re.captures(input) {
         Some(captures) => {
             let whole_match = captures.get(0).unwrap();
 
-            (
-                whole_match.start(),
-                captures.get(1).unwrap().as_str(),
-                captures.get(2).unwrap().as_str().trim().trim_matches('"'),
-                captures.get(3).unwrap().as_str(),
-                whole_match.end(),
-            )
+            left = whole_match.start();
+            indent = captures.get(1).unwrap().as_str();
+            boot_args = captures.get(2).unwrap().as_str().trim().trim_matches('"');
+            tail = captures.get(3).unwrap().as_str();
+            right = whole_match.end();
         }
-        None => (input.len(), "", "", "\n", input.len()),
+        None => {
+            left = input.len();
+            indent = "";
+            boot_args = "";
+            tail = "\n";
+            right = input.len();
+        }
     };
 
     let mut cmdline = KernelCommandLine::from_str(boot_args)?;

--- a/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
+++ b/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
@@ -49,8 +49,7 @@ fn main() -> Result<()> {
 }
 
 /// Disable checks from the kernel command line
-// Naming each binding at its assignment is clearer here than destructuring a 5-tuple,
-// where it is easy to misread which value ends up in which variable.
+// Naming each binding at its assignment is clearer than destructuring a 5-tuple.
 #[allow(clippy::needless_late_init)]
 fn process_cmdline(input: &str) -> Result<String> {
     let boot_args_re = Regex::new(r"(^|\n)BOOT_ARGS=(.*)(\s+#|\n|$)").unwrap();

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
@@ -130,7 +130,7 @@ fn render_if_too_small(f: &mut Frame, size: Rect) -> bool {
 fn create_parameter_lines(params: &RecoveryParams) -> Vec<Line<'_>> {
     let calculated_version_hash = params.version_hash_full.as_deref().unwrap_or("<pending>");
     let mut lines = vec![
-        format!("Inputted parameters:"),
+        "Inputted parameters:".to_string(),
         format!("VERSION: {}", params.version),
     ];
 

--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -660,7 +660,7 @@ fn get_account_identifier_transactions(
         .min(icp_ledger::max_blocks_per_request(&PrincipalId::from(msg_caller())) as u64)
         .min(usize::MAX as u64) as usize;
     // TODO: deal with the user setting start to u64::MAX
-    let start = arg.start.map_or(u64::MAX, |n| n);
+    let start = arg.start.unwrap_or(u64::MAX);
     let key = account_identifier_block_ids_key(arg.account_identifier, start);
     let mut settled_transactions = vec![];
     let indices = with_account_identifier_block_ids(|account_identifier_block_ids| {

--- a/rs/monitoring/metrics_proxy/src/client.rs
+++ b/rs/monitoring/metrics_proxy/src/client.rs
@@ -53,6 +53,8 @@ impl From<HttpError> for ScrapeError {
 ///
 /// # Errors
 /// * `ScrapeError`
+// Boxing the error would be a breaking change of this function's public API.
+#[allow(clippy::result_large_err)]
 pub async fn scrape(
     client: reqwest::Client,
     c: &crate::config::ConnectTo,

--- a/rs/monitoring/metrics_proxy/src/client.rs
+++ b/rs/monitoring/metrics_proxy/src/client.rs
@@ -53,7 +53,6 @@ impl From<HttpError> for ScrapeError {
 ///
 /// # Errors
 /// * `ScrapeError`
-// Boxing the error would be a breaking change of this function's public API.
 #[allow(clippy::result_large_err)]
 pub async fn scrape(
     client: reqwest::Client,

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -804,7 +804,6 @@ where
         }
     }
 
-    // Boxing `DeployError` would require changing all of its (many) call sites.
     #[allow(clippy::result_large_err)]
     async fn do_deploy_new_sns(
         thread_safe_sns: &'static LocalKey<RefCell<SnsWasmCanister<M>>>,
@@ -1231,7 +1230,6 @@ where
 
     /// Creates the Canisters for the SNS to be deployed, or returns a failure message and
     /// SnsCanisterIds to delete if any.
-    // Boxing the error would require changing all of this function's call sites.
     #[allow(clippy::result_large_err)]
     async fn create_sns_canisters(
         canister_api: &impl CanisterApi,

--- a/rs/nns/sns-wasm/src/sns_wasm.rs
+++ b/rs/nns/sns-wasm/src/sns_wasm.rs
@@ -804,6 +804,8 @@ where
         }
     }
 
+    // Boxing `DeployError` would require changing all of its (many) call sites.
+    #[allow(clippy::result_large_err)]
     async fn do_deploy_new_sns(
         thread_safe_sns: &'static LocalKey<RefCell<SnsWasmCanister<M>>>,
         canister_api: &impl CanisterApi,
@@ -1229,6 +1231,8 @@ where
 
     /// Creates the Canisters for the SNS to be deployed, or returns a failure message and
     /// SnsCanisterIds to delete if any.
+    // Boxing the error would require changing all of this function's call sites.
+    #[allow(clippy::result_large_err)]
     async fn create_sns_canisters(
         canister_api: &impl CanisterApi,
         subnet_id: SubnetId,

--- a/rs/nns/test_utils/golden_nns_state/src/lib.rs
+++ b/rs/nns/test_utils/golden_nns_state/src/lib.rs
@@ -186,6 +186,11 @@ fn add_canister_range_to_routing_table(
 
 #[cfg(test)]
 mod tests {
+    // `create_routing_table` takes a `Vec<RangeInclusive<u64>>`, i.e. the `Vec`s below
+    // intentionally hold canister ID ranges as elements; they are not meant to be
+    // expanded into the (astronomically many) values contained in those ranges.
+    #![allow(clippy::single_range_in_vec_init)]
+
     use super::*;
 
     #[test]

--- a/rs/rosetta-api/icrc1/src/construction_api/endpoints.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/endpoints.rs
@@ -1,3 +1,8 @@
+// The handlers in this module return `axum::response::Result`, whose `Err` variant is
+// axum's `ErrorResponse`. Its size is not under our control and boxing it would change
+// the handler signatures axum expects.
+#![allow(clippy::result_large_err)]
+
 use super::{services, types::ConstructionPayloadsRequestMetadata};
 use crate::{
     MultiTokenAppState,

--- a/rs/rosetta-api/icrc1/src/construction_api/endpoints.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/endpoints.rs
@@ -1,6 +1,3 @@
-// The handlers in this module return `axum::response::Result`, whose `Err` variant is
-// axum's `ErrorResponse`. Its size is not under our control and boxing it would change
-// the handler signatures axum expects.
 #![allow(clippy::result_large_err)]
 
 use super::{services, types::ConstructionPayloadsRequestMetadata};

--- a/rs/rosetta-api/icrc1/src/data_api/endpoints.rs
+++ b/rs/rosetta-api/icrc1/src/data_api/endpoints.rs
@@ -1,3 +1,8 @@
+// The handlers in this module return `axum::response::Result`, whose `Err` variant is
+// axum's `ErrorResponse`. Its size is not under our control and boxing it would change
+// the handler signatures axum expects.
+#![allow(clippy::result_large_err)]
+
 use super::services::{self, initial_sync_is_completed};
 use crate::{
     MultiTokenAppState,

--- a/rs/rosetta-api/icrc1/src/data_api/endpoints.rs
+++ b/rs/rosetta-api/icrc1/src/data_api/endpoints.rs
@@ -1,6 +1,3 @@
-// The handlers in this module return `axum::response::Result`, whose `Err` variant is
-// axum's `ErrorResponse`. Its size is not under our control and boxing it would change
-// the handler signatures axum expects.
 #![allow(clippy::result_large_err)]
 
 use super::services::{self, initial_sync_is_completed};

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1955,7 +1955,7 @@ fn summarize_blob_field(blob: &[u8]) -> Vec<u8> {
              - Trailing 32 Bytes (in hex): {}",
             blob.len(),
             format_u8_slice(&Sha256::hash(blob)),
-            format_u8_slice(blob.chunks_exact(32).next().unwrap_or(&[])),
+            format_u8_slice(blob.get(..32).unwrap_or(&[])),
             format_u8_slice(blob.rchunks_exact(32).next().unwrap_or(&[])),
         )
         .as_bytes(),

--- a/rs/sns/governance/src/types/tests.rs
+++ b/rs/sns/governance/src/types/tests.rs
@@ -1031,9 +1031,7 @@ fn test_neuron_permission_list_display_impl() {
     let neuron_permission_list = NeuronPermissionList::all();
     assert_eq!(
         format!("permissions: {neuron_permission_list}"),
-        format!(
-            "permissions: [Unspecified, ConfigureDissolveState, ManagePrincipals, SubmitProposal, Vote, Disburse, Split, MergeMaturity, DisburseMaturity, StakeMaturity, ManageVotingPermission]"
-        )
+        "permissions: [Unspecified, ConfigureDissolveState, ManagePrincipals, SubmitProposal, Vote, Disburse, Split, MergeMaturity, DisburseMaturity, StakeMaturity, ManageVotingPermission]"
     );
 }
 

--- a/rs/test_utilities/execution_environment/src/wat_canister/builder.rs
+++ b/rs/test_utilities/execution_environment/src/wat_canister/builder.rs
@@ -150,7 +150,7 @@ impl WatCanisterBuilder {
         let mut rendered_functions = Vec::new();
 
         // Drain the ASTs to compute rendering
-        let funcs: Vec<WatFunc> = self.functions.drain(..).collect();
+        let funcs: Vec<WatFunc> = std::mem::take(&mut self.functions);
 
         let has_start = funcs.iter().any(|f| f.method == Method::Start);
 

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -304,7 +304,7 @@ impl std::fmt::Display for TopologySnapshot {
                 "\tNode id={}, ipv6={:<width$}, domain_name={}, index={}",
                 n.node_id,
                 n.get_ip_addr(),
-                n.get_domain().map_or("n/a".to_string(), |domain| domain),
+                n.get_domain().unwrap_or("n/a".to_string()),
                 idx,
                 width = max_length_ipv6,
             )

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -304,7 +304,7 @@ impl std::fmt::Display for TopologySnapshot {
                 "\tNode id={}, ipv6={:<width$}, domain_name={}, index={}",
                 n.node_id,
                 n.get_ip_addr(),
-                n.get_domain().unwrap_or("n/a".to_string()),
+                n.get_domain().unwrap_or_else(|| "n/a".to_string()),
                 idx,
                 width = max_length_ipv6,
             )


### PR DESCRIPTION
`cargo clippy` fixes to prepare for upgrading to
[rustc-1.98.1](https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/).

Clippy 0.1.98 reports **85 warnings across 23 files** that Clippy 0.1.97 does not. 11 of them
come from two lints that are new in 1.98; the other 74 come from existing lints whose reach
1.98 widened:

| lint | # | why it fires now | fix |
| --- | --: | --- | --- |
| [`useless_format`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#useless_format) | 39 | 1.98 also lints through macro expansions, so `format!("some literal")` inside `slog::debug!` and the prometheus `register_*_with_registry!` macros is now reported | pass the literal directly (see below) |
| [`result_large_err`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#result_large_err) | 28 | [#17130](https://github.com/rust-lang/rust-clippy/pull/17130) fixed the lint to also fire on `async fn` | `#[allow(clippy::result_large_err)]` |
| [`chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks) | 8 | new lint in 1.98 ([#16931](https://github.com/rust-lang/rust-clippy/pull/16931)) | rewritten to `slice::as_chunks::<N>()` / `slice::get(..N)` |
| [`single_range_in_vec_init`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#single_range_in_vec_init) | 5 | [#17146](https://github.com/rust-lang/rust-clippy/pull/17146) made it detect more range shapes | `#[allow(...)]` — false positive here, see below |
| [`map_or_identity`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#map_or_identity) | 3 | new lint in 1.98 | `x.map_or(d, \|v\| v)` → `x.unwrap_or(d)` |
| [`drain_collect`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect) | 1 | | `v.drain(..).collect()` → `std::mem::take(&mut v)` |
| [`needless_late_init`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#needless_late_init) | 1 | [#16746](https://github.com/rust-lang/rust-clippy/pull/16746) extended it to grouped assignments | `#[allow(...)]` — naming each binding at its assignment reads better than a 5-tuple destructure |

Three of these deserve a word:

* **`useless_format`** sites just pass the string literal now, rather than clippy's suggested
  `.to_string()`: `slog`'s `Value` is implemented for `&'static str` and the prometheus
  `register_*_with_registry!` macros take `Into<String>`, so no allocation or conversion is
  needed. That is also what these files already do elsewhere — `rs/crypto/src/sign/mod.rs` logs
  a bare literal at 90 other sites, and `ic_boundary`'s `metrics.rs` registers
  `"check_total"`/`"check_status"` that way. (The one exception is
  `manual_guestos_recovery/src/ui.rs`, where the literal is an element of a `Vec<String>` and
  so does need `.to_string()`.)

* **`result_large_err`** is silenced with `#[allow]` rather than fixed, in line with the ~39
  existing uses of that allow in this repo. Boxing these error types would churn signatures
  across their call sites for no practical gain — none of these paths is performance-sensitive,
  which is the whole point of the lint. If any of them is worth boxing, that is a change worth
  making on its own merits rather than as a side effect of a toolchain bump.

* **`single_range_in_vec_init`** is a false positive at all 5 sites: those `Vec`s intentionally
  hold canister ID ranges *as elements* and are passed to a `fn(Vec<RangeInclusive<u64>>)`, so
  clippy's "did you mean to `.collect()` the range" suggestion does not apply. Allowed at the
  module level with a comment.

Note also that clippy's machine-applicable suggestion for `chunks_exact_to_as_chunks` does not
compile at 5 of the 8 sites — a const-generic argument that is not a literal needs braces
(`as_chunks::<{ std::mem::size_of::<u64>() }>()`), and `&[]` is not a `&[T; N]` — so those were
written by hand. `blob.chunks_exact(32).next()` became the equivalent and clearer
`blob.get(..32)`.

Because this PR lands *before* the toolchain bump, it has to stay clean on 1.97.1 too, and that
decides which lints may be silenced and which must be rewritten. `#[allow]` is used only for
lints that Clippy 0.1.97 already knows (`result_large_err`, `single_range_in_vec_init`,
`needless_late_init`) — 1.98 merely widened where those apply. The two lints that are genuinely
*new* in 1.98 (`chunks_exact_to_as_chunks`, `map_or_identity`) are fixed in the code, because
allowing them would trip rustc's `unknown_lints` under `--deny warnings` on the currently
pinned toolchain.

The toolchain upgrade itself is the PR stacked on top of this one.

## Testing

`./ci/scripts/rust-lint.sh` exits 0 both on the currently pinned **1.97.1** and on **1.98.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
