### PR TITLE
chore: rustc: 1.97.1 -> 1.98.1

### DIFF
--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -12,7 +12,7 @@ single_version_override(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
-    versions = ["1.97.1"],
+    versions = ["1.98.1"],
 )
 
 # Repin with `CARGO_BAZEL_REPIN=true bazel build @crate_index//...`

--- a/rs/bitcoin/ckbtc/minter/canbench/results.yml
+++ b/rs/bitcoin/ckbtc/minter/canbench/results.yml
@@ -2,185 +2,185 @@ benches:
   build_estimate_retrieve_btc_fee_1_50k_sats:
     total:
       calls: 1
-      instructions: 255870
+      instructions: 255940
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4374
+        instructions: 4357
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250029
+        instructions: 250012
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_1_50k_sats:
     total:
       calls: 1
-      instructions: 257878
+      instructions: 257948
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255367
+        instructions: 255437
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4374
+        instructions: 4357
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250029
+        instructions: 250012
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_2_100k_sats:
     total:
       calls: 1
-      instructions: 257924
+      instructions: 257994
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255413
+        instructions: 255483
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4420
+        instructions: 4403
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250075
+        instructions: 250058
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_3_1m_sats:
     total:
       calls: 1
-      instructions: 257971
+      instructions: 258041
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 255460
+        instructions: 255530
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 3032
+        instructions: 3015
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 250122
+        instructions: 250105
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_4_10m_sats:
     total:
       calls: 1
-      instructions: 258963
+      instructions: 259033
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 256452
+        instructions: 256522
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4074
+        instructions: 4057
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 251114
+        instructions: 251097
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_5_1_btc:
     total:
       calls: 1
-      instructions: 258963
+      instructions: 259033
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 256452
+        instructions: 256522
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3159
+        instructions: 3246
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 4074
+        instructions: 4057
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 251114
+        instructions: 251097
         heap_increase: 0
         stable_memory_increase: 0
   build_unsigned_transaction_6_10_btc:
     total:
       calls: 1
-      instructions: 264334
+      instructions: 264401
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_unsigned_transaction:
         calls: 1
-        instructions: 261823
+        instructions: 261890
         heap_increase: 0
         stable_memory_increase: 0
       build_unsigned_transaction_from_inputs:
         calls: 1
-        instructions: 3593
+        instructions: 3677
         heap_increase: 0
         stable_memory_increase: 0
       greedy:
         calls: 1
-        instructions: 11840
+        instructions: 11823
         heap_increase: 0
         stable_memory_increase: 0
       utxos_selection:
         calls: 1
-        instructions: 256051
+        instructions: 256034
         heap_increase: 0
         stable_memory_increase: 0
 version: 0.6.0

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -2,206 +2,206 @@ benches:
   add_neuron_active_maximum:
     total:
       calls: 1
-      instructions: 64560789
+      instructions: 64544969
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical:
     total:
       calls: 1
-      instructions: 4571954
+      instructions: 4570916
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
       calls: 1
-      instructions: 64560919
+      instructions: 64545095
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
       calls: 1
-      instructions: 4572084
+      instructions: 4571042
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_everything:
     total:
       calls: 1
-      instructions: 105852824
+      instructions: 107485195
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all:
     total:
       calls: 1
-      instructions: 42448137
+      instructions: 42549140
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
       calls: 1
-      instructions: 2422308
+      instructions: 2447760
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:
       calls: 1
-      instructions: 2844707
+      instructions: 2860514
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   draw_maturity_from_neurons_fund:
     total:
       calls: 1
-      instructions: 7704643
+      instructions: 7698945
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons:
     total:
       calls: 1
-      instructions: 2225895
+      instructions: 2235280
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons:
     total:
       calls: 1
-      instructions: 34338293
+      instructions: 34331850
       heap_increase: 4
       stable_memory_increase: 0
     scopes: {}
   list_neurons_by_subaccount:
     total:
       calls: 1
-      instructions: 33207594
+      instructions: 33204220
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_proposals:
     total:
       calls: 1
-      instructions: 77012
+      instructions: 76976
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids:
     total:
       calls: 1
-      instructions: 38263617
+      instructions: 38298605
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation:
     total:
       calls: 1
-      instructions: 205284067
+      instructions: 205340385
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation:
     total:
       calls: 1
-      instructions: 3413370
+      instructions: 3670047
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
       calls: 1
-      instructions: 51078376
+      instructions: 51101976
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   record_known_neuron_vote:
     total:
       calls: 1
-      instructions: 184304
+      instructions: 184152
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   record_neuron_vote_known_neuron_voting_history:
     total:
       calls: 1
-      instructions: 144353
+      instructions: 144298
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all:
     total:
       calls: 1
-      instructions: 279927
+      instructions: 280358
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   unstake_maturity_of_dissolved_neurons:
     total:
       calls: 1
-      instructions: 65062861
+      instructions: 65103121
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       list_neuron_ids:
         calls: 1
-        instructions: 39674813
+        instructions: 39711691
         heap_increase: 0
         stable_memory_increase: 0
       unstake_maturity:
         calls: 1
-        instructions: 25385884
+        instructions: 25389266
         heap_increase: 0
         stable_memory_increase: 0
   voting_power_snapshots_is_latest_snapshot_a_spike_false:
     total:
       calls: 1
-      instructions: 30690
+      instructions: 30655
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   voting_power_snapshots_is_latest_snapshot_a_spike_true:
     total:
       calls: 1
-      instructions: 30701
+      instructions: 30666
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   voting_power_snapshots_latest_snapshot_timestamp_seconds:
     total:
       calls: 1
-      instructions: 7698
+      instructions: 7675
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_maximum:
     total:
       calls: 1
-      instructions: 4106793
+      instructions: 4106177
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical:
     total:
       calls: 1
-      instructions: 848552
+      instructions: 848665
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_maximum:
     total:
       calls: 1
-      instructions: 2242315
+      instructions: 2242233
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_typical:
     total:
       calls: 1
-      instructions: 392358
+      instructions: 392588
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/recovery/subnet_splitting/tests/integration_tests.rs
+++ b/rs/recovery/subnet_splitting/tests/integration_tests.rs
@@ -206,36 +206,36 @@ fn load_metrics_e2e_test() {
             states_sizes_bytes
                 .source
                 .min(states_sizes_bytes.destination),
-            2927104,
+            3693264,
             0.1
         );
         assert_near!(
             states_sizes_bytes
                 .source
                 .max(states_sizes_bytes.destination),
-            6335280,
+            5539880,
             0.1
         );
         assert_near!(
             instructions_executed
                 .source
                 .min(instructions_executed.destination),
-            144348469,
+            144321167,
             0.1
         );
         assert_near!(
             instructions_executed
                 .source
                 .max(instructions_executed.destination),
-            145717733,
+            145740365,
             0.1
         );
-        assert_eq_oriented!(canisters_installed, 14, 6);
-        assert_eq_oriented!(ingress_messages_executed, 26, 13);
-        assert_eq_oriented!(remote_subnet_messages_executed_lower_bound, 6, 4);
-        assert_eq_oriented!(local_subnet_messages_executed_upper_bound, 19, 9);
-        assert_eq_oriented!(http_outcalls_executed, 8, 2);
-        assert_eq_oriented!(heartbeats_and_global_timers_executed, 313, 381);
+        assert_eq_oriented!(canisters_installed, 8, 12);
+        assert_eq_oriented!(ingress_messages_executed, 15, 24);
+        assert_eq_oriented!(remote_subnet_messages_executed_lower_bound, 4, 6);
+        assert_eq_oriented!(local_subnet_messages_executed_upper_bound, 11, 17);
+        assert_eq_oriented!(http_outcalls_executed, 4, 6);
+        assert_eq_oriented!(heartbeats_and_global_timers_executed, 368, 326);
         // A single split cannot report some metrics in the original orientation and others in the
         // swapped one, so require all the orientation-sensitive metrics to agree on one labeling.
         assert!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 targets = ["wasm32-unknown-unknown"]
 profile = "default"
 components = []


### PR DESCRIPTION
Upgrade the rust toolchain from 1.97.1 to 1.98.1. See:
https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/.

The `cargo clippy` fixes this needs are in the PR below this one in the stack, so this PR is
just the version bump in `rust-toolchain.toml` and `bazel/rust.MODULE.bazel`, plus the NNS
governance canbench baseline that the new codegen shifts.

Only one benchmark moved by more than the 5% noise threshold of
`//rs/nns/governance:governance-canbench_test`:

| status | name | calls | ins | ins Δ% | HI | HI Δ% | SMI | SMI Δ% |
|--------|------|-------|-----|--------|----|-------|-----|--------|
| + | `neuron_metrics_calculation` | | 3.67M | **+7.52%** | 0 | 0.00% | 0 | 0.00% |

so `rs/nns/governance/canbench/canbench_results.yml` was regenerated with
`bazel run //rs/nns/governance:governance-canbench_update`. The two icrc1 ledger canbench tests
stay within their noise threshold, so their results files are unchanged.

CI then flagged two more targets, both fixed here:

**`//rs/bitcoin/ckbtc/minter:ckbtc_minter_canbench_test`** — regenerated with
`bazel run //rs/bitcoin/ckbtc/minter:ckbtc_minter_canbench_update` (34 instruction counts).

**`//rs/recovery/subnet_splitting:integration_test`** — this one has no `_update` target; its
expected values are hardcoded in the test, so all ten were re-pinned by hand from a single
1.98.1 reference run, in one consistent source/destination orientation.

What changed is the *partition*, not the workload. Every total is identical — canisters 20,
ingress messages 39, remote 10, local 28, http outcalls 10, heartbeats 694 — and total
instructions moved by 0.0016%. `split-finder` solves a symmetric MILP over load samples derived
from measured execution, and that tiny shift was enough to flip a near-tied optimum to a
different partition; both balance instructions ~50/50, so both are equally optimal for the
solver's objective.

| metric | 1.97.1 | 1.98.1 |
| --- | --- | --- |
| `states_sizes_bytes` | 6335280 / 2927104 | 3693264 / 5539880 |
| `canisters_installed` | 14 / 6 | 8 / 12 |
| `ingress_messages_executed` | 26 / 13 | 15 / 24 |
| `remote_subnet_messages_executed_lower_bound` | 6 / 4 | 4 / 6 |
| `local_subnet_messages_executed_upper_bound` | 19 / 9 | 11 / 17 |
| `http_outcalls_executed` | 8 / 2 | 4 / 6 |
| `heartbeats_and_global_timers_executed` | 313 / 381 | 368 / 326 |

Before changing the values I checked that this is a real shift and not a flake: the test is
deterministic (5/5 uncached runs on 1.98.1 give byte-identical values), and on 1.97.1 this
machine reproduces the currently committed values exactly and passes — so the environment
agrees with CI and the new values should too.

⚠️ Worth a separate look by the owners: because the test pins the exact solution of a
degenerate optimisation, it will keep flipping on unrelated changes. Asserting on the totals
and on the ~50/50 instruction balance — which *both* partitions satisfy — would make it robust.

No repin is needed: no third-party crate dependency changed, so the `Cargo.Bazel.*.lock` files
are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
