### PR TITLE
feat: [DSM-147] Strict XNet slice byte limits for suffix pulls

### DIFF
--- a/rs/canonical_state/src/size_limit_visitor.rs
+++ b/rs/canonical_state/src/size_limit_visitor.rs
@@ -27,8 +27,8 @@ impl Matcher {
 }
 
 /// Visitor that limits the byte size of blob leaves matching a given pattern by
-/// skipping all leaves after at least one leaf was visited and the size limit
-/// has been reached.
+/// skipping all leaves after the size limit has been reached and, optionally,
+/// at least one leaf was visited (iff `include_one` is set).
 ///
 /// Skips whole leaves (label and value), by caching the label and invoking the
 /// wrapped visitor on both iff the inclusion of the blob size would not exceed
@@ -51,7 +51,7 @@ pub struct SizeLimitVisitor<V> {
     /// Accumulator of visited leaf sizes.
     size: usize,
     /// If set, one matching node must be included when present, even if
-    /// `size_limit` is exceeded.
+    /// `size_limit` is exceeded. Cleared after one node has been included.
     include_one: bool,
 
     /// Label of most recently visited matching node.
@@ -62,7 +62,10 @@ impl<V> SizeLimitVisitor<V>
 where
     V: Visitor,
 {
-    pub fn new(pattern: Vec<Matcher>, size_limit: usize, visitor: V) -> Self {
+    /// Creates a visitor limiting matching leaves to `size_limit` bytes. Unless
+    /// `include_one` is set, in which case the first matching leaf is included
+    /// regardless of its size.
+    pub fn new(pattern: Vec<Matcher>, size_limit: usize, include_one: bool, visitor: V) -> Self {
         assert!(!pattern.is_empty());
 
         Self {
@@ -72,7 +75,7 @@ where
 
             path_match: vec![],
             size: 0,
-            include_one: true,
+            include_one,
 
             leaf_label: None,
         }

--- a/rs/canonical_state/src/size_limit_visitor/tests.rs
+++ b/rs/canonical_state/src/size_limit_visitor/tests.rs
@@ -73,6 +73,7 @@ fn multiple_subtrees() {
     let visitor = SizeLimitVisitor::new(
         pattern,
         4 * MESSAGE_SIZE - 1,
+        true,
         TracingVisitor::new(NoopVisitor),
     );
 
@@ -143,9 +144,11 @@ fn stacked_visitors() {
     let visitor = SizeLimitVisitor::new(
         msg_pattern,
         3 * MESSAGE_SIZE,
+        true,
         SizeLimitVisitor::new(
             header_pattern,
             HEADER_SIZE,
+            true,
             TracingVisitor::new(NoopVisitor),
         ),
     );

--- a/rs/canonical_state/tests/size_limit_visitor.rs
+++ b/rs/canonical_state/tests/size_limit_visitor.rs
@@ -91,6 +91,7 @@ fn size_limit_proptest(#[strategy(arb_fixture(10))] fixture: Fixture) {
     let visitor = SizeLimitVisitor::new(
         pattern,
         size_limit,
+        true,
         SubtreeVisitor::new(&subtree_pattern, MessageSpyVisitor::default()),
     );
     let (actual_size, actual_begin, actual_end) = traverse(&state, Height::new(0), visitor);

--- a/rs/interfaces/certified_stream_store/src/lib.rs
+++ b/rs/interfaces/certified_stream_store/src/lib.rs
@@ -87,6 +87,10 @@ pub trait CertifiedStreamStore: Send + Sync {
     /// and messages beginning at `msg_begin` and containing at most `msg_limit`
     /// messages totaling at most `byte_limit` bytes.
     ///
+    /// `byte_limit` is enforced strictly for partial slices (`witness_begin <
+    /// msg_begin`). For full slices, the first message ignores `byte_limit`, to
+    /// avoid streams stalling indefinitely behind a large message.
+    ///
     /// Precondition: `witness_begin.is_none() && msg_begin.is_none() ||
     /// witness_begin.unwrap() <= msg_begin.unwrap()`.
     fn encode_certified_stream_slice(

--- a/rs/state_manager/benches/bench_traversal.rs
+++ b/rs/state_manager/benches/bench_traversal.rs
@@ -179,6 +179,7 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
                 StreamIndex::from(0),
                 StreamIndex::from(100),
                 None,
+                true,
             ))
         });
     });

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -4198,6 +4198,8 @@ impl CertifiedStreamStore for StateManagerImpl {
             msg_from,
             to,
             byte_limit,
+            // For full slices, include one message (if any) regardless of `byte_limit`.
+            witness_from == msg_from,
         );
 
         let witness_partial_tree =

--- a/rs/state_manager/src/stream_encoding.rs
+++ b/rs/state_manager/src/stream_encoding.rs
@@ -40,7 +40,8 @@ fn find_path<'a>(
 
 /// Encodes a stream slice for the specified `subnet`, consisting of available
 /// messages beginning at `from` and ending before `to`, of total size at most
-/// `byte_limit`, using canonical tree form.
+/// `byte_limit` (but at least one, if `include_one` is set), using canonical
+/// tree form.
 ///
 /// Returns the encoded slice and the actual end index (which may be different
 /// from `to` if `byte_limit` is reached).
@@ -77,6 +78,7 @@ pub fn encode_stream_slice(
     from: StreamIndex,
     to: StreamIndex,
     byte_limit: Option<usize>,
+    include_one: bool,
 ) -> (LabeledTree<Vec<u8>>, StreamIndex) {
     use Matcher as M;
     use Pattern as P;
@@ -91,6 +93,7 @@ pub fn encode_stream_slice(
     let visitor = SizeLimitVisitor::new(
         size_limit_pattern,
         byte_limit,
+        include_one,
         LabeledTreeVisitor::default(),
     );
 

--- a/rs/state_manager/src/stream_encoding/tests.rs
+++ b/rs/state_manager/src/stream_encoding/tests.rs
@@ -45,6 +45,7 @@ fn stream_encode_decode_roundtrip(
         stream_slice.header().begin(),
         stream_slice.header().end(),
         None,
+        true,
     )
     .0;
     let bytes = encode_tree(tree_encoding.clone());
@@ -83,6 +84,7 @@ fn stream_encode_with_size_limit(
         stream_slice.header().begin(),
         stream_slice.header().end(),
         Some(size_limit),
+        true,
     )
     .0;
     let bytes = encode_tree(tree_encoding.clone());
@@ -103,4 +105,53 @@ fn stream_encode_with_size_limit(
         }
         Err(e) => panic!("Failed to decode tree {tree_encoding:?}: {e}"),
     }
+}
+
+/// A zero byte limit yields a header-only slice iff `include_one` is `false`.
+#[test_strategy::proptest]
+fn stream_encode_with_strict_size_limit(
+    #[strategy(arb_stream(
+        1, // min_size
+        10, // max_size
+        0, // min_signal_count
+        10, // max_signal_count
+        MAX_SUPPORTED_CERTIFICATION_VERSION,
+    ))]
+    stream: Stream,
+) {
+    let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
+
+    let subnet = subnet_test_id(42);
+    let stream_slice: StreamSlice = stream.clone().into();
+    state.modify_streams(|streams| {
+        streams.insert(subnet, stream);
+    });
+    state.metadata.certification_version = MAX_SUPPORTED_CERTIFICATION_VERSION;
+
+    let encode = |include_one| {
+        let bytes = encode_tree(
+            encode_stream_slice(
+                &state,
+                Height::new(0),
+                subnet,
+                stream_slice.header().begin(),
+                stream_slice.header().end(),
+                Some(0),
+                include_one,
+            )
+            .0,
+        );
+        decode_stream_slice(&bytes[..])
+            .expect("failed to decode slice")
+            .1
+    };
+
+    assert_eq!(
+        None,
+        encode(false).messages().map(|messages| messages.len())
+    );
+    assert_eq!(
+        Some(1),
+        encode(true).messages().map(|messages| messages.len())
+    );
 }

--- a/rs/state_manager/tests/common/mod.rs
+++ b/rs/state_manager/tests/common/mod.rs
@@ -195,7 +195,8 @@ pub fn encode_decode_stream_test<
 /// `CertifiedStreamSlice`, and checks that:
 ///
 ///  1. the payload is the same as that of a `CertifiedStreamSlice` with both
-///     witness and payload beginning at `msg_begin` and the same limits; and
+///     witness and payload beginning at `msg_begin` and covering the same
+///     messages; and
 ///  2. the witness is the same as that of a `CertifiedStreamSlice` with both
 ///     witness and payload beginning at `witness_begin` and matching message limit.
 ///
@@ -232,30 +233,24 @@ pub fn encode_partial_slice_test(
             )
             .expect("failed to encode certified stream");
 
+        // Actual message count, potentially cut short by `byte_limit`.
+        let msg_count = stream_encoding::decode_stream_slice(&slice.payload)
+            .expect("failed to decode slice payload")
+            .1
+            .messages()
+            .map_or(0, |messages| messages.len());
+
         // Slice with the same payload and matching witness.
         let same_payload_slice = state_manager
             .encode_certified_stream_slice(
                 destination_subnet,
                 Some(msg_begin),
                 Some(msg_begin),
-                Some(msg_limit),
-                Some(byte_limit),
+                Some(msg_count),
+                None,
             )
             .expect("failed to encode certified stream");
         assert_eq!(same_payload_slice.payload, slice.payload);
-
-        let receiver_metrics = MetricsRegistry::new();
-        let (receiver_state_manager, _tmp) =
-            state_manager_with_verifier_result(destination_subnet, true, &receiver_metrics, log);
-
-        let decoded_slice = receiver_state_manager
-            .decode_certified_stream_slice(
-                sender_subnet,
-                RegistryVersion::new(1),
-                &same_payload_slice,
-            )
-            .unwrap_or_else(|e| panic!("Failed to decode slice with error {e:?}"));
-        let msg_count = decoded_slice.messages().map_or(0, |m| m.len());
 
         // Slice with the same witness and matching payload.
         let same_witness_slice = state_manager
@@ -268,6 +263,10 @@ pub fn encode_partial_slice_test(
             )
             .expect("failed to encode certified stream");
         assert_eq!(same_witness_slice.merkle_proof, slice.merkle_proof);
+
+        let receiver_metrics = MetricsRegistry::new();
+        let (receiver_state_manager, _tmp) =
+            state_manager_with_verifier_result(destination_subnet, true, &receiver_metrics, log);
 
         // Sanity check: if an actual partial slice, decoding should fail.
         if witness_begin != msg_begin {

--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -1413,8 +1413,8 @@ pub fn adjusted_byte_limit(slice_byte_size: usize) -> usize {
     slice_byte_size.saturating_sub(350) * 98 / 100
 }
 
-/// Computes `RefillStreamSliceIndices` for every subnet whose stream slices should be refilled
-/// in the given certified slice pool owned by the given subnet.
+/// Computes `RefillStreamSliceIndices` for every subnet with a cached stream
+/// position in the given certified slice pool owned by the given subnet.
 pub fn refill_stream_slice_indices(
     pool_lock: Arc<Mutex<CertifiedSlicePool>>,
     own_subnet_id: SubnetId,
@@ -1467,11 +1467,10 @@ pub fn refill_stream_slice_indices(
             ),
         };
 
-        if slice_byte_limit < SLICE_BYTE_SIZE_MIN {
-            // No more space left in the pool for this slice, skip it.
-            continue;
-        }
-
+        // Poll every subnet regardless of how low `slice_byte_limit` is:
+        //  * A header-only suffix may usefully replace the pooled slice's.
+        //  * A complete slice will always include the first message, if any. We rely on
+        //    this to avoid stalling streams indefinitely behind large messages.
         result.insert(
             subnet_id,
             RefillStreamSliceIndices {

--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -43,6 +43,7 @@ use ic_registry_client_helpers::{node::NodeRegistry, subnet::SubnetListRegistry}
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{ReplicatedState, replicated_state::ReplicatedStateMessageRouting};
 use ic_types::batch::{ValidationContext, XNetPayload};
+use ic_types::messages::MAX_INTER_CANISTER_PAYLOAD_IN_BYTES;
 use ic_types::registry::RegistryClientError;
 use ic_types::state_manager::StateManagerError;
 use ic_types::xnet::{CertifiedStreamSlice, RejectSignal, StreamIndex};
@@ -138,6 +139,8 @@ pub struct XNetPayloadBuilderMetrics {
     pub validate_payload_duration: HistogramVec,
     /// Track outstanding background query tasks
     pub outstanding_queries: IntGauge,
+    /// Count of pulled slices larger than the requested size.
+    pub pull_size_too_large: IntCounter,
     /// Critical error: failed `count_bytes()` on valid slice.
     pub critical_error_slice_count_bytes_failed: IntCounter,
     /// Critical error: mismatch between the byte sizes computed by `take_slice()`,
@@ -212,6 +215,10 @@ impl XNetPayloadBuilderMetrics {
             outstanding_queries: metrics_registry.int_gauge(
                 METRIC_OUTSTANDING_XNET_QUERIES,
                 "Number of xnet queries that have not finished",
+            ),
+            pull_size_too_large: metrics_registry.int_counter(
+                "xnet_builder_pull_size_too_large_count",
+                "Count of pulled slices larger than the requested size",
             ),
             critical_error_slice_count_bytes_failed: metrics_registry
                 .error_counter(CRITICAL_ERROR_SLICE_COUNT_BYTES_FAILED),
@@ -1574,9 +1581,26 @@ impl PoolRefillTask {
                 match query_result {
                     Ok(slice) => {
                         let logger = log.clone();
+                        let pull_size_too_large = metrics.pull_size_too_large.clone();
                         let res = tokio::task::spawn_blocking(move || {
+                            // Helper to log and instrument pulled slices above the requested byte limit.
+                            // For now, only track such occurrences. In the future, we may drop them.
+                            let observe_pull_size_too_large = |limit: usize, actual: usize| {
+                                warn!(
+                                    log,
+                                    "Stream from {subnet_id}: pulled payload size ({actual}) exceeds byte limit ({limit})",
+                                );
+                                pull_size_too_large.inc();
+                            };
+
                             if indices.witness_begin != indices.msg_begin {
-                                // Pulled a stream suffix, append to pooled slice.
+                                // Slice suffix, append to pooled slice.
+
+                                if slice.payload.len() > indices.byte_limit * 11 / 10 + 1024 {
+                                    // Payload is larger than what we requested, only bump an error metric for now.
+                                    observe_pull_size_too_large(indices.byte_limit, slice.payload.len());
+                                }
+
                                 CertifiedSlicePool::append(
                                     &pool,
                                     subnet_id,
@@ -1586,7 +1610,14 @@ impl PoolRefillTask {
                                     log,
                                 )
                             } else {
-                                // Pulled a complete stream, put it into the pool.
+                                // Complete slice, put it into the pool.
+
+                                let byte_limit = indices.byte_limit.max(MAX_INTER_CANISTER_PAYLOAD_IN_BYTES.get() as usize);
+                                if slice.payload.len() > byte_limit * 11 / 10 + 1024 {
+                                    // Payload is larger than what we requested, only bump an error metric for now.
+                                    observe_pull_size_too_large(byte_limit, slice.payload.len());
+                                }
+
                                 CertifiedSlicePool::put(
                                     &pool,
                                     subnet_id,


### PR DESCRIPTION
`SizeLimitVisitor` includes the first message regardless of `byte_limit`, so a stream cannot stall behind a message the caller has no room for. A suffix pull needs no such guarantee: the caller already holds some messages and can make progress. The endpoint infers this from `witness_begin == msg_begin`, so nothing changes on the wire.

A stream that has filled its share of the pool therefore stops drawing messages, while one with nothing pooled is still guaranteed one. Which in turn lets us drop the `SLICE_BYTE_SIZE_MIN` floor: a request whose remaining allowance is too small for a message now returns a fresh header and witness, which does not grow the pool.

`encode_partial_slice_test` compared a partial slice's payload against a full slice encoded with the same `byte_limit`, which now differ whenever that limit is below one message. It takes the message count from the partial slice's own payload instead, so the assertions no longer depend on matching limit semantics.