### PR TITLE
chore: Switch zstd_compress from -10 to -8 --long=27

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -44,7 +44,9 @@ def _zstd_compress(ctx):
 
     ctx.actions.run(
         executable = ctx.file._zstd,
-        arguments = ["-q", "--threads=0", "-10", "-f", "-z", "-o", out.path] + [s.path for s in ctx.files.srcs],
+        # Higher --long setting produces compressed files that most zstd decompressors (e.g. zstd, tar or mc) won't
+        # decompress unless additional args are specified.
+        arguments = ["-q", "--threads=0", "--long=27", "-8", "-f", "-z", "-o", out.path] + [s.path for s in ctx.files.srcs],
         inputs = ctx.files.srcs,
         outputs = [out],
         env = {"ZSTDMT_NBWORKERS_MAX": str(_COMPRESS_CONCURRENCY)},


### PR DESCRIPTION
Our images contain the same large files many times over, at distances of tens to hundreds of MB: every statically linked Rust binary in `/opt/ic/bin` embeds the same Rust std/crate code. In addition, #11506 introduces overlay images for fast GuestOS upgrades which duplicates binaries from the root partition. `--long=27` extends the match range to 128 MB. To save some time, we decrease the compression rate param from 10 to 8, this gives us improved speed. Only the memory usage increases.

| Target | Time | Size | Peak RAM |
|---|---|---|---|
| `//ic-os/guestos/envs/dev:disk-img.tar.zst` | 43.7 → 27.9 s (−36%) | 583.2 → 529.3 MB (−9%) | 27 → 152 MB |
| `//ic-os/guestos/envs/dev:update-img.tar.zst` | 42.7 → 28.8 s (−33%) | 581.0 → 527.3 MB (−9%) | 27 → 152 MB |
| `//ic-os/hostos/envs/dev:update-img.tar.zst` | 33.0 → 25.2 s (−24%) | 1155.3 → 1126.3 MB (−2%) | 27 → 152 MB |
| `//rs/tests:colocate_uvm_config_image` | 5.1 → 3.7 s (−29%) | 46.7 → 44.2 MB (−5%) | 27 → 152 MB |

`-9 --long=27` is ~15% slower than `-8 --long=27` for < 1% smaller output.