### PR TITLE
feat: [DSM-148] `CertifiedSlicePool`: highest seen peer headers

### DIFF
--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -17,14 +17,15 @@ use ic_metrics::{
 use ic_protobuf::messaging::xnet::v1;
 use ic_protobuf::proxy::{ProtoProxy, ProxyDecodeError};
 use ic_types::{
-    CountBytes, RegistryVersion, SubnetId,
+    CountBytes, Height, RegistryVersion, SubnetId,
     consensus::certification::Certification,
-    xnet::{CertifiedStreamSlice, StreamIndex},
+    xnet::{CertifiedStreamSlice, StreamHeader, StreamIndex},
 };
 use messages::Messages;
 use prometheus::{Histogram, IntCounterVec, IntGauge};
 use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::convert::{From, TryFrom, TryInto};
 use std::sync::Mutex;
 
@@ -158,6 +159,10 @@ mod header {
 
         pub(super) fn signals_end(&self) -> StreamIndex {
             self.decoded.signals_end()
+        }
+
+        pub(super) fn decoded(&self) -> &StreamHeader {
+            &self.decoded
         }
     }
 
@@ -1122,7 +1127,20 @@ pub struct CertifiedSlicePool {
     /// advanced to the end of the slice returned by a `take_slice()` call.
     stream_positions: BTreeMap<SubnetId, ExpectedIndices>,
 
+    /// The furthest-advanced certified header seen from each peer subnet. Unlike
+    /// a pooled slice, which is dropped once consumed, this is retained: it is
+    /// the only record of how far the peer has seen our signals (its `begin`)
+    /// and of what it has on offer (its `end` and `signals_end`).
+    peer_headers: BTreeMap<SubnetId, PeerHeader>,
+
     metrics: CertifiedSlicePoolMetrics,
+}
+
+/// A peer subnet's high-water-mark header, along with the height of the
+/// certification it was taken from, which orders the headers received.
+struct PeerHeader {
+    certification_height: Height,
+    header: StreamHeader,
 }
 
 impl CertifiedSlicePool {
@@ -1132,6 +1150,7 @@ impl CertifiedSlicePool {
         Self {
             slices: Default::default(),
             stream_positions: Default::default(),
+            peer_headers: Default::default(),
             metrics: CertifiedSlicePoolMetrics::new(metrics_registry),
         }
     }
@@ -1450,6 +1469,8 @@ impl CertifiedSlicePool {
         subnet_id: SubnetId,
         mut unpacked: UnpackedStreamSlice,
     ) -> CertifiedSliceResult<Option<UnpackedStreamSlice>> {
+        self.maybe_set_peer_header(subnet_id, &unpacked);
+
         // Trim off everything before the cached stream position.
         let stream_position = self.stream_positions.get(&subnet_id);
         if let Some(stream_position) = stream_position {
@@ -1474,6 +1495,42 @@ impl CertifiedSlicePool {
         } else {
             self.metrics.observe_put(STATUS_SUCCESS);
             Ok(self.slices.insert(subnet_id, unpacked))
+        }
+    }
+
+    /// Returns the given peer subnet's high-water-mark header, if any.
+    pub fn peer_header(&self, subnet_id: SubnetId) -> Option<&StreamHeader> {
+        self.peer_headers
+            .get(&subnet_id)
+            .map(|peer_header| &peer_header.header)
+    }
+
+    /// Records the slice header as the peer's high-water-mark header, unless one
+    /// with a greater certified height is already on record.
+    fn maybe_set_peer_header(&mut self, subnet_id: SubnetId, slice: &UnpackedStreamSlice) {
+        let certification_height = slice.certification.height;
+        let header = slice.payload.header.decoded();
+
+        match self.peer_headers.entry(subnet_id) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(PeerHeader {
+                    certification_height,
+                    header: header.clone(),
+                });
+            }
+
+            Entry::Occupied(mut recorded) => {
+                if recorded.get().certification_height < certification_height {
+                    // Higher certified height implies >= header indices.
+                    debug_assert!(recorded.get().header.begin() <= header.begin());
+                    debug_assert!(recorded.get().header.end() <= header.end());
+                    debug_assert!(recorded.get().header.signals_end() <= header.signals_end());
+                    recorded.insert(PeerHeader {
+                        certification_height,
+                        header: header.clone(),
+                    });
+                }
+            }
         }
     }
 

--- a/rs/xnet/payload_builder/tests/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/tests/certified_slice_pool.rs
@@ -14,7 +14,7 @@ use ic_test_utilities_metrics::{HistogramStats, metric_vec};
 use ic_test_utilities_state::arb_stream_slice;
 use ic_test_utilities_types::xnet::StreamSliceBuilder;
 use ic_types::messages::MAX_XNET_PAYLOAD_SIZE_ERROR_MARGIN_PERCENT;
-use ic_types::xnet::{CertifiedStreamSlice, StreamIndex, StreamSlice};
+use ic_types::xnet::{CertifiedStreamSlice, StreamHeader, StreamIndex, StreamSlice};
 use ic_types::{CountBytes, RegistryVersion, SubnetId};
 use ic_xnet_payload_builder::certified_slice_pool::{
     CertifiedSliceError, CertifiedSlicePool, CertifiedSliceResult, InvalidAppend, InvalidSlice,
@@ -649,6 +649,10 @@ fn slice_stats(
     subnet_id: SubnetId,
 ) -> (Option<ExpectedIndices>, Option<StreamIndex>, usize, usize) {
     pool.lock().unwrap().slice_stats(subnet_id)
+}
+
+fn peer_header(pool: &Mutex<CertifiedSlicePool>, subnet_id: SubnetId) -> Option<StreamHeader> {
+    pool.lock().unwrap().peer_header(subnet_id).cloned()
 }
 
 fn peers(pool: &Mutex<CertifiedSlicePool>) -> Vec<SubnetId> {
@@ -1399,7 +1403,7 @@ fn pool_append_invalid_slice_to_empty(
 fn pool_take_slice_respects_signal_limit(
     #[strategy(arb_stream_slice(
         MAX_SIGNALS, // min_size
-        2 * MAX_SIGNALS, // max_size
+        MAX_SIGNALS + 100, // max_size
         0, // min_signal_count
         0, // max_signal_count
         CURRENT_CERTIFICATION_VERSION,
@@ -1741,6 +1745,62 @@ fn pool_put_more_useful_slice_only(
             ]),
             fixture.fetch_pool_put_count()
         );
+    });
+}
+
+/// Tests that a peer's header is recorded on every incoming slice, whether or
+/// not the slice is pooled; and that it never regresses.
+#[test_strategy::proptest(ProptestConfig::with_cases(10))]
+fn pool_peer_header(
+    #[strategy(arb_stream_slice(
+        2, // min_size
+        10, // max_size
+        0, // min_signal_count
+        10, // max_signal_count
+        CURRENT_CERTIFICATION_VERSION,
+    ))]
+    test_slice: (Stream, StreamIndex, usize),
+) {
+    let (mut stream, from, msg_count) = test_slice;
+
+    with_test_replica_logger(|log| {
+        let header = stream.header();
+        let fixture =
+            StateManagerFixture::remote(log.clone()).with_stream(DST_SUBNET, stream.clone());
+        let slice = fixture.get_slice(DST_SUBNET, from, msg_count);
+
+        // A single message slice, from a later certified state with one extra signal.
+        stream.push_accept_signal();
+        let newer_header = stream.header();
+        let fixture = fixture.with_stream(DST_SUBNET, stream);
+        let newer_prefix_slice = fixture.get_slice(DST_SUBNET, from, 1);
+
+        let mut store = MockCertifiedStreamStore::new();
+        // Actual return value does not matter as long as it's `Ok(_)`.
+        store
+            .expect_decode_certified_stream_slice()
+            .returning(|_, _, _| Ok(StreamSliceBuilder::new().build()));
+        let pool = Mutex::new(CertifiedSlicePool::new(&fixture.metrics));
+
+        // Nothing on record for a peer we have heard nothing from.
+        assert_eq!(None, peer_header(&pool, SRC_SUBNET));
+
+        put(&pool, SRC_SUBNET, slice.clone(), &store, &log).unwrap();
+        assert_eq!(Some(header), peer_header(&pool, SRC_SUBNET));
+
+        // The single message slice is not pooled, but its header is still recorded.
+        put(&pool, SRC_SUBNET, newer_prefix_slice, &store, &log).unwrap();
+        assert_matches!(slice_stats(&pool, SRC_SUBNET), (_, _, count, _) if count == msg_count);
+        assert_eq!(Some(newer_header.clone()), peer_header(&pool, SRC_SUBNET));
+
+        // And an earlier certified header does not replace it.
+        put(&pool, SRC_SUBNET, slice, &store, &log).unwrap();
+        assert_eq!(Some(newer_header.clone()), peer_header(&pool, SRC_SUBNET));
+
+        // And taking the slice leaves the header in place.
+        take_slice(&pool, SRC_SUBNET, None, None, None);
+        assert_eq!(slice_stats(&pool, SRC_SUBNET), (None, None, 0, 0));
+        assert_eq!(Some(newer_header), peer_header(&pool, SRC_SUBNET));
     });
 }
 


### PR DESCRIPTION
Record the latest (highest stream indices / greatest certified height) stream header observed for every peer subnet in `CertifiedSlicePool`.

This is to be used for triggering and handling XNet adverts (do we have any signals to advertise relative to the peer's `begin`; and, respectively, are there any new messages or signals for us to pull).