### PR TITLE
feat: Fast upgrades: upgrade permit shares, pool, and pool manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8323,6 +8323,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-consensus-upgrade"
+version = "0.9.0"
+dependencies = [
+ "ic-consensus-utils",
+ "ic-interfaces",
+ "ic-interfaces-mocks",
+ "ic-logger",
+ "ic-protobuf",
+ "ic-registry-client-fake",
+ "ic-registry-proto-data-provider",
+ "ic-test-utilities-consensus",
+ "ic-test-utilities-registry",
+ "ic-test-utilities-types",
+ "ic-types",
+ "num-traits",
+ "slog",
+]
+
+[[package]]
 name = "ic-consensus-utils"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "rs/consensus/idkg",
     "rs/consensus/mocks",
     "rs/consensus/utils",
+    "rs/consensus/upgrade",
     "rs/consensus/chain_key",
     "rs/criterion_time",
     "rs/cross-chain/blob_store",

--- a/rs/artifact_pool/src/lib.rs
+++ b/rs/artifact_pool/src/lib.rs
@@ -11,6 +11,7 @@ mod metrics;
 mod pool_common;
 #[cfg(test)]
 mod test_utils;
+pub mod upgrade_permit_auth_pool;
 
 pub mod backup;
 mod lmdb_iterator;

--- a/rs/artifact_pool/src/upgrade_permit_auth_pool.rs
+++ b/rs/artifact_pool/src/upgrade_permit_auth_pool.rs
@@ -1,0 +1,311 @@
+use crate::{
+    metrics::{POOL_TYPE_UNVALIDATED, POOL_TYPE_VALIDATED},
+    pool_common::{HasLabel, PoolSection},
+};
+use ic_interfaces::{
+    p2p::consensus::{
+        ArtifactTransmit, ArtifactTransmits, ArtifactWithOpt, MutablePool, UnvalidatedArtifact,
+        ValidatedPoolReader,
+    },
+    upgrade::{UpgradePermitAuthChangeAction, UpgradePermitAuthChangeSet, UpgradePermitAuthPool},
+};
+use ic_logger::ReplicaLogger;
+use ic_metrics::MetricsRegistry;
+use ic_types::{
+    artifact::{IdentifiableArtifact, UpgradePermitAuthorizationShareId},
+    consensus::UpgradePermitAuthorizationShare,
+};
+use prometheus::IntCounter;
+
+const POOL_NAME: &str = "upgrade_permit_auth";
+
+type ValidatedSection =
+    PoolSection<UpgradePermitAuthorizationShareId, UpgradePermitAuthorizationShare>;
+type UnvalidatedSection = PoolSection<
+    UpgradePermitAuthorizationShareId,
+    UnvalidatedArtifact<UpgradePermitAuthorizationShare>,
+>;
+
+/// Upgrade Permit Authorization Pool implementation.
+pub struct UpgradePermitAuthPoolImpl {
+    validated: ValidatedSection,
+    unvalidated: UnvalidatedSection,
+    invalidated_artifacts: IntCounter,
+    log: ReplicaLogger,
+}
+
+impl UpgradePermitAuthPoolImpl {
+    pub fn new(metrics: MetricsRegistry, log: ReplicaLogger) -> Self {
+        Self {
+            invalidated_artifacts: metrics.int_counter(
+                "upgrade_permit_auth_invalidated_artifacts",
+                "The number of invalidated upgrade permit auth artifacts",
+            ),
+            validated: PoolSection::new(metrics.clone(), POOL_NAME, POOL_TYPE_VALIDATED),
+            unvalidated: PoolSection::new(metrics, POOL_NAME, POOL_TYPE_UNVALIDATED),
+            log,
+        }
+    }
+}
+
+impl UpgradePermitAuthPool for UpgradePermitAuthPoolImpl {
+    fn get_validated_shares(
+        &self,
+    ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_> {
+        Box::new(self.validated.values())
+    }
+
+    fn get_unvalidated_shares(
+        &self,
+    ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_> {
+        Box::new(self.unvalidated.values().map(|pa| &pa.message))
+    }
+}
+
+impl MutablePool<UpgradePermitAuthorizationShare> for UpgradePermitAuthPoolImpl {
+    type Mutations = UpgradePermitAuthChangeSet;
+
+    fn insert(&mut self, artifact: UnvalidatedArtifact<UpgradePermitAuthorizationShare>) {
+        let id = artifact.message.id();
+        self.unvalidated.insert(id, artifact);
+    }
+
+    fn remove(&mut self, id: &UpgradePermitAuthorizationShareId) {
+        self.unvalidated.remove(id);
+    }
+
+    fn apply(
+        &mut self,
+        change_set: UpgradePermitAuthChangeSet,
+    ) -> ArtifactTransmits<UpgradePermitAuthorizationShare> {
+        let changed = !change_set.is_empty();
+        let mut transmits = vec![];
+        for action in change_set {
+            match action {
+                UpgradePermitAuthChangeAction::AddToValidated(share) => {
+                    transmits.push(ArtifactTransmit::Deliver(ArtifactWithOpt {
+                        artifact: share.clone(),
+                        is_latency_sensitive: true,
+                    }));
+                    self.validated.insert(share.id(), share);
+                }
+                UpgradePermitAuthChangeAction::MoveToValidated(share) => {
+                    let id = share.id();
+                    self.unvalidated.remove(&id);
+                    transmits.push(ArtifactTransmit::Deliver(ArtifactWithOpt {
+                        artifact: share.clone(),
+                        is_latency_sensitive: true,
+                    }));
+                    self.validated.insert(id, share);
+                }
+                UpgradePermitAuthChangeAction::RemoveValidated(id) => {
+                    if self.validated.remove(&id).is_some() {
+                        transmits.push(ArtifactTransmit::Abort(id));
+                    }
+                }
+                UpgradePermitAuthChangeAction::RemoveUnvalidated(id) => {
+                    self.unvalidated.remove(&id);
+                }
+                UpgradePermitAuthChangeAction::HandleInvalid(id, reason) => {
+                    ic_logger::warn!(
+                        self.log,
+                        "Invalidating upgrade permit auth artifact {id:?}: {reason}"
+                    );
+                    self.invalidated_artifacts.inc();
+                    self.unvalidated.remove(&id);
+                }
+            }
+        }
+        ArtifactTransmits {
+            transmits,
+            poll_immediately: changed,
+        }
+    }
+}
+
+impl ValidatedPoolReader<UpgradePermitAuthorizationShare> for UpgradePermitAuthPoolImpl {
+    fn get(
+        &self,
+        id: &UpgradePermitAuthorizationShareId,
+    ) -> Option<UpgradePermitAuthorizationShare> {
+        self.validated.get(id).cloned()
+    }
+
+    fn get_all_for_initial_broadcast(
+        &self,
+    ) -> Box<dyn Iterator<Item = UpgradePermitAuthorizationShare> + '_> {
+        // Not persisted — no initial broadcast on restart.
+        Box::new(std::iter::empty())
+    }
+}
+
+impl HasLabel for UpgradePermitAuthorizationShare {
+    fn label(&self) -> &str {
+        "upgrade_permit_auth_share"
+    }
+}
+
+impl HasLabel for UnvalidatedArtifact<UpgradePermitAuthorizationShare> {
+    fn label(&self) -> &str {
+        self.message.label()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_logger::replica_logger::no_op_logger;
+    use ic_test_utilities_types::ids::node_test_id;
+    use ic_types::Height;
+    use ic_types::consensus::UpgradePermitAuthorizationRequest;
+    use ic_types::crypto::{BasicSig, BasicSigOf};
+    use ic_types::signature::BasicSignature;
+    use ic_types::time::UNIX_EPOCH;
+
+    fn fake_share(
+        signer: u64,
+        requestor: u64,
+        request_height: u64,
+    ) -> UpgradePermitAuthorizationShare {
+        UpgradePermitAuthorizationShare {
+            content: UpgradePermitAuthorizationRequest {
+                requestor: node_test_id(requestor),
+                request_height: Height::from(request_height),
+            },
+            signature: BasicSignature {
+                signature: BasicSigOf::new(BasicSig(vec![])),
+                signer: node_test_id(signer),
+            },
+        }
+    }
+
+    fn to_unvalidated(
+        share: UpgradePermitAuthorizationShare,
+    ) -> UnvalidatedArtifact<UpgradePermitAuthorizationShare> {
+        UnvalidatedArtifact {
+            message: share,
+            peer_id: node_test_id(0),
+            timestamp: UNIX_EPOCH,
+        }
+    }
+
+    fn pool() -> UpgradePermitAuthPoolImpl {
+        UpgradePermitAuthPoolImpl::new(MetricsRegistry::new(), no_op_logger())
+    }
+
+    #[test]
+    fn test_insert_and_remove_unvalidated() {
+        let mut pool = pool();
+        let share = fake_share(1, 2, 10);
+        let id = share.id();
+
+        pool.insert(to_unvalidated(share.clone()));
+        assert!(pool.get_unvalidated_shares().eq([&share]));
+        assert!(pool.get(&id).is_none());
+
+        pool.remove(&id);
+        assert_eq!(pool.get_unvalidated_shares().count(), 0);
+    }
+
+    #[test]
+    fn test_add_to_validated_broadcasts() {
+        let mut pool = pool();
+        let share = fake_share(1, 2, 10);
+
+        let result = pool.apply(vec![UpgradePermitAuthChangeAction::AddToValidated(
+            share.clone(),
+        )]);
+
+        assert!(result.poll_immediately);
+        assert_eq!(result.transmits.len(), 1);
+        assert!(matches!(
+            &result.transmits[0],
+            ArtifactTransmit::Deliver(a) if a.artifact == share
+        ));
+        assert!(pool.get_validated_shares().eq([&share]));
+        assert_eq!(pool.get(&share.id()).unwrap(), share);
+    }
+
+    #[test]
+    fn test_move_to_validated_replaces_unvalidated_and_broadcasts() {
+        let mut pool = pool();
+        let share = fake_share(1, 2, 10);
+        pool.insert(to_unvalidated(share.clone()));
+        assert!(pool.get_unvalidated_shares().eq([&share]));
+
+        let result = pool.apply(vec![UpgradePermitAuthChangeAction::MoveToValidated(
+            share.clone(),
+        )]);
+
+        assert_eq!(result.transmits.len(), 1);
+        assert_eq!(pool.get_unvalidated_shares().count(), 0);
+        assert!(pool.get_validated_shares().eq([&share]));
+        assert_eq!(pool.get(&share.id()).unwrap(), share);
+    }
+
+    #[test]
+    fn test_remove_validated_aborts_broadcast() {
+        let mut pool = pool();
+        let share = fake_share(1, 2, 10);
+        pool.apply(vec![UpgradePermitAuthChangeAction::AddToValidated(
+            share.clone(),
+        )]);
+
+        let result = pool.apply(vec![UpgradePermitAuthChangeAction::RemoveValidated(
+            share.id(),
+        )]);
+
+        assert!(result.poll_immediately);
+        assert!(matches!(&result.transmits[0], ArtifactTransmit::Abort(id) if *id == share.id()));
+        assert_eq!(pool.get_validated_shares().count(), 0);
+
+        // Removing again is a no-op without a redundant Abort.
+        let result = pool.apply(vec![UpgradePermitAuthChangeAction::RemoveValidated(
+            share.id(),
+        )]);
+        assert_eq!(result.transmits.len(), 0);
+    }
+
+    #[test]
+    fn test_handle_invalid_drops_unvalidated_without_broadcast() {
+        let mut pool = pool();
+        let share = fake_share(1, 2, 10);
+        pool.insert(to_unvalidated(share.clone()));
+
+        let result = pool.apply(vec![UpgradePermitAuthChangeAction::HandleInvalid(
+            share.id(),
+            "bad signature".to_string(),
+        )]);
+
+        assert!(result.poll_immediately);
+        assert!(result.transmits.is_empty());
+        assert_eq!(pool.get_unvalidated_shares().count(), 0);
+    }
+
+    #[test]
+    fn test_empty_change_set_does_not_poll() {
+        let mut pool = pool();
+        let result = pool.apply(vec![]);
+        assert!(!result.poll_immediately);
+        assert!(result.transmits.is_empty());
+    }
+
+    #[test]
+    fn test_shares_keyed_by_signer_and_request() {
+        let mut pool = pool();
+        pool.apply(vec![
+            // Same signer, different requests: two entries.
+            UpgradePermitAuthChangeAction::AddToValidated(fake_share(1, 2, 10)),
+            UpgradePermitAuthChangeAction::AddToValidated(fake_share(1, 2, 11)),
+            UpgradePermitAuthChangeAction::AddToValidated(fake_share(3, 2, 10)),
+            UpgradePermitAuthChangeAction::AddToValidated(fake_share(4, 2, 10)),
+        ]);
+        assert_eq!(pool.get_validated_shares().count(), 4);
+
+        // Re-adding the same (signer, request) pair overwrites.
+        pool.apply(vec![UpgradePermitAuthChangeAction::AddToValidated(
+            fake_share(1, 2, 10),
+        )]);
+        assert_eq!(pool.get_validated_shares().count(), 4);
+    }
+}

--- a/rs/consensus/mocks/src/lib.rs
+++ b/rs/consensus/mocks/src/lib.rs
@@ -2,6 +2,7 @@
 
 use ic_artifact_pool::{
     canister_http_pool::CanisterHttpPoolImpl, dkg_pool::DkgPoolImpl, idkg_pool::IDkgPoolImpl,
+    upgrade_permit_auth_pool::UpgradePermitAuthPoolImpl,
 };
 use ic_config::artifact_pool::ArtifactPoolConfig;
 use ic_consensus_utils::membership::Membership;
@@ -114,6 +115,7 @@ pub struct Dependencies {
     pub dkg_pool: Arc<RwLock<DkgPoolImpl>>,
     pub idkg_pool: Arc<RwLock<IDkgPoolImpl>>,
     pub canister_http_pool: Arc<RwLock<CanisterHttpPoolImpl>>,
+    pub upgrade_permit_auth_pool: Arc<RwLock<UpgradePermitAuthPoolImpl>>,
 }
 
 pub struct DependenciesBuilder {
@@ -282,6 +284,10 @@ impl DependenciesBuilder {
         )));
         let canister_http_pool = Arc::new(RwLock::new(CanisterHttpPoolImpl::new(
             ic_metrics::MetricsRegistry::new(),
+            log.clone(),
+        )));
+        let upgrade_permit_auth_pool = Arc::new(RwLock::new(UpgradePermitAuthPoolImpl::new(
+            ic_metrics::MetricsRegistry::new(),
             log,
         )));
         let pool = TestConsensusPool::new(
@@ -325,6 +331,7 @@ impl DependenciesBuilder {
             dkg_pool,
             idkg_pool,
             canister_http_pool,
+            upgrade_permit_auth_pool,
         }
     }
 }

--- a/rs/consensus/src/consensus/payload_builder.rs
+++ b/rs/consensus/src/consensus/payload_builder.rs
@@ -547,6 +547,7 @@ pub(crate) mod test {
                         canister_http: settings.http_outcalls_payload_to_return,
                         query_stats: settings.query_stats_payload_to_return,
                         chain_key: settings.chain_key_payload_to_return,
+                        upgrade: vec![],
                     },
                     dkg: DkgDataPayload::new_empty(Height::from(0)),
                     idkg: None,

--- a/rs/consensus/upgrade/BUILD.bazel
+++ b/rs/consensus/upgrade/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "upgrade",
+    srcs = glob(["src/**/*.rs"]),
+    crate_features = select({
+        "//conditions:default": [],
+    }),
+    crate_name = "ic_consensus_upgrade",
+    proc_macro_deps = [
+        # Keep sorted.
+    ],
+    deps = [
+        # Keep sorted.
+        "//rs/consensus/utils",
+        "//rs/interfaces",
+        "//rs/monitoring/logger",
+        "//rs/types/types",
+        "@crate_index//:num-traits",
+        "@crate_index//:slog",
+    ],
+)
+
+rust_doc(
+    name = "consensus_upgrade_doc",
+    crate = ":upgrade",
+)
+
+rust_test(
+    name = "upgrade_test",
+    crate = ":upgrade",
+    deps = [
+        # Keep sorted.
+        "//rs/interfaces/mocks",
+        "//rs/protobuf",
+        "//rs/registry/fake",
+        "//rs/registry/proto_data_provider",
+        "//rs/test_utilities/consensus",
+        "//rs/test_utilities/registry",
+        "//rs/test_utilities/types",
+    ],
+)

--- a/rs/consensus/upgrade/Cargo.toml
+++ b/rs/consensus/upgrade/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ic-consensus-upgrade"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[dependencies]
+ic-consensus-utils = { path = "../utils" }
+ic-interfaces = { path = "../../interfaces" }
+ic-logger = { path = "../../monitoring/logger" }
+ic-types = { path = "../../types/types" }
+num-traits = { workspace = true }
+slog = { workspace = true }
+
+[dev-dependencies]
+ic-interfaces-mocks = { path = "../../interfaces/mocks" }
+ic-protobuf = { path = "../../protobuf" }
+ic-registry-client-fake = { path = "../../registry/fake" }
+ic-registry-proto-data-provider = { path = "../../registry/proto_data_provider" }
+ic-test-utilities-consensus = { path = "../../test_utilities/consensus" }
+ic-test-utilities-registry = { path = "../../test_utilities/registry" }
+ic-test-utilities-types = { path = "../../test_utilities/types" }

--- a/rs/consensus/upgrade/src/lib.rs
+++ b/rs/consensus/upgrade/src/lib.rs
@@ -1,0 +1,207 @@
+//! The upgrade permit protocol for the Phase-2 rolling GuestOS reboots.
+
+use ic_consensus_utils::crypto::ConsensusCrypto;
+use ic_consensus_utils::membership::Membership;
+use ic_interfaces::upgrade::InvalidUpgradePayloadReason;
+use ic_logger::{ReplicaLogger, warn};
+use ic_types::consensus::UpgradePermitAuthorizationShare;
+use ic_types::{Height, NodeId, RegistryVersion};
+use std::collections::BTreeSet;
+
+pub mod pool_manager;
+
+pub(crate) struct SubnetMembership {
+    /// Current members staying even at the new CUP.
+    pub staying_members: BTreeSet<NodeId>,
+}
+
+impl SubnetMembership {
+    /// Is the node a current member staying even at the new CUP?
+    pub fn staying(&self, node: &NodeId) -> bool {
+        self.staying_members.contains(node)
+    }
+}
+
+/// Subnet membership at the block height and registry version.
+pub(crate) fn subnet_membership(
+    membership: &Membership,
+    block_height: Height,
+    block_registry_version: RegistryVersion,
+    logger: &ReplicaLogger,
+) -> SubnetMembership {
+    let registry_at_height: BTreeSet<NodeId> = membership
+        .get_nodes_at_version(block_registry_version)
+        .map(|nodes| nodes.into_iter().collect())
+        .unwrap_or_default();
+    let current_members: BTreeSet<NodeId> = match membership.get_nodes(block_height) {
+        Ok(nodes) => nodes.into_iter().collect(),
+        Err(e) => {
+            warn!(
+                logger,
+                "upgrade_payload: couldn't determine the committee at height {block_height:?}: {e:?}"
+            );
+            registry_at_height.clone()
+        }
+    };
+    let staying_members = current_members
+        .intersection(&registry_at_height)
+        .cloned()
+        .collect();
+    SubnetMembership { staying_members }
+}
+
+/// Check a share's content, staying signer, and signature. Returns the
+/// signer.
+pub(crate) fn validate_share(
+    share: &UpgradePermitAuthorizationShare,
+    requestor: NodeId,
+    request_height: Height,
+    membership: &SubnetMembership,
+    registry_version: RegistryVersion,
+    crypto: &dyn ConsensusCrypto,
+) -> Result<NodeId, InvalidUpgradePayloadReason> {
+    let signer = share.signature.signer;
+    if share.content.requestor != requestor || share.content.request_height != request_height {
+        return Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare { signer });
+    }
+    if !membership.staying(&signer) {
+        return Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare { signer });
+    }
+    crypto
+        .verify_basic_sig(
+            &share.signature.signature,
+            &share.content,
+            signer,
+            registry_version,
+        )
+        .map_err(|_| InvalidUpgradePayloadReason::AuthorizeInvalidShare { signer })?;
+    Ok(signer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_interfaces_mocks::crypto::MockCrypto;
+    use ic_test_utilities_types::ids::node_test_id;
+    use ic_types::consensus::UpgradePermitAuthorizationRequest;
+    use ic_types::crypto::{BasicSig, BasicSigOf, CryptoError};
+    use ic_types::signature::BasicSignature;
+
+    const REGISTRY_VERSION: RegistryVersion = RegistryVersion::new(1);
+
+    fn share(signer: u64, requestor: u64, request_height: u64) -> UpgradePermitAuthorizationShare {
+        UpgradePermitAuthorizationShare {
+            content: UpgradePermitAuthorizationRequest {
+                requestor: node_test_id(requestor),
+                request_height: Height::from(request_height),
+            },
+            signature: BasicSignature {
+                signature: BasicSigOf::new(BasicSig(vec![])),
+                signer: node_test_id(signer),
+            },
+        }
+    }
+
+    fn membership(staying: &[NodeId]) -> SubnetMembership {
+        SubnetMembership {
+            staying_members: staying.iter().copied().collect(),
+        }
+    }
+
+    fn verifying_crypto() -> MockCrypto {
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_verify_basic_sig_upgrade_permit_auth()
+            .returning(|_, _, _, _| Ok(()));
+        crypto
+    }
+
+    #[test]
+    fn test_rejects_requestor_mismatch() {
+        let share = share(2, 3, 10);
+        let membership = membership(&[node_test_id(1), node_test_id(2)]);
+        // No verify expectation: the share is rejected before verification.
+        let result = validate_share(
+            &share,
+            node_test_id(4),
+            Height::from(10),
+            &membership,
+            REGISTRY_VERSION,
+            &MockCrypto::new(),
+        );
+        assert_eq!(
+            result,
+            Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare {
+                signer: node_test_id(2)
+            })
+        );
+    }
+
+    #[test]
+    fn test_rejects_request_height_mismatch() {
+        let share = share(2, 3, 10);
+        let membership = membership(&[node_test_id(1), node_test_id(2)]);
+        let result = validate_share(
+            &share,
+            node_test_id(3),
+            Height::from(11),
+            &membership,
+            REGISTRY_VERSION,
+            &MockCrypto::new(),
+        );
+        assert_eq!(
+            result,
+            Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare {
+                signer: node_test_id(2)
+            })
+        );
+    }
+
+    #[test]
+    fn test_rejects_non_staying_signer() {
+        let share = share(2, 3, 10);
+        let membership = membership(&[node_test_id(1)]);
+        let result = validate_share(
+            &share,
+            node_test_id(3),
+            Height::from(10),
+            &membership,
+            REGISTRY_VERSION,
+            &MockCrypto::new(),
+        );
+        assert_eq!(
+            result,
+            Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare {
+                signer: node_test_id(2)
+            })
+        );
+    }
+
+    #[test]
+    fn test_rejects_invalid_signature() {
+        let share = share(2, 3, 10);
+        let membership = membership(&[node_test_id(1), node_test_id(2)]);
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_verify_basic_sig_upgrade_permit_auth()
+            .returning(|_, _, _, _| {
+                Err(CryptoError::TransientInternalError {
+                    internal_error: "boom".to_string(),
+                })
+            });
+        let result = validate_share(
+            &share,
+            node_test_id(3),
+            Height::from(10),
+            &membership,
+            REGISTRY_VERSION,
+            &crypto,
+        );
+        assert_eq!(
+            result,
+            Err(InvalidUpgradePayloadReason::AuthorizeInvalidShare {
+                signer: node_test_id(2)
+            })
+        );
+    }
+}

--- a/rs/consensus/upgrade/src/lib.rs
+++ b/rs/consensus/upgrade/src/lib.rs
@@ -108,14 +108,6 @@ mod tests {
         }
     }
 
-    fn verifying_crypto() -> MockCrypto {
-        let mut crypto = MockCrypto::new();
-        crypto
-            .expect_verify_basic_sig_upgrade_permit_auth()
-            .returning(|_, _, _, _| Ok(()));
-        crypto
-    }
-
     #[test]
     fn test_rejects_requestor_mismatch() {
         let share = share(2, 3, 10);

--- a/rs/consensus/upgrade/src/pool_manager.rs
+++ b/rs/consensus/upgrade/src/pool_manager.rs
@@ -1,0 +1,676 @@
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::{SubnetMembership, subnet_membership, validate_share};
+use ic_consensus_utils::crypto::ConsensusCrypto;
+use ic_consensus_utils::membership::Membership;
+use ic_interfaces::consensus_pool::ConsensusBlockCache;
+use ic_interfaces::p2p::consensus::{Bouncer, BouncerFactory, BouncerValue, PoolMutationsProducer};
+use ic_interfaces::upgrade::{
+    UpgradePermitAuthChangeAction, UpgradePermitAuthChangeSet, UpgradePermitAuthPool,
+};
+use ic_logger::{ReplicaLogger, info, warn};
+use ic_types::artifact::IdentifiableArtifact;
+use ic_types::batch::bytes_to_upgrade_payload;
+use ic_types::consensus::{Block, UpgradePermitAuthorizationShare, upgrade::UpgradePermitAction};
+use ic_types::{Height, NodeId};
+use num_traits::SaturatingSub;
+
+/// Shares whose request height falls this many blocks below the finalized
+/// tip are purged from the pool.
+const SHARE_EXPIRY_BLOCKS: Height = Height::new(20);
+
+/// Signs shares for requests in finalized blocks, validates gossiped shares,
+/// and purges expired ones.
+pub struct UpgradePermitAuthPoolManager {
+    node_id: NodeId,
+    crypto: Arc<dyn ConsensusCrypto>,
+    consensus_pool_cache: Arc<dyn ConsensusBlockCache>,
+    membership: Arc<Membership>,
+    /// Requests we've already signed (node, request_height).
+    signed_requests: Mutex<BTreeSet<(NodeId, Height)>>,
+    /// Last finalized height we scanned for requests.
+    last_scanned: Mutex<Height>,
+    logger: ReplicaLogger,
+}
+
+impl UpgradePermitAuthPoolManager {
+    pub fn new(
+        node_id: NodeId,
+        crypto: Arc<dyn ConsensusCrypto>,
+        consensus_pool_cache: Arc<dyn ConsensusBlockCache>,
+        membership: Arc<Membership>,
+        logger: ReplicaLogger,
+    ) -> Self {
+        Self {
+            node_id,
+            crypto,
+            consensus_pool_cache,
+            membership,
+            signed_requests: Mutex::new(BTreeSet::new()),
+            last_scanned: Mutex::new(Height::from(0)),
+            logger,
+        }
+    }
+
+    /// Membership at the finalized block's own height and registry version.
+    fn block_membership(&self, block: &Block) -> SubnetMembership {
+        subnet_membership(
+            &self.membership,
+            block.height,
+            block.context.registry_version,
+            &self.logger,
+        )
+    }
+
+    /// Scan finalized blocks for new `Request` actions and sign an auth share
+    /// for each one we haven't signed yet.
+    fn sign_shares_for_new_requests(&self) -> UpgradePermitAuthChangeSet {
+        let chain = self.consensus_pool_cache.finalized_chain();
+        let tip = chain.tip().height;
+        let mut last = self.last_scanned.lock().unwrap();
+        let start = last.increment();
+        if start > tip {
+            return vec![];
+        }
+        *last = tip;
+
+        let mut signed = self.signed_requests.lock().unwrap();
+        let mut change_set = vec![];
+
+        for height_num in start.get()..=tip.get() {
+            let height = Height::from(height_num);
+            let Ok(block) = chain.get_block_by_height(height) else {
+                continue;
+            };
+            let payload = block.payload.as_ref();
+            if payload.is_summary() {
+                continue;
+            }
+            let upgrade_bytes = &payload.as_data().batch.upgrade;
+            if upgrade_bytes.is_empty() {
+                continue;
+            }
+            let Ok(actions) = bytes_to_upgrade_payload(upgrade_bytes) else {
+                continue;
+            };
+            let membership = self.block_membership(block);
+            if !membership.staying(&self.node_id) {
+                continue;
+            }
+            for action in actions {
+                let UpgradePermitAction::Request(request) = action else {
+                    continue;
+                };
+                let key = (request.requestor, request.request_height);
+                if signed.contains(&key) {
+                    continue;
+                }
+                match self
+                    .crypto
+                    .sign(&request, self.node_id, block.context.registry_version)
+                {
+                    Ok(signature) => {
+                        signed.insert(key);
+                        info!(
+                            self.logger,
+                            "permit_auth: signed share for node {:?} at height {:?}",
+                            request.requestor,
+                            request.request_height
+                        );
+                        change_set.push(UpgradePermitAuthChangeAction::AddToValidated(
+                            UpgradePermitAuthorizationShare {
+                                content: request,
+                                signature,
+                            },
+                        ));
+                    }
+                    Err(e) => {
+                        warn!(
+                            self.logger,
+                            "permit_auth: failed to sign share for node {:?}: {:?}",
+                            request.requestor,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+        change_set
+    }
+
+    /// Validate gossiped shares found in the unvalidated section of the pool.
+    fn validate_gossiped_shares(
+        &self,
+        pool: &dyn UpgradePermitAuthPool,
+    ) -> UpgradePermitAuthChangeSet {
+        let chain = self.consensus_pool_cache.finalized_chain();
+        let mut change_set = vec![];
+
+        for share in pool.get_unvalidated_shares() {
+            let Ok(block) = chain.get_block_by_height(share.content.request_height) else {
+                change_set.push(UpgradePermitAuthChangeAction::HandleInvalid(
+                    share.id(),
+                    format!(
+                        "block at request_height {:?} not found in finalized chain",
+                        share.content.request_height
+                    ),
+                ));
+                continue;
+            };
+            let membership = self.block_membership(block);
+            match validate_share(
+                share,
+                share.content.requestor,
+                share.content.request_height,
+                &membership,
+                block.context.registry_version,
+                self.crypto.as_ref(),
+            ) {
+                Ok(_) => {
+                    change_set.push(UpgradePermitAuthChangeAction::MoveToValidated(
+                        share.clone(),
+                    ));
+                }
+                Err(reason) => {
+                    warn!(
+                        self.logger,
+                        "permit_auth: dropping invalid share: {reason:?}",
+                    );
+                    change_set.push(UpgradePermitAuthChangeAction::HandleInvalid(
+                        share.id(),
+                        format!("invalid share: {reason:?}"),
+                    ));
+                }
+            }
+        }
+
+        change_set
+    }
+
+    /// Purge shares (both validated and unvalidated) whose request has expired
+    /// (the request height is older than `REQUEST_TIMEOUT_BLOCKS` below the
+    /// current finalized height).
+    fn purge_expired_shares(&self, pool: &dyn UpgradePermitAuthPool) -> UpgradePermitAuthChangeSet {
+        let current_height = self.consensus_pool_cache.finalized_chain().tip().height;
+        let expiry_threshold = current_height.saturating_sub(&SHARE_EXPIRY_BLOCKS);
+
+        let expired_validated = pool
+            .get_validated_shares()
+            .filter(|share| share.content.request_height < expiry_threshold)
+            .map(|share| UpgradePermitAuthChangeAction::RemoveValidated(share.into()));
+
+        let expired_unvalidated = pool
+            .get_unvalidated_shares()
+            .filter(|share| share.content.request_height < expiry_threshold)
+            .map(|share| UpgradePermitAuthChangeAction::RemoveUnvalidated(share.into()));
+
+        expired_validated.chain(expired_unvalidated).collect()
+    }
+}
+
+impl<T: UpgradePermitAuthPool> PoolMutationsProducer<T> for UpgradePermitAuthPoolManager {
+    type Mutations = UpgradePermitAuthChangeSet;
+
+    fn on_state_change(&self, pool: &T) -> Self::Mutations {
+        let mut change_set = self.sign_shares_for_new_requests();
+        change_set.extend(self.validate_gossiped_shares(pool));
+        change_set.extend(self.purge_expired_shares(pool));
+        change_set
+    }
+}
+
+/// Bouncer that accepts all upgrade permit auth shares.
+pub struct UpgradePermitAuthBouncer;
+
+impl<Pool> BouncerFactory<ic_types::artifact::UpgradePermitAuthorizationShareId, Pool>
+    for UpgradePermitAuthBouncer
+{
+    fn new_bouncer(
+        &self,
+        _pool: &Pool,
+    ) -> Bouncer<ic_types::artifact::UpgradePermitAuthorizationShareId> {
+        Box::new(|_id| BouncerValue::Wants)
+    }
+
+    fn refresh_period(&self) -> Duration {
+        Duration::from_secs(60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_interfaces::consensus_pool::{ConsensusBlockChain, ConsensusBlockChainErr};
+    use ic_interfaces_mocks::crypto::MockCrypto;
+    use ic_logger::replica_logger::no_op_logger;
+    use ic_protobuf::types::v1 as pb;
+    use ic_registry_client_fake::FakeRegistryClient;
+    use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
+    use ic_test_utilities_consensus::{FakeConsensusPoolCache, fake::Fake, make_genesis};
+    use ic_test_utilities_registry::{SubnetRecordBuilder, add_single_subnet_record};
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id, test_replica_version};
+    use ic_types::NumBytes;
+    use ic_types::RegistryVersion;
+    use ic_types::artifact::{IdentifiableArtifact, UpgradePermitAuthorizationShareId};
+    use ic_types::batch::{BatchPayload, ValidationContext, upgrade_payload_to_bytes};
+    use ic_types::consensus::upgrade::UpgradePermitAction;
+    use ic_types::consensus::{
+        BlockPayload, DataPayload, Payload, Rank, UpgradePermitAuthorizationRequest,
+        dkg::{DkgDataPayload, DkgSummary},
+    };
+    use ic_types::crypto::{
+        BasicSig, BasicSigOf, CryptoError, CryptoHash, CryptoHashOf, crypto_hash,
+    };
+    use ic_types::signature::BasicSignature;
+    use ic_types::time::UNIX_EPOCH;
+    use std::collections::BTreeMap;
+    use std::ops::RangeInclusive;
+
+    fn registry_version() -> RegistryVersion {
+        RegistryVersion::from(1)
+    }
+
+    fn members() -> Vec<NodeId> {
+        vec![node_test_id(1), node_test_id(2), node_test_id(3)]
+    }
+
+    fn signing_crypto() -> MockCrypto {
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_sign_basic_upgrade_permit_auth()
+            .returning(|_| Ok(BasicSigOf::new(BasicSig(vec![]))));
+        crypto
+    }
+
+    fn verifying_crypto() -> MockCrypto {
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_verify_basic_sig_upgrade_permit_auth()
+            .returning(|_, _, _, _| Ok(()));
+        crypto
+    }
+
+    fn membership_of(members: &[NodeId]) -> Arc<Membership> {
+        let data_provider = Arc::new(ProtoRegistryDataProvider::new());
+        add_single_subnet_record(
+            &data_provider,
+            registry_version().get(),
+            subnet_test_id(1),
+            SubnetRecordBuilder::default()
+                .with_membership(members)
+                .build(),
+        );
+        let registry = Arc::new(FakeRegistryClient::new(Arc::clone(&data_provider) as Arc<_>));
+        registry.update_to_latest_version();
+        let cup = make_genesis(DkgSummary::fake());
+        let consensus_cache = Arc::new(FakeConsensusPoolCache::new(pb::CatchUpPackage::from(cup)));
+        Arc::new(Membership::new(
+            consensus_cache,
+            registry,
+            subnet_test_id(1),
+        ))
+    }
+
+    fn genesis_block() -> Block {
+        make_genesis(DkgSummary::fake()).content.block.into_inner()
+    }
+
+    fn data_block(height: u64, actions: &[UpgradePermitAction]) -> Block {
+        Block::new(
+            CryptoHashOf::new(CryptoHash(vec![0; 32])),
+            Payload::new(
+                crypto_hash,
+                BlockPayload::Data(DataPayload {
+                    batch: BatchPayload {
+                        upgrade: upgrade_payload_to_bytes(
+                            actions.to_vec(),
+                            NumBytes::new(u64::MAX),
+                        ),
+                        ..BatchPayload::default()
+                    },
+                    dkg: DkgDataPayload::new_empty(Height::from(height)),
+                    idkg: None,
+                }),
+            ),
+            Height::from(height),
+            Rank(0),
+            ValidationContext {
+                registry_version: registry_version(),
+                certified_height: Height::from(height),
+                time: UNIX_EPOCH,
+            },
+            test_replica_version(),
+        )
+    }
+
+    fn empty_blocks(heights: RangeInclusive<u64>) -> Vec<Block> {
+        heights.map(|height| data_block(height, &[])).collect()
+    }
+
+    struct FakeFinalizedChain {
+        blocks: Vec<Block>,
+    }
+
+    impl ConsensusBlockChain for FakeFinalizedChain {
+        fn tip(&self) -> &Block {
+            self.blocks.last().unwrap()
+        }
+
+        fn get_block_by_height(&self, height: Height) -> Result<&Block, ConsensusBlockChainErr> {
+            self.blocks
+                .iter()
+                .find(|block| block.height == height)
+                .ok_or(ConsensusBlockChainErr::BlockNotFound(height))
+        }
+
+        fn len(&self) -> usize {
+            self.blocks.len()
+        }
+
+        fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &Block> + '_> {
+            Box::new(self.blocks.iter().filter(move |b| b.height > height))
+        }
+    }
+
+    struct FakeBlockCache {
+        chain: Arc<FakeFinalizedChain>,
+    }
+
+    impl ConsensusBlockCache for FakeBlockCache {
+        fn finalized_chain(&self) -> Arc<dyn ConsensusBlockChain> {
+            self.chain.clone()
+        }
+    }
+
+    fn pool_manager(
+        node_id: NodeId,
+        members: &[NodeId],
+        blocks: Vec<Block>,
+        crypto: MockCrypto,
+    ) -> UpgradePermitAuthPoolManager {
+        let mut chain = vec![genesis_block()];
+        chain.extend(blocks);
+        UpgradePermitAuthPoolManager::new(
+            node_id,
+            Arc::new(crypto),
+            Arc::new(FakeBlockCache {
+                chain: Arc::new(FakeFinalizedChain { blocks: chain }),
+            }),
+            membership_of(members),
+            no_op_logger(),
+        )
+    }
+
+    struct FakePool {
+        validated: BTreeMap<UpgradePermitAuthorizationShareId, UpgradePermitAuthorizationShare>,
+        unvalidated: BTreeMap<UpgradePermitAuthorizationShareId, UpgradePermitAuthorizationShare>,
+    }
+
+    impl FakePool {
+        fn new() -> Self {
+            Self {
+                validated: BTreeMap::new(),
+                unvalidated: BTreeMap::new(),
+            }
+        }
+
+        fn with_validated(mut self, share: UpgradePermitAuthorizationShare) -> Self {
+            self.validated.insert(share.id(), share);
+            self
+        }
+
+        fn with_unvalidated(mut self, share: UpgradePermitAuthorizationShare) -> Self {
+            self.unvalidated.insert(share.id(), share);
+            self
+        }
+    }
+
+    impl UpgradePermitAuthPool for FakePool {
+        fn get_validated_shares(
+            &self,
+        ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_> {
+            Box::new(self.validated.values())
+        }
+
+        fn get_unvalidated_shares(
+            &self,
+        ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_> {
+            Box::new(self.unvalidated.values())
+        }
+    }
+
+    fn share(signer: u64, requestor: u64, request_height: u64) -> UpgradePermitAuthorizationShare {
+        UpgradePermitAuthorizationShare {
+            content: UpgradePermitAuthorizationRequest {
+                requestor: node_test_id(requestor),
+                request_height: Height::from(request_height),
+            },
+            signature: BasicSignature {
+                signature: BasicSigOf::new(BasicSig(vec![])),
+                signer: node_test_id(signer),
+            },
+        }
+    }
+
+    fn request(requestor: u64, request_height: u64) -> UpgradePermitAction {
+        UpgradePermitAction::Request(UpgradePermitAuthorizationRequest {
+            requestor: node_test_id(requestor),
+            request_height: Height::from(request_height),
+        })
+    }
+
+    fn assert_single_add_to_validated(
+        change_set: &UpgradePermitAuthChangeSet,
+        expected: &UpgradePermitAuthorizationShare,
+    ) {
+        assert_eq!(change_set.len(), 1);
+        assert!(matches!(
+            &change_set[0],
+            UpgradePermitAuthChangeAction::AddToValidated(s) if s == expected
+        ));
+    }
+
+    fn assert_single_handle_invalid(
+        change_set: &UpgradePermitAuthChangeSet,
+        expected: &UpgradePermitAuthorizationShare,
+    ) {
+        assert_eq!(change_set.len(), 1);
+        assert!(matches!(
+            &change_set[0],
+            UpgradePermitAuthChangeAction::HandleInvalid(id, _) if id == &expected.id()
+        ));
+    }
+
+    #[test]
+    fn test_signs_share_for_request_in_finalized_block() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(1, &[request(2, 1)])],
+            signing_crypto(),
+        );
+        let change_set = manager.on_state_change(&FakePool::new());
+        assert_single_add_to_validated(&change_set, &share(1, 2, 1));
+    }
+
+    #[test]
+    fn test_does_not_sign_when_node_leaving_subnet() {
+        let manager = pool_manager(
+            node_test_id(4),
+            &members(),
+            vec![data_block(1, &[request(2, 1)])],
+            signing_crypto(),
+        );
+        assert!(manager.on_state_change(&FakePool::new()).is_empty());
+    }
+
+    #[test]
+    fn test_ignores_blocks_without_requests() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(1, &[]), data_block(2, &[])],
+            signing_crypto(),
+        );
+        assert!(manager.on_state_change(&FakePool::new()).is_empty());
+    }
+
+    #[test]
+    fn test_does_not_rescan_finalized_blocks() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(1, &[request(2, 1)])],
+            signing_crypto(),
+        );
+        assert_single_add_to_validated(&manager.on_state_change(&FakePool::new()), &share(1, 2, 1));
+        assert!(manager.on_state_change(&FakePool::new()).is_empty());
+    }
+
+    #[test]
+    fn test_deduplicates_repeated_requests() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![
+                data_block(1, &[request(2, 1)]),
+                data_block(2, &[request(2, 1)]),
+            ],
+            signing_crypto(),
+        );
+        let change_set = manager.on_state_change(&FakePool::new());
+        assert_single_add_to_validated(&change_set, &share(1, 2, 1));
+    }
+
+    #[test]
+    fn test_signing_failure_yields_no_action() {
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_sign_basic_upgrade_permit_auth()
+            .returning(|_| {
+                Err(CryptoError::TransientInternalError {
+                    internal_error: "boom".to_string(),
+                })
+            });
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(1, &[request(2, 1)])],
+            crypto,
+        );
+        assert!(manager.on_state_change(&FakePool::new()).is_empty());
+    }
+
+    #[test]
+    fn test_validates_gossiped_share() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(5, &[])],
+            verifying_crypto(),
+        );
+        let gossiped = share(2, 3, 5);
+        let pool = FakePool::new().with_unvalidated(gossiped.clone());
+        let change_set = manager.on_state_change(&pool);
+        assert_eq!(change_set.len(), 1);
+        assert!(matches!(
+            &change_set[0],
+            UpgradePermitAuthChangeAction::MoveToValidated(s) if s == &gossiped
+        ));
+    }
+
+    #[test]
+    fn test_drops_share_with_invalid_signature() {
+        let mut crypto = MockCrypto::new();
+        crypto
+            .expect_verify_basic_sig_upgrade_permit_auth()
+            .returning(|_, _, _, _| {
+                Err(CryptoError::TransientInternalError {
+                    internal_error: "boom".to_string(),
+                })
+            });
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(5, &[])],
+            crypto,
+        );
+        let gossiped = share(2, 3, 5);
+        let pool = FakePool::new().with_unvalidated(gossiped.clone());
+        assert_single_handle_invalid(&manager.on_state_change(&pool), &gossiped);
+    }
+
+    #[test]
+    fn test_drops_share_from_non_staying_signer() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(5, &[])],
+            verifying_crypto(),
+        );
+        let gossiped = share(9, 3, 5);
+        let pool = FakePool::new().with_unvalidated(gossiped.clone());
+        assert_single_handle_invalid(&manager.on_state_change(&pool), &gossiped);
+    }
+
+    #[test]
+    fn test_drops_share_without_request_block() {
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            vec![data_block(5, &[])],
+            verifying_crypto(),
+        );
+        let gossiped = share(2, 3, 99);
+        let pool = FakePool::new().with_unvalidated(gossiped.clone());
+        assert_single_handle_invalid(&manager.on_state_change(&pool), &gossiped);
+    }
+
+    #[test]
+    fn test_purges_expired_validated_shares() {
+        // Threshold is tip (100) - SHARE_EXPIRY_BLOCKS (20) = 80: shares with
+        // request height below 80 are purged, at or above it are kept.
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            empty_blocks(1..=100),
+            MockCrypto::new(),
+        );
+        let expired = share(2, 3, 79);
+        let pool = FakePool::new()
+            .with_validated(expired.clone())
+            .with_validated(share(3, 2, 80));
+        let change_set = manager.on_state_change(&pool);
+        assert_eq!(change_set.len(), 1);
+        assert!(matches!(
+            &change_set[0],
+            UpgradePermitAuthChangeAction::RemoveValidated(id) if id == &expired.id()
+        ));
+    }
+
+    #[test]
+    fn test_purges_expired_unvalidated_shares() {
+        // The share is both validated (moved out of unvalidated) and purged
+        // (removed from unvalidated); applying both leaves it validated only.
+        let manager = pool_manager(
+            node_test_id(1),
+            &members(),
+            empty_blocks(1..=100),
+            verifying_crypto(),
+        );
+        let expired = share(2, 3, 79);
+        let pool = FakePool::new().with_unvalidated(expired.clone());
+        let change_set = manager.on_state_change(&pool);
+        assert_eq!(change_set.len(), 2);
+        assert!(matches!(
+            &change_set[0],
+            UpgradePermitAuthChangeAction::MoveToValidated(s) if s == &expired
+        ));
+        assert!(matches!(
+            &change_set[1],
+            UpgradePermitAuthChangeAction::RemoveUnvalidated(id) if id == &expired.id()
+        ));
+    }
+}

--- a/rs/consensus/utils/src/crypto.rs
+++ b/rs/consensus/utils/src/crypto.rs
@@ -4,7 +4,7 @@ use ic_types::{
     canister_http::CanisterHttpResponseReceipt,
     consensus::{
         BlockMetadata, CatchUpContent, FinalizationContent, NotarizationContent,
-        RandomBeaconContent, RandomTapeContent, dkg,
+        RandomBeaconContent, RandomTapeContent, UpgradePermitAuthorizationRequest, dkg,
         hashed::Hashed,
         idkg::{IDkgComplaintContent, IDkgOpeningContent},
     },
@@ -425,7 +425,11 @@ pub trait ConsensusCrypto:
     + SignVerify<IDkgDealing, BasicSignature<IDkgDealing>, RegistryVersion>
     + SignVerify<IDkgComplaintContent, BasicSignature<IDkgComplaintContent>, RegistryVersion>
     + SignVerify<IDkgOpeningContent, BasicSignature<IDkgOpeningContent>, RegistryVersion>
-    + SignVerify<RandomBeaconContent, ThresholdSignatureShare<RandomBeaconContent>, NiDkgId>
+    + SignVerify<
+        UpgradePermitAuthorizationRequest,
+        BasicSignature<UpgradePermitAuthorizationRequest>,
+        RegistryVersion,
+    > + SignVerify<RandomBeaconContent, ThresholdSignatureShare<RandomBeaconContent>, NiDkgId>
     + SignVerify<RandomTapeContent, ThresholdSignatureShare<RandomTapeContent>, NiDkgId>
     + SignVerify<CatchUpContent, ThresholdSignatureShare<CatchUpContent>, NiDkgId>
     + SignVerify<dkg::DealingContent, BasicSignature<dkg::DealingContent>, RegistryVersion>

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -30,7 +30,7 @@ use ic_interfaces::crypto::{
 use ic_types::canister_http::CanisterHttpResponseReceipt;
 use ic_types::consensus::{
     BlockMetadata, CatchUpContent, CatchUpContentProtobufBytes, FinalizationContent,
-    NotarizationContent, RandomBeaconContent, RandomTapeContent,
+    NotarizationContent, RandomBeaconContent, RandomTapeContent, UpgradePermitAuthorizationRequest,
     certification::CertificationContent,
     dkg as consensus_dkg,
     idkg::{IDkgComplaintContent, IDkgOpeningContent},
@@ -310,6 +310,10 @@ mockall::mock! {
             &self, message: &CanisterHttpResponseReceipt,
         ) -> CryptoResult<BasicSigOf<CanisterHttpResponseReceipt>>;
 
+        pub fn sign_basic_upgrade_permit_auth(
+            &self, message: &UpgradePermitAuthorizationRequest,
+        ) -> CryptoResult<BasicSigOf<UpgradePermitAuthorizationRequest>>;
+
         pub fn sign_basic_query(
             &self, message: &QueryResponseHash,
         ) -> CryptoResult<BasicSigOf<QueryResponseHash>>;
@@ -486,6 +490,37 @@ mockall::mock! {
                 NodeId,
                 BasicSigOf<CanisterHttpResponseReceipt>,
                 CanisterHttpResponseReceipt,
+                RegistryVersion,
+            )>,
+        ) -> CryptoResult<()>;
+
+        // UpgradePermitAuthorizationRequest
+        pub fn verify_basic_sig_upgrade_permit_auth(
+            &self,
+            signature: &BasicSigOf<UpgradePermitAuthorizationRequest>,
+            message: &UpgradePermitAuthorizationRequest, signer: NodeId,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn combine_basic_sig_upgrade_permit_auth(
+            &self,
+            signatures: BTreeMap<NodeId, BasicSigOf<UpgradePermitAuthorizationRequest>>,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<BasicSignatureBatch<UpgradePermitAuthorizationRequest>>;
+
+        pub fn verify_basic_sig_batch_upgrade_permit_auth(
+            &self,
+            signature_batch: &BasicSignatureBatch<UpgradePermitAuthorizationRequest>,
+            message: &UpgradePermitAuthorizationRequest,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn verify_basic_sig_batch_multi_msg_upgrade_permit_auth(
+            &self,
+            inputs: Vec<(
+                NodeId,
+                BasicSigOf<UpgradePermitAuthorizationRequest>,
+                UpgradePermitAuthorizationRequest,
                 RegistryVersion,
             )>,
         ) -> CryptoResult<()>;
@@ -786,6 +821,10 @@ impl_basic_signer!(IDkgDealing, sign_basic_idkg_dealing);
 impl_basic_signer!(IDkgComplaintContent, sign_basic_idkg_complaint);
 impl_basic_signer!(IDkgOpeningContent, sign_basic_idkg_opening);
 impl_basic_signer!(CanisterHttpResponseReceipt, sign_basic_http);
+impl_basic_signer!(
+    UpgradePermitAuthorizationRequest,
+    sign_basic_upgrade_permit_auth
+);
 impl_basic_signer!(QueryResponseHash, sign_basic_query);
 
 impl_basic_sig_verifier!(
@@ -836,6 +875,13 @@ impl_basic_sig_verifier!(
     combine_basic_sig_http,
     verify_basic_sig_batch_http,
     verify_basic_sig_batch_multi_msg_http
+);
+impl_basic_sig_verifier!(
+    UpgradePermitAuthorizationRequest,
+    verify_basic_sig_upgrade_permit_auth,
+    combine_basic_sig_upgrade_permit_auth,
+    verify_basic_sig_batch_upgrade_permit_auth,
+    verify_basic_sig_batch_multi_msg_upgrade_permit_auth
 );
 
 impl_threshold_signer!(CertificationContent, sign_threshold_certification);

--- a/rs/interfaces/src/consensus.rs
+++ b/rs/interfaces/src/consensus.rs
@@ -15,6 +15,7 @@ use crate::{
         InvalidSelfValidatingPayloadReason, SelfValidatingPayloadValidationError,
         SelfValidatingPayloadValidationFailure,
     },
+    upgrade::InvalidUpgradePayloadReason,
     validation::{ValidationError, ValidationResult},
 };
 use ic_base_types::{NumBytes, SubnetId};
@@ -75,6 +76,7 @@ pub enum InvalidPayloadReason {
     InvalidCanisterHttpPayload(InvalidCanisterHttpPayloadReason),
     InvalidQueryStatsPayload(InvalidQueryStatsPayloadReason),
     InvalidChainKeyPayload(InvalidChainKeyPayloadReason),
+    InvalidUpgradePayload(InvalidUpgradePayloadReason),
     /// The overall block size is too large, even though the individual payloads are valid
     PayloadTooBig {
         expected: NumBytes,

--- a/rs/interfaces/src/crypto.rs
+++ b/rs/interfaces/src/crypto.rs
@@ -26,7 +26,7 @@ pub use vetkd::*;
 use ic_crypto_interfaces_sig_verification::BasicSigVerifierByPublicKey;
 use ic_types::consensus::{
     BlockMetadata, CatchUpContent, CatchUpContentProtobufBytes, FinalizationContent,
-    NotarizationContent, RandomBeaconContent, RandomTapeContent,
+    NotarizationContent, RandomBeaconContent, RandomTapeContent, UpgradePermitAuthorizationRequest,
     certification::CertificationContent,
     dkg as consensus_dkg,
     idkg::{IDkgComplaintContent, IDkgOpeningContent},
@@ -73,6 +73,9 @@ pub trait Crypto:
     // IDkgOpeningContent
     + BasicSigner<IDkgOpeningContent>
     + BasicSigVerifier<IDkgOpeningContent>
+    // UpgradePermitAuthorizationRequest
+    + BasicSigner<UpgradePermitAuthorizationRequest>
+    + BasicSigVerifier<UpgradePermitAuthorizationRequest>
     + IDkgProtocol
     + ThresholdEcdsaSigner
     + ThresholdEcdsaSigVerifier
@@ -141,6 +144,8 @@ impl<T> Crypto for T where
         + BasicSigVerifier<IDkgComplaintContent>
         + BasicSigner<IDkgOpeningContent>
         + BasicSigVerifier<IDkgOpeningContent>
+        + BasicSigner<UpgradePermitAuthorizationRequest>
+        + BasicSigVerifier<UpgradePermitAuthorizationRequest>
         + BasicSigner<CanisterHttpResponseReceipt>
         + BasicSigVerifier<CanisterHttpResponseReceipt>
         + BasicSigner<QueryResponseHash>

--- a/rs/interfaces/src/lib.rs
+++ b/rs/interfaces/src/lib.rs
@@ -19,6 +19,7 @@ pub mod p2p;
 pub mod query_stats;
 pub mod self_validating_payload;
 pub mod time_source;
+pub mod upgrade;
 pub mod validation;
 
 // Note [Associated Types in Interfaces]

--- a/rs/interfaces/src/p2p/consensus.rs
+++ b/rs/interfaces/src/p2p/consensus.rs
@@ -52,7 +52,7 @@ pub struct ArtifactTransmits<T: IdentifiableArtifact> {
     /// The list of replication transmits returned by the client. Mutations are applied in order by P2P-replication.
     pub transmits: Vec<ArtifactTransmit<T>>,
     /// The field instructs the polling component (the one that calls `on_state_change` + `apply_changes`)
-    /// that polling immediately can be benefitial. For example, polling consensus when the field is set to
+    /// that polling immediately can be beneficial. For example, polling consensus when the field is set to
     /// true results in lower consensus latencies.
     pub poll_immediately: bool,
 }

--- a/rs/interfaces/src/upgrade.rs
+++ b/rs/interfaces/src/upgrade.rs
@@ -1,0 +1,55 @@
+use ic_types::NodeId;
+use ic_types::artifact::UpgradePermitAuthorizationShareId;
+use ic_types::consensus::UpgradePermitAuthorizationShare;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum InvalidUpgradePayloadReason {
+    /// A `Request` was issued for a node other than the block maker.
+    RequestNodeMismatch { node: NodeId, proposer: NodeId },
+    /// A `Return` was issued for a node other than the block maker.
+    ReturnNodeMismatch { node: NodeId, proposer: NodeId },
+    /// The number of outstanding permits (requested or authorized) meets
+    /// the subnet's maximum number of rebooting nodes.
+    SlotsExhausted { slots_in_use: usize, permits: usize },
+    /// An `Authorize` was issued for a node with no outstanding request.
+    AuthorizeNoOutstandingRequest { node: NodeId },
+    /// An `Authorize` contains an invalid share (bad signature, content
+    /// mismatch, or signer is not a member).
+    AuthorizeInvalidShare { signer: NodeId },
+    /// An `Authorize` does not carry enough valid shares (≥ the active
+    /// staying nodes).
+    AuthorizeInsufficientShares { collected: usize, threshold: usize },
+    /// Failed to decode the upgrade payload from protobuf.
+    DecodeFailed(String),
+}
+
+/// Change actions that can be applied to the [`UpgradePermitAuthPool`].
+#[derive(Debug)]
+pub enum UpgradePermitAuthChangeAction {
+    /// Add a locally-produced share directly to validated.
+    AddToValidated(UpgradePermitAuthorizationShare),
+    /// Move a gossiped share from unvalidated to validated (after signature
+    /// verification).
+    MoveToValidated(UpgradePermitAuthorizationShare),
+    /// Remove a validated share (e.g. after the request was authorized or
+    /// timed out).
+    RemoveValidated(UpgradePermitAuthorizationShareId),
+    /// Remove an unvalidated share.
+    RemoveUnvalidated(UpgradePermitAuthorizationShareId),
+    /// Handle an invalid share (bad signature, no matching request, etc.).
+    HandleInvalid(UpgradePermitAuthorizationShareId, String),
+}
+
+pub type UpgradePermitAuthChangeSet = Vec<UpgradePermitAuthChangeAction>;
+
+/// Query interface for the upgrade permit authorization pool.
+pub trait UpgradePermitAuthPool: Send + Sync {
+    /// Return an iterator over all validated shares.
+    fn get_validated_shares(
+        &self,
+    ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_>;
+    /// Return an iterator over all unvalidated shares.
+    fn get_unvalidated_shares(
+        &self,
+    ) -> Box<dyn Iterator<Item = &UpgradePermitAuthorizationShare> + '_>;
+}

--- a/rs/protobuf/def/types/v1/artifact.proto
+++ b/rs/protobuf/def/types/v1/artifact.proto
@@ -12,6 +12,11 @@ message DkgMessageId {
   uint64 height = 2;
 }
 
+message UpgradePermitAuthMessageId {
+  bytes hash = 1;
+  uint64 height = 2;
+}
+
 message ConsensusMessageId {
   ConsensusMessageHash hash = 1;
   uint64 height = 2;

--- a/rs/protobuf/def/types/v1/consensus.proto
+++ b/rs/protobuf/def/types/v1/consensus.proto
@@ -10,6 +10,7 @@ import "registry/subnet/v1/subnet.proto";
 import "types/v1/artifact.proto";
 import "types/v1/dkg.proto";
 import "types/v1/idkg.proto";
+import "types/v1/signature.proto";
 import "types/v1/types.proto";
 
 message CertificationMessage {
@@ -69,6 +70,7 @@ message Block {
   bytes canister_http_payload_bytes = 15;
   bytes query_stats_payload_bytes = 16;
   bytes chain_key_payload_bytes = 17;
+  bytes upgrade_payload_bytes = 18;
   bytes payload_hash = 11;
 }
 

--- a/rs/protobuf/def/types/v1/upgrade.proto
+++ b/rs/protobuf/def/types/v1/upgrade.proto
@@ -1,0 +1,39 @@
+// Protocol buffers for the Phase-2 upgrade permit protocol: permit requests
+// in block payloads and gossiped authorization shares.
+
+syntax = "proto3";
+package types.v1;
+
+import "types/v1/signature.proto";
+import "types/v1/types.proto";
+
+message UpgradeAction {
+  oneof action {
+    RequestUpgradePermit request_permit = 1;
+    AuthorizeUpgradePermit authorize_permit = 2;
+    ReturnUpgradePermit return_permit = 3;
+  }
+}
+
+message UpgradePermitRequest {
+  types.v1.NodeId requestor = 1;
+  uint64 request_height = 2;
+}
+
+message RequestUpgradePermit {
+  UpgradePermitRequest request = 1;
+}
+
+message AuthorizeUpgradePermit {
+  UpgradePermitRequest request = 1;
+  repeated types.v1.BasicSignature signatures = 2;
+}
+
+message ReturnUpgradePermit {
+  types.v1.NodeId node = 1;
+}
+
+message UpgradePermitAuthorizationShare {
+  UpgradePermitRequest request = 1;
+  types.v1.BasicSignature signature = 2;
+}

--- a/rs/protobuf/generator/src/lib.rs
+++ b/rs/protobuf/generator/src/lib.rs
@@ -407,6 +407,7 @@ fn build_types_proto(def: &Path, out: &Path) {
         def.join("types/v1/canister_http.proto"),
         def.join("types/v1/artifact.proto"),
         def.join("types/v1/errors.proto"),
+        def.join("types/v1/upgrade.proto"),
     ];
     compile_protos(config, def, &files);
 }

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -1317,6 +1317,13 @@ pub struct DkgMessageId {
     pub height: u64,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UpgradePermitAuthMessageId {
+    #[prost(bytes = "vec", tag = "1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub height: u64,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ConsensusMessageId {
     #[prost(message, optional, tag = "1")]
     pub hash: ::core::option::Option<ConsensusMessageHash>,
@@ -1489,6 +1496,8 @@ pub struct Block {
     pub query_stats_payload_bytes: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "17")]
     pub chain_key_payload_bytes: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "18")]
+    pub upgrade_payload_bytes: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "11")]
     pub payload_hash: ::prost::alloc::vec::Vec<u8>,
 }
@@ -1851,4 +1860,52 @@ impl ChainKeyErrorCode {
             _ => None,
         }
     }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpgradeAction {
+    #[prost(oneof = "upgrade_action::Action", tags = "1, 2, 3")]
+    pub action: ::core::option::Option<upgrade_action::Action>,
+}
+/// Nested message and enum types in `UpgradeAction`.
+pub mod upgrade_action {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Action {
+        #[prost(message, tag = "1")]
+        RequestPermit(super::RequestUpgradePermit),
+        #[prost(message, tag = "2")]
+        AuthorizePermit(super::AuthorizeUpgradePermit),
+        #[prost(message, tag = "3")]
+        ReturnPermit(super::ReturnUpgradePermit),
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UpgradePermitRequest {
+    #[prost(message, optional, tag = "1")]
+    pub requestor: ::core::option::Option<NodeId>,
+    #[prost(uint64, tag = "2")]
+    pub request_height: u64,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RequestUpgradePermit {
+    #[prost(message, optional, tag = "1")]
+    pub request: ::core::option::Option<UpgradePermitRequest>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizeUpgradePermit {
+    #[prost(message, optional, tag = "1")]
+    pub request: ::core::option::Option<UpgradePermitRequest>,
+    #[prost(message, repeated, tag = "2")]
+    pub signatures: ::prost::alloc::vec::Vec<BasicSignature>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReturnUpgradePermit {
+    #[prost(message, optional, tag = "1")]
+    pub node: ::core::option::Option<NodeId>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct UpgradePermitAuthorizationShare {
+    #[prost(message, optional, tag = "1")]
+    pub request: ::core::option::Option<UpgradePermitRequest>,
+    #[prost(message, optional, tag = "2")]
+    pub signature: ::core::option::Option<BasicSignature>,
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3172,6 +3172,7 @@ impl StateMachine {
                     .map(|p| p.get().to_vec())
                     .unwrap_or_default(),
                 query_stats: payload.query_stats,
+                upgrade: vec![],
             },
             chain_key_data: ChainKeyData {
                 master_public_keys: self.chain_key_subnet_public_keys.clone(),

--- a/rs/test_utilities/types/src/batch/payload.rs
+++ b/rs/test_utilities/types/src/batch/payload.rs
@@ -15,6 +15,7 @@ impl Default for PayloadBuilder {
                 canister_http: vec![],
                 query_stats: vec![],
                 chain_key: vec![],
+                upgrade: vec![],
             },
         }
     }

--- a/rs/types/types/src/artifact.rs
+++ b/rs/types/types/src/artifact.rs
@@ -4,10 +4,11 @@ use crate::{
     canister_http::CanisterHttpResponseShare,
     consensus::{
         ConsensusMessage, ConsensusMessageHash, ConsensusMessageHashable, HasHash, HasHeight,
+        UpgradePermitAuthorizationShare,
         certification::{CertificationMessage, CertificationMessageHash},
         idkg::IDkgArtifactId,
     },
-    crypto::{CryptoHash, crypto_hash},
+    crypto::{CryptoHash, CryptoHashOf, crypto_hash},
     messages::{MessageId, SignedIngress},
 };
 #[cfg(test)]
@@ -246,3 +247,57 @@ pub type IDkgMessageId = IDkgArtifactId;
 // CanisterHttp artifacts
 
 pub type CanisterHttpResponseId = CanisterHttpResponseShare;
+
+// -----------------------------------------------------------------------------
+// Upgrade permit authorization artifacts
+
+/// Upgrade permit authorization message identifier carries both a message hash
+/// and a height, used by the upgrade permit auth pool for lookup.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct UpgradePermitAuthorizationShareId {
+    pub hash: CryptoHashOf<UpgradePermitAuthorizationShare>,
+    pub height: Height,
+}
+
+impl HasHeight for UpgradePermitAuthorizationShareId {
+    fn height(&self) -> Height {
+        self.height
+    }
+}
+
+impl IdentifiableArtifact for UpgradePermitAuthorizationShare {
+    const NAME: &'static str = "upgrade";
+    type Id = UpgradePermitAuthorizationShareId;
+    fn id(&self) -> Self::Id {
+        UpgradePermitAuthorizationShareId {
+            hash: crypto_hash(self),
+            height: self.content.height(),
+        }
+    }
+}
+
+impl From<&UpgradePermitAuthorizationShare> for UpgradePermitAuthorizationShareId {
+    fn from(share: &UpgradePermitAuthorizationShare) -> Self {
+        share.id()
+    }
+}
+
+impl From<UpgradePermitAuthorizationShareId> for pb::UpgradePermitAuthMessageId {
+    fn from(id: UpgradePermitAuthorizationShareId) -> Self {
+        Self {
+            hash: id.hash.clone().get().0,
+            height: id.height.get(),
+        }
+    }
+}
+
+impl TryFrom<pb::UpgradePermitAuthMessageId> for UpgradePermitAuthorizationShareId {
+    type Error = ProxyDecodeError;
+
+    fn try_from(id: pb::UpgradePermitAuthMessageId) -> Result<Self, Self::Error> {
+        Ok(Self {
+            hash: CryptoHash(id.hash.clone()).into(),
+            height: Height::from(id.height),
+        })
+    }
+}

--- a/rs/types/types/src/batch.rs
+++ b/rs/types/types/src/batch.rs
@@ -6,6 +6,7 @@ mod chain_key;
 mod execution_environment;
 mod ingress;
 mod self_validating;
+mod upgrade;
 mod xnet;
 
 pub use self::{
@@ -24,8 +25,10 @@ pub use self::{
     },
     ingress::{IngressPayload, IngressPayloadError},
     self_validating::{MAX_BITCOIN_PAYLOAD_IN_BYTES, SelfValidatingPayload},
+    upgrade::{bytes_to_upgrade_payload, upgrade_payload_to_bytes},
     xnet::XNetPayload,
 };
+use crate::consensus::upgrade::UpgradePermitAction;
 use crate::{
     Height, Randomness, RegistryVersion, ReplicaVersion, SubnetId, Time,
     consensus::idkg::{IDkgMasterPublicKeyId, PreSigId, common::PreSignature},
@@ -177,6 +180,7 @@ pub struct BatchPayload {
     pub canister_http: Vec<u8>,
     pub query_stats: Vec<u8>,
     pub chain_key: Vec<u8>,
+    pub upgrade: Vec<u8>,
 }
 
 /// Batch properties collected form the last DKG summary block.
@@ -202,6 +206,7 @@ pub struct BatchMessages {
     pub certified_stream_slices: BTreeMap<SubnetId, CertifiedStreamSlice>,
     pub bitcoin_adapter_responses: Vec<BitcoinAdapterResponse>,
     pub query_stats: Option<QueryStatsPayload>,
+    pub upgrade: Vec<UpgradePermitAction>,
 }
 
 /// Error type that can occur during an `BatchPayload::into_messages` call
@@ -209,6 +214,7 @@ pub struct BatchMessages {
 pub enum IntoMessagesError {
     IngressPayloadError(IngressPayloadError),
     QueryStatsPayloadError(ProxyDecodeError),
+    UpgradePayloadError(ProxyDecodeError),
 }
 
 impl BatchPayload {
@@ -226,6 +232,12 @@ impl BatchPayload {
             bitcoin_adapter_responses: self.self_validating.0,
             query_stats: QueryStatsPayload::deserialize(&self.query_stats)
                 .map_err(IntoMessagesError::QueryStatsPayloadError)?,
+            upgrade: if self.upgrade.is_empty() {
+                Vec::new()
+            } else {
+                bytes_to_upgrade_payload(&self.upgrade)
+                    .map_err(IntoMessagesError::UpgradePayloadError)?
+            },
         })
     }
 
@@ -237,6 +249,7 @@ impl BatchPayload {
             canister_http,
             query_stats,
             chain_key,
+            upgrade,
         } = &self;
 
         ingress.is_empty()
@@ -245,6 +258,7 @@ impl BatchPayload {
             && canister_http.is_empty()
             && query_stats.is_empty()
             && chain_key.is_empty()
+            && upgrade.is_empty()
     }
 }
 
@@ -405,6 +419,7 @@ mod tests {
             canister_http,
             query_stats,
             chain_key,
+            upgrade: _,
         } = BatchPayload::default();
 
         assert_eq!(ingress.total_ids_size_estimate(), NumBytes::new(0));
@@ -429,6 +444,7 @@ mod tests {
             canister_http,
             query_stats,
             chain_key,
+            upgrade,
         } = &payload;
 
         assert!(ingress.is_empty());
@@ -437,6 +453,7 @@ mod tests {
         assert!(canister_http.is_empty());
         assert!(query_stats.is_empty());
         assert!(chain_key.is_empty());
+        assert!(upgrade.is_empty());
     }
 
     #[test]

--- a/rs/types/types/src/batch/upgrade.rs
+++ b/rs/types/types/src/batch/upgrade.rs
@@ -1,0 +1,196 @@
+use ic_base_types::NumBytes;
+use ic_protobuf::proxy::{ProxyDecodeError, try_from_option_field};
+use ic_protobuf::types::v1 as pb;
+use pb::upgrade_action::Action;
+use std::collections::BTreeMap;
+
+use super::{iterator_to_bytes, slice_to_messages};
+use crate::consensus::UpgradePermitAuthorizationRequest;
+use crate::consensus::upgrade::UpgradePermitAction;
+use crate::signature::{BasicSignature, BasicSignatureBatch};
+
+/// Serializes a list of [`UpgradePermitAction`]s to a length-delimited protobuf
+/// stream, respecting the `max_size` budget. Actions that don't fit are
+/// silently dropped.
+pub fn upgrade_payload_to_bytes(actions: Vec<UpgradePermitAction>, max_size: NumBytes) -> Vec<u8> {
+    let message_iterator = actions.into_iter().map(pb::UpgradeAction::from);
+    iterator_to_bytes(message_iterator, max_size)
+}
+
+/// Deserializes a length-delimited protobuf stream into a list of
+/// [`UpgradePermitAction`]s. An empty byte slice yields an empty list.
+pub fn bytes_to_upgrade_payload(data: &[u8]) -> Result<Vec<UpgradePermitAction>, ProxyDecodeError> {
+    let messages: Vec<pb::UpgradeAction> =
+        slice_to_messages(data).map_err(ProxyDecodeError::DecodeError)?;
+    messages
+        .into_iter()
+        .map(UpgradePermitAction::try_from)
+        .collect()
+}
+
+impl From<UpgradePermitAction> for pb::UpgradeAction {
+    fn from(action: UpgradePermitAction) -> Self {
+        let proto_action = match action {
+            UpgradePermitAction::Request(request) => {
+                Action::RequestPermit(pb::RequestUpgradePermit {
+                    request: Some(pb::UpgradePermitRequest::from(request)),
+                })
+            }
+            UpgradePermitAction::Authorize {
+                request,
+                signatures,
+            } => Action::AuthorizePermit(pb::AuthorizeUpgradePermit {
+                request: Some(pb::UpgradePermitRequest::from(request)),
+                signatures: signatures
+                    .signatures_map
+                    .into_iter()
+                    .map(|(signer, signature)| {
+                        pb::BasicSignature::from(BasicSignature { signature, signer })
+                    })
+                    .collect(),
+            }),
+            UpgradePermitAction::Return { node } => Action::ReturnPermit(pb::ReturnUpgradePermit {
+                node: Some(crate::node_id_into_protobuf(node)),
+            }),
+        };
+        Self {
+            action: Some(proto_action),
+        }
+    }
+}
+
+impl TryFrom<pb::UpgradeAction> for UpgradePermitAction {
+    type Error = ProxyDecodeError;
+
+    fn try_from(proto: pb::UpgradeAction) -> Result<Self, Self::Error> {
+        let action = proto
+            .action
+            .ok_or(ProxyDecodeError::MissingField("UpgradeAction::action"))?;
+        Ok(match action {
+            Action::RequestPermit(request) => UpgradePermitAction::Request(try_from_option_field(
+                request.request,
+                "RequestUpgradePermit::request",
+            )?),
+            Action::AuthorizePermit(authorize) => UpgradePermitAction::Authorize {
+                request: try_from_option_field(
+                    authorize.request,
+                    "AuthorizeUpgradePermit::request",
+                )?,
+                signatures: signature_batch(authorize.signatures)?,
+            },
+            Action::ReturnPermit(return_permit) => UpgradePermitAction::Return {
+                node: crate::node_id_try_from_option(return_permit.node)?,
+            },
+        })
+    }
+}
+
+/// Decodes a list of basic signatures over the same content into a
+/// [`BasicSignatureBatch`], rejecting duplicate signers.
+fn signature_batch(
+    signatures: Vec<pb::BasicSignature>,
+) -> Result<BasicSignatureBatch<UpgradePermitAuthorizationRequest>, ProxyDecodeError> {
+    let mut signatures_map = BTreeMap::new();
+    for signature in signatures {
+        let signature: BasicSignature<UpgradePermitAuthorizationRequest> = signature.try_into()?;
+        if signatures_map
+            .insert(signature.signer, signature.signature)
+            .is_some()
+        {
+            return Err(ProxyDecodeError::DuplicateEntry {
+                key: format!("{:?}", signature.signer),
+                v1: "signature".to_string(),
+                v2: "signature".to_string(),
+            });
+        }
+    }
+    Ok(BasicSignatureBatch { signatures_map })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Height;
+    use crate::NodeId;
+    use ic_base_types::PrincipalId;
+
+    fn node(node_index: u64) -> NodeId {
+        NodeId::from(PrincipalId::new_node_test_id(node_index))
+    }
+
+    #[test]
+    fn test_round_trip_request() {
+        let actions = vec![UpgradePermitAction::Request(
+            UpgradePermitAuthorizationRequest {
+                requestor: node(3),
+                request_height: Height::new(42),
+            },
+        )];
+        let bytes = upgrade_payload_to_bytes(actions.clone(), NumBytes::new(u64::MAX));
+        let decoded = bytes_to_upgrade_payload(&bytes).unwrap();
+        assert_eq!(actions, decoded);
+    }
+
+    #[test]
+    fn test_round_trip_authorize() {
+        let actions = vec![UpgradePermitAction::Authorize {
+            request: UpgradePermitAuthorizationRequest {
+                requestor: node(5),
+                request_height: Height::new(3),
+            },
+            signatures: BasicSignatureBatch {
+                signatures_map: BTreeMap::new(),
+            },
+        }];
+        let bytes = upgrade_payload_to_bytes(actions.clone(), NumBytes::new(u64::MAX));
+        let decoded = bytes_to_upgrade_payload(&bytes).unwrap();
+        assert_eq!(actions, decoded);
+    }
+
+    #[test]
+    fn test_round_trip_return() {
+        let actions = vec![UpgradePermitAction::Return { node: node(7) }];
+        let bytes = upgrade_payload_to_bytes(actions.clone(), NumBytes::new(u64::MAX));
+        let decoded = bytes_to_upgrade_payload(&bytes).unwrap();
+        assert_eq!(actions, decoded);
+    }
+
+    #[test]
+    fn test_round_trip_empty() {
+        let bytes = upgrade_payload_to_bytes(vec![], NumBytes::new(u64::MAX));
+        assert!(bytes.is_empty());
+        let decoded = bytes_to_upgrade_payload(&bytes).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn test_round_trip_multiple_actions() {
+        let actions = vec![
+            UpgradePermitAction::Request(UpgradePermitAuthorizationRequest {
+                requestor: node(1),
+                request_height: Height::new(10),
+            }),
+            UpgradePermitAction::Authorize {
+                request: UpgradePermitAuthorizationRequest {
+                    requestor: node(2),
+                    request_height: Height::new(4),
+                },
+                signatures: BasicSignatureBatch {
+                    signatures_map: BTreeMap::new(),
+                },
+            },
+            UpgradePermitAction::Return { node: node(3) },
+        ];
+        let bytes = upgrade_payload_to_bytes(actions.clone(), NumBytes::new(u64::MAX));
+        let decoded = bytes_to_upgrade_payload(&bytes).unwrap();
+        assert_eq!(actions, decoded);
+    }
+
+    #[test]
+    fn test_max_size_drops_overflow() {
+        // With max_size = 0, no actions should be encoded.
+        let actions = vec![UpgradePermitAction::Return { node: node(1) }];
+        let bytes = upgrade_payload_to_bytes(actions, NumBytes::new(0));
+        assert!(bytes.is_empty());
+    }
+}

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -32,6 +32,7 @@ pub mod hashed;
 pub mod idkg;
 mod payload;
 pub mod thunk;
+pub mod upgrade;
 
 pub use catchup::*;
 use hashed::Hashed;
@@ -1298,6 +1299,7 @@ impl From<&Block> for pb::Block {
             canister_http_payload_bytes,
             query_stats_payload_bytes,
             chain_key_payload_bytes,
+            upgrade_payload_bytes,
             idkg_payload,
         ) = if payload.is_summary() {
             (
@@ -1305,6 +1307,7 @@ impl From<&Block> for pb::Block {
                 None,
                 None,
                 None,
+                vec![],
                 vec![],
                 vec![],
                 vec![],
@@ -1320,6 +1323,7 @@ impl From<&Block> for pb::Block {
                 batch.canister_http.clone(),
                 batch.query_stats.clone(),
                 batch.chain_key.clone(),
+                batch.upgrade.clone(),
                 payload.as_data().idkg.as_ref().map(|idkg| idkg.into()),
             )
         };
@@ -1338,6 +1342,7 @@ impl From<&Block> for pb::Block {
             canister_http_payload_bytes,
             query_stats_payload_bytes,
             chain_key_payload_bytes,
+            upgrade_payload_bytes,
             idkg_payload,
             payload_hash: block.payload.get_hash().clone().get().0,
         }
@@ -1369,6 +1374,7 @@ impl TryFrom<pb::Block> for Block {
             canister_http: block.canister_http_payload_bytes,
             query_stats: block.query_stats_payload_bytes,
             chain_key: block.chain_key_payload_bytes,
+            upgrade: block.upgrade_payload_bytes,
         };
 
         let payload = match dkg_payload {
@@ -1763,6 +1769,84 @@ impl ConsensusMessageHashable for EquivocationProof {
 
     fn into_message(self) -> ConsensusMessage {
         ConsensusMessage::EquivocationProof(self)
+    }
+}
+
+/// UpgradePermitAuthorizationRequest holds the values that are signed in an
+/// upgrade permit authorization share.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct UpgradePermitAuthorizationRequest {
+    pub requestor: NodeId,
+    pub request_height: Height,
+}
+
+impl SignedBytesWithoutDomainSeparator for UpgradePermitAuthorizationRequest {
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
+    }
+}
+
+impl HasHeight for UpgradePermitAuthorizationRequest {
+    fn height(&self) -> Height {
+        self.request_height
+    }
+}
+
+/// An upgrade permit authorization share is a basic signature share on an
+/// [`UpgradePermitAuthorizationRequest`].
+pub type UpgradePermitAuthorizationShare =
+    Signed<UpgradePermitAuthorizationRequest, BasicSignature<UpgradePermitAuthorizationRequest>>;
+
+impl PbArtifact for UpgradePermitAuthorizationShare {
+    type PbId = pb::UpgradePermitAuthMessageId;
+    type PbIdError = ProxyDecodeError;
+    type PbMessage = pb::UpgradePermitAuthorizationShare;
+    type PbMessageError = ProxyDecodeError;
+}
+
+impl From<UpgradePermitAuthorizationRequest> for pb::UpgradePermitRequest {
+    fn from(content: UpgradePermitAuthorizationRequest) -> Self {
+        pb::UpgradePermitRequest {
+            requestor: Some(node_id_into_protobuf(content.requestor)),
+            request_height: content.request_height.get(),
+        }
+    }
+}
+
+impl TryFrom<pb::UpgradePermitRequest> for UpgradePermitAuthorizationRequest {
+    type Error = ProxyDecodeError;
+
+    fn try_from(content: pb::UpgradePermitRequest) -> Result<Self, Self::Error> {
+        Ok(UpgradePermitAuthorizationRequest {
+            requestor: node_id_try_from_option(content.requestor)?,
+            request_height: Height::from(content.request_height),
+        })
+    }
+}
+
+impl From<UpgradePermitAuthorizationShare> for pb::UpgradePermitAuthorizationShare {
+    fn from(share: UpgradePermitAuthorizationShare) -> Self {
+        pb::UpgradePermitAuthorizationShare {
+            request: Some(pb::UpgradePermitRequest::from(share.content)),
+            signature: Some(pb::BasicSignature::from(share.signature)),
+        }
+    }
+}
+
+impl TryFrom<pb::UpgradePermitAuthorizationShare> for UpgradePermitAuthorizationShare {
+    type Error = ProxyDecodeError;
+
+    fn try_from(message: pb::UpgradePermitAuthorizationShare) -> Result<Self, Self::Error> {
+        let request =
+            try_from_option_field(message.request, "UpgradePermitAuthorizationShare::request")?;
+        let signature = try_from_option_field(
+            message.signature,
+            "UpgradePermitAuthorizationShare::signature",
+        )?;
+        Ok(UpgradePermitAuthorizationShare {
+            content: request,
+            signature,
+        })
     }
 }
 

--- a/rs/types/types/src/consensus/upgrade.rs
+++ b/rs/types/types/src/consensus/upgrade.rs
@@ -1,0 +1,39 @@
+//! Phase-2 quick-upgrade permit types.
+//!
+//! The permit flow works in three stages:
+//!
+//! 1. **Request**: A block maker includes `UpgradePermitAction::Request` in
+//!    its block when it wants to reboot. Validators check outstanding requests
+//!    the allowed max parallel reboots.
+//!
+//! 2. **Authorize**: After the request block is finalized, each node gossips an
+//!    [`crate::consensus::UpgradePermitAuthorizationShare`]. When a block maker
+//!    collects enough shares, it includes `UpgradePermitAction::Authorize` in its block.
+//!
+//! 3. **Return**: After rebooting, the node includes
+//!    `UpgradePermitAction::Return` to release the slot.
+
+use serde::{Deserialize, Serialize};
+
+use crate::NodeId;
+use crate::consensus::UpgradePermitAuthorizationRequest;
+use crate::signature::BasicSignatureBatch;
+
+/// A single action in a block's upgrade payload section. A block may carry
+/// multiple actions (e.g. `Request` for the block maker and `Authorize` for
+/// another node).
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
+pub enum UpgradePermitAction {
+    /// Request permission to reboot. The block maker requests for itself.
+    /// `request_height` is the height of the block containing this request,
+    /// used for timeout tracking.
+    Request(UpgradePermitAuthorizationRequest),
+    /// Authorize a node to reboot — the signed request and the basic
+    /// signatures over it collected from the staying members.
+    Authorize {
+        request: UpgradePermitAuthorizationRequest,
+        signatures: BasicSignatureBatch<UpgradePermitAuthorizationRequest>,
+    },
+    /// Release a previously authorized permit (reboot complete).
+    Return { node: NodeId },
+}

--- a/rs/types/types/src/crypto/hash.rs
+++ b/rs/types/types/src/crypto/hash.rs
@@ -7,7 +7,7 @@ use crate::canister_http::{
 use crate::consensus::{
     Block, BlockMetadata, BlockPayload, CatchUpContent, CatchUpContentProtobufBytes,
     CatchUpShareContent, ConsensusMessage, EquivocationProof, FinalizationContent, HashedBlock,
-    NotarizationContent, RandomBeaconContent, RandomTapeContent,
+    NotarizationContent, RandomBeaconContent, RandomTapeContent, UpgradePermitAuthorizationRequest,
     certification::{
         Certification, CertificationContent, CertificationMessage, CertificationShare,
     },
@@ -69,6 +69,15 @@ mod private {
     impl CryptoHashDomainSeal for Signed<HashedBlock, BasicSignature<BlockMetadata>> {}
     impl CryptoHashDomainSeal for EquivocationProof {}
     impl CryptoHashDomainSeal for BlockPayload {}
+
+    impl CryptoHashDomainSeal for UpgradePermitAuthorizationRequest {}
+    impl CryptoHashDomainSeal
+        for Signed<
+            UpgradePermitAuthorizationRequest,
+            BasicSignature<UpgradePermitAuthorizationRequest>,
+        >
+    {
+    }
 
     impl CryptoHashDomainSeal for RandomBeaconContent {}
     impl CryptoHashDomainSeal for Signed<RandomBeaconContent, ThresholdSignature<RandomBeaconContent>> {}
@@ -219,6 +228,20 @@ impl CryptoHashDomain for Signed<HashedBlock, BasicSignature<BlockMetadata>> {
 impl CryptoHashDomain for EquivocationProof {
     fn domain(&self) -> String {
         DomainSeparator::EquivocationProof.to_string()
+    }
+}
+
+impl CryptoHashDomain for UpgradePermitAuthorizationRequest {
+    fn domain(&self) -> String {
+        DomainSeparator::UpgradePermitAuthorizationRequest.to_string()
+    }
+}
+
+impl CryptoHashDomain
+    for Signed<UpgradePermitAuthorizationRequest, BasicSignature<UpgradePermitAuthorizationRequest>>
+{
+    fn domain(&self) -> String {
+        DomainSeparator::UpgradePermitAuthorizationShare.to_string()
     }
 }
 

--- a/rs/types/types/src/crypto/hash/domain_separator.rs
+++ b/rs/types/types/src/crypto/hash/domain_separator.rs
@@ -16,6 +16,8 @@ pub enum DomainSeparator {
     BlockMetadata,
     BlockMetadataProposal,
     EquivocationProof,
+    UpgradePermitAuthorizationRequest,
+    UpgradePermitAuthorizationShare,
     InmemoryPayload,
     RandomBeaconContent,
     RandomBeacon,
@@ -80,6 +82,12 @@ impl DomainSeparator {
             DomainSeparator::BlockMetadata => "block_metadata_domain",
             DomainSeparator::BlockMetadataProposal => "block_metadata_proposal_domain",
             DomainSeparator::EquivocationProof => "equivocation_proof_domain",
+            DomainSeparator::UpgradePermitAuthorizationRequest => {
+                "upgrade_permit_authorization_request_domain"
+            }
+            DomainSeparator::UpgradePermitAuthorizationShare => {
+                "upgrade_permit_authorization_share_domain"
+            }
             DomainSeparator::InmemoryPayload => "inmemory_payload_domain",
             DomainSeparator::RandomBeaconContent => "random_beacon_content_domain",
             DomainSeparator::RandomBeacon => "random_beacon_domain",
@@ -194,6 +202,14 @@ fn domain_separators_are_stable() {
         ("BlockMetadata", "block_metadata_domain"),
         ("BlockMetadataProposal", "block_metadata_proposal_domain"),
         ("EquivocationProof", "equivocation_proof_domain"),
+        (
+            "UpgradePermitAuthorizationRequest",
+            "upgrade_permit_authorization_request_domain",
+        ),
+        (
+            "UpgradePermitAuthorizationShare",
+            "upgrade_permit_authorization_share_domain",
+        ),
         ("InmemoryPayload", "inmemory_payload_domain"),
         ("RandomBeaconContent", "random_beacon_content_domain"),
         ("RandomBeacon", "random_beacon_domain"),

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -551,7 +551,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "764535296841f3db421a928cfadff3460be406d0182da64034eee623a9a97e99",
+            "c20a87578beb94df369dabfefc30c0d47d170c75d68236aae3b16335c0f21c4a",
             "Hash of CatchUpContent changed"
         );
     }
@@ -569,7 +569,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "7f183aaeb495159567a340b5bf61233cf3226141268febaee47de3e4c69cbc4b",
+            "db509a477f3ed01ec251325527e946b2e674f249d013bafc0d061620000a6e0d",
             "Hash of CatchUpShareContent changed"
         );
     }
@@ -617,7 +617,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "31f744bc26627fadbf1d73c66cb54603319a87966a488b6f41c4f0cfc1a30c89",
+            "33c4f3fb79a8520a4c1d6d814aa5bae53e5aa58ad517dfddec45be7dfd930053",
             "Hash of CatchUpPackage changed"
         );
     }
@@ -647,7 +647,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "bff423705e4cb96b7a391c4cccba8ed1ce441dabf2693ed5b9545a2b57d946bd",
+            "47648b17b0b80122fa1adc34a6d6e82ae8fb5af4a92b2495c41c91052ace1a10",
             "Hash of CatchUpPackageShare changed"
         );
     }
@@ -990,7 +990,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "b040378bc7d9d2b7c2e9067215eae6380a65316922369a1bc6d8376f31fe5d0a",
+            "5b8ca671118db0ed4f57939788881d95810b36f8d13a9954ecf2c57067e2b8d9",
             "Hash of Block changed"
         );
     }
@@ -1033,7 +1033,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "d591d695f67c644ddcc5315d96c25f00dede77c725859408ab7f113a18a0bf9a",
+            "9bb9a7c7dacd7513fc58d13b238740e2f8e282c3d6cb66bd3aef520904583ae9",
             "Hash of BlockProposal changed"
         );
     }
@@ -1070,7 +1070,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "c94d927dd7300814fef610a7560ba5a7775a859bb3511796cf23cfb59c038a4f",
+            "f289b64bb469c9aab1710c44b0b2fc778de9e5a552858eb10a566b8bc803d930",
             "Hash of BlockPayload changed"
         );
     }

--- a/rs/types/types/src/crypto/sign.rs
+++ b/rs/types/types/src/crypto/sign.rs
@@ -4,7 +4,7 @@ use super::hash::domain_separator::DomainSeparator;
 use crate::canister_http::CanisterHttpResponseReceipt;
 use crate::consensus::{
     BlockMetadata, CatchUpContent, CatchUpContentProtobufBytes, FinalizationContent,
-    NotarizationContent, RandomBeaconContent, RandomTapeContent,
+    NotarizationContent, RandomBeaconContent, RandomTapeContent, UpgradePermitAuthorizationRequest,
     certification::CertificationContent,
     dkg::DealingContent,
     idkg::{IDkgComplaintContent, IDkgOpeningContent},
@@ -64,6 +64,7 @@ mod private {
     impl SignatureDomainSeal for DealingContent {}
     impl SignatureDomainSeal for NotarizationContent {}
     impl SignatureDomainSeal for FinalizationContent {}
+    impl SignatureDomainSeal for UpgradePermitAuthorizationRequest {}
     impl SignatureDomainSeal for IDkgDealing {}
     impl SignatureDomainSeal for SignedIDkgDealing {}
     impl SignatureDomainSeal for IDkgComplaintContent {}
@@ -112,6 +113,12 @@ impl SignatureDomain for NotarizationContent {
 impl SignatureDomain for FinalizationContent {
     fn domain(&self) -> Vec<u8> {
         domain_with_prepended_length(DomainSeparator::FinalizationContent.as_str())
+    }
+}
+
+impl SignatureDomain for UpgradePermitAuthorizationRequest {
+    fn domain(&self) -> Vec<u8> {
+        domain_with_prepended_length(DomainSeparator::UpgradePermitAuthorizationRequest.as_str())
     }
 }
 


### PR DESCRIPTION
First step of the Phase-2 rolling-reboot consensus protocol, which adds the data types and the artifact mechanism.

* Add `UpgradePermitAction` (`Request` / `Authorize` / `Return`). `UpgradePermitAuthorizationRequest` is the signed content, `UpgradePermitAuthorizationShare` is the gossiped artifact.
* Add the in-memory `UpgradePermitAuthPoolImpl` which is modeled after other pools.
* Add the `ic-consensus-upgrade` crate with `UpgradePermitAuthPoolManager`. It signs shares for requests in finalized blocks and validates gossiped shares.
* Register the new proto file with the generator and add `UpgradePermitAuthorizationRequest` (signing) and `UpgradePermitAuthorizationShare` (pool-ID hashing) domain separators.